### PR TITLE
refactor(runtime): execute RuntimeGraph natively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           pytest -q \
             tests/test_kernel_contracts.py \
             tests/test_runtime_queues.py \
+            tests/test_runtime_executor.py \
             tests/test_plugin_registry.py \
             tests/test_config_schema.py \
             tests/test_clock_sync.py \
@@ -59,6 +60,7 @@ jobs:
             tests/test_pipeline.py \
             tests/test_builtin_plugins.py \
             tests/test_config_resolution.py \
+            tests/test_runtime_executor.py \
             tests/test_kernel_contracts.py \
             tests/test_runtime_queues.py \
             tests/test_plugin_registry.py \

--- a/packages/neuros-core/src/neuros/pipeline.py
+++ b/packages/neuros-core/src/neuros/pipeline.py
@@ -1,23 +1,113 @@
-"""High-level pipeline wrappers for neurOS."""
+"""High-level compatibility wrappers over the typed neurOS runtime."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from neuros.agents.orchestrator_agent import Orchestrator
+from neuros.contracts import DecoderCapabilities, DecoderOutput
+from neuros.processing.adaptation import AdaptiveThreshold
+from neuros.processing.feature_extraction import BandPowerExtractor
+from neuros.processing.filters import SmoothingFilter
 from neuros.processing.health_monitor import QualityMonitor
-from neuros.runtime import OverflowPolicy
+from neuros.processing.operators import FeatureTransform
+from neuros.runtime import (
+    NodeKind,
+    OverflowPolicy,
+    RuntimeEdge,
+    RuntimeExecutor,
+    RuntimeGraph,
+    RuntimeNode,
+)
+
+
+class _DecoderAdapter:
+    """Normalize legacy train/predict models to the Decoder contract."""
+
+    def __init__(self, model: Any, *, adaptation: bool = False) -> None:
+        self.model = model
+        self.adaptation = AdaptiveThreshold(window_size=50) if adaptation else None
+
+    @property
+    def capabilities(self) -> DecoderCapabilities:
+        value = getattr(self.model, "capabilities", None)
+        return value if isinstance(value, DecoderCapabilities) else DecoderCapabilities()
+
+    def infer(self, X: np.ndarray) -> DecoderOutput:
+        if hasattr(self.model, "infer"):
+            output = self.model.infer(X)
+        elif hasattr(self.model, "predict"):
+            prediction = np.asarray(self.model.predict(X))
+            output = DecoderOutput(
+                prediction=prediction[0] if prediction.size == 1 else prediction,
+                confidence=None,
+                model_id=type(self.model).__name__,
+            )
+        else:
+            raise TypeError("model must provide infer(X) or predict(X)")
+        if not isinstance(output, DecoderOutput):
+            output = DecoderOutput(prediction=output, confidence=None)
+        if self.adaptation is None or output.confidence is None:
+            return output
+        self.adaptation.update(output.confidence)
+        return replace(
+            output,
+            metadata={
+                **dict(output.metadata),
+                "adaptive_threshold": float(self.adaptation.threshold),
+                "adaptive_trigger": bool(self.adaptation.should_trigger(output.confidence)),
+            },
+        )
+
+
+def _with_default_smoothing(filters: List[object]) -> list[object]:
+    result = list(filters)
+    if not any(isinstance(item, SmoothingFilter) for item in result):
+        result.append(SmoothingFilter(window_size=5))
+    return result
+
+
+def _compat_metrics(
+    snapshot: dict[str, Any],
+    *,
+    decoder_node: str,
+    model: Any,
+    driver_name: str,
+    monitor: Any | None,
+) -> dict[str, Any]:
+    node_metrics = snapshot["nodes"].get(decoder_node, {})
+    samples = int(node_metrics.get("processed", 0))
+    runtime_s = float(snapshot.get("runtime_seconds", 0.0))
+    stage_mean_ms = sum(
+        float(metrics.get("mean_latency_ms", 0.0))
+        for metrics in snapshot.get("nodes", {}).values()
+    )
+    result: dict[str, Any] = {
+        "duration": runtime_s,
+        "samples": samples,
+        "throughput": samples / runtime_s if runtime_s > 0 else 0.0,
+        "mean_latency": stage_mean_ms / 1000.0,
+        "model": type(model).__name__,
+        "driver": driver_name,
+        "runtime": snapshot,
+        "dropped": sum(
+            int(edge.get("dropped", 0)) for edge in snapshot.get("edges", {}).values()
+        ),
+    }
+    if monitor is not None and hasattr(monitor, "result"):
+        result.update(monitor.result())
+    return result
 
 
 @dataclass
 class Pipeline:
-    """Configurable single-stream neurOS pipeline.
+    """Single-stream facade that compiles to a :class:`RuntimeGraph`.
 
-    Concrete drivers and decoders are injected by callers. This keeps
-    ``neuros-core`` independent from ``neuros-drivers`` and ``neuros-models``.
+    Custom legacy ``processing_agent_class`` implementations temporarily use the
+    old orchestrator.  Standard pipelines execute exclusively through the native
+    graph runtime.
     """
 
     driver: Any
@@ -41,38 +131,96 @@ class Pipeline:
     def train(self, X: np.ndarray, y: np.ndarray) -> None:
         self.model.train(X, y)
 
+    def to_graph(self) -> RuntimeGraph:
+        if self.processing_agent_class is not None:
+            raise RuntimeError(
+                "Custom processing agents are legacy-only; migrate them to a Transform "
+                "before compiling to RuntimeGraph"
+            )
+        monitor = self.monitor
+        if monitor is None:
+            monitor = QualityMonitor()
+            self.monitor = monitor
+        transform = FeatureTransform(
+            filters=_with_default_smoothing(self.filters),
+            extractor=BandPowerExtractor(fs=self.fs, bands=self.bands),
+        )
+        graph = RuntimeGraph()
+        graph.add_node(RuntimeNode("source:primary", NodeKind.SOURCE, self.driver))
+        graph.add_node(RuntimeNode("transform:features", NodeKind.TRANSFORM, transform))
+        graph.add_node(
+            RuntimeNode(
+                "decoder:primary",
+                NodeKind.DECODER,
+                _DecoderAdapter(self.model, adaptation=self.adaptation),
+            )
+        )
+        if monitor is not None:
+            graph.add_node(RuntimeNode("monitor:quality", NodeKind.MONITOR, monitor))
+        graph.connect(
+            RuntimeEdge(
+                "source:primary",
+                "transform:features",
+                capacity=self.queue_capacity,
+                overflow=self.overflow_policy.value,
+            )
+        )
+        graph.connect(
+            RuntimeEdge(
+                "transform:features",
+                "decoder:primary",
+                capacity=self.queue_capacity,
+                overflow=self.overflow_policy.value,
+            )
+        )
+        graph.validate()
+        return graph
+
     async def run(self, duration: Optional[float] = None) -> Dict[str, Any]:
