### PR TITLE
feat(recording): add lossless session archives and deterministic replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
             tests/test_plugin_registry.py \
             tests/test_config_schema.py \
             tests/test_clock_sync.py \
-            tests/test_replay.py
+            tests/test_replay.py \
+            tests/test_session_archive.py
 
   bci-smoke:
     name: BCI end-to-end smoke
@@ -52,12 +53,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python scripts/bootstrap.py --profile bci --test-tools
-      - name: Exercise installed CLI
+      - name: Exercise installed CLI and persistent replay
         run: |
           neuros doctor --json
           neuros validate configs/examples/mock_bci.yaml --json
           neuros run configs/examples/mock_bci.yaml --duration 0.05 --json
-      - name: Run pipeline, config, plugin and CLI smoke tests
+          SESSION_DIR="${RUNNER_TEMP}/neuros-session"
+          neuros record configs/examples/mock_bci.yaml --output "${SESSION_DIR}" --session-id ci --duration 0.05 --json
+          neuros inspect "${SESSION_DIR}" --verify --json
+          neuros replay "${SESSION_DIR}" --config configs/examples/mock_bci.yaml --json
+      - name: Run pipeline, config, plugin, CLI, and recording smoke tests
         run: |
           pytest -q \
             tests/test_pipeline.py \
@@ -65,12 +70,30 @@ jobs:
             tests/test_config_resolution.py \
             tests/test_runtime_executor.py \
             tests/test_cli_v3.py \
+            tests/test_recording_cli.py \
+            tests/test_session_archive.py \
             tests/test_kernel_contracts.py \
             tests/test_runtime_queues.py \
             tests/test_plugin_registry.py \
             tests/test_config_schema.py \
             tests/test_clock_sync.py \
             tests/test_replay.py
+
+  recording-interop:
+    name: Recording interoperability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install recording exporters
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[recording,test]"
+      - name: Verify NWB and Zarr exports
+        run: pytest -q tests/test_recording_exports.py tests/test_session_archive.py
 
   orion-contracts:
     name: ORION contracts

--- a/packages/neuros-core/pyproject.toml
+++ b/packages/neuros-core/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 
 [project.optional-dependencies]
 evaluation = ["scikit-learn>=1.2"]
