### PR TITLE
test(quality): add scientific validity and real-time reliability gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
             tests/test_config_schema.py \
             tests/test_clock_sync.py \
             tests/test_replay.py \
-            tests/test_session_archive.py
+            tests/test_session_archive.py \
+            tests/test_quality_v3.py
 
   bci-smoke:
     name: BCI end-to-end smoke
@@ -78,6 +79,27 @@ jobs:
             tests/test_config_schema.py \
             tests/test_clock_sync.py \
             tests/test_replay.py
+
+  scientific-quality:
+    name: Scientific and latency gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install BCI quality profile
+        run: |
+          python -m pip install --upgrade pip
+          python scripts/bootstrap.py --profile bci --test-tools
+      - name: Run deterministic quality tests
+        run: pytest -q tests/test_quality_v3.py tests/test_feature_extraction_compat.py
+      - name: Run version-controlled quality gate
+        run: |
+          python scripts/run_quality_gate.py configs/examples/mock_bci.yaml \
+            --thresholds configs/quality/ci.yaml \
+            --report "${RUNNER_TEMP}/quality-report.json"
 
   recording-interop:
     name: Recording interoperability

--- a/configs/quality/ci.yaml
+++ b/configs/quality/ci.yaml
@@ -1,0 +1,15 @@
+runtime:
+  min_decoder_samples: 5
+  max_drop_fraction: 0.0
+  max_decoder_p99_ms: 250.0
+  max_transform_p99_ms: 250.0
+  max_failed_nodes: 0
+
+scientific:
+  frequencies_hz: [6.0, 10.0, 20.0, 40.0]
+  min_selectivity_ratio: 3.0
+  sample_rate_hz: 250.0
+
+benchmark:
+  duration_s: 0.15
+  seed: 42

--- a/packages/neuros-core/src/neuros/quality/__init__.py
+++ b/packages/neuros-core/src/neuros/quality/__init__.py
@@ -1,0 +1,26 @@
+"""Scientific validity, fault injection, provenance, and runtime quality gates."""
+
+from .faults import FaultProfile, PerturbedSource, perturb_frame
+from .manifest import BenchmarkManifest, content_hash
+from .metrics import QualityGateResult, QualityThresholds, evaluate_runtime_snapshot
+from .scientific import (
+    FrequencyProbeResult,
+    expected_eeg_band,
+    frequency_selectivity_probe,
+    synthetic_tone,
+)
+
+__all__ = [
+    "BenchmarkManifest",
+    "FaultProfile",
+    "FrequencyProbeResult",
+    "PerturbedSource",
+    "QualityGateResult",
+    "QualityThresholds",
+    "content_hash",
+    "evaluate_runtime_snapshot",
+    "expected_eeg_band",
+    "frequency_selectivity_probe",
+    "perturb_frame",
+    "synthetic_tone",
+]