+        if self.processing_agent_class is not None:
+            from neuros.agents.orchestrator_agent import Orchestrator
+
+            orchestrator = Orchestrator(
+                driver=self.driver,
+                model=self.model,
+                fs=self.fs,
+                duration=duration,
+                bands=self.bands,
+                adaptation=self.adaptation,
+                filters=self.filters,
+                processing_agent_class=self.processing_agent_class,
+                processing_kwargs=self.processing_kwargs,
+                monitor=self.monitor,
+                queue_capacity=self.queue_capacity,
+                overflow_policy=self.overflow_policy,
+            )
+            return await orchestrator.run()
+
         run_duration = duration
         if run_duration is None and hasattr(self.driver, "get_duration"):
             try:
-                run_duration = float(self.driver.get_duration())
+                candidate = float(self.driver.get_duration())
+                run_duration = candidate if candidate > 0 else None
             except (TypeError, ValueError):
-                run_duration = None
-        if self.monitor is None:
-            try:
-                self.monitor = QualityMonitor()
-            except Exception:
-                self.monitor = None
-        orchestrator = Orchestrator(
-            driver=self.driver,
-            model=self.model,
-            fs=self.fs,
-            duration=run_duration,
-            bands=self.bands,
-            adaptation=self.adaptation,
-            filters=self.filters,
-            processing_agent_class=self.processing_agent_class,
-            processing_kwargs=self.processing_kwargs,
-            monitor=self.monitor,
-            queue_capacity=self.queue_capacity,
-            overflow_policy=self.overflow_policy,
+                pass
+        executor = RuntimeExecutor(self.to_graph())
+        snapshot = (
+            await executor.run_for(run_duration)
+            if run_duration is not None
+            else await executor.run()
         )
-        return await orchestrator.run()
+        return _compat_metrics(
+            snapshot,
+            decoder_node="decoder:primary",
+            model=self.model,
+            driver_name=type(self.driver).__name__,
+            monitor=self.monitor,
+        )
 
 
 @dataclass
 class MultiModalPipeline:
-    """High-level wrapper around the multi-modal runtime."""
+    """Multi-stream facade using the same RuntimeExecutor as Pipeline."""
 
     drivers: List[Any]
     model: Any
@@ -95,35 +243,104 @@ class MultiModalPipeline:
     def train(self, X: np.ndarray, y: np.ndarray) -> None:
         self.model.train(X, y)
 
-    async def run(self, duration: Optional[float] = None) -> Dict[str, Any]:
-        from neuros.agents.multimodal_orchestrator import MultiModalOrchestrator
+    @property
+    def _has_legacy_agents(self) -> bool:
+        return any(item is not None for item in (self.processing_agent_classes or []))
 
-        run_duration = duration
-        if run_duration is None:
-            for driver in self.drivers:
-                if hasattr(driver, "get_duration"):
-                    try:
-                        run_duration = float(driver.get_duration())
-                        break
-                    except (TypeError, ValueError):
-                        pass
-        if self.monitor is None:
-            try:
-                self.monitor = QualityMonitor()
-            except Exception:
-                self.monitor = None
-        orchestrator = MultiModalOrchestrator(
-            drivers=self.drivers,
-            model=self.model,
-            extractors=self.extractors or [None] * len(self.drivers),
-            fs_list=self.fs_list or [None] * len(self.drivers),
-            filters_list=self.filters_list or [None] * len(self.drivers),
-            adaptation=self.adaptation,
-            duration=run_duration,
-            processing_agent_classes=self.processing_agent_classes or [None] * len(self.drivers),
-            processing_kwargs_list=self.processing_kwargs_list or [None] * len(self.drivers),
-            monitor=self.monitor,
-            queue_capacity=self.queue_capacity,
-            overflow_policy=self.overflow_policy,
+    def to_graph(self) -> RuntimeGraph:
+        if self._has_legacy_agents:
+            raise RuntimeError("Custom processing agents must be migrated before graph compilation")
+        monitor = self.monitor
+        if monitor is None:
+            monitor = QualityMonitor()
+            self.monitor = monitor
+        extractors = self.extractors or [None] * len(self.drivers)
+        fs_list = self.fs_list or [None] * len(self.drivers)
+        filters_list = self.filters_list or [None] * len(self.drivers)
+        graph = RuntimeGraph()
+        tails: list[str] = []
+        for index, driver in enumerate(self.drivers):
+            source_id = f"source:{index}"
+            transform_id = f"transform:{index}"
+            fs = fs_list[index] or getattr(driver, "sampling_rate", 250.0)
+            extractor = extractors[index] or BandPowerExtractor(fs=fs)
+            filters = _with_default_smoothing(filters_list[index] or [])
+            graph.add_node(RuntimeNode(source_id, NodeKind.SOURCE, driver))
+            graph.add_node(
+                RuntimeNode(
+                    transform_id,
+                    NodeKind.TRANSFORM,
+                    FeatureTransform(filters=filters, extractor=extractor),
+                )
+            )
+            graph.connect(
+                RuntimeEdge(
+                    source_id,
+                    transform_id,
+                    capacity=self.queue_capacity,
+                    overflow=self.overflow_policy.value,
+                )
+            )
+            tails.append(transform_id)
+        if len(tails) == 1:
+            upstream = tails[0]
+        else:
+            upstream = "fusion:primary"
+            graph.add_node(RuntimeNode(upstream, NodeKind.FUSION, None))
+            for tail in tails:
+                graph.connect(
+                    RuntimeEdge(
+                        tail,
+                        upstream,
+                        capacity=self.queue_capacity,
+                        overflow=self.overflow_policy.value,
+                    )
+                )
+        graph.add_node(
+            RuntimeNode(
+                "decoder:primary",
+                NodeKind.DECODER,
+                _DecoderAdapter(self.model, adaptation=self.adaptation),
+            )
         )
-        return await orchestrator.run()
+        graph.connect(
+            RuntimeEdge(
+                upstream,
+                "decoder:primary",
+                capacity=self.queue_capacity,
+                overflow=self.overflow_policy.value,
+            )
+        )
+        if monitor is not None:
+            graph.add_node(RuntimeNode("monitor:quality", NodeKind.MONITOR, monitor))
+        graph.validate()
+        return graph
+
+    async def run(self, duration: Optional[float] = None) -> Dict[str, Any]:
+        if self._has_legacy_agents:
+            from neuros.agents.multimodal_orchestrator import MultiModalOrchestrator
+
+            orchestrator = MultiModalOrchestrator(
+                drivers=self.drivers,
+                model=self.model,
+                extractors=self.extractors or [None] * len(self.drivers),
+                fs_list=self.fs_list or [None] * len(self.drivers),
+                filters_list=self.filters_list or [None] * len(self.drivers),
+                adaptation=self.adaptation,
+                duration=duration,
+                processing_agent_classes=self.processing_agent_classes or [None] * len(self.drivers),
+                processing_kwargs_list=self.processing_kwargs_list or [None] * len(self.drivers),
+                monitor=self.monitor,
+                queue_capacity=self.queue_capacity,
+                overflow_policy=self.overflow_policy,
+            )
+            return await orchestrator.run()
+        executor = RuntimeExecutor(self.to_graph())
+        snapshot = await executor.run_for(duration) if duration is not None else await executor.run()
+        return _compat_metrics(
+            snapshot,
+            decoder_node="decoder:primary",
+            model=self.model,
+            driver_name="+".join(type(driver).__name__ for driver in self.drivers),
+            monitor=self.monitor,
+        )

--- a/packages/neuros-core/src/neuros/processing/__init__.py
+++ b/packages/neuros-core/src/neuros/processing/__init__.py
@@ -1,18 +1,26 @@
-"""
-Signal processing and feature extraction modules.
+"""Signal processing and feature extraction modules."""
 
-These functions and classes operate on raw neural data to clean it and
-extract informative features for downstream models.  They are designed to be
-small and composable so that they can be arranged flexibly in a pipeline.
-"""
-
-from neuros.processing.filters import BandpassFilter, SmoothingFilter  # noqa: F401
-from neuros.processing.feature_extraction import (
+from neuros.processing.adaptation import AdaptiveThreshold  # noqa: F401
+from neuros.processing.feature_extraction import (  # noqa: F401
+    AudioFeatureExtractor,
     BandPowerExtractor,
     HeartRateExtractor,
-    SkinConductanceExtractor,
-    RespirationExtractor,
     HormoneExtractor,
-    AudioFeatureExtractor,
-)  # noqa: F401
-from neuros.processing.adaptation import AdaptiveThreshold  # noqa: F401
+    RespirationExtractor,
+    SkinConductanceExtractor,
+)
+from neuros.processing.filters import BandpassFilter, SmoothingFilter  # noqa: F401
+from neuros.processing.operators import FeatureTransform  # noqa: F401
+
+__all__ = [
+    "AdaptiveThreshold",
+    "AudioFeatureExtractor",
+    "BandPowerExtractor",
+    "BandpassFilter",
+    "FeatureTransform",
+    "HeartRateExtractor",
+    "HormoneExtractor",
+    "RespirationExtractor",
+    "SkinConductanceExtractor",
+    "SmoothingFilter",
+]

--- a/packages/neuros-core/src/neuros/processing/health_monitor.py
+++ b/packages/neuros-core/src/neuros/processing/health_monitor.py
@@ -1,59 +1,46 @@
-"""
-Quality monitor for neurOS.
-
-This module defines a simple class for monitoring data quality during
-pipeline runs.  The monitor accumulates the mean and standard
-deviation of incoming samples over time.  At the end of a run, the
-mean of the sample means and the mean of the sample standard
-deviations are returned as quality metrics.  These metrics
-approximate overall signal amplitude and variability.
-
-The monitor can handle 1D arrays (e.g. EEG or EMG channels), 2D arrays
-(e.g. video or calcium imaging frames) and scalar values.  It uses
-``numpy`` to compute statistics.
-"""
+"""Quality monitoring for neurOS runtime streams."""
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Any, Iterable, Mapping
 
 import numpy as np
 
+from neuros.contracts import SignalFrame
+
 
 class QualityMonitor:
-    """Accumulate basic quality metrics for streaming data."""
+    """Accumulate lightweight amplitude/variability quality metrics.
+
+    ``update`` accepts raw arrays for backwards compatibility and the structured
+    monitor event emitted by :class:`RuntimeExecutor`.  SignalFrame inputs are
+    reduced over their data payload rather than their metadata.
+    """
 
     def __init__(self) -> None:
         self.sum_mean: float = 0.0
         self.sum_std: float = 0.0
         self.count: int = 0
 
-    def update(self, sample: Iterable[float] | np.ndarray) -> None:
-        """Update the monitor with a new sample.
-
-        Parameters
-        ----------
-        sample : array‑like
-            The raw data sample.  Can be a NumPy array of any shape or
-            an iterable of numbers.  The monitor flattens the sample
-            and computes its mean and standard deviation.
-        """
-        arr = np.asarray(sample, dtype=np.float32)
-        # flatten to one dimension for statistics
+    def update(self, sample: Iterable[float] | np.ndarray | Mapping[str, Any] | SignalFrame) -> None:
+        if isinstance(sample, Mapping) and "item" in sample:
+            sample = sample["item"]
+        if isinstance(sample, SignalFrame):
+            sample = sample.data
+        # Decoder outputs and other non-numeric runtime events are not raw signal
+        # quality observations; ignore them rather than fabricating a statistic.
+        try:
+            arr = np.asarray(sample, dtype=np.float32)
+        except (TypeError, ValueError):
+            return
+        if arr.size == 0:
+            return
         flat = arr.ravel()
         self.sum_mean += float(flat.mean())
         self.sum_std += float(flat.std())
         self.count += 1
 
-    def result(self) -> dict:
-        """Return averaged quality metrics.
-
-        Returns
-        -------
-        dict
-            Dictionary with keys ``quality_mean`` and ``quality_std``.
-            If no samples were observed, both values are zero.
-        """
+    def result(self) -> dict[str, float]:
         if self.count == 0:
             return {"quality_mean": 0.0, "quality_std": 0.0}
         return {

--- a/packages/neuros-core/src/neuros/processing/operators.py
+++ b/packages/neuros-core/src/neuros/processing/operators.py
@@ -1,0 +1,45 @@
+"""Composable processing operators for the typed neurOS runtime."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Iterable
+
+import numpy as np
+
+from neuros.contracts import SignalFrame
+
+
+class FeatureTransform:
+    """Apply a sequence of legacy filters followed by a feature extractor.
+
+    This adapter is deliberately small: it lets the existing processing library
+    participate in RuntimeGraph execution without teaching the kernel about any
+    concrete filter or extractor implementation.
+    """
+
+    def __init__(self, *, filters: Iterable[Any] = (), extractor: Any) -> None:
+        if extractor is None or not hasattr(extractor, "extract"):
+            raise TypeError("extractor must provide extract(data)")
+        self.filters = tuple(filters)
+        self.extractor = extractor
+
+    def transform(self, item: Any) -> Any:
+        frame = item if isinstance(item, SignalFrame) else None
+        data = np.asarray(frame.data if frame is not None else item)
+        for filter_obj in self.filters:
+            if not hasattr(filter_obj, "apply"):
+                raise TypeError(f"Filter {type(filter_obj).__name__} lacks apply(data)")
+            data = np.asarray(filter_obj.apply(data))
+        features = np.asarray(self.extractor.extract(data))
+        if frame is None:
+            return features
+        return replace(
+            frame,
+            data=features,
+            metadata={
+                **dict(frame.metadata),
+                "representation": "features",
+                "extractor": type(self.extractor).__name__,
+            },
+        )

--- a/packages/neuros-core/src/neuros/runtime/__init__.py
+++ b/packages/neuros-core/src/neuros/runtime/__init__.py
@@ -1,15 +1,20 @@
 """Runtime primitives for neurOS."""
 
+from .executor import ExecutionClass, NodeStats, RuntimeExecutor, RuntimeFailure
 from .graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from .lifecycle import RuntimeEvent, RuntimeState
 from .queues import OverflowPolicy, QueueStats, put_with_policy
 
 __all__ = [
+    "ExecutionClass",
     "NodeKind",
+    "NodeStats",
     "OverflowPolicy",
     "QueueStats",
     "RuntimeEdge",
     "RuntimeEvent",
+    "RuntimeExecutor",
+    "RuntimeFailure",
     "RuntimeGraph",
     "RuntimeNode",
     "RuntimeState",

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -1,0 +1,542 @@
+"""Native execution engine for :class:`neuros.runtime.RuntimeGraph`.
+
+The executor is intentionally small and explicit.  It owns queue/backpressure
+semantics, lifecycle, failure propagation, node scheduling, latency telemetry,
+and the live/replay symmetry of the neurOS data plane.  Concrete hardware,
+models, storage backends, and ORION implementations remain outside the kernel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from collections import deque
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any, AsyncIterator, Callable
+
+import numpy as np
+
+from neuros.contracts import DecoderOutput, SignalFrame
+from neuros.errors import ProcessingError
+from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
+from neuros.runtime.lifecycle import RuntimeEvent, RuntimeState
+from neuros.runtime.queues import OverflowPolicy, QueueStats, put_with_policy
+
+
+class ExecutionClass(str, Enum):
+    """Execution isolation requested by a runtime node.
+
+    ``GPU`` is scheduled inline because the operator owns its framework/device
+    context; the label exists so graph specifications and telemetry preserve the
+    scheduling intent. ``PROCESS`` is opt-in because operators must be picklable.
+    """
+
+    INLINE = "inline"
+    THREAD = "thread"
+    PROCESS = "process"
+    GPU = "gpu"
+
+
+@dataclass(slots=True)
+class NodeStats:
+    processed: int = 0
+    failed: int = 0
+    total_latency_ns: int = 0
+    max_latency_ns: int = 0
+    _recent_latency_ns: deque[int] = field(
+        default_factory=lambda: deque(maxlen=4096), repr=False
+    )
+
+    def observe(self, latency_ns: int) -> None:
+        self.processed += 1
+        self.total_latency_ns += latency_ns
+        self.max_latency_ns = max(self.max_latency_ns, latency_ns)
+        self._recent_latency_ns.append(latency_ns)
+
+    def snapshot(self) -> dict[str, float | int]:
+        values = sorted(self._recent_latency_ns)
+
+        def percentile(q: float) -> float:
+            if not values:
+                return 0.0
+            index = min(len(values) - 1, max(0, round(q * (len(values) - 1))))
+            return values[index] / 1_000_000.0
+
+        mean_ms = (
+            self.total_latency_ns / self.processed / 1_000_000.0
+            if self.processed
+            else 0.0
+        )
+        return {
+            "processed": self.processed,
+            "failed": self.failed,
+            "mean_latency_ms": mean_ms,
+            "p50_latency_ms": percentile(0.50),
+            "p95_latency_ms": percentile(0.95),
+            "p99_latency_ms": percentile(0.99),
+            "max_latency_ms": self.max_latency_ns / 1_000_000.0,
+        }
+
+
+@dataclass(slots=True)
+class EdgeChannel:
+    edge: RuntimeEdge
+    queue: asyncio.Queue[Any]
+    policy: OverflowPolicy
+    stats: QueueStats = field(default_factory=QueueStats)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeFailure:
+    node_id: str
+    error_type: str
+    message: str
+
+
+class _Stop:
+    __slots__ = ()
+
+
+_STOP = _Stop()
+
+
+def _call(func: Callable[[Any], Any], item: Any) -> Any:
+    return func(item)
+
+
+class RuntimeExecutor:
+    """Execute a validated :class:`RuntimeGraph`.
+
+    The runtime supports finite replay sources and indefinitely streaming live
+    sources with the same graph.  Each edge owns a bounded queue and explicit
+    overflow policy.  A source completion sentinel is propagated through the
+    graph so finite experiments terminate deterministically without cancellation.
+    """
+
+    def __init__(
+        self,
+        graph: RuntimeGraph,
+        *,
+        drain_timeout_s: float = 2.0,
+    ) -> None:
+        if drain_timeout_s <= 0:
+            raise ValueError("drain_timeout_s must be positive")
+        graph.validate()
+        self.graph = graph
+        self.drain_timeout_s = drain_timeout_s
+        self.state = RuntimeState.CREATED
+        self.failure: RuntimeFailure | None = None
+        self.started_ns: int | None = None
+        self.stopped_ns: int | None = None
+        self._channels: dict[tuple[str, str], EdgeChannel] = {}
+        self._incoming: dict[str, list[EdgeChannel]] = {node_id: [] for node_id in graph.nodes}
+        self._outgoing: dict[str, list[EdgeChannel]] = {node_id: [] for node_id in graph.nodes}
+        self._node_stats = {node_id: NodeStats() for node_id in graph.nodes}
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._completion_task: asyncio.Task[None] | None = None
+        self._output_queue: asyncio.Queue[Any] = asyncio.Queue()
+        self._event_queue: asyncio.Queue[RuntimeEvent] = asyncio.Queue()
+        self._process_pool: ProcessPoolExecutor | None = None
+        self._stopping = False
+        self._build_channels()
+
+    def _build_channels(self) -> None:
+        for edge in self.graph.edges:
+            key = (edge.source, edge.target)
+            if key in self._channels:
+                raise ValueError(f"Duplicate runtime edge: {edge.source} -> {edge.target}")
+            channel = EdgeChannel(
+                edge=edge,
+                queue=asyncio.Queue(maxsize=edge.capacity),
+                policy=OverflowPolicy(edge.overflow),
+            )
+            self._channels[key] = channel
+            self._outgoing[edge.source].append(channel)
+            self._incoming[edge.target].append(channel)
+
+    async def _transition(self, state: RuntimeState, event: str, **metadata: Any) -> None:
+        self.state = state
+        await self._event_queue.put(RuntimeEvent(event=event, state=state, metadata=metadata))
+
+    @property
+    def node_stats(self) -> dict[str, NodeStats]:
+        return self._node_stats
+
+    @property
+    def edge_channels(self) -> dict[tuple[str, str], EdgeChannel]:
+        return self._channels
+
+    async def start(self) -> None:
+        if self.state is not RuntimeState.CREATED:
+            raise RuntimeError(f"Runtime can only start from CREATED, got {self.state.value}")
+        await self._transition(RuntimeState.STARTING, "runtime_starting")
+        self.started_ns = time.monotonic_ns()
+
+        for node in self.graph.nodes.values():
+            if node.kind is NodeKind.MONITOR:
+                continue
+            self._tasks[node.node_id] = asyncio.create_task(
+                self._run_guarded(node), name=f"neuros:{node.node_id}"
+            )
+
+        self._completion_task = asyncio.create_task(
+            self._supervise(), name="neuros:supervisor"
+        )
+        await self._transition(RuntimeState.RUNNING, "runtime_running")
+
+    async def _supervise(self) -> None:
+        if not self._tasks:
+            await self._finish_successfully()
+            return
+        results = await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+        if self.failure is not None:
+            self.stopped_ns = time.monotonic_ns()
+            if self.state is not RuntimeState.FAILED:
+                await self._transition(RuntimeState.FAILED, "runtime_failed")
+            return
+        unexpected = [
+            result
+            for result in results
+            if isinstance(result, BaseException)
+            and not isinstance(result, asyncio.CancelledError)
+        ]
+        if unexpected and not self._stopping:
+            exc = unexpected[0]
+            self.failure = RuntimeFailure("unknown", type(exc).__name__, str(exc))
+            self.stopped_ns = time.monotonic_ns()
+            await self._transition(RuntimeState.FAILED, "runtime_failed")
+            return
+        await self._finish_successfully()
+
+    async def _finish_successfully(self) -> None:
+        if self.state not in (RuntimeState.DRAINING, RuntimeState.STOPPED):
+            await self._transition(RuntimeState.DRAINING, "runtime_draining")
+        self.stopped_ns = time.monotonic_ns()
+        if self.state is not RuntimeState.STOPPED:
+            await self._transition(RuntimeState.STOPPED, "runtime_stopped")
+        if self._process_pool is not None:
+            self._process_pool.shutdown(wait=False, cancel_futures=True)
+            self._process_pool = None
+
+    async def _run_guarded(self, node: RuntimeNode) -> None:
+        try:
+            if node.kind is NodeKind.SOURCE:
+                await self._run_source(node)
+            elif node.kind is NodeKind.FUSION:
+                await self._run_fusion(node)
+            else:
+                await self._run_unary(node)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._node_stats[node.node_id].failed += 1
+            if self.failure is None:
+                self.failure = RuntimeFailure(node.node_id, type(exc).__name__, str(exc))
+                await self._transition(
+                    RuntimeState.FAILED,
+                    "node_failed",
+                    node_id=node.node_id,
+                    error_type=type(exc).__name__,
+                    message=str(exc),
+                )
+                for peer_id, task in self._tasks.items():
+                    if peer_id != node.node_id and not task.done():
+                        task.cancel()
+            raise
+
+    async def _run_source(self, node: RuntimeNode) -> None:
+        source = node.operator
+        if not all(hasattr(source, name) for name in ("start", "stop", "frames")):
+            raise TypeError(f"Source node {node.node_id} does not implement Source")
+        await source.start()
+        try:
+            async for item in source.frames():
+                await self._emit(node, item)
+        finally:
+            await source.stop()
+            await self._emit_stop(node.node_id)
+
+    async def _run_unary(self, node: RuntimeNode) -> None:
+        incoming = self._incoming[node.node_id]
+        if len(incoming) != 1:
+            raise ValueError(
+                f"{node.kind.value} node {node.node_id} requires exactly one input; "
+                f"got {len(incoming)}"
+            )
+        channel = incoming[0]
+        while True:
+            item = await channel.queue.get()
+            channel.queue.task_done()
+            if item is _STOP:
+                await self._emit_stop(node.node_id)
+                return
+            started = time.perf_counter_ns()
+            result = await self._invoke(node, item)
+            self._node_stats[node.node_id].observe(time.perf_counter_ns() - started)
+            if result is not None and node.kind is not NodeKind.SINK:
+                await self._emit(node, result)
+
+    async def _run_fusion(self, node: RuntimeNode) -> None:
+        incoming = self._incoming[node.node_id]
+        if len(incoming) < 2:
+            raise ValueError(f"Fusion node {node.node_id} requires at least two inputs")
+        latest: dict[str, Any] = {}
+        closed: set[str] = set()
+        sequence_id = 0
+        while len(closed) < len(incoming):
+            pending = {
+                asyncio.create_task(channel.queue.get()): channel for channel in incoming
+                if channel.edge.source not in closed
+            }
+            if not pending:
+                break
+            done, not_done = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in not_done:
+                task.cancel()
+            for task in not_done:
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            for task in done:
+                channel = pending[task]
+                item = task.result()
+                channel.queue.task_done()
+                source_id = channel.edge.source
+                if item is _STOP:
+                    closed.add(source_id)
+                    continue
+                latest[source_id] = item
+                if len(latest) == len(incoming):
+                    started = time.perf_counter_ns()
+                    result = await self._fuse(node, latest, sequence_id)
+                    self._node_stats[node.node_id].observe(time.perf_counter_ns() - started)
+                    sequence_id += 1
+                    await self._emit(node, result)
+        await self._emit_stop(node.node_id)
+
+    async def _fuse(
+        self, node: RuntimeNode, latest: dict[str, Any], sequence_id: int
+    ) -> Any:
+        if node.operator is not None and hasattr(node.operator, "fuse"):
+            return await self._invoke_callable(node, node.operator.fuse, dict(latest))
+
+        values = list(latest.values())
+        if all(isinstance(item, SignalFrame) for item in values):
+            frames = [item for item in values if isinstance(item, SignalFrame)]
+            data = np.concatenate([np.asarray(frame.data).reshape(-1) for frame in frames])
+            reference = max(frames, key=lambda frame: frame.timestamp_ns)
+            return replace(
+                reference,
+                stream_id=str(node.metadata.get("stream_id", node.node_id)),
+                sequence_id=sequence_id,
+                data=data,
+                synchronized_time_ns=max(
+                    (frame.synchronized_time_ns or frame.timestamp_ns) for frame in frames
+                ),
+                metadata={
+                    **dict(reference.metadata),
+                    "fused_sources": tuple(frame.stream_id for frame in frames),
+                },
+            )
+        return np.concatenate([np.asarray(item).reshape(-1) for item in values])
+
+    async def _invoke(self, node: RuntimeNode, item: Any) -> Any:
+        operator = node.operator
+        if node.kind is NodeKind.TRANSFORM:
+            if not hasattr(operator, "transform"):
+                raise TypeError(f"Transform node {node.node_id} lacks transform()")
+            return await self._invoke_callable(node, operator.transform, item)
+        if node.kind is NodeKind.DECODER:
+            if not hasattr(operator, "infer"):
+                raise TypeError(f"Decoder node {node.node_id} lacks infer()")
+            value = np.asarray(item.data if isinstance(item, SignalFrame) else item)
+            if value.ndim == 1:
+                value = value.reshape(1, -1)
+            return await self._invoke_callable(node, operator.infer, value)
+        if node.kind is NodeKind.SINK:
+            if not hasattr(operator, "write"):
+                raise TypeError(f"Sink node {node.node_id} lacks write()")
+            result = operator.write(item)
+            if inspect.isawaitable(result):
+                await result
+            return None
+        raise ProcessingError(f"Unsupported unary node kind: {node.kind.value}")
+
+    async def _invoke_callable(
+        self, node: RuntimeNode, func: Callable[[Any], Any], item: Any
+    ) -> Any:
+        execution = ExecutionClass(node.executor)
+        if execution in (ExecutionClass.INLINE, ExecutionClass.GPU):
+            result = func(item)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        if execution is ExecutionClass.THREAD:
+            return await asyncio.to_thread(func, item)
+        if execution is ExecutionClass.PROCESS:
+            if self._process_pool is None:
+                self._process_pool = ProcessPoolExecutor()
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(self._process_pool, _call, func, item)
+        raise ValueError(f"Unsupported execution class: {execution.value}")
+
+    async def _emit(self, node: RuntimeNode, item: Any) -> None:
+        await self._notify_monitors(node, item)
+        if isinstance(item, DecoderOutput) or node.kind is NodeKind.DECODER:
+            await self._output_queue.put(item)
+        outgoing = self._outgoing[node.node_id]
+        if not outgoing:
+            return
+        for channel in outgoing:
+            await put_with_policy(
+                channel.queue,
+                item,
+                policy=channel.policy,
+                stats=channel.stats,
+            )
+
+    async def _emit_stop(self, node_id: str) -> None:
+        for channel in self._outgoing[node_id]:
+            # Shutdown markers must never be dropped, regardless of data policy.
+            await channel.queue.put(_STOP)
+
+    async def _notify_monitors(self, node: RuntimeNode, item: Any) -> None:
+        for monitor_node in self.graph.nodes.values():
+            if monitor_node.kind is not NodeKind.MONITOR:
+                continue
+            monitor = monitor_node.operator
+            if not hasattr(monitor, "update"):
+                continue
+            result = monitor.update(
+                {
+                    "node_id": node.node_id,
+                    "kind": node.kind.value,
+                    "item": item,
+                    "monotonic_time_ns": time.monotonic_ns(),
+                }
+            )
+            if inspect.isawaitable(result):
+                await result
+
+    async def outputs(self) -> AsyncIterator[Any]:
+        """Subscribe to decoder outputs until the runtime terminates."""
+        if self.state is RuntimeState.CREATED:
+            raise RuntimeError("start() must be called before outputs()")
+        while True:
+            if (
+                self._completion_task is not None
+                and self._completion_task.done()
+                and self._output_queue.empty()
+            ):
+                return
+            try:
+                item = await asyncio.wait_for(self._output_queue.get(), timeout=0.05)
+            except asyncio.TimeoutError:
+                continue
+            self._output_queue.task_done()
+            yield item
+
+    async def events(self) -> AsyncIterator[RuntimeEvent]:
+        while True:
+            if (
+                self._completion_task is not None
+                and self._completion_task.done()
+                and self._event_queue.empty()
+            ):
+                return
+            try:
+                event = await asyncio.wait_for(self._event_queue.get(), timeout=0.05)
+            except asyncio.TimeoutError:
+                continue
+            self._event_queue.task_done()
+            yield event
+
+    async def wait(self) -> None:
+        if self._completion_task is None:
+            raise RuntimeError("Runtime has not been started")
+        await self._completion_task
+        if self.failure is not None:
+            raise RuntimeError(
+                f"Runtime failed at {self.failure.node_id}: "
+                f"{self.failure.error_type}: {self.failure.message}"
+            )
+
+    async def stop(self) -> None:
+        if self.state in (RuntimeState.STOPPED, RuntimeState.FAILED):
+            return
+        if self.state is RuntimeState.CREATED:
+            self.stopped_ns = time.monotonic_ns()
+            await self._transition(RuntimeState.STOPPED, "runtime_stopped")
+            return
+        self._stopping = True
+        await self._transition(RuntimeState.DRAINING, "runtime_draining")
+        source_tasks = [
+            self._tasks[node_id]
+            for node_id, node in self.graph.nodes.items()
+            if node.kind is NodeKind.SOURCE and node_id in self._tasks
+        ]
+        for task in source_tasks:
+            if not task.done():
+                task.cancel()
+        try:
+            if self._completion_task is not None:
+                await asyncio.wait_for(
+                    asyncio.shield(self._completion_task), timeout=self.drain_timeout_s
+                )
+        except asyncio.TimeoutError:
+            for task in self._tasks.values():
+                if not task.done():
+                    task.cancel()
+            if self._completion_task is not None:
+                await asyncio.gather(self._completion_task, return_exceptions=True)
+        if self.state is not RuntimeState.FAILED:
+            await self._finish_successfully()
+
+    async def run(self) -> dict[str, Any]:
+        await self.start()
+        await self.wait()
+        return self.snapshot()
+
+    async def run_for(self, duration_s: float) -> dict[str, Any]:
+        if duration_s <= 0:
+            raise ValueError("duration_s must be positive")
+        await self.start()
+        await asyncio.sleep(duration_s)
+        await self.stop()
+        return self.snapshot()
+
+    def snapshot(self) -> dict[str, Any]:
+        edge_metrics = {
+            f"{source}->{target}": {
+                "accepted": channel.stats.accepted,
+                "dropped": channel.stats.dropped,
+                "high_water_mark": channel.stats.high_water_mark,
+                "capacity": channel.edge.capacity,
+                "overflow_policy": channel.policy.value,
+            }
+            for (source, target), channel in self._channels.items()
+        }
+        runtime_ns = 0
+        if self.started_ns is not None:
+            runtime_ns = (self.stopped_ns or time.monotonic_ns()) - self.started_ns
+        return {
+            "state": self.state.value,
+            "runtime_seconds": runtime_ns / 1_000_000_000.0,
+            "failure": None
+            if self.failure is None
+            else {
+                "node_id": self.failure.node_id,
+                "error_type": self.failure.error_type,
+                "message": self.failure.message,
+            },
+            "nodes": {
+                node_id: stats.snapshot() for node_id, stats in self._node_stats.items()
+            },
+            "edges": edge_metrics,
+        }

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -7,6 +7,8 @@ from enum import Enum
 from types import MappingProxyType
 from typing import Any, Mapping
 
+from .queues import OverflowPolicy
+
 
 class NodeKind(str, Enum):
     SOURCE = "source"
@@ -31,6 +33,8 @@ class RuntimeNode:
             raise ValueError("node_id must be non-empty")
         if self.latency_budget_ms is not None and self.latency_budget_ms <= 0:
             raise ValueError("latency_budget_ms must be positive")
+        if self.executor not in {"inline", "thread", "process", "gpu"}:
+            raise ValueError(f"Unsupported executor: {self.executor}")
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
 
@@ -44,11 +48,14 @@ class RuntimeEdge:
     def __post_init__(self) -> None:
         if self.capacity <= 0:
             raise ValueError("capacity must be positive")
+        OverflowPolicy(self.overflow)
+        if self.source == self.target:
+            raise ValueError("self edges are not allowed")
 
 
 @dataclass(slots=True)
 class RuntimeGraph:
-    """A validated directed graph of runtime operators."""
+    """A validated directed acyclic graph of runtime operators."""
 
     nodes: dict[str, RuntimeNode] = field(default_factory=dict)
     edges: list[RuntimeEdge] = field(default_factory=list)
@@ -61,9 +68,60 @@ class RuntimeGraph:
     def connect(self, edge: RuntimeEdge) -> None:
         if edge.source not in self.nodes or edge.target not in self.nodes:
             raise ValueError("Both edge endpoints must be registered nodes")
+        if any(
+            existing.source == edge.source and existing.target == edge.target
+            for existing in self.edges
+        ):
+            raise ValueError(f"Duplicate edge: {edge.source} -> {edge.target}")
         self.edges.append(edge)
+
+    def incoming(self, node_id: str) -> tuple[RuntimeEdge, ...]:
+        return tuple(edge for edge in self.edges if edge.target == node_id)
+
+    def outgoing(self, node_id: str) -> tuple[RuntimeEdge, ...]:
+        return tuple(edge for edge in self.edges if edge.source == node_id)
+
+    def topological_order(self) -> tuple[str, ...]:
+        indegree = {node_id: 0 for node_id in self.nodes}
+        adjacency: dict[str, list[str]] = {node_id: [] for node_id in self.nodes}
+        for edge in self.edges:
+            indegree[edge.target] += 1
+            adjacency[edge.source].append(edge.target)
+        ready = sorted(node_id for node_id, degree in indegree.items() if degree == 0)
+        order: list[str] = []
+        while ready:
+            node_id = ready.pop(0)
+            order.append(node_id)
+            for target in adjacency[node_id]:
+                indegree[target] -= 1
+                if indegree[target] == 0:
+                    ready.append(target)
+                    ready.sort()
+        if len(order) != len(self.nodes):
+            raise ValueError("RuntimeGraph must be acyclic")
+        return tuple(order)
 
     def validate(self) -> None:
         for edge in self.edges:
             if edge.source not in self.nodes or edge.target not in self.nodes:
                 raise ValueError(f"Invalid edge: {edge.source} -> {edge.target}")
+        self.topological_order()
+
+        for node_id, node in self.nodes.items():
+            incoming = self.incoming(node_id)
+            outgoing = self.outgoing(node_id)
+            if node.kind is NodeKind.SOURCE and incoming:
+                raise ValueError(f"Source node {node_id} cannot have incoming edges")
+            if node.kind is NodeKind.FUSION and len(incoming) < 2:
+                raise ValueError(f"Fusion node {node_id} requires at least two inputs")
+            if node.kind in (NodeKind.TRANSFORM, NodeKind.DECODER, NodeKind.SINK):
+                if len(incoming) != 1:
+                    raise ValueError(
+                        f"{node.kind.value} node {node_id} requires exactly one input"
+                    )
+            if node.kind is NodeKind.SINK and outgoing:
+                raise ValueError(f"Sink node {node_id} cannot have outgoing edges")
+            if node.kind is NodeKind.MONITOR and (incoming or outgoing):
+                raise ValueError(
+                    f"Monitor node {node_id} is observational and must not own data edges"
+                )

--- a/tests/test_runtime_executor.py
+++ b/tests/test_runtime_executor.py
@@ -1,0 +1,146 @@
+import asyncio
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderCapabilities, DecoderOutput, SignalFrame, StreamDescriptor
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+
+
+class FiniteSource:
+    def __init__(self, stream_id: str, values: list[float]):
+        self._descriptor = StreamDescriptor(
+            stream_id=stream_id,
+            modality="eeg",
+            sample_rate_hz=100.0,
+            channel_names=("ch0",),
+        )
+        self.values = values
+        self.started = False
+
+    @property
+    def descriptor(self):
+        return self._descriptor
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.started = False
+
+    async def frames(self):
+        for index, value in enumerate(self.values):
+            await asyncio.sleep(0)
+            yield SignalFrame(
+                stream_id=self._descriptor.stream_id,
+                sequence_id=index,
+                data=np.array([value], dtype=np.float32),
+                sample_rate_hz=100.0,
+                host_receive_time_ns=1_000 + index,
+            )
+
+
+class Scale:
+    def __init__(self, factor: float):
+        self.factor = factor
+
+    def transform(self, frame: SignalFrame):
+        from dataclasses import replace
+
+        return replace(frame, data=frame.data * self.factor)
+
+
+class Decoder:
+    @property
+    def capabilities(self):
+        return DecoderCapabilities(probabilities=True)
+
+    def infer(self, X):
+        score = float(np.asarray(X).reshape(-1)[0])
+        return DecoderOutput(prediction=int(score >= 2.0), confidence=0.75)
+
+
+class Sink:
+    def __init__(self):
+        self.items = []
+
+    async def write(self, item):
+        self.items.append(item)
+
+
+class FailTransform:
+    def transform(self, item):
+        raise ValueError("synthetic failure")
+
+
+def build_graph(source, transform, decoder, sink=None):
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, source))
+    graph.add_node(RuntimeNode("transform", NodeKind.TRANSFORM, transform))
+    graph.add_node(RuntimeNode("decoder", NodeKind.DECODER, decoder))
+    graph.connect(RuntimeEdge("source", "transform", capacity=2, overflow="block"))
+    graph.connect(RuntimeEdge("transform", "decoder", capacity=2, overflow="block"))
+    if sink is not None:
+        graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+        graph.connect(RuntimeEdge("decoder", "sink", capacity=2, overflow="block"))
+    return graph
+
+
+@pytest.mark.asyncio
+async def test_runtime_executor_runs_finite_graph_and_taps_decoder_outputs():
+    sink = Sink()
+    executor = RuntimeExecutor(
+        build_graph(FiniteSource("a", [0.5, 1.0, 2.0]), Scale(2.0), Decoder(), sink)
+    )
+    await executor.start()
+    outputs = [output async for output in executor.outputs()]
+    await executor.wait()
+
+    assert [output.prediction for output in outputs] == [0, 1, 1]
+    assert len(sink.items) == 3
+    snapshot = executor.snapshot()
+    assert snapshot["state"] == "stopped"
+    assert snapshot["nodes"]["decoder"]["processed"] == 3
+    assert snapshot["edges"]["source->transform"]["dropped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_executor_fuses_multiple_signal_sources():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("a", NodeKind.SOURCE, FiniteSource("a", [1.0, 2.0])))
+    graph.add_node(RuntimeNode("b", NodeKind.SOURCE, FiniteSource("b", [3.0, 4.0])))
+    graph.add_node(RuntimeNode("fusion", NodeKind.FUSION, None))
+    graph.add_node(RuntimeNode("decoder", NodeKind.DECODER, Decoder()))
+    graph.connect(RuntimeEdge("a", "fusion", overflow="block"))
+    graph.connect(RuntimeEdge("b", "fusion", overflow="block"))
+    graph.connect(RuntimeEdge("fusion", "decoder", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    await executor.start()
+    outputs = [output async for output in executor.outputs()]
+    await executor.wait()
+    assert outputs
+    assert executor.snapshot()["nodes"]["fusion"]["processed"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_runtime_executor_propagates_node_failure():
+    executor = RuntimeExecutor(
+        build_graph(FiniteSource("a", [1.0]), FailTransform(), Decoder())
+    )
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        await executor.run()
+    snapshot = executor.snapshot()
+    assert snapshot["state"] == "failed"
+    assert snapshot["failure"]["node_id"] == "transform"
+
+
+def test_runtime_graph_rejects_cycles():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("a", NodeKind.TRANSFORM, Scale(1.0)))
+    graph.add_node(RuntimeNode("b", NodeKind.TRANSFORM, Scale(1.0)))
+    # Use direct edge construction so validation catches both the cycle and
+    # invalid transform topology in one deterministic place.
+    graph.edges.extend([RuntimeEdge("a", "b"), RuntimeEdge("b", "a")])
+    with pytest.raises(ValueError, match="acyclic"):
+        graph.validate()


### PR DESCRIPTION
## Stack

**Base:** PR #1 (`agent/neuros-kernel-refactor`)

This is stack layer 2. Review PR #1 first, then this PR.

## What changes

- adds a supervised native `RuntimeExecutor` for `RuntimeGraph`
- supports finite replay and indefinitely streaming sources through the same engine
- adds inline/thread/process/GPU execution classes
- adds sentinel-based draining, explicit cancellation, and first-failure propagation
- records bounded per-node mean/p50/p95/p99/max latency telemetry
- uses the existing explicit overflow policy and queue-drop/high-water metrics on every edge
- adds built-in latest-value multimodal fusion for `SignalFrame`
- exposes decoder outputs as a subscription independent of sinks
- strengthens graph validation to enforce a DAG and valid node topology
- introduces `FeatureTransform` so legacy filters/extractors can run as typed operators
- routes standard single-stream and multimodal `Pipeline` APIs through the native graph runtime
- retains custom legacy processing agents as an explicit migration escape hatch
- adds runtime execution, fusion, failure, and cycle-regression tests

## Compatibility

The public `Pipeline` API remains available. Standard pipelines now compile to a graph. A custom `processing_agent_class` still routes through the old orchestrator until that custom agent is migrated to a `Transform`.

## Review focus

1. shutdown and finite-source semantics
2. failure propagation
3. queue/backpressure behavior
4. graph topology constraints
5. compatibility metrics returned by `Pipeline`

## Validation

GitHub Actions extends the kernel and BCI jobs with native executor tests. This PR should remain draft until those jobs pass cleanly.