+zarr = ["zarr>=2.16,<3"]
+nwb = ["pynwb>=2.5"]
+recording = ["zarr>=2.16,<3", "pynwb>=2.5"]
 test = ["pytest>=7.4", "pytest-asyncio>=0.21", "scikit-learn>=1.2"]
 dev = [
     "neuros-core[evaluation,test]",

--- a/packages/neuros-core/src/neuros/config/build.py
+++ b/packages/neuros-core/src/neuros/config/build.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping
 
 from neuros.config.schema import PipelineConfig, PluginConfig
 from neuros.errors import ConfigurationError
@@ -45,22 +45,31 @@ def resolve_config(
     config: PipelineConfig,
     *,
     registry: PluginRegistry | None = None,
+    source_overrides: Mapping[str, Any] | None = None,
 ) -> ResolvedPipeline:
-    """Instantiate configured plugins and compile the topology to RuntimeGraph.
+    """Instantiate configured plugins and compile them to ``RuntimeGraph``.
 
-    The returned graph is a validated execution specification. The current
-    compatibility orchestrators do not yet execute arbitrary graphs directly;
-    this function establishes the stable compilation boundary for that executor.
+    ``source_overrides`` is keyed by stream ID and is primarily used for
+    deterministic replay. It prevents hardware source construction entirely,
+    which means a recorded experiment can be replayed on a machine that does
+    not have the original device SDK installed.
     """
 
     plugin_registry = registry or default_registry
     plugin_registry.discover()
+    overrides = dict(source_overrides or {})
+    unknown = set(overrides) - {stream.stream_id for stream in config.streams}
+    if unknown:
+        raise ConfigurationError(f"Unknown source override stream IDs: {sorted(unknown)}")
+
     graph = RuntimeGraph()
     resolved_streams: list[ResolvedStream] = []
     stream_tails: list[str] = []
 
     for stream in config.streams:
-        source = _create(plugin_registry, PluginKind.SOURCE, stream.source)
+        source = overrides.get(stream.stream_id)
+        if source is None:
+            source = _create(plugin_registry, PluginKind.SOURCE, stream.source)
         transforms = tuple(
             _create(plugin_registry, PluginKind.TRANSFORM, transform)
             for transform in stream.transforms

--- a/packages/neuros-core/src/neuros/recording/__init__.py
+++ b/packages/neuros-core/src/neuros/recording/__init__.py
@@ -1,5 +1,29 @@
-"""Recording and replay primitives for neurOS."""
+"""Recording, persistent archive, replay, and interoperability primitives."""
 
+from .archive import (
+    ARCHIVE_SCHEMA_VERSION,
+    ArchiveReplaySource,
+    RecordingSource,
+    SessionArchiveReader,
+    SessionArchiveWriter,
+    SessionManifest,
+    canonical_hash,
+)
+from .exporters import export_nwb, export_zarr
+from .identity import StreamIdentitySource
 from .replay import FrameRecorder, ReplaySource
 
-__all__ = ["FrameRecorder", "ReplaySource"]
+__all__ = [
+    "ARCHIVE_SCHEMA_VERSION",
+    "ArchiveReplaySource",
+    "FrameRecorder",
+    "RecordingSource",
+    "ReplaySource",
+    "SessionArchiveReader",
+    "SessionArchiveWriter",
+    "SessionManifest",
+    "StreamIdentitySource",
+    "canonical_hash",
+    "export_nwb",
+    "export_zarr",
+]

--- a/packages/neuros-core/src/neuros/recording/archive.py
+++ b/packages/neuros-core/src/neuros/recording/archive.py
@@ -1,0 +1,375 @@
+"""Lossless persistent session archives for neurOS SignalFrame streams."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import platform
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any, AsyncIterator, Iterable, Mapping
+
+import numpy as np
+
+from neuros.contracts import ClockDomain, QualityFlag, SignalFrame, StreamDescriptor
+
+
+ARCHIVE_SCHEMA_VERSION = 1
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (ClockDomain, QualityFlag)):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def canonical_hash(value: Any) -> str:
+    payload = json.dumps(
+        _jsonable(value), sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _git_sha() -> str | None:
+    if os.environ.get("GITHUB_SHA"):
+        return os.environ["GITHUB_SHA"]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, text=True
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _package_versions() -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name in ("neuros", "neuros-core", "neuros-drivers", "neuros-models", "neuros-orion"):
+        try:
+            result[name] = importlib_metadata.version(name)
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    return result
+
+
+def _descriptor_to_dict(descriptor: StreamDescriptor) -> dict[str, Any]:
+    return {
+        "stream_id": descriptor.stream_id,
+        "modality": descriptor.modality,
+        "sample_rate_hz": descriptor.sample_rate_hz,
+        "channel_names": list(descriptor.channel_names),
+        "channel_types": list(descriptor.channel_types),
+        "units": list(descriptor.units),
+        "device": descriptor.device,
+        "manufacturer": descriptor.manufacturer,
+        "clock_domain": descriptor.clock_domain.value,
+        "metadata": _jsonable(dict(descriptor.metadata)),
+    }
+
+
+def _descriptor_from_dict(raw: Mapping[str, Any]) -> StreamDescriptor:
+    return StreamDescriptor(
+        stream_id=str(raw["stream_id"]),
+        modality=str(raw["modality"]),
+        sample_rate_hz=float(raw["sample_rate_hz"]),
+        channel_names=tuple(raw.get("channel_names", [])),
+        channel_types=tuple(raw.get("channel_types", [])),
+        units=tuple(raw.get("units", [])),
+        device=raw.get("device"),
+        manufacturer=raw.get("manufacturer"),
+        clock_domain=ClockDomain(raw.get("clock_domain", ClockDomain.UNKNOWN.value)),
+        metadata=raw.get("metadata", {}),
+    )
+
+
+@dataclass(slots=True)
+class SessionManifest:
+    session_id: str
+    created_at: str
+    schema_version: int = ARCHIVE_SCHEMA_VERSION
+    status: str = "recording"
+    git_sha: str | None = None
+    config_hash: str | None = None
+    package_versions: dict[str, str] = field(default_factory=dict)
+    host: dict[str, Any] = field(default_factory=dict)
+    streams: dict[str, dict[str, Any]] = field(default_factory=dict)
+    runtime_metrics: dict[str, Any] = field(default_factory=dict)
+    model_artifacts: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return _jsonable(asdict(self))
+
+
+class SessionArchiveWriter:
+    """Append SignalFrames to a lossless, dependency-free directory archive.
+
+    Data arrays are stored as individual NPY payloads so arbitrary frame shapes
+    are preserved. An NDJSON index records every timing/provenance field and a
+    SHA-256 hash of each data payload. This is the canonical replay source; NWB
+    and Zarr are export formats rather than the authority for neurOS semantics.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        session_id: str,
+        config: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        model_artifacts: Iterable[Mapping[str, Any]] = (),
+        overwrite: bool = False,
+    ) -> None:
+        self.root = Path(root)
+        if self.root.exists() and any(self.root.iterdir()) and not overwrite:
+            raise FileExistsError(f"Archive is not empty: {self.root}")
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / "streams").mkdir(exist_ok=True)
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._descriptors: dict[str, StreamDescriptor] = {}
+        self._counts: dict[str, int] = {}
+        self.manifest = SessionManifest(
+            session_id=session_id,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            git_sha=_git_sha(),
+            config_hash=canonical_hash(config) if config is not None else None,
+            package_versions=_package_versions(),
+            host={
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "machine": platform.machine(),
+            },
+            model_artifacts=[_jsonable(dict(item)) for item in model_artifacts],
+            metadata=_jsonable(dict(metadata or {})),
+        )
+        if config is not None:
+            self._write_json_atomic(self.root / "config.json", _jsonable(config))
+        self._flush_manifest()
+
+    def _write_json_atomic(self, path: Path, value: Any) -> None:
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        temporary.write_text(
+            json.dumps(value, indent=2, sort_keys=True, default=str), encoding="utf-8"
+        )
+        temporary.replace(path)
+
+    def _flush_manifest(self) -> None:
+        self._write_json_atomic(self.root / "manifest.json", self.manifest.to_dict())
+
+    def register_stream(self, descriptor: StreamDescriptor) -> None:
+        existing = self._descriptors.get(descriptor.stream_id)
+        if existing is not None and existing != descriptor:
+            raise ValueError(f"Conflicting descriptor for stream {descriptor.stream_id}")
+        if existing is not None:
+            return
+        self._descriptors[descriptor.stream_id] = descriptor
+        self._counts[descriptor.stream_id] = 0
+        stream_root = self.root / "streams" / descriptor.stream_id
+        (stream_root / "frames").mkdir(parents=True, exist_ok=True)
+        self._write_json_atomic(stream_root / "descriptor.json", _descriptor_to_dict(descriptor))
+        self.manifest.streams[descriptor.stream_id] = {
+            "descriptor": _descriptor_to_dict(descriptor),
+            "frame_count": 0,
+        }
+        self._flush_manifest()
+
+    async def write(self, item: SignalFrame) -> None:
+        if self._closed:
+            raise RuntimeError("SessionArchiveWriter is closed")
+        if not isinstance(item, SignalFrame):
+            raise TypeError("SessionArchiveWriter accepts SignalFrame objects")
+        async with self._lock:
+            if item.stream_id not in self._descriptors:
+                channels = int(np.asarray(item.data).shape[0]) if np.asarray(item.data).ndim else 1
+                self.register_stream(
+                    StreamDescriptor(
+                        stream_id=item.stream_id,
+                        modality=str(item.metadata.get("modality", "unknown")),
+                        sample_rate_hz=item.sample_rate_hz,
+                        channel_names=tuple(f"ch{i}" for i in range(channels)),
+                        clock_domain=item.clock_domain,
+                    )
+                )
+            index = self._counts[item.stream_id]
+            stream_root = self.root / "streams" / item.stream_id
+            relative_data = Path("frames") / f"{index:012d}.npy"
+            data_path = stream_root / relative_data
+            temporary = data_path.with_suffix(".npy.tmp")
+            with temporary.open("wb") as handle:
+                np.save(handle, np.asarray(item.data), allow_pickle=False)
+                handle.flush()
+                os.fsync(handle.fileno())
+            temporary.replace(data_path)
+            payload_hash = hashlib.sha256(data_path.read_bytes()).hexdigest()
+            row = {
+                "index": index,
+                "sequence_id": item.sequence_id,
+                "data": str(relative_data),
+                "data_sha256": payload_hash,
+                "sample_rate_hz": item.sample_rate_hz,
+                "host_receive_time_ns": item.host_receive_time_ns,
+                "device_time_ns": item.device_time_ns,
+                "synchronized_time_ns": item.synchronized_time_ns,
+                "clock_domain": item.clock_domain.value,
+                "quality": int(item.quality),
+                "metadata": _jsonable(dict(item.metadata)),
+            }
+            with (stream_root / "index.ndjson").open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            self._counts[item.stream_id] += 1
+            self.manifest.streams[item.stream_id]["frame_count"] = self._counts[item.stream_id]
+
+    async def close(self, *, runtime_metrics: Mapping[str, Any] | None = None) -> None:
+        if self._closed:
+            return
+        async with self._lock:
+            self.manifest.status = "complete"
+            self.manifest.runtime_metrics = _jsonable(dict(runtime_metrics or {}))
+            self._flush_manifest()
+            self._closed = True
+
+
+class SessionArchiveReader:
+    def __init__(self, root: str | Path, *, verify_hashes: bool = True) -> None:
+        self.root = Path(root)
+        raw = json.loads((self.root / "manifest.json").read_text(encoding="utf-8"))
+        if int(raw.get("schema_version", -1)) != ARCHIVE_SCHEMA_VERSION:
+            raise ValueError("Unsupported neurOS archive schema")
+        self.manifest = raw
+        self.verify_hashes = verify_hashes
+
+    @property
+    def stream_ids(self) -> tuple[str, ...]:
+        return tuple(self.manifest.get("streams", {}).keys())
+
+    def descriptor(self, stream_id: str) -> StreamDescriptor:
+        raw = json.loads(
+            (self.root / "streams" / stream_id / "descriptor.json").read_text(encoding="utf-8")
+        )
+        return _descriptor_from_dict(raw)
+
+    def iter_frames(self, stream_id: str) -> Iterable[SignalFrame]:
+        stream_root = self.root / "streams" / stream_id
+        index_path = stream_root / "index.ndjson"
+        if not index_path.exists():
+            return
+        for line in index_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            data_path = stream_root / row["data"]
+            if self.verify_hashes:
+                actual = hashlib.sha256(data_path.read_bytes()).hexdigest()
+                if actual != row["data_sha256"]:
+                    raise IOError(f"Data hash mismatch: {data_path}")
+            with data_path.open("rb") as handle:
+                data = np.load(handle, allow_pickle=False)
+            yield SignalFrame(
+                stream_id=stream_id,
+                sequence_id=int(row["sequence_id"]),
+                data=data,
+                sample_rate_hz=float(row["sample_rate_hz"]),
+                host_receive_time_ns=int(row["host_receive_time_ns"]),
+                device_time_ns=None if row["device_time_ns"] is None else int(row["device_time_ns"]),
+                synchronized_time_ns=None
+                if row["synchronized_time_ns"] is None
+                else int(row["synchronized_time_ns"]),
+                clock_domain=ClockDomain(row["clock_domain"]),
+                quality=QualityFlag(int(row["quality"])),
+                metadata=row.get("metadata", {}),
+            )
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "session_id": self.manifest["session_id"],
+            "status": self.manifest["status"],
+            "created_at": self.manifest["created_at"],
+            "git_sha": self.manifest.get("git_sha"),
+            "config_hash": self.manifest.get("config_hash"),
+            "streams": {
+                stream_id: self.manifest["streams"][stream_id]["frame_count"]
+                for stream_id in self.stream_ids
+            },
+            "runtime_metrics": self.manifest.get("runtime_metrics", {}),
+        }
+
+
+class ArchiveReplaySource:
+    """Stream frames lazily from a persistent archive."""
+
+    def __init__(
+        self,
+        reader: SessionArchiveReader,
+        stream_id: str,
+        *,
+        realtime: bool = False,
+        speed: float = 1.0,
+    ) -> None:
+        if speed <= 0:
+            raise ValueError("speed must be positive")
+        self.reader = reader
+        self.stream_id = stream_id
+        self.realtime = realtime
+        self.speed = speed
+        self._running = False
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return self.reader.descriptor(self.stream_id)
+
+    async def start(self) -> None:
+        self._running = True
+
+    async def stop(self) -> None:
+        self._running = False
+
+    async def frames(self) -> AsyncIterator[SignalFrame]:
+        previous: int | None = None
+        for frame in self.reader.iter_frames(self.stream_id):
+            if not self._running:
+                return
+            if self.realtime and previous is not None:
+                delay = max(0, frame.timestamp_ns - previous) / 1_000_000_000.0
+                await asyncio.sleep(delay / self.speed)
+            yield frame
+            previous = frame.timestamp_ns
+            await asyncio.sleep(0)
+
+
+class RecordingSource:
+    """Source decorator that records exact frames before forwarding them."""
+
+    def __init__(self, source: Any, writer: SessionArchiveWriter) -> None:
+        self.source = source
+        self.writer = writer
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return self.source.descriptor
+
+    async def start(self) -> None:
+        self.writer.register_stream(self.descriptor)
+        await self.source.start()
+
+    async def stop(self) -> None:
+        await self.source.stop()
+
+    async def frames(self) -> AsyncIterator[SignalFrame]:
+        async for frame in self.source.frames():
+            await self.writer.write(frame)
+            yield frame

--- a/packages/neuros-core/src/neuros/recording/exporters.py
+++ b/packages/neuros-core/src/neuros/recording/exporters.py
@@ -1,0 +1,144 @@
+"""Optional NWB and Zarr exports from the canonical neurOS session archive."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .archive import SessionArchiveReader, _descriptor_to_dict, _jsonable
+
+
+def _frames(reader: SessionArchiveReader, stream_id: str):
+    frames = list(reader.iter_frames(stream_id))
+    if not frames:
+        raise ValueError(f"Cannot export empty stream: {stream_id}")
+    shapes = {tuple(np.asarray(frame.data).shape) for frame in frames}
+    if len(shapes) != 1:
+        raise ValueError(
+            f"NWB/Zarr dense export requires a stable frame shape for {stream_id}; got {sorted(shapes)}"
+        )
+    return frames
+
+
+def export_zarr(archive: str | Path, destination: str | Path) -> Path:
+    """Export a neurOS archive to a dense Zarr hierarchy.
+
+    Exact per-frame neurOS metadata is retained as JSON in group attributes;
+    the canonical archive remains the authoritative lossless replay format.
+    """
+
+    try:
+        import zarr
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("Zarr export requires `pip install neuros-core[zarr]`") from exc
+
+    reader = SessionArchiveReader(archive)
+    destination = Path(destination)
+    root = zarr.open_group(str(destination), mode="w")
+    root.attrs["neuros_manifest_json"] = json.dumps(reader.manifest, sort_keys=True, default=str)
+
+    for stream_id in reader.stream_ids:
+        descriptor = reader.descriptor(stream_id)
+        frames = _frames(reader, stream_id)
+        group = root.create_group(stream_id)
+        data = np.stack([np.asarray(frame.data) for frame in frames])
+        group.create_dataset("data", data=data, chunks=(1, *data.shape[1:]))
+        group.create_dataset(
+            "sequence_id", data=np.asarray([frame.sequence_id for frame in frames], dtype=np.int64)
+        )
+        group.create_dataset(
+            "host_receive_time_ns",
+            data=np.asarray([frame.host_receive_time_ns for frame in frames], dtype=np.int64),
+        )
+        group.create_dataset(
+            "device_time_ns",
+            data=np.asarray([
+                -1 if frame.device_time_ns is None else frame.device_time_ns for frame in frames
+            ], dtype=np.int64),
+        )
+        group.create_dataset(
+            "synchronized_time_ns",
+            data=np.asarray([
+                -1 if frame.synchronized_time_ns is None else frame.synchronized_time_ns
+                for frame in frames
+            ], dtype=np.int64),
+        )
+        group.create_dataset(
+            "quality", data=np.asarray([int(frame.quality) for frame in frames], dtype=np.int64)
+        )
+        group.attrs["descriptor_json"] = json.dumps(
+            _descriptor_to_dict(descriptor), sort_keys=True, default=str
+        )
+        group.attrs["frame_metadata_json"] = json.dumps(
+            [_jsonable(dict(frame.metadata)) for frame in frames], sort_keys=True, default=str
+        )
+    return destination
+
+
+def export_nwb(archive: str | Path, destination: str | Path) -> Path:
+    """Export a neurOS archive to NWB for ecosystem interoperability."""
+
+    try:
+        from pynwb import NWBHDF5IO, NWBFile, TimeSeries
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("NWB export requires `pip install neuros-core[nwb]`") from exc
+
+    reader = SessionArchiveReader(archive)
+    destination = Path(destination)
+    created = datetime.fromisoformat(reader.manifest["created_at"])
+    nwbfile = NWBFile(
+        session_description=str(reader.manifest.get("metadata", {}).get("description", "neurOS session")),
+        identifier=str(reader.manifest["session_id"]),
+        session_start_time=created,
+    )
+
+    exact_metadata: dict[str, Any] = {
+        "manifest": reader.manifest,
+        "streams": {},
+    }
+    for stream_id in reader.stream_ids:
+        descriptor = reader.descriptor(stream_id)
+        frames = _frames(reader, stream_id)
+        data = np.stack([np.asarray(frame.data) for frame in frames])
+        timestamps = np.asarray([frame.timestamp_ns / 1_000_000_000.0 for frame in frames])
+        unit = descriptor.units[0] if descriptor.units else "a.u."
+        series = TimeSeries(
+            name=stream_id,
+            data=data,
+            unit=unit,
+            timestamps=timestamps,
+            description=(
+                f"neurOS {descriptor.modality} stream; exact clock domains, sequence IDs, "
+                "quality flags, and frame metadata are stored in neuros_exact_metadata"
+            ),
+        )
+        nwbfile.add_acquisition(series)
+        exact_metadata["streams"][stream_id] = {
+            "descriptor": _descriptor_to_dict(descriptor),
+            "frames": [
+                {
+                    "sequence_id": frame.sequence_id,
+                    "sample_rate_hz": frame.sample_rate_hz,
+                    "host_receive_time_ns": frame.host_receive_time_ns,
+                    "device_time_ns": frame.device_time_ns,
+                    "synchronized_time_ns": frame.synchronized_time_ns,
+                    "clock_domain": frame.clock_domain.value,
+                    "quality": int(frame.quality),
+                    "metadata": _jsonable(dict(frame.metadata)),
+                }
+                for frame in frames
+            ],
+        }
+
+    nwbfile.add_scratch(
+        json.dumps(exact_metadata, sort_keys=True, default=str),
+        name="neuros_exact_metadata",
+        description="Lossless neurOS frame/timing/provenance metadata for round-trip reconstruction.",
+    )
+    with NWBHDF5IO(str(destination), "w") as io:
+        io.write(nwbfile)
+    return destination

--- a/packages/neuros-core/src/neuros/recording/identity.py
+++ b/packages/neuros-core/src/neuros/recording/identity.py
@@ -1,0 +1,58 @@
+"""Source wrappers for canonical runtime stream identity."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, AsyncIterator
+
+from neuros.contracts import SignalFrame, StreamDescriptor
+
+
+class StreamIdentitySource:
+    """Expose a source under the stream ID chosen by runtime configuration.
+
+    Hardware drivers may have a device-native or class-derived stream ID. Once a
+    source is bound to a configured RuntimeGraph stream, that configured ID is
+    the canonical identity used for recording, replay, fusion, and provenance.
+    The original driver-provided ID is retained in metadata.
+    """
+
+    def __init__(self, source: Any, stream_id: str) -> None:
+        if not stream_id:
+            raise ValueError("stream_id must be non-empty")
+        self.source = source
+        self.stream_id = stream_id
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        descriptor = self.source.descriptor
+        if descriptor.stream_id == self.stream_id:
+            return descriptor
+        return replace(
+            descriptor,
+            stream_id=self.stream_id,
+            metadata={
+                **dict(descriptor.metadata),
+                "source_stream_id": descriptor.stream_id,
+            },
+        )
+
+    async def start(self) -> None:
+        await self.source.start()
+
+    async def stop(self) -> None:
+        await self.source.stop()
+
+    async def frames(self) -> AsyncIterator[SignalFrame]:
+        async for frame in self.source.frames():
+            if frame.stream_id == self.stream_id:
+                yield frame
+                continue
+            yield replace(
+                frame,
+                stream_id=self.stream_id,
+                metadata={
+                    **dict(frame.metadata),
+                    "source_stream_id": frame.stream_id,
+                },
+            )

--- a/packages/neuros/pyproject.toml
+++ b/packages/neuros/pyproject.toml
@@ -37,6 +37,7 @@ bci = [
     "neuros-models[pytorch]>=2.0.0",
     "neuros-ui[dashboard]>=2.0.0",
 ]
+recording = ["neuros-core[recording]>=2.0.0"]
 research = [
     "neuros-models[all]>=2.0.0",
     "neuros-foundation[all]>=2.0.0",

--- a/packages/neuros/src/neuros/cli/app.py
+++ b/packages/neuros/src/neuros/cli/app.py
@@ -17,6 +17,7 @@ from neuros.plugins import PluginKind
 from .config_commands import execute_config, validate_config
 from .diagnostics import devices, doctor, plugin_inventory
 from .legacy import handle as handle_legacy
+from .recording_commands import inspect_archive, record_config, replay_archive
 
 
 def _add_json_flag(parser: argparse.ArgumentParser) -> None:
@@ -51,6 +52,40 @@ def _parse_args() -> argparse.Namespace:
     )
     run_parser.add_argument("--show-outputs", action="store_true", help="Stream decoder outputs as JSONL")
     _add_json_flag(run_parser)
+
+    record_parser = subparsers.add_parser(
+        "record", help="Run a config while recording exact SignalFrames"
+    )
+    record_parser.add_argument("config", type=str)
+    record_parser.add_argument("--output", type=str, required=True, help="Session archive directory")
+    record_parser.add_argument("--session-id", type=str, default="session")
+    record_parser.add_argument("--duration", type=float, default=10.0)
+    record_parser.add_argument("--overwrite", action="store_true")
+    record_parser.add_argument(
+        "--export",
+        action="append",
+        choices=["nwb", "zarr"],
+        default=[],
+        help="Optional interoperability export; may be repeated",
+    )
+    record_parser.add_argument("--show-outputs", action="store_true")
+    _add_json_flag(record_parser)
+
+    inspect_parser = subparsers.add_parser("inspect", help="Inspect a neurOS session archive")
+    inspect_parser.add_argument("archive", type=str)
+    inspect_parser.add_argument("--verify", action="store_true", help="Verify every frame SHA-256")
+    _add_json_flag(inspect_parser)
+
+    replay_parser = subparsers.add_parser(
+        "replay", help="Replay a session archive through the original processing graph"
+    )
+    replay_parser.add_argument("archive", type=str)
+    replay_parser.add_argument("--config", type=str, required=True)
+    replay_parser.add_argument("--realtime", action="store_true")
+    replay_parser.add_argument("--speed", type=float, default=1.0)
+    replay_parser.add_argument("--duration", type=float, default=None)
+    replay_parser.add_argument("--show-outputs", action="store_true")
+    _add_json_flag(replay_parser)
 
     bench_parser = subparsers.add_parser("benchmark", help="Benchmark a config or legacy synthetic pipeline")
     bench_parser.add_argument("config", nargs="?", default=None, help="Optional Pipeline YAML config")
@@ -175,6 +210,44 @@ def main() -> None:
             _emit(result, machine=args.json)
             return
 
+        if args.command == "record":
+            callback = _print_output if args.show_outputs else None
+            result = cli_api.asyncio.run(
+                record_config(
+                    args.config,
+                    args.output,
+                    session_id=args.session_id,
+                    duration_s=args.duration,
+                    overwrite=args.overwrite,
+                    export_formats=args.export,
+                    on_output=callback,
+                )
+            )
+            _emit(result, machine=args.json)
+            return
+
+        if args.command == "inspect":
+            _emit(
+                inspect_archive(args.archive, verify_hashes=args.verify),
+                machine=args.json,
+            )
+            return
+
+        if args.command == "replay":
+            callback = _print_output if args.show_outputs else None
+            result = cli_api.asyncio.run(
+                replay_archive(
+                    args.archive,
+                    args.config,
+                    realtime=args.realtime,
+                    speed=args.speed,
+                    duration_s=args.duration,
+                    on_output=callback,
+                )
+            )
+            _emit(result, machine=args.json)
+            return
+
         if args.command == "benchmark" and args.config is not None:
             result = cli_api.asyncio.run(
                 execute_config(args.config, duration_s=args.duration)
@@ -196,6 +269,9 @@ def main() -> None:
     except KeyError as exc:
         print(f"plugin error: {exc}", file=sys.stderr)
         raise SystemExit(3) from exc
+    except (FileNotFoundError, IOError) as exc:
+        print(f"recording error: {exc}", file=sys.stderr)
+        raise SystemExit(5) from exc
     except KeyboardInterrupt:
         print("interrupted", file=sys.stderr)
         raise SystemExit(130)

--- a/packages/neuros/src/neuros/cli/recording_commands.py
+++ b/packages/neuros/src/neuros/cli/recording_commands.py
@@ -1,0 +1,185 @@
+"""Record, inspect, replay, and export neurOS session archives."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Iterable
+
+import yaml
+
+from neuros.config import load_config, resolve_config
+from neuros.errors import ConfigurationError
+from neuros.recording import (
+    ArchiveReplaySource,
+    RecordingSource,
+    SessionArchiveReader,
+    SessionArchiveWriter,
+    StreamIdentitySource,
+    export_nwb,
+    export_zarr,
+)
+from neuros.runtime import NodeKind, RuntimeExecutor, RuntimeGraph
+
+from .config_commands import _assert_decoder_ready
+
+OutputCallback = Callable[[Any], Awaitable[None] | None]
+
+
+def _raw_config(path: str | Path) -> dict[str, Any]:
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ConfigurationError("configuration root must be a mapping")
+    return raw
+
+
+def _recording_graph(graph: RuntimeGraph, writer: SessionArchiveWriter) -> RuntimeGraph:
+    """Decorate graph sources with canonical stream identity and recording.
+
+    A driver may expose a class/device-derived descriptor ID such as
+    ``mockdriver`` while the runtime config binds it to a semantic stream such
+    as ``eeg``. The configured graph identity is canonical for recording and
+    replay; the device-native identity is retained as frame/descriptor metadata.
+    """
+
+    result = RuntimeGraph()
+    for node in graph.nodes.values():
+        operator = node.operator
+        if node.kind is NodeKind.SOURCE:
+            configured_stream_id = node.metadata.get("stream_id")
+            if configured_stream_id:
+                operator = StreamIdentitySource(operator, str(configured_stream_id))
+            operator = RecordingSource(operator, writer)
+        result.add_node(replace(node, operator=operator))
+    for edge in graph.edges:
+        result.connect(edge)
+    result.validate()
+    return result
+
+
+async def _consume_outputs(executor: RuntimeExecutor, callback: OutputCallback | None) -> None:
+    async for output in executor.outputs():
+        if callback is None:
+            continue
+        result = callback(output)
+        if asyncio.iscoroutine(result):
+            await result
+
+
+async def record_config(
+    config_path: str | Path,
+    output: str | Path,
+    *,
+    session_id: str,
+    duration_s: float,
+    overwrite: bool = False,
+    export_formats: Iterable[str] = (),
+    on_output: OutputCallback | None = None,
+) -> dict[str, Any]:
+    if duration_s <= 0:
+        raise ConfigurationError("record duration must be positive")
+    config = load_config(config_path)
+    raw_config = _raw_config(config_path)
+    resolved = resolve_config(config)
+    _assert_decoder_ready(resolved.decoder)
+    writer = SessionArchiveWriter(
+        output,
+        session_id=session_id,
+        config=raw_config,
+        metadata={"config_path": str(config_path)},
+        overwrite=overwrite,
+    )
+    executor = RuntimeExecutor(_recording_graph(resolved.graph, writer))
+    await executor.start()
+    consumer = asyncio.create_task(_consume_outputs(executor, on_output))
+    try:
+        await asyncio.sleep(duration_s)
+        await executor.stop()
+        await consumer
+        snapshot = executor.snapshot()
+        await writer.close(runtime_metrics=snapshot)
+    except BaseException:
+        consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+        if executor.state.value not in {"stopped", "failed"}:
+            await executor.stop()
+        await writer.close(runtime_metrics=executor.snapshot())
+        raise
+
+    exports: dict[str, str] = {}
+    archive_path = Path(output)
+    for export_format in export_formats:
+        normalized = export_format.lower()
+        if normalized == "zarr":
+            target = archive_path.parent / f"{archive_path.name}.zarr"
+            exports[normalized] = str(export_zarr(archive_path, target))
+        elif normalized == "nwb":
+            target = archive_path.parent / f"{archive_path.name}.nwb"
+            exports[normalized] = str(export_nwb(archive_path, target))
+        else:
+            raise ConfigurationError(f"Unsupported export format: {export_format}")
+    return {
+        "archive": str(archive_path),
+        "exports": exports,
+        **SessionArchiveReader(archive_path).summary(),
+    }
+
+
+async def replay_archive(
+    archive: str | Path,
+    config_path: str | Path,
+    *,
+    realtime: bool = False,
+    speed: float = 1.0,
+    duration_s: float | None = None,
+    on_output: OutputCallback | None = None,
+) -> dict[str, Any]:
+    if speed <= 0:
+        raise ConfigurationError("replay speed must be positive")
+    reader = SessionArchiveReader(archive)
+    config = load_config(config_path)
+    configured_ids = {stream.stream_id for stream in config.streams}
+    missing = configured_ids - set(reader.stream_ids)
+    if missing:
+        raise ConfigurationError(f"Archive is missing configured streams: {sorted(missing)}")
+    overrides = {
+        stream.stream_id: ArchiveReplaySource(
+            reader, stream.stream_id, realtime=realtime, speed=speed
+        )
+        for stream in config.streams
+    }
+    resolved = resolve_config(config, source_overrides=overrides)
+    _assert_decoder_ready(resolved.decoder)
+    executor = RuntimeExecutor(resolved.graph)
+    await executor.start()
+    consumer = asyncio.create_task(_consume_outputs(executor, on_output))
+    try:
+        if duration_s is None:
+            await executor.wait()
+        else:
+            if duration_s <= 0:
+                raise ConfigurationError("replay duration must be positive")
+            await asyncio.sleep(duration_s)
+            await executor.stop()
+        await consumer
+    except BaseException:
+        consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+        if executor.state.value not in {"stopped", "failed"}:
+            await executor.stop()
+        raise
+    return executor.snapshot()
+
+
+def inspect_archive(path: str | Path, *, verify_hashes: bool = False) -> dict[str, Any]:
+    reader = SessionArchiveReader(path, verify_hashes=verify_hashes)
+    result = reader.summary()
+    if verify_hashes:
+        for stream_id in reader.stream_ids:
+            # Iteration performs payload verification lazily.
+            sum(1 for _ in reader.iter_frames(stream_id))
+        result["integrity"] = "verified"
+    else:
+        result["integrity"] = "not_checked"
+    return result

--- a/tests/test_recording_cli.py
+++ b/tests/test_recording_cli.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from neuros.cli.recording_commands import inspect_archive, record_config, replay_archive
+from neuros.recording import SessionArchiveReader
+
+
+CONFIG = Path("configs/examples/mock_bci.yaml")
+
+
+@pytest.mark.asyncio
+async def test_record_inspect_replay_workflow(tmp_path: Path):
+    archive = tmp_path / "session"
+    recorded = await record_config(
+        CONFIG,
+        archive,
+        session_id="ci-session",
+        duration_s=0.05,
+    )
+    assert recorded["status"] == "complete"
+    assert set(recorded["streams"]) == {"eeg"}
+    assert recorded["streams"]["eeg"] > 0
+
+    reader = SessionArchiveReader(archive)
+    descriptor = reader.descriptor("eeg")
+    assert descriptor.stream_id == "eeg"
+    assert descriptor.metadata["source_stream_id"] == "mockdriver"
+    first_frame = next(iter(reader.iter_frames("eeg")))
+    assert first_frame.stream_id == "eeg"
+    assert first_frame.metadata["source_stream_id"] == "mockdriver"
+
+    inspected = inspect_archive(archive, verify_hashes=True)
+    assert inspected["integrity"] == "verified"
+    assert inspected["streams"]["eeg"] == recorded["streams"]["eeg"]
+
+    replayed = await replay_archive(archive, CONFIG)
+    assert replayed["state"] == "stopped"
+    assert replayed["nodes"]["decoder:primary"]["processed"] > 0
+    assert replayed["edges"]["source:eeg->transform:eeg:0"]["dropped"] == 0

--- a/tests/test_recording_exports.py
+++ b/tests/test_recording_exports.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuros.contracts import SignalFrame, StreamDescriptor
+from neuros.recording import SessionArchiveWriter, export_nwb, export_zarr
+
+
+async def _archive(root: Path) -> Path:
+    writer = SessionArchiveWriter(root, session_id="interop")
+    writer.register_stream(
+        StreamDescriptor(
+            stream_id="eeg",
+            modality="eeg",
+            sample_rate_hz=100.0,
+            channel_names=("C3", "C4"),
+            units=("uV", "uV"),
+        )
+    )
+    for index in range(3):
+        await writer.write(
+            SignalFrame(
+                stream_id="eeg",
+                sequence_id=index,
+                data=np.ones((2, 4), dtype=np.float32) * index,
+                sample_rate_hz=100.0,
+                host_receive_time_ns=1_000_000_000 + index * 10_000_000,
+                synchronized_time_ns=1_000_000_000 + index * 10_000_000,
+                metadata={"index": index},
+            )
+        )
+    await writer.close()
+    return root
+
+
+@pytest.mark.asyncio
+async def test_zarr_export_contains_frame_and_timing_arrays(tmp_path: Path):
+    zarr = pytest.importorskip("zarr")
+    archive = await _archive(tmp_path / "session")
+    destination = export_zarr(archive, tmp_path / "session.zarr")
+    root = zarr.open_group(str(destination), mode="r")
+    assert root["eeg/data"].shape == (3, 2, 4)
+    np.testing.assert_array_equal(root["eeg/sequence_id"][:], [0, 1, 2])
+    assert "descriptor_json" in root["eeg"].attrs
+
+
+@pytest.mark.asyncio
+async def test_nwb_export_contains_acquisition_and_exact_metadata(tmp_path: Path):
+    pynwb = pytest.importorskip("pynwb")
+    archive = await _archive(tmp_path / "session")
+    destination = export_nwb(archive, tmp_path / "session.nwb")
+    with pynwb.NWBHDF5IO(str(destination), "r", load_namespaces=True) as io:
+        nwbfile = io.read()
+        assert "eeg" in nwbfile.acquisition
+        assert nwbfile.acquisition["eeg"].data.shape == (3, 2, 4)
+        assert "neuros_exact_metadata" in nwbfile.scratch

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuros.contracts import ClockDomain, QualityFlag, SignalFrame, StreamDescriptor
+from neuros.recording import SessionArchiveReader, SessionArchiveWriter
+
+
+def _frames():
+    return [
+        SignalFrame(
+            stream_id="eeg",
+            sequence_id=index,
+            data=np.arange(6, dtype=np.float32).reshape(2, 3) + index,
+            sample_rate_hz=250.0,
+            host_receive_time_ns=1_000_000 + index,
+            device_time_ns=2_000_000 + index,
+            synchronized_time_ns=3_000_000 + index,
+            clock_domain=ClockDomain.SYNCHRONIZED,
+            quality=QualityFlag.ARTIFACT_SUSPECTED if index == 1 else QualityFlag.GOOD,
+            metadata={"trial": index, "label": "left" if index % 2 == 0 else "right"},
+        )
+        for index in range(3)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_archive_round_trips_exact_frame_semantics(tmp_path: Path):
+    descriptor = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=250.0,
+        channel_names=("C3", "C4"),
+        channel_types=("eeg", "eeg"),
+        units=("uV", "uV"),
+        device="synthetic",
+        manufacturer="neurOS",
+        clock_domain=ClockDomain.SYNCHRONIZED,
+        metadata={"reference": "common-average"},
+    )
+    root = tmp_path / "session"
+    writer = SessionArchiveWriter(
+        root,
+        session_id="s1",
+        config={"schema_version": 1, "test": True},
+        metadata={"subject": "anonymous"},
+    )
+    writer.register_stream(descriptor)
+    original = _frames()
+    for frame in original:
+        await writer.write(frame)
+    await writer.close(runtime_metrics={"state": "stopped", "dropped": 0})
+
+    reader = SessionArchiveReader(root)
+    assert reader.descriptor("eeg") == descriptor
+    restored = list(reader.iter_frames("eeg"))
+    assert len(restored) == len(original)
+    for expected, actual in zip(original, restored):
+        assert actual.sequence_id == expected.sequence_id
+        np.testing.assert_array_equal(actual.data, expected.data)
+        assert actual.sample_rate_hz == expected.sample_rate_hz
+        assert actual.host_receive_time_ns == expected.host_receive_time_ns
+        assert actual.device_time_ns == expected.device_time_ns
+        assert actual.synchronized_time_ns == expected.synchronized_time_ns
+        assert actual.clock_domain == expected.clock_domain
+        assert actual.quality == expected.quality
+        assert dict(actual.metadata) == dict(expected.metadata)
+
+    summary = reader.summary()
+    assert summary["streams"] == {"eeg": 3}
+    assert summary["config_hash"]
+    assert summary["runtime_metrics"]["dropped"] == 0
+    manifest = json.loads((root / "manifest.json").read_text())
+    assert manifest["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_session_archive_detects_corrupted_frame_payload(tmp_path: Path):
+    root = tmp_path / "session"
+    writer = SessionArchiveWriter(root, session_id="s1")
+    writer.register_stream(
+        StreamDescriptor(stream_id="eeg", modality="eeg", sample_rate_hz=250.0)
+    )
+    await writer.write(_frames()[0])
+    await writer.close()
+
+    payload = next((root / "streams" / "eeg" / "frames").glob("*.npy"))
+    raw = bytearray(payload.read_bytes())
+    raw[-1] ^= 0xFF
+    payload.write_bytes(bytes(raw))
+
+    reader = SessionArchiveReader(root, verify_hashes=True)
+    with pytest.raises(IOError, match="hash mismatch"):
+        list(reader.iter_frames("eeg"))


### PR DESCRIPTION
## Stack

**Base:** PR #9 (`agent/cli-v3`)

This is stack layer 4. Review PR #1 → #8 → #9 → this PR.

## What changes

- adds a canonical, dependency-free neurOS session archive for exact `SignalFrame` persistence
- stores sequence IDs, device/host/synchronized clocks, clock domain, quality flags, metadata, sample rate, and per-frame SHA-256
- records stream descriptors, config hash, Git SHA, package versions, host metadata, runtime metrics, and model-artifact references in the manifest
- uses atomic manifest writes and fsync on frame/index writes
- adds lazy `ArchiveReplaySource` and `RecordingSource`
- adds config `source_overrides`, allowing recorded experiments to replay without constructing the original hardware driver
- adds optional NWB and Zarr exports, with exact neurOS metadata embedded for interoperability
- adds `neuros record`, `neuros inspect`, and `neuros replay`
- adds `neuros[recording]` / `neuros-core[recording]` extras
- adds exact round-trip, corruption, live record/replay, NWB, and Zarr tests

## Storage rule

The neurOS archive is the canonical lossless replay representation. NWB and Zarr are interoperable exports. This avoids weakening neurOS clock/provenance semantics to fit an external format while still participating in the neuroscience ecosystem.

## Review focus

1. crash-safe archive semantics
2. exact timestamp/quality/provenance round-trip
3. SHA-256 integrity checks
4. replay independence from hardware SDKs
5. optional NWB/Zarr boundary

## Validation

CI adds a dependency-free record→verify→replay path and a separate recording-interoperability job that opens the generated NWB and Zarr outputs.