--- a/packages/neuros-core/src/neuros/quality/faults.py
+++ b/packages/neuros-core/src/neuros/quality/faults.py
@@ -1,0 +1,125 @@
+"""Deterministic fault injection for neural-stream resilience testing."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+from typing import Any, AsyncIterator
+
+import numpy as np
+
+from neuros.contracts import QualityFlag, SignalFrame, StreamDescriptor
+
+
+@dataclass(frozen=True, slots=True)
+class FaultProfile:
+    seed: int = 0
+    packet_drop_probability: float = 0.0
+    timestamp_jitter_std_ms: float = 0.0
+    channel_dropout_probability: float = 0.0
+    clock_drift_ppm: float = 0.0
+    additive_noise_std: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("packet_drop_probability", "channel_dropout_probability"):
+            value = float(getattr(self, name))
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be in [0, 1]")
+        if self.timestamp_jitter_std_ms < 0 or self.additive_noise_std < 0:
+            raise ValueError("jitter/noise standard deviations must be non-negative")
+
+
+def perturb_frame(
+    frame: SignalFrame,
+    profile: FaultProfile,
+    rng: np.random.Generator,
+    *,
+    origin_device_time_ns: int | None = None,
+) -> SignalFrame:
+    """Apply frame-local deterministic perturbations without changing sequence ID."""
+
+    data = np.asarray(frame.data).copy()
+    quality = frame.quality
+    metadata = dict(frame.metadata)
+
+    if profile.channel_dropout_probability > 0 and data.ndim >= 1:
+        channel_count = data.shape[0]
+        mask = rng.random(channel_count) < profile.channel_dropout_probability
+        if mask.any():
+            data[mask] = 0
+            quality |= QualityFlag.DISCONNECTED_CHANNEL
+            metadata["fault_channel_dropout"] = tuple(int(index) for index in np.flatnonzero(mask))
+
+    if profile.additive_noise_std > 0:
+        data = data.astype(float, copy=False) + rng.normal(
+            0.0, profile.additive_noise_std, size=data.shape
+        )
+        metadata["fault_additive_noise_std"] = profile.additive_noise_std
+
+    jitter_ns = 0
+    if profile.timestamp_jitter_std_ms > 0:
+        jitter_ns = int(rng.normal(0.0, profile.timestamp_jitter_std_ms * 1_000_000.0))
+        metadata["fault_timestamp_jitter_ns"] = jitter_ns
+
+    device_time = frame.device_time_ns
+    synchronized_time = frame.synchronized_time_ns
+    if device_time is not None and profile.clock_drift_ppm:
+        origin = origin_device_time_ns if origin_device_time_ns is not None else device_time
+        elapsed = device_time - origin
+        drift_ns = int(elapsed * profile.clock_drift_ppm / 1_000_000.0)
+        device_time += drift_ns
+        quality |= QualityFlag.CLOCK_UNCERTAIN
+        metadata["fault_clock_drift_ppm"] = profile.clock_drift_ppm
+
+    if synchronized_time is not None:
+        synchronized_time += jitter_ns
+    elif device_time is not None:
+        device_time += jitter_ns
+
+    return replace(
+        frame,
+        data=data,
+        device_time_ns=device_time,
+        synchronized_time_ns=synchronized_time,
+        quality=quality,
+        metadata=metadata,
+    )
+
+
+class PerturbedSource:
+    """Wrap any Source with reproducible packet/data/timing perturbations."""
+
+    def __init__(self, source: Any, profile: FaultProfile) -> None:
+        self.source = source
+        self.profile = profile
+        self._rng = np.random.default_rng(profile.seed)
+        self._origin_device_time_ns: int | None = None
+        self.dropped_packets = 0
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return self.source.descriptor
+
+    async def start(self) -> None:
+        self._rng = np.random.default_rng(self.profile.seed)
+        self._origin_device_time_ns = None
+        self.dropped_packets = 0
+        await self.source.start()
+
+    async def stop(self) -> None:
+        await self.source.stop()
+
+    async def frames(self) -> AsyncIterator[SignalFrame]:
+        async for frame in self.source.frames():
+            if self._origin_device_time_ns is None and frame.device_time_ns is not None:
+                self._origin_device_time_ns = frame.device_time_ns
+            if self.profile.packet_drop_probability > 0 and self._rng.random() < self.profile.packet_drop_probability:
+                self.dropped_packets += 1
+                await asyncio.sleep(0)
+                continue
+            yield perturb_frame(
+                frame,
+                self.profile,
+                self._rng,
+                origin_device_time_ns=self._origin_device_time_ns,
+            )

--- a/packages/neuros-core/src/neuros/quality/manifest.py
+++ b/packages/neuros-core/src/neuros/quality/manifest.py
@@ -1,0 +1,84 @@
+"""Reproducibility manifests for neurOS benchmarks and scientific gates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from importlib import metadata as importlib_metadata
+from typing import Any, Mapping
+
+
+def content_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def current_git_sha() -> str | None:
+    if os.environ.get("GITHUB_SHA"):
+        return os.environ["GITHUB_SHA"]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def installed_versions() -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name in ("neuros", "neuros-core", "neuros-drivers", "neuros-models", "neuros-orion"):
+        try:
+            result[name] = importlib_metadata.version(name)
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkManifest:
+    benchmark_id: str
+    created_at: str
+    git_sha: str | None
+    config_hash: str | None
+    data_hash: str | None
+    artifact_ids: tuple[str, ...] = ()
+    seed: int | None = None
+    packages: Mapping[str, str] = field(default_factory=dict)
+    host: Mapping[str, str] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def capture(
+        cls,
+        benchmark_id: str,
+        *,
+        config: Any | None = None,
+        data_fingerprint: Any | None = None,
+        artifact_ids: tuple[str, ...] = (),
+        seed: int | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "BenchmarkManifest":
+        return cls(
+            benchmark_id=benchmark_id,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            git_sha=current_git_sha(),
+            config_hash=content_hash(config) if config is not None else None,
+            data_hash=content_hash(data_fingerprint) if data_fingerprint is not None else None,
+            artifact_ids=artifact_ids,
+            seed=seed,
+            packages=installed_versions(),
+            host={
+                "python": platform.python_version(),
+                "platform": platform.platform(),
+                "machine": platform.machine(),
+            },
+            metadata=dict(metadata or {}),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/packages/neuros-core/src/neuros/quality/metrics.py
+++ b/packages/neuros-core/src/neuros/quality/metrics.py
@@ -1,0 +1,98 @@
+"""BCI-relevant runtime quality metrics and version-controlled gates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class QualityThresholds:
+    """Generic runtime acceptance thresholds.
+
+    These defaults are intentionally conservative enough for shared CI. Device-
+    specific and application-specific latency requirements belong in hardware
+    qualification profiles rather than being smuggled into generic unit tests.
+    """
+
+    min_decoder_samples: int = 1
+    max_drop_fraction: float = 0.0
+    max_decoder_p99_ms: float = 250.0
+    max_transform_p99_ms: float = 250.0
+    max_failed_nodes: int = 0
+
+    def __post_init__(self) -> None:
+        if self.min_decoder_samples < 0:
+            raise ValueError("min_decoder_samples must be >= 0")
+        if not 0.0 <= self.max_drop_fraction <= 1.0:
+            raise ValueError("max_drop_fraction must be in [0, 1]")
+        if self.max_decoder_p99_ms <= 0 or self.max_transform_p99_ms <= 0:
+            raise ValueError("latency limits must be positive")
+        if self.max_failed_nodes < 0:
+            raise ValueError("max_failed_nodes must be >= 0")
+
+
+@dataclass(frozen=True, slots=True)
+class QualityGateResult:
+    passed: bool
+    checks: Mapping[str, bool]
+    metrics: Mapping[str, float | int]
+    failures: tuple[str, ...]
+
+
+def _edge_counts(snapshot: Mapping[str, Any]) -> tuple[int, int]:
+    accepted = 0
+    dropped = 0
+    for edge in snapshot.get("edges", {}).values():
+        accepted += int(edge.get("accepted", 0))
+        dropped += int(edge.get("dropped", 0))
+    return accepted, dropped
+
+
+def evaluate_runtime_snapshot(
+    snapshot: Mapping[str, Any],
+    thresholds: QualityThresholds = QualityThresholds(),
+) -> QualityGateResult:
+    """Evaluate a RuntimeExecutor snapshot against explicit acceptance gates."""
+
+    nodes = snapshot.get("nodes", {})
+    decoder = nodes.get("decoder:primary", {})
+    decoder_samples = int(decoder.get("processed", 0))
+    decoder_p99 = float(decoder.get("p99_latency_ms", 0.0))
+    transform_p99 = max(
+        (
+            float(metrics.get("p99_latency_ms", 0.0))
+            for node_id, metrics in nodes.items()
+            if str(node_id).startswith("transform:")
+        ),
+        default=0.0,
+    )
+    failed_nodes = sum(int(metrics.get("failed", 0)) > 0 for metrics in nodes.values())
+    accepted, dropped = _edge_counts(snapshot)
+    attempted = accepted + dropped
+    drop_fraction = dropped / attempted if attempted else 0.0
+
+    checks = {
+        "runtime_stopped_cleanly": snapshot.get("state") == "stopped" and snapshot.get("failure") is None,
+        "decoder_activity": decoder_samples >= thresholds.min_decoder_samples,
+        "edge_loss": drop_fraction <= thresholds.max_drop_fraction,
+        "decoder_p99_latency": decoder_p99 <= thresholds.max_decoder_p99_ms,
+        "transform_p99_latency": transform_p99 <= thresholds.max_transform_p99_ms,
+        "node_failures": failed_nodes <= thresholds.max_failed_nodes,
+    }
+    failures = tuple(name for name, passed in checks.items() if not passed)
+    return QualityGateResult(
+        passed=not failures,
+        checks=checks,
+        metrics={
+            "decoder_samples": decoder_samples,
+            "decoder_p99_ms": decoder_p99,
+            "transform_p99_ms": transform_p99,
+            "failed_nodes": failed_nodes,
+            "accepted_edge_items": accepted,
+            "dropped_edge_items": dropped,
+            "drop_fraction": drop_fraction,
+            "runtime_seconds": float(snapshot.get("runtime_seconds", 0.0)),
+        },
+        failures=failures,
+    )

--- a/packages/neuros-core/src/neuros/quality/scientific.py
+++ b/packages/neuros-core/src/neuros/quality/scientific.py
@@ -1,0 +1,74 @@
+"""Small deterministic scientific oracles for BCI processing validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from neuros.processing.feature_extraction import BandPowerExtractor
+
+
+@dataclass(frozen=True, slots=True)
+class FrequencyProbeResult:
+    frequency_hz: float
+    expected_band: str
+    winning_band: str
+    powers: dict[str, float]
+    selectivity_ratio: float
+
+    @property
+    def passed(self) -> bool:
+        return self.winning_band == self.expected_band and self.selectivity_ratio > 1.0
+
+
+def synthetic_tone(
+    frequency_hz: float,
+    *,
+    sample_rate_hz: float = 250.0,
+    duration_s: float = 4.0,
+    amplitude: float = 1.0,
+    noise_std: float = 0.02,
+    seed: int = 0,
+) -> np.ndarray:
+    if frequency_hz <= 0 or sample_rate_hz <= 0 or duration_s <= 0:
+        raise ValueError("frequency, sample rate, and duration must be positive")
+    rng = np.random.default_rng(seed)
+    t = np.arange(int(sample_rate_hz * duration_s), dtype=float) / sample_rate_hz
+    signal = amplitude * np.sin(2.0 * np.pi * frequency_hz * t)
+    signal += rng.normal(0.0, noise_std, size=signal.shape)
+    return signal[np.newaxis, :].astype(np.float32)
+
+
+def expected_eeg_band(frequency_hz: float) -> str:
+    for name, (low, high) in BandPowerExtractor.DEFAULT_BANDS.items():
+        if low <= frequency_hz <= high:
+            return name
+    raise ValueError(f"Frequency {frequency_hz} Hz is outside canonical EEG bands")
+
+
+def frequency_selectivity_probe(
+    frequency_hz: float,
+    *,
+    sample_rate_hz: float = 250.0,
+    seed: int = 0,
+) -> FrequencyProbeResult:
+    signal = synthetic_tone(
+        frequency_hz,
+        sample_rate_hz=sample_rate_hz,
+        seed=seed,
+    )
+    extractor = BandPowerExtractor(fs=sample_rate_hz)
+    features = extractor.extract(signal)
+    names = list(extractor.bands)
+    powers = {name: float(features[index]) for index, name in enumerate(names)}
+    ordered = sorted(powers.items(), key=lambda item: item[1], reverse=True)
+    winner, top_power = ordered[0]
+    second_power = max(ordered[1][1], np.finfo(float).eps)
+    return FrequencyProbeResult(
+        frequency_hz=frequency_hz,
+        expected_band=expected_eeg_band(frequency_hz),
+        winning_band=winner,
+        powers=powers,
+        selectivity_ratio=top_power / second_power,
+    )

--- a/scripts/run_quality_gate.py
+++ b/scripts/run_quality_gate.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Run generic neurOS runtime and scientific validity gates."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import yaml
+
+from neuros.cli.config_commands import execute_config
+from neuros.quality import (
+    BenchmarkManifest,
+    QualityThresholds,
+    evaluate_runtime_snapshot,
+    frequency_selectivity_probe,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", help="Executable neurOS pipeline YAML")
+    parser.add_argument(
+        "--thresholds", default="configs/quality/ci.yaml", help="Quality threshold YAML"
+    )
+    parser.add_argument("--report", default=None, help="Optional JSON report path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    threshold_raw = yaml.safe_load(Path(args.thresholds).read_text(encoding="utf-8"))
+    runtime_raw = threshold_raw["runtime"]
+    scientific_raw = threshold_raw["scientific"]
+    benchmark_raw = threshold_raw["benchmark"]
+
+    thresholds = QualityThresholds(**runtime_raw)
+    snapshot = asyncio.run(
+        execute_config(args.config, duration_s=float(benchmark_raw["duration_s"]))
+    )
+    runtime_gate = evaluate_runtime_snapshot(snapshot, thresholds)
+
+    probes = [
+        frequency_selectivity_probe(
+            float(frequency),
+            sample_rate_hz=float(scientific_raw["sample_rate_hz"]),
+            seed=int(benchmark_raw["seed"]),
+        )
+        for frequency in scientific_raw["frequencies_hz"]
+    ]
+    scientific_passed = all(
+        probe.passed
+        and probe.selectivity_ratio >= float(scientific_raw["min_selectivity_ratio"])
+        for probe in probes
+    )
+
+    manifest = BenchmarkManifest.capture(
+        "generic-ci-quality",
+        config={
+            "pipeline": Path(args.config).read_text(encoding="utf-8"),
+            "thresholds": threshold_raw,
+        },
+        data_fingerprint={
+            "synthetic_frequencies_hz": scientific_raw["frequencies_hz"],
+            "sample_rate_hz": scientific_raw["sample_rate_hz"],
+        },
+        seed=int(benchmark_raw["seed"]),
+    )
+    report = {
+        "passed": runtime_gate.passed and scientific_passed,
+        "runtime_gate": {
+            "passed": runtime_gate.passed,
+            "checks": dict(runtime_gate.checks),
+            "metrics": dict(runtime_gate.metrics),
+            "failures": list(runtime_gate.failures),
+        },
+        "scientific_gate": {
+            "passed": scientific_passed,
+            "probes": [asdict(probe) | {"passed": probe.passed} for probe in probes],
+        },
+        "manifest": manifest.to_dict(),
+    }
+    text = json.dumps(report, indent=2, sort_keys=True, default=str)
+    print(text)
+    if args.report:
+        Path(args.report).write_text(text, encoding="utf-8")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quality_v3.py
+++ b/tests/test_quality_v3.py
@@ -1,0 +1,100 @@
+import json
+
+import numpy as np
+
+from neuros.contracts import ClockDomain, QualityFlag, SignalFrame
+from neuros.quality import (
+    BenchmarkManifest,
+    FaultProfile,
+    QualityThresholds,
+    evaluate_runtime_snapshot,
+    frequency_selectivity_probe,
+    perturb_frame,
+)
+
+
+def _snapshot(*, dropped=0, p99=2.0, processed=10):
+    return {
+        "state": "stopped",
+        "failure": None,
+        "runtime_seconds": 0.1,
+        "nodes": {
+            "transform:eeg:0": {
+                "processed": processed,
+                "failed": 0,
+                "p99_latency_ms": 1.0,
+            },
+            "decoder:primary": {
+                "processed": processed,
+                "failed": 0,
+                "p99_latency_ms": p99,
+            },
+        },
+        "edges": {
+            "source:eeg->transform:eeg:0": {"accepted": processed, "dropped": dropped},
+            "transform:eeg:0->decoder:primary": {"accepted": processed, "dropped": 0},
+        },
+    }
+
+
+def test_quality_gate_passes_clean_snapshot_and_rejects_loss():
+    thresholds = QualityThresholds(
+        min_decoder_samples=5,
+        max_drop_fraction=0.0,
+        max_decoder_p99_ms=10.0,
+        max_transform_p99_ms=10.0,
+    )
+    assert evaluate_runtime_snapshot(_snapshot(), thresholds).passed
+    failed = evaluate_runtime_snapshot(_snapshot(dropped=1), thresholds)
+    assert not failed.passed
+    assert "edge_loss" in failed.failures
+
+
+def test_fault_injection_is_deterministic_and_marks_quality():
+    frame = SignalFrame(
+        stream_id="eeg",
+        sequence_id=3,
+        data=np.ones((4, 8), dtype=np.float32),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=100,
+        device_time_ns=1_000_000_000,
+        synchronized_time_ns=1_000_000_000,
+        clock_domain=ClockDomain.SYNCHRONIZED,
+    )
+    profile = FaultProfile(
+        seed=7,
+        timestamp_jitter_std_ms=1.0,
+        channel_dropout_probability=0.5,
+        additive_noise_std=0.01,
+        clock_drift_ppm=100.0,
+    )
+    a = perturb_frame(frame, profile, np.random.default_rng(7), origin_device_time_ns=0)
+    b = perturb_frame(frame, profile, np.random.default_rng(7), origin_device_time_ns=0)
+    np.testing.assert_array_equal(a.data, b.data)
+    assert a.device_time_ns == b.device_time_ns
+    assert a.synchronized_time_ns == b.synchronized_time_ns
+    assert a.quality & QualityFlag.CLOCK_UNCERTAIN
+    assert a.quality & QualityFlag.DISCONNECTED_CHANNEL
+
+
+def test_known_frequency_probes_recover_expected_eeg_bands():
+    for frequency, band in [(6.0, "theta"), (10.0, "alpha"), (20.0, "beta"), (40.0, "gamma")]:
+        result = frequency_selectivity_probe(frequency, seed=42)
+        assert result.expected_band == band
+        assert result.winning_band == band
+        assert result.selectivity_ratio > 3.0
+
+
+def test_benchmark_manifest_is_json_serializable_and_hashed():
+    manifest = BenchmarkManifest.capture(
+        "unit-test",
+        config={"a": 1},
+        data_fingerprint={"dataset": "synthetic", "n": 10},
+        seed=4,
+        artifact_ids=("decoder:v1",),
+    )
+    payload = manifest.to_dict()
+    json.dumps(payload)
+    assert payload["config_hash"]
+    assert payload["data_hash"]
+    assert payload["seed"] == 4


### PR DESCRIPTION
## Stack

**Base:** PR #10 (`agent/recording-v3`)

This is stack layer 5. Review PR #1 → #8 → #9 → #10 → this PR.

## What changes

- adds explicit runtime quality thresholds for decoder activity, queue loss, node failures, and p99 latency
- adds deterministic signal fault injection for packet loss, channel dropout, timestamp jitter, additive noise, and clock drift
- adds reproducible `BenchmarkManifest` capture with Git SHA, config/data hashes, package versions, artifact IDs, seed, and host metadata
- adds deterministic known-frequency EEG scientific probes that must recover theta/alpha/beta/gamma band dominance
- adds `configs/quality/ci.yaml` with version-controlled generic CI thresholds
- adds `scripts/run_quality_gate.py` to produce a JSON evidence report and fail closed when a gate is missed
- adds quality/fault/manifest/scientific tests
- adds a dedicated `scientific-quality` GitHub Actions lane

## Scope rule

Generic CI thresholds are intentionally loose enough for shared runners. Hardware, firmware, and application-specific latency requirements should be stricter qualification profiles with explicit device metadata, not hidden assumptions in generic tests.

## Review focus

1. gate math and fail-closed behavior
2. deterministic fault semantics
3. scientific probe validity
4. benchmark provenance fields
5. separation between generic CI and hardware qualification

## Validation

CI runs the unit-level quality suite and then executes the version-controlled quality gate against the real mock/config/runtime path, emitting a JSON report.