### PR TITLE
feat(orion): implement benchmarked neural tokenization layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: pytest -q tests/test_recording_exports.py tests/test_session_archive.py
 
   orion-contracts:
-    name: ORION contracts
+    name: ORION contracts and tokenization
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -130,5 +130,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python scripts/bootstrap.py --profile orion --test-tools
-      - name: Run ORION contract tests
-        run: pytest -q tests/test_orion_contracts.py tests/test_kernel_contracts.py
+      - name: Run ORION contract and tokenization tests
+        run: |
+          pytest -q \
+            tests/test_orion_contracts.py \
+            tests/test_orion_tokenization.py \
+            tests/test_kernel_contracts.py
+      - name: Run controlled tokenizer benchmark
+        run: |
+          OUT="${RUNNER_TEMP}/orion-tokenization"
+          python scripts/orion/run_tokenizer_benchmark.py \
+            configs/orion/tokenization_smoke.yaml \
+            --output "${OUT}"
+          test -s "${OUT}/metrics.json"
+          test -s "${OUT}/comparison_table.csv"
+          test -s "${OUT}/tokenizer_cards.md"

--- a/configs/orion/tokenization_smoke.yaml
+++ b/configs/orion/tokenization_smoke.yaml
@@ -1,0 +1,21 @@
+synthetic:
+  n_units: 16
+  repeats: 4
+  background_rate_hz: 2.0
+
+tokenizers:
+  bin_ms: 10.0
+  burst_isi_ms: 12.0
+  min_burst_spikes: 3
+  synchrony_window_ms: 5.0
+  min_active_units: 3
+  vq_bin_ms: 5.0
+  vq_window_ms: 50.0
+  vq_codebook_size: 12
+  assembly_bin_ms: 20.0
+  n_assemblies: 4
+
+benchmark:
+  seed: 42
+  jitter_ms: 5.0
+  unit_dropout_probability: 0.25

--- a/packages/orion/pyproject.toml
+++ b/packages/orion/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "neuros-orion"
 version = "0.1.0"
-description = "ORION neural intelligence contracts and adaptive representation interfaces"
+description = "ORION neural intelligence, tokenization, and adaptive representation interfaces"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
@@ -14,7 +14,16 @@ keywords = ["bci", "neuroscience", "foundation-models", "neural-representations"
 dependencies = ["neuros-core>=2.0.0", "numpy>=1.24.0"]
 
 [project.optional-dependencies]
-test = ["pytest>=7.4"]
+test = ["pytest>=7.4", "pytest-asyncio>=0.21"]
+
+[project.entry-points."neuros.tokenizers"]
+event = "orion.tokenization:EventSpikeTokenizer"
+binned_count = "orion.tokenization:BinnedCountTokenizer"
+isi_relative = "orion.tokenization:ISIRelativeTimeTokenizer"
+burst = "orion.tokenization:BurstTokenizer"
+synchrony = "orion.tokenization:SynchronyPacketTokenizer"
+vq_motif = "orion.tokenization:VQMotifTokenizer"
+assembly = "orion.tokenization:AssemblyTokenizer"
 
 [project.urls]
 Repository = "https://github.com/sidhulyalkar/neurOS-v1"

--- a/packages/orion/src/orion/__init__.py
+++ b/packages/orion/src/orion/__init__.py
@@ -1,4 +1,4 @@
-"""ORION neural intelligence interfaces."""
+"""ORION neural intelligence interfaces and tokenization research layer."""
 
 from .contracts import (
     AdaptationProposal,
@@ -9,13 +9,31 @@ from .contracts import (
     RepresentationBatch,
     TokenizerManifest,
 )
+from .tokenization import (
+    AssemblyTokenizer,
+    BinnedCountTokenizer,
+    BurstTokenizer,
+    EventSpikeTokenizer,
+    ISIRelativeTimeTokenizer,
+    SpikeEvent,
+    SynchronyPacketTokenizer,
+    VQMotifTokenizer,
+)
 
 __all__ = [
     "AdaptationProposal",
     "AdaptiveDecoder",
+    "AssemblyTokenizer",
+    "BinnedCountTokenizer",
+    "BurstTokenizer",
+    "EventSpikeTokenizer",
+    "ISIRelativeTimeTokenizer",
     "NeuralEncoder",
     "NeuroTokenBatch",
     "NeuroTokenizer",
     "RepresentationBatch",
+    "SpikeEvent",
+    "SynchronyPacketTokenizer",
     "TokenizerManifest",
+    "VQMotifTokenizer",
 ]

--- a/packages/orion/src/orion/tokenization/__init__.py
+++ b/packages/orion/src/orion/tokenization/__init__.py
@@ -1,5 +1,58 @@
-"""Tokenization namespace for ORION implementations."""
+"""ORION neural tokenization implementations and evaluation tools."""
 
 from orion.contracts import NeuroTokenBatch, NeuroTokenizer, TokenizerManifest
+from orion.tokenization.baselines import (
+    BinnedCountTokenizer,
+    BurstTokenizer,
+    EventSpikeTokenizer,
+    ISIRelativeTimeTokenizer,
+    SynchronyPacketTokenizer,
+)
+from orion.tokenization.benchmark import (
+    TokenizerScore,
+    benchmark_tokenizers,
+    default_tokenizers,
+    run_synthetic_benchmark,
+    write_benchmark_reports,
+)
+from orion.tokenization.events import (
+    MotifInterval,
+    SpikeEvent,
+    events_from_frames,
+    events_to_frames,
+    normalize_events,
+)
+from orion.tokenization.learned import AssemblyTokenizer, VQMotifTokenizer
+from orion.tokenization.synthetic import (
+    SyntheticSpikeSession,
+    dropout_units,
+    generate_synthetic_session,
+    jitter_events,
+)
 
-__all__ = ["NeuroTokenBatch", "NeuroTokenizer", "TokenizerManifest"]
+__all__ = [
+    "AssemblyTokenizer",
+    "BinnedCountTokenizer",
+    "BurstTokenizer",
+    "EventSpikeTokenizer",
+    "ISIRelativeTimeTokenizer",
+    "MotifInterval",
+    "NeuroTokenBatch",
+    "NeuroTokenizer",
+    "SpikeEvent",
+    "SynchronyPacketTokenizer",
+    "SyntheticSpikeSession",
+    "TokenizerManifest",
+    "TokenizerScore",
+    "VQMotifTokenizer",
+    "benchmark_tokenizers",
+    "default_tokenizers",
+    "dropout_units",
+    "events_from_frames",
+    "events_to_frames",
+    "generate_synthetic_session",
+    "jitter_events",
+    "normalize_events",
+    "run_synthetic_benchmark",
+    "write_benchmark_reports",
+]

--- a/packages/orion/src/orion/tokenization/baselines.py
+++ b/packages/orion/src/orion/tokenization/baselines.py
@@ -1,0 +1,368 @@
+"""Interpretable ORION spike tokenization baselines."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+
+from neuros.contracts import SignalFrame
+from orion.contracts import NeuroTokenBatch, TokenizerManifest
+from orion.tokenization.events import SpikeEvent, events_from_frames, normalize_events
+
+
+def _make_batch(
+    tokenizer_id: str,
+    token_ids: Iterable[int],
+    timestamps_ns: Iterable[int],
+    *,
+    side_features: dict[str, Iterable[Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> NeuroTokenBatch:
+    ids = np.asarray(list(token_ids), dtype=np.int64)
+    times = np.asarray(list(timestamps_ns), dtype=np.int64)
+    side = {
+        key: np.asarray(list(values)) for key, values in (side_features or {}).items()
+    }
+    return NeuroTokenBatch(
+        token_ids=ids,
+        timestamps_ns=times,
+        side_features=side,
+        metadata={"tokenizer_id": tokenizer_id, **(metadata or {})},
+    )
+
+
+class EventSpikeTokenizer:
+    """One token per sorted spike event, preserving exact event timing."""
+
+    UNIT_OFFSET = 1000
+
+    def __init__(self) -> None:
+        self._manifest = TokenizerManifest("event", "1.0.0", parameters={})
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        events = normalize_events(events)
+        return _make_batch(
+            "event",
+            (self.UNIT_OFFSET + event.unit_id for event in events),
+            (event.timestamp_ns for event in events),
+            side_features={"unit_id": (event.unit_id for event in events)},
+            metadata={"input_events": len(events)},
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))
+
+
+class BinnedCountTokenizer:
+    """Collapse spikes into unit-specific count tokens within fixed time bins."""
+
+    UNIT_OFFSET = 2000
+
+    def __init__(self, bin_ms: float = 10.0) -> None:
+        if bin_ms <= 0:
+            raise ValueError("bin_ms must be positive")
+        self.bin_ns = int(round(bin_ms * 1_000_000.0))
+        self._manifest = TokenizerManifest(
+            "binned_count", "1.0.0", parameters={"bin_ms": bin_ms}
+        )
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        events = normalize_events(events)
+        if not events:
+            return _make_batch("binned_count", [], [], metadata={"input_events": 0})
+        origin = events[0].timestamp_ns
+        counts: dict[tuple[int, int], int] = defaultdict(int)
+        for event in events:
+            bin_index = (event.timestamp_ns - origin) // self.bin_ns
+            counts[(int(bin_index), event.unit_id)] += 1
+        keys = sorted(counts)
+        return _make_batch(
+            "binned_count",
+            (self.UNIT_OFFSET + unit_id for _, unit_id in keys),
+            (origin + bin_index * self.bin_ns for bin_index, _ in keys),
+            side_features={
+                "unit_id": (unit_id for _, unit_id in keys),
+                "count": (counts[key] for key in keys),
+                "bin_index": (bin_index for bin_index, _ in keys),
+            },
+            metadata={"input_events": len(events), "bin_ns": self.bin_ns},
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))
+
+
+class ISIRelativeTimeTokenizer:
+    """Represent global relative timing with quantized WAIT + unit SPIKE tokens."""
+
+    WAIT_OFFSET = 10
+    SPIKE_OFFSET = 3000
+
+    def __init__(
+        self,
+        *,
+        min_wait_ms: float = 0.25,
+        max_wait_ms: float = 2000.0,
+        wait_bins: int = 32,
+    ) -> None:
+        if min_wait_ms <= 0 or max_wait_ms <= min_wait_ms or wait_bins < 2:
+            raise ValueError("invalid wait bin configuration")
+        self.edges_ns = np.geomspace(
+            min_wait_ms * 1_000_000.0,
+            max_wait_ms * 1_000_000.0,
+            wait_bins + 1,
+        )
+        self._manifest = TokenizerManifest(
+            "isi_relative",
+            "1.0.0",
+            parameters={
+                "min_wait_ms": min_wait_ms,
+                "max_wait_ms": max_wait_ms,
+                "wait_bins": wait_bins,
+            },
+        )
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def _wait_bin(self, delta_ns: int) -> int:
+        if delta_ns <= 0:
+            return 0
+        return int(np.clip(np.searchsorted(self.edges_ns, delta_ns, side="right") - 1, 0, len(self.edges_ns) - 2))
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        events = normalize_events(events)
+        token_ids: list[int] = []
+        timestamps: list[int] = []
+        kinds: list[int] = []
+        units: list[int] = []
+        delta_ms: list[float] = []
+        local_isi_ms: list[float] = []
+        last_global: int | None = None
+        last_by_unit: dict[int, int] = {}
+        for event in events:
+            delta = 0 if last_global is None else event.timestamp_ns - last_global
+            if delta > 0:
+                token_ids.append(self.WAIT_OFFSET + self._wait_bin(delta))
+                timestamps.append(event.timestamp_ns)
+                kinds.append(0)
+                units.append(-1)
+                delta_ms.append(delta / 1_000_000.0)
+                local_isi_ms.append(np.nan)
+            token_ids.append(self.SPIKE_OFFSET + event.unit_id)
+            timestamps.append(event.timestamp_ns)
+            kinds.append(1)
+            units.append(event.unit_id)
+            delta_ms.append(delta / 1_000_000.0)
+            local = event.timestamp_ns - last_by_unit[event.unit_id] if event.unit_id in last_by_unit else -1
+            local_isi_ms.append(local / 1_000_000.0 if local >= 0 else np.nan)
+            last_global = event.timestamp_ns
+            last_by_unit[event.unit_id] = event.timestamp_ns
+        return _make_batch(
+            "isi_relative",
+            token_ids,
+            timestamps,
+            side_features={
+                "kind": kinds,
+                "unit_id": units,
+                "delta_ms": delta_ms,
+                "unit_isi_ms": local_isi_ms,
+            },
+            metadata={"input_events": len(events)},
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))
+
+
+@dataclass(frozen=True, slots=True)
+class _SemanticToken:
+    timestamp_ns: int
+    token_id: int
+    kind: int
+    unit_id: int
+    count: int
+    duration_ns: int
+
+
+class BurstTokenizer:
+    """Compress within-unit rapid firing into burst/pause/rebound semantics."""
+
+    EVENT_OFFSET = 4000
+    BURST_OFFSET = 5000
+    PAUSE_OFFSET = 6000
+    REBOUND_OFFSET = 7000
+
+    def __init__(
+        self,
+        *,
+        burst_isi_ms: float = 12.0,
+        min_burst_spikes: int = 3,
+        pause_ms: float = 150.0,
+    ) -> None:
+        if burst_isi_ms <= 0 or min_burst_spikes < 2 or pause_ms <= burst_isi_ms:
+            raise ValueError("invalid burst configuration")
+        self.burst_isi_ns = int(burst_isi_ms * 1_000_000.0)
+        self.min_burst_spikes = min_burst_spikes
+        self.pause_ns = int(pause_ms * 1_000_000.0)
+        self._manifest = TokenizerManifest(
+            "burst",
+            "1.0.0",
+            parameters={
+                "burst_isi_ms": burst_isi_ms,
+                "min_burst_spikes": min_burst_spikes,
+                "pause_ms": pause_ms,
+            },
+        )
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        events = normalize_events(events)
+        by_unit: dict[int, list[SpikeEvent]] = defaultdict(list)
+        for event in events:
+            by_unit[event.unit_id].append(event)
+        semantic: list[_SemanticToken] = []
+        for unit_id, unit_events in by_unit.items():
+            clusters: list[list[SpikeEvent]] = []
+            current: list[SpikeEvent] = []
+            for event in unit_events:
+                if current and event.timestamp_ns - current[-1].timestamp_ns > self.burst_isi_ns:
+                    clusters.append(current)
+                    current = []
+                current.append(event)
+            if current:
+                clusters.append(current)
+
+            previous_end: int | None = None
+            for cluster in clusters:
+                start = cluster[0].timestamp_ns
+                end = cluster[-1].timestamp_ns
+                if previous_end is not None and start - previous_end >= self.pause_ns:
+                    semantic.append(
+                        _SemanticToken(
+                            previous_end + self.pause_ns,
+                            self.PAUSE_OFFSET + unit_id,
+                            2,
+                            unit_id,
+                            0,
+                            start - previous_end,
+                        )
+                    )
+                    semantic.append(
+                        _SemanticToken(start, self.REBOUND_OFFSET + unit_id, 3, unit_id, len(cluster), 0)
+                    )
+                if len(cluster) >= self.min_burst_spikes:
+                    semantic.append(
+                        _SemanticToken(
+                            start,
+                            self.BURST_OFFSET + unit_id,
+                            1,
+                            unit_id,
+                            len(cluster),
+                            end - start,
+                        )
+                    )
+                else:
+                    semantic.extend(
+                        _SemanticToken(event.timestamp_ns, self.EVENT_OFFSET + unit_id, 0, unit_id, 1, 0)
+                        for event in cluster
+                    )
+                previous_end = end
+        semantic.sort(key=lambda token: (token.timestamp_ns, token.kind, token.unit_id))
+        return _make_batch(
+            "burst",
+            (token.token_id for token in semantic),
+            (token.timestamp_ns for token in semantic),
+            side_features={
+                "kind": (token.kind for token in semantic),
+                "unit_id": (token.unit_id for token in semantic),
+                "count": (token.count for token in semantic),
+                "duration_ns": (token.duration_ns for token in semantic),
+            },
+            metadata={"input_events": len(events)},
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))
+
+
+class SynchronyPacketTokenizer:
+    """Collapse small-window population coactivation into synchrony packets."""
+
+    EVENT_OFFSET = 8000
+    PACKET_TOKEN = 9000
+
+    def __init__(self, *, window_ms: float = 5.0, min_active_units: int = 3) -> None:
+        if window_ms <= 0 or min_active_units < 2:
+            raise ValueError("invalid synchrony configuration")
+        self.window_ns = int(window_ms * 1_000_000.0)
+        self.min_active_units = min_active_units
+        self._manifest = TokenizerManifest(
+            "synchrony",
+            "1.0.0",
+            parameters={"window_ms": window_ms, "min_active_units": min_active_units},
+        )
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        events = normalize_events(events)
+        ids: list[int] = []
+        times: list[int] = []
+        kinds: list[int] = []
+        active_counts: list[int] = []
+        units_hash: list[int] = []
+        index = 0
+        while index < len(events):
+            start = events[index].timestamp_ns
+            end_index = index
+            active: set[int] = set()
+            while end_index < len(events) and events[end_index].timestamp_ns - start <= self.window_ns:
+                active.add(events[end_index].unit_id)
+                end_index += 1
+            if len(active) >= self.min_active_units:
+                ids.append(self.PACKET_TOKEN)
+                times.append(start)
+                kinds.append(1)
+                active_counts.append(len(active))
+                units_hash.append(hash(tuple(sorted(active))) & 0x7FFFFFFF)
+                index = end_index
+            else:
+                event = events[index]
+                ids.append(self.EVENT_OFFSET + event.unit_id)
+                times.append(event.timestamp_ns)
+                kinds.append(0)
+                active_counts.append(1)
+                units_hash.append(event.unit_id)
+                index += 1
+        return _make_batch(
+            "synchrony",
+            ids,
+            times,
+            side_features={
+                "kind": kinds,
+                "active_unit_count": active_counts,
+                "unit_signature": units_hash,
+            },
+            metadata={"input_events": len(events), "window_ns": self.window_ns},
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))

--- a/packages/orion/src/orion/tokenization/benchmark.py
+++ b/packages/orion/src/orion/tokenization/benchmark.py
@@ -1,0 +1,294 @@
+"""Controlled ORION tokenizer comparison and reporting harness."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+from neuros.quality import BenchmarkManifest
+from orion.contracts import NeuroTokenBatch
+from orion.tokenization.baselines import (
+    BinnedCountTokenizer,
+    BurstTokenizer,
+    EventSpikeTokenizer,
+    ISIRelativeTimeTokenizer,
+    SynchronyPacketTokenizer,
+)
+from orion.tokenization.events import MotifInterval, SpikeEvent
+from orion.tokenization.learned import AssemblyTokenizer, VQMotifTokenizer
+from orion.tokenization.synthetic import (
+    SyntheticSpikeSession,
+    dropout_units,
+    generate_synthetic_session,
+    jitter_events,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TokenizerScore:
+    tokenizer: str
+    input_events: int
+    token_count: int
+    compression_ratio: float
+    token_entropy_bits: float
+    encode_ms: float
+    motif_decoding_accuracy: float
+    jitter_similarity: float
+    unit_dropout_similarity: float
+    active_token_types: int
+
+
+def token_entropy(batch: NeuroTokenBatch) -> float:
+    if len(batch.token_ids) == 0:
+        return 0.0
+    _, counts = np.unique(batch.token_ids, return_counts=True)
+    probabilities = counts / counts.sum()
+    return float(-(probabilities * np.log2(probabilities)).sum())
+
+
+def token_histogram(batch: NeuroTokenBatch, bins: int = 128) -> np.ndarray:
+    histogram = np.zeros(bins, dtype=np.float64)
+    for token_id in np.asarray(batch.token_ids, dtype=np.int64):
+        histogram[int(token_id) % bins] += 1.0
+    norm = np.linalg.norm(histogram)
+    return histogram / norm if norm > 0 else histogram
+
+
+def histogram_similarity(a: NeuroTokenBatch, b: NeuroTokenBatch) -> float:
+    left = token_histogram(a)
+    right = token_histogram(b)
+    return float(np.clip(np.dot(left, right), 0.0, 1.0))
+
+
+def _motif_vector(
+    batch: NeuroTokenBatch,
+    motif: MotifInterval,
+    *,
+    hash_bins: int = 64,
+    temporal_bins: int = 4,
+) -> np.ndarray:
+    vector = np.zeros(hash_bins * temporal_bins, dtype=np.float64)
+    duration = max(1, motif.end_ns - motif.start_ns)
+    for token_id, timestamp in zip(batch.token_ids, batch.timestamps_ns):
+        timestamp_int = int(timestamp)
+        if not motif.start_ns <= timestamp_int < motif.end_ns:
+            continue
+        phase = min(
+            temporal_bins - 1,
+            int((timestamp_int - motif.start_ns) * temporal_bins / duration),
+        )
+        vector[phase * hash_bins + int(token_id) % hash_bins] += 1.0
+    norm = np.linalg.norm(vector)
+    return vector / norm if norm > 0 else vector
+
+
+def motif_decoding_accuracy(
+    train_batch: NeuroTokenBatch,
+    train_motifs: Sequence[MotifInterval],
+    test_batch: NeuroTokenBatch,
+    test_motifs: Sequence[MotifInterval],
+) -> float:
+    """Nearest-centroid motif decoding using only training-session centroids."""
+
+    by_label: dict[str, list[np.ndarray]] = {}
+    for motif in train_motifs:
+        by_label.setdefault(motif.label, []).append(_motif_vector(train_batch, motif))
+    centroids = {
+        label: np.mean(np.stack(vectors), axis=0) for label, vectors in by_label.items()
+    }
+    if not centroids or not test_motifs:
+        return 0.0
+    correct = 0
+    total = 0
+    labels = sorted(centroids)
+    for motif in test_motifs:
+        if motif.label not in centroids:
+            continue
+        vector = _motif_vector(test_batch, motif)
+        distances = {
+            label: float(np.sum((vector - centroids[label]) ** 2)) for label in labels
+        }
+        prediction = min(distances, key=distances.get)
+        correct += int(prediction == motif.label)
+        total += 1
+    return correct / total if total else 0.0
+
+
+def default_tokenizers(config: Mapping[str, Any] | None = None) -> list[Any]:
+    raw = dict(config or {})
+    return [
+        EventSpikeTokenizer(),
+        BinnedCountTokenizer(bin_ms=float(raw.get("bin_ms", 10.0))),
+        ISIRelativeTimeTokenizer(),
+        BurstTokenizer(
+            burst_isi_ms=float(raw.get("burst_isi_ms", 12.0)),
+            min_burst_spikes=int(raw.get("min_burst_spikes", 3)),
+        ),
+        SynchronyPacketTokenizer(
+            window_ms=float(raw.get("synchrony_window_ms", 5.0)),
+            min_active_units=int(raw.get("min_active_units", 3)),
+        ),
+        VQMotifTokenizer(
+            bin_ms=float(raw.get("vq_bin_ms", 5.0)),
+            window_ms=float(raw.get("vq_window_ms", 50.0)),
+            codebook_size=int(raw.get("vq_codebook_size", 12)),
+            seed=int(raw.get("seed", 0)),
+        ),
+        AssemblyTokenizer(
+            bin_ms=float(raw.get("assembly_bin_ms", 20.0)),
+            n_assemblies=int(raw.get("n_assemblies", 4)),
+        ),
+    ]
+
+
+def _fit_if_needed(tokenizer: Any, events: Sequence[SpikeEvent]) -> None:
+    fit = getattr(tokenizer, "fit_events", None)
+    if fit is not None:
+        fit(events)
+
+
+def benchmark_tokenizers(
+    *,
+    train: SyntheticSpikeSession,
+    test: SyntheticSpikeSession,
+    tokenizers: Iterable[Any] | None = None,
+    jitter_ms: float = 5.0,
+    unit_dropout_probability: float = 0.25,
+    seed: int = 0,
+) -> tuple[TokenizerScore, ...]:
+    tokenizers = list(tokenizers or default_tokenizers({"seed": seed}))
+    jittered = jitter_events(
+        test.events, std_ms=jitter_ms, seed=seed + 101, duration_ns=test.duration_ns
+    )
+    dropped = dropout_units(
+        test.events,
+        probability=unit_dropout_probability,
+        n_units=test.n_units,
+        seed=seed + 202,
+    )
+    scores: list[TokenizerScore] = []
+    for tokenizer in tokenizers:
+        _fit_if_needed(tokenizer, train.events)
+        train_batch = tokenizer.encode_events(train.events)
+        started = time.perf_counter_ns()
+        test_batch = tokenizer.encode_events(test.events)
+        encode_ms = (time.perf_counter_ns() - started) / 1_000_000.0
+        jitter_batch = tokenizer.encode_events(jittered)
+        dropout_batch = tokenizer.encode_events(dropped)
+        token_count = len(test_batch.token_ids)
+        compression = len(test.events) / token_count if token_count else math.inf
+        scores.append(
+            TokenizerScore(
+                tokenizer=tokenizer.manifest.tokenizer_id,
+                input_events=len(test.events),
+                token_count=token_count,
+                compression_ratio=float(compression),
+                token_entropy_bits=token_entropy(test_batch),
+                encode_ms=encode_ms,
+                motif_decoding_accuracy=motif_decoding_accuracy(
+                    train_batch, train.motifs, test_batch, test.motifs
+                ),
+                jitter_similarity=histogram_similarity(test_batch, jitter_batch),
+                unit_dropout_similarity=histogram_similarity(test_batch, dropout_batch),
+                active_token_types=int(len(np.unique(test_batch.token_ids))),
+            )
+        )
+    return tuple(scores)
+
+
+def run_synthetic_benchmark(config: Mapping[str, Any]) -> dict[str, Any]:
+    synthetic = dict(config.get("synthetic", {}))
+    benchmark = dict(config.get("benchmark", {}))
+    tokenizer_config = dict(config.get("tokenizers", {}))
+    seed = int(benchmark.get("seed", 42))
+    train = generate_synthetic_session(
+        seed=seed,
+        n_units=int(synthetic.get("n_units", 16)),
+        repeats=int(synthetic.get("repeats", 4)),
+        background_rate_hz=float(synthetic.get("background_rate_hz", 2.0)),
+    )
+    test = generate_synthetic_session(
+        seed=seed + 1,
+        n_units=train.n_units,
+        repeats=int(synthetic.get("repeats", 4)),
+        background_rate_hz=float(synthetic.get("background_rate_hz", 2.0)),
+    )
+    tokenizers = default_tokenizers(tokenizer_config | {"seed": seed})
+    scores = benchmark_tokenizers(
+        train=train,
+        test=test,
+        tokenizers=tokenizers,
+        jitter_ms=float(benchmark.get("jitter_ms", 5.0)),
+        unit_dropout_probability=float(benchmark.get("unit_dropout_probability", 0.25)),
+        seed=seed,
+    )
+    manifest = BenchmarkManifest.capture(
+        "orion-synthetic-tokenization-v1",
+        config=config,
+        data_fingerprint={
+            "train_seed": train.seed,
+            "test_seed": test.seed,
+            "n_units": train.n_units,
+            "train_events": len(train.events),
+            "test_events": len(test.events),
+            "motif_labels": sorted({motif.label for motif in train.motifs}),
+        },
+        seed=seed,
+    )
+    return {
+        "manifest": manifest.to_dict(),
+        "train": {
+            "events": len(train.events),
+            "motifs": len(train.motifs),
+            "duration_ns": train.duration_ns,
+        },
+        "test": {
+            "events": len(test.events),
+            "motifs": len(test.motifs),
+            "duration_ns": test.duration_ns,
+        },
+        "scores": [asdict(score) for score in scores],
+    }
+
+
+def write_benchmark_reports(report: Mapping[str, Any], output_dir: str | Path) -> None:
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "metrics.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True, default=str), encoding="utf-8"
+    )
+    scores = list(report["scores"])
+    if scores:
+        with (output / "comparison_table.csv").open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(scores[0]))
+            writer.writeheader()
+            writer.writerows(scores)
+    lines = [
+        "# ORION Tokenizer Cards",
+        "",
+        "All scores use a separately seeded test session. Fit-requiring tokenizers are fit only on the training session.",
+        "",
+    ]
+    for score in scores:
+        lines.extend(
+            [
+                f"## {score['tokenizer']}",
+                "",
+                f"- tokens: {score['token_count']} from {score['input_events']} spikes",
+                f"- compression: {score['compression_ratio']:.3f}x",
+                f"- entropy: {score['token_entropy_bits']:.3f} bits",
+                f"- motif decoding accuracy: {score['motif_decoding_accuracy']:.3f}",
+                f"- 5 ms jitter histogram similarity: {score['jitter_similarity']:.3f}",
+                f"- unit-dropout histogram similarity: {score['unit_dropout_similarity']:.3f}",
+                f"- encode time: {score['encode_ms']:.3f} ms",
+                "",
+            ]
+        )
+    (output / "tokenizer_cards.md").write_text("\n".join(lines), encoding="utf-8")

--- a/packages/orion/src/orion/tokenization/events.py
+++ b/packages/orion/src/orion/tokenization/events.py
@@ -1,0 +1,110 @@
+"""Canonical spike-event schemas and neurOS SignalFrame translation for ORION."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+
+from neuros.contracts import SignalFrame
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class SpikeEvent:
+    timestamp_ns: int
+    unit_id: int
+
+    def __post_init__(self) -> None:
+        if self.timestamp_ns < 0:
+            raise ValueError("timestamp_ns must be non-negative")
+        if self.unit_id < 0:
+            raise ValueError("unit_id must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class MotifInterval:
+    label: str
+    start_ns: int
+    end_ns: int
+    units: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.label:
+            raise ValueError("motif label must be non-empty")
+        if self.start_ns < 0 or self.end_ns <= self.start_ns:
+            raise ValueError("motif interval must have positive duration")
+
+
+def normalize_events(events: Iterable[SpikeEvent]) -> tuple[SpikeEvent, ...]:
+    """Return events in a deterministic timestamp/unit order."""
+    return tuple(sorted(events, key=lambda event: (event.timestamp_ns, event.unit_id)))
+
+
+def events_from_frames(frames: Sequence[SignalFrame]) -> tuple[SpikeEvent, ...]:
+    """Translate supported neurOS spike representations into events.
+
+    Supported conventions:
+    - ``metadata['representation'] == 'spike_event'`` with ``metadata['unit_id']``.
+    - ``metadata['representation'] == 'spike_counts'`` with a one-dimensional
+      count vector and optional ``metadata['unit_ids']``.
+
+    This deliberately refuses to infer spikes from arbitrary continuous signals.
+    Spike detection/sorting belongs upstream and must be explicit in provenance.
+    """
+
+    events: list[SpikeEvent] = []
+    for frame in frames:
+        representation = frame.metadata.get("representation")
+        timestamp_ns = int(frame.synchronized_time_ns or frame.device_time_ns or frame.host_receive_time_ns)
+        if representation == "spike_event":
+            unit_id = frame.metadata.get("unit_id")
+            if unit_id is None:
+                raise ValueError("spike_event frame requires metadata['unit_id']")
+            events.append(SpikeEvent(timestamp_ns=timestamp_ns, unit_id=int(unit_id)))
+            continue
+        if representation == "spike_counts":
+            counts = np.asarray(frame.data)
+            if counts.ndim != 1:
+                raise ValueError("spike_counts frame data must be one-dimensional")
+            unit_ids = frame.metadata.get("unit_ids")
+            if unit_ids is None:
+                unit_ids = tuple(range(len(counts)))
+            if len(unit_ids) != len(counts):
+                raise ValueError("unit_ids must align with spike count channels")
+            for unit_id, count in zip(unit_ids, counts):
+                count_int = int(count)
+                if count_int < 0 or not np.isclose(count, count_int):
+                    raise ValueError("spike counts must be non-negative integers")
+                events.extend(
+                    SpikeEvent(timestamp_ns=timestamp_ns, unit_id=int(unit_id))
+                    for _ in range(count_int)
+                )
+            continue
+        raise ValueError(
+            "ORION spike tokenizers require explicit spike_event or spike_counts SignalFrames"
+        )
+    return normalize_events(events)
+
+
+def events_to_frames(
+    events: Iterable[SpikeEvent],
+    *,
+    stream_id: str = "spikes",
+    sample_rate_hz: float = 1000.0,
+) -> list[SignalFrame]:
+    """Create event-style SignalFrames for tests, replay, and benchmark adapters."""
+    result: list[SignalFrame] = []
+    for sequence_id, event in enumerate(normalize_events(events)):
+        result.append(
+            SignalFrame(
+                stream_id=stream_id,
+                sequence_id=sequence_id,
+                data=np.asarray([1], dtype=np.int16),
+                sample_rate_hz=sample_rate_hz,
+                host_receive_time_ns=event.timestamp_ns,
+                synchronized_time_ns=event.timestamp_ns,
+                metadata={"representation": "spike_event", "unit_id": event.unit_id},
+            )
+        )
+    return result

--- a/packages/orion/src/orion/tokenization/learned.py
+++ b/packages/orion/src/orion/tokenization/learned.py
@@ -1,0 +1,311 @@
+"""Lightweight learned ORION tokenizers with explicit fit/encode boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from neuros.contracts import SignalFrame
+from orion.contracts import NeuroTokenBatch, TokenizerManifest
+from orion.tokenization.events import SpikeEvent, events_from_frames, normalize_events
+
+
+def _rasterize(
+    events: Sequence[SpikeEvent],
+    *,
+    bin_ns: int,
+    n_units: int | None = None,
+    origin_ns: int | None = None,
+    end_ns: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, int]:
+    events = normalize_events(events)
+    inferred_units = max((event.unit_id for event in events), default=-1) + 1
+    units = max(inferred_units, n_units or 0)
+    if units <= 0:
+        return np.zeros((0, 0), dtype=np.float32), np.zeros(0, dtype=np.int64), 0
+    if not events and origin_ns is None:
+        return np.zeros((0, units), dtype=np.float32), np.zeros(0, dtype=np.int64), units
+    origin = int(origin_ns if origin_ns is not None else events[0].timestamp_ns)
+    finish = int(end_ns if end_ns is not None else events[-1].timestamp_ns + bin_ns)
+    bins = max(1, int(np.ceil((finish - origin) / bin_ns)))
+    raster = np.zeros((bins, units), dtype=np.float32)
+    for event in events:
+        index = min(bins - 1, max(0, (event.timestamp_ns - origin) // bin_ns))
+        raster[int(index), event.unit_id] += 1.0
+    timestamps = origin + np.arange(bins, dtype=np.int64) * bin_ns
+    return raster, timestamps, units
+
+
+def _windows(raster: np.ndarray, timestamps: np.ndarray, window_bins: int) -> tuple[np.ndarray, np.ndarray]:
+    if raster.shape[0] < window_bins:
+        return np.zeros((0, window_bins * raster.shape[1]), dtype=np.float32), np.zeros(0, dtype=np.int64)
+    vectors = np.stack(
+        [raster[index : index + window_bins].reshape(-1) for index in range(raster.shape[0] - window_bins + 1)]
+    )
+    times = timestamps[: len(vectors)]
+    return vectors.astype(np.float32), times.astype(np.int64)
+
+
+class VQMotifTokenizer:
+    """Vector-quantize local spike raster motifs with deterministic Lloyd k-means.
+
+    This is intentionally a small representation-learning baseline, not a VQ-VAE.
+    It tests whether a learned local codebook earns its complexity before ORION
+    introduces a neural encoder/decoder around the quantizer.
+    """
+
+    TOKEN_OFFSET = 10_000
+
+    def __init__(
+        self,
+        *,
+        bin_ms: float = 5.0,
+        window_ms: float = 50.0,
+        codebook_size: int = 16,
+        seed: int = 0,
+        max_iter: int = 50,
+    ) -> None:
+        if bin_ms <= 0 or window_ms < bin_ms or codebook_size < 2 or max_iter < 1:
+            raise ValueError("invalid VQ motif configuration")
+        self.bin_ns = int(bin_ms * 1_000_000.0)
+        self.window_bins = max(1, int(round(window_ms / bin_ms)))
+        self.codebook_size = codebook_size
+        self.seed = seed
+        self.max_iter = max_iter
+        self.codebook_: np.ndarray | None = None
+        self.n_units_: int | None = None
+        self._manifest = TokenizerManifest(
+            "vq_motif",
+            "1.0.0",
+            parameters={
+                "bin_ms": bin_ms,
+                "window_ms": window_ms,
+                "codebook_size": codebook_size,
+                "seed": seed,
+                "max_iter": max_iter,
+            },
+        )
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def fit_events(self, events: Sequence[SpikeEvent]) -> "VQMotifTokenizer":
+        raster, timestamps, units = _rasterize(events, bin_ns=self.bin_ns)
+        vectors, _ = _windows(raster, timestamps, self.window_bins)
+        if len(vectors) < self.codebook_size:
+            raise ValueError(
+                f"Need at least {self.codebook_size} raster windows to fit VQMotifTokenizer"
+            )
+        rng = np.random.default_rng(self.seed)
+        initial_indices = rng.choice(len(vectors), size=self.codebook_size, replace=False)
+        centers = vectors[initial_indices].astype(np.float64, copy=True)
+        for _ in range(self.max_iter):
+            distances = ((vectors[:, None, :] - centers[None, :, :]) ** 2).sum(axis=2)
+            labels = distances.argmin(axis=1)
+            updated = centers.copy()
+            for cluster in range(self.codebook_size):
+                members = vectors[labels == cluster]
+                if len(members):
+                    updated[cluster] = members.mean(axis=0)
+                else:
+                    # Deterministically reseed empty clusters with the point farthest
+                    # from its assigned center.
+                    nearest = distances[np.arange(len(vectors)), labels]
+                    updated[cluster] = vectors[int(np.argmax(nearest))]
+            if np.allclose(updated, centers, rtol=0.0, atol=1e-7):
+                centers = updated
+                break
+            centers = updated
+        self.codebook_ = centers.astype(np.float32)
+        self.n_units_ = units
+        return self
+
+    def fit(self, frames: list[SignalFrame]) -> "VQMotifTokenizer":
+        return self.fit_events(events_from_frames(frames))
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        if self.codebook_ is None or self.n_units_ is None:
+            raise RuntimeError("VQMotifTokenizer must be fit before encode")
+        events = normalize_events(events)
+        if not events:
+            return NeuroTokenBatch(
+                token_ids=np.zeros(0, dtype=np.int64),
+                timestamps_ns=np.zeros(0, dtype=np.int64),
+                metadata={"tokenizer_id": "vq_motif", "input_events": 0},
+            )
+        raster, timestamps, _ = _rasterize(
+            events, bin_ns=self.bin_ns, n_units=self.n_units_
+        )
+        vectors, times = _windows(raster, timestamps, self.window_bins)
+        if not len(vectors):
+            return NeuroTokenBatch(
+                token_ids=np.zeros(0, dtype=np.int64),
+                timestamps_ns=np.zeros(0, dtype=np.int64),
+                metadata={"tokenizer_id": "vq_motif", "input_events": len(events)},
+            )
+        distances = ((vectors[:, None, :] - self.codebook_[None, :, :]) ** 2).sum(axis=2)
+        labels = distances.argmin(axis=1).astype(np.int64)
+        nearest = np.sqrt(distances[np.arange(len(vectors)), labels])
+        usage = np.bincount(labels, minlength=self.codebook_size)
+        return NeuroTokenBatch(
+            token_ids=self.TOKEN_OFFSET + labels,
+            timestamps_ns=times,
+            side_features={"cluster": labels, "quantization_error": nearest},
+            metadata={
+                "tokenizer_id": "vq_motif",
+                "input_events": len(events),
+                "codebook_usage": usage.tolist(),
+                "active_codes": int(np.count_nonzero(usage)),
+            },
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))
+
+
+@dataclass(frozen=True, slots=True)
+class AssemblySummary:
+    component: int
+    top_units: tuple[int, ...]
+    threshold: float
+
+
+class AssemblyTokenizer:
+    """Discover reproducible population assemblies using deterministic SVD."""
+
+    TOKEN_OFFSET = 12_000
+    ON = 0
+    PEAK = 1
+    OFF = 2
+
+    def __init__(
+        self,
+        *,
+        bin_ms: float = 20.0,
+        n_assemblies: int = 4,
+        threshold_std: float = 1.5,
+        top_units: int = 5,
+    ) -> None:
+        if bin_ms <= 0 or n_assemblies < 1 or threshold_std <= 0 or top_units < 1:
+            raise ValueError("invalid assembly configuration")
+        self.bin_ns = int(bin_ms * 1_000_000.0)
+        self.n_assemblies = n_assemblies
+        self.threshold_std = threshold_std
+        self.top_units = top_units
+        self.components_: np.ndarray | None = None
+        self.thresholds_: np.ndarray | None = None
+        self.n_units_: int | None = None
+        self.summaries_: tuple[AssemblySummary, ...] = ()
+        self._manifest = TokenizerManifest(
+            "assembly",
+            "1.0.0",
+            parameters={
+                "bin_ms": bin_ms,
+                "n_assemblies": n_assemblies,
+                "threshold_std": threshold_std,
+                "top_units": top_units,
+            },
+        )
+
+    @property
+    def manifest(self) -> TokenizerManifest:
+        return self._manifest
+
+    def fit_events(self, events: Sequence[SpikeEvent]) -> "AssemblyTokenizer":
+        raster, _, units = _rasterize(events, bin_ns=self.bin_ns)
+        if raster.shape[0] < 2 or units < 1:
+            raise ValueError("Need at least two active bins to fit AssemblyTokenizer")
+        centered = raster - raster.mean(axis=0, keepdims=True)
+        _, _, vt = np.linalg.svd(centered, full_matrices=False)
+        count = min(self.n_assemblies, vt.shape[0])
+        components = vt[:count].copy()
+        # Fix SVD sign ambiguity so fits are stable across implementations.
+        for index in range(count):
+            pivot = int(np.argmax(np.abs(components[index])))
+            if components[index, pivot] < 0:
+                components[index] *= -1
+        activation = np.abs(raster @ components.T)
+        thresholds = activation.mean(axis=0) + self.threshold_std * activation.std(axis=0)
+        summaries = []
+        for index, component in enumerate(components):
+            top = np.argsort(np.abs(component))[::-1][: self.top_units]
+            summaries.append(
+                AssemblySummary(index, tuple(int(unit) for unit in top), float(thresholds[index]))
+            )
+        self.components_ = components.astype(np.float32)
+        self.thresholds_ = thresholds.astype(np.float32)
+        self.n_units_ = units
+        self.summaries_ = tuple(summaries)
+        return self
+
+    def fit(self, frames: list[SignalFrame]) -> "AssemblyTokenizer":
+        return self.fit_events(events_from_frames(frames))
+
+    def encode_events(self, events: Sequence[SpikeEvent]) -> NeuroTokenBatch:
+        if self.components_ is None or self.thresholds_ is None or self.n_units_ is None:
+            raise RuntimeError("AssemblyTokenizer must be fit before encode")
+        events = normalize_events(events)
+        if not events:
+            return NeuroTokenBatch(
+                token_ids=np.zeros(0, dtype=np.int64),
+                timestamps_ns=np.zeros(0, dtype=np.int64),
+                metadata={"tokenizer_id": "assembly", "input_events": 0},
+            )
+        raster, timestamps, _ = _rasterize(
+            events, bin_ns=self.bin_ns, n_units=self.n_units_
+        )
+        activation = np.abs(raster @ self.components_.T)
+        records: list[tuple[int, int, int, float]] = []
+        for component in range(self.components_.shape[0]):
+            active = activation[:, component] >= self.thresholds_[component]
+            index = 0
+            while index < len(active):
+                if not active[index]:
+                    index += 1
+                    continue
+                start = index
+                while index + 1 < len(active) and active[index + 1]:
+                    index += 1
+                end = index
+                local = activation[start : end + 1, component]
+                peak = start + int(np.argmax(local))
+                records.extend(
+                    [
+                        (int(timestamps[start]), component, self.ON, float(activation[start, component])),
+                        (int(timestamps[peak]), component, self.PEAK, float(activation[peak, component])),
+                        (int(timestamps[end] + self.bin_ns), component, self.OFF, float(activation[end, component])),
+                    ]
+                )
+                index += 1
+        records.sort(key=lambda item: (item[0], item[1], item[2]))
+        ids = np.asarray(
+            [self.TOKEN_OFFSET + component * 3 + kind for _, component, kind, _ in records],
+            dtype=np.int64,
+        )
+        return NeuroTokenBatch(
+            token_ids=ids,
+            timestamps_ns=np.asarray([item[0] for item in records], dtype=np.int64),
+            side_features={
+                "component": np.asarray([item[1] for item in records], dtype=np.int64),
+                "kind": np.asarray([item[2] for item in records], dtype=np.int8),
+                "activation": np.asarray([item[3] for item in records], dtype=np.float32),
+            },
+            metadata={
+                "tokenizer_id": "assembly",
+                "input_events": len(events),
+                "assemblies": [
+                    {
+                        "component": summary.component,
+                        "top_units": summary.top_units,
+                        "threshold": summary.threshold,
+                    }
+                    for summary in self.summaries_
+                ],
+            },
+        )
+
+    def encode(self, frames: list[SignalFrame]) -> NeuroTokenBatch:
+        return self.encode_events(events_from_frames(frames))

--- a/packages/orion/src/orion/tokenization/synthetic.py
+++ b/packages/orion/src/orion/tokenization/synthetic.py
@@ -1,0 +1,179 @@
+"""Deterministic synthetic spike sessions with labeled ORION motif ground truth."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+from orion.tokenization.events import MotifInterval, SpikeEvent, normalize_events
+
+
+@dataclass(frozen=True, slots=True)
+class SyntheticSpikeSession:
+    events: tuple[SpikeEvent, ...]
+    motifs: tuple[MotifInterval, ...]
+    duration_ns: int
+    n_units: int
+    seed: int
+
+
+def _ns(seconds: float) -> int:
+    return int(round(seconds * 1_000_000_000.0))
+
+
+def generate_synthetic_session(
+    *,
+    seed: int = 0,
+    n_units: int = 16,
+    repeats: int = 4,
+    background_rate_hz: float = 2.0,
+) -> SyntheticSpikeSession:
+    """Generate Poisson background plus six repeated neural motifs.
+
+    The generator is intentionally mechanistic and labeled. It is not claimed to
+    reproduce a specific biological preparation; its purpose is to expose timing,
+    population, burst, pause, and assembly structure under controlled ground truth.
+    """
+
+    if n_units < 12 or repeats < 2 or background_rate_hz < 0:
+        raise ValueError("synthetic benchmark requires >=12 units, >=2 repeats, non-negative rate")
+    labels = (
+        "burst",
+        "synchrony",
+        "assembly",
+        "leader_chain",
+        "pause_rebound",
+        "movement_volley",
+    )
+    motif_spacing_s = 0.45
+    block_s = len(labels) * motif_spacing_s + 0.75
+    duration_s = repeats * block_s + 1.0
+    duration_ns = _ns(duration_s)
+    rng = np.random.default_rng(seed)
+
+    events: list[SpikeEvent] = []
+    for unit_id in range(n_units):
+        expected = background_rate_hz * duration_s
+        count = int(rng.poisson(expected))
+        times = rng.integers(0, duration_ns, size=count, endpoint=False)
+        events.extend(SpikeEvent(int(time), unit_id) for time in times)
+
+    motifs: list[MotifInterval] = []
+    pause_windows: list[tuple[int, int, int]] = []
+    for repeat in range(repeats):
+        block_start_s = 0.5 + repeat * block_s
+        for label_index, label in enumerate(labels):
+            start_ns = _ns(block_start_s + label_index * motif_spacing_s)
+            end_ns = start_ns + _ns(0.18)
+
+            if label == "burst":
+                unit = repeat % n_units
+                for index in range(7):
+                    events.append(SpikeEvent(start_ns + index * _ns(0.004), unit))
+                units = (unit,)
+
+            elif label == "synchrony":
+                units = tuple(range(6))
+                for unit in units:
+                    events.append(
+                        SpikeEvent(start_ns + int(rng.integers(0, _ns(0.003))), unit)
+                    )
+
+            elif label == "assembly":
+                units = tuple(range(6, 12))
+                for volley in range(4):
+                    base = start_ns + volley * _ns(0.025)
+                    for unit in units:
+                        events.append(
+                            SpikeEvent(base + int(rng.integers(0, _ns(0.004))), unit)
+                        )
+
+            elif label == "leader_chain":
+                units = tuple(range(8))
+                for index, unit in enumerate(units):
+                    events.append(SpikeEvent(start_ns + index * _ns(0.006), unit))
+
+            elif label == "pause_rebound":
+                unit = (repeat + 3) % n_units
+                units = (unit,)
+                pause_windows.append((start_ns, start_ns + _ns(0.12), unit))
+                rebound = start_ns + _ns(0.125)
+                for index in range(5):
+                    events.append(SpikeEvent(rebound + index * _ns(0.005), unit))
+
+            else:  # movement_volley
+                units = tuple(range(4, 14))
+                for index, unit in enumerate(units):
+                    # Broad onset volley with a deterministic propagation gradient.
+                    events.append(
+                        SpikeEvent(
+                            start_ns + index * _ns(0.002) + int(rng.integers(0, _ns(0.002))),
+                            unit,
+                        )
+                    )
+
+            motifs.append(MotifInterval(label, start_ns, end_ns, units))
+
+    if pause_windows:
+        filtered: list[SpikeEvent] = []
+        for event in events:
+            suppress = any(
+                unit == event.unit_id and start <= event.timestamp_ns < end
+                for start, end, unit in pause_windows
+            )
+            if not suppress:
+                filtered.append(event)
+        events = filtered
+        # Re-add rebound spikes that were deliberately inside the removal logic's
+        # surrounding motif construction only when they fall after the pause.
+        for start, _, unit in pause_windows:
+            rebound = start + _ns(0.125)
+            for index in range(5):
+                candidate = SpikeEvent(rebound + index * _ns(0.005), unit)
+                if candidate not in events:
+                    events.append(candidate)
+
+    return SyntheticSpikeSession(
+        events=normalize_events(events),
+        motifs=tuple(motifs),
+        duration_ns=duration_ns,
+        n_units=n_units,
+        seed=seed,
+    )
+
+
+def jitter_events(
+    events: Iterable[SpikeEvent],
+    *,
+    std_ms: float,
+    seed: int,
+    duration_ns: int | None = None,
+) -> tuple[SpikeEvent, ...]:
+    if std_ms < 0:
+        raise ValueError("std_ms must be non-negative")
+    rng = np.random.default_rng(seed)
+    limit = duration_ns if duration_ns is not None else None
+    result = []
+    for event in events:
+        jitter = int(rng.normal(0.0, std_ms * 1_000_000.0))
+        timestamp = max(0, event.timestamp_ns + jitter)
+        if limit is not None:
+            timestamp = min(limit - 1, timestamp)
+        result.append(SpikeEvent(timestamp, event.unit_id))
+    return normalize_events(result)
+
+
+def dropout_units(
+    events: Iterable[SpikeEvent],
+    *,
+    probability: float,
+    n_units: int,
+    seed: int,
+) -> tuple[SpikeEvent, ...]:
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("probability must be in [0, 1]")
+    rng = np.random.default_rng(seed)
+    dropped = set(np.flatnonzero(rng.random(n_units) < probability).tolist())
+    return normalize_events(event for event in events if event.unit_id not in dropped)

--- a/scripts/orion/run_tokenizer_benchmark.py
+++ b/scripts/orion/run_tokenizer_benchmark.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run the controlled ORION synthetic tokenizer benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+from orion.tokenization import run_synthetic_benchmark, write_benchmark_reports
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "config", nargs="?", default="configs/orion/tokenization_smoke.yaml"
+    )
+    parser.add_argument("--output", default="reports/orion/tokenization-smoke")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    raw = yaml.safe_load(Path(args.config).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("benchmark config must be a mapping")
+    report = run_synthetic_benchmark(raw)
+    write_benchmark_reports(report, args.output)
+    print(json.dumps(report, indent=2, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_orion_tokenization.py
+++ b/tests/test_orion_tokenization.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from orion.tokenization import (
+    AssemblyTokenizer,
+    BinnedCountTokenizer,
+    BurstTokenizer,
+    EventSpikeTokenizer,
+    ISIRelativeTimeTokenizer,
+    SynchronyPacketTokenizer,
+    VQMotifTokenizer,
+    generate_synthetic_session,
+    run_synthetic_benchmark,
+    write_benchmark_reports,
+)
+
+
+def test_synthetic_generator_is_deterministic_and_contains_all_motifs():
+    first = generate_synthetic_session(seed=7)
+    second = generate_synthetic_session(seed=7)
+    assert first.events == second.events
+    assert first.motifs == second.motifs
+    assert {motif.label for motif in first.motifs} == {
+        "burst",
+        "synchrony",
+        "assembly",
+        "leader_chain",
+        "pause_rebound",
+        "movement_volley",
+    }
+
+
+def test_interpretable_tokenizers_preserve_expected_semantics():
+    session = generate_synthetic_session(seed=3)
+    event = EventSpikeTokenizer().encode_events(session.events)
+    binned = BinnedCountTokenizer(bin_ms=10).encode_events(session.events)
+    isi = ISIRelativeTimeTokenizer().encode_events(session.events)
+    burst = BurstTokenizer().encode_events(session.events)
+    synchrony = SynchronyPacketTokenizer().encode_events(session.events)
+
+    assert len(event.token_ids) == len(session.events)
+    assert len(binned.token_ids) < len(event.token_ids)
+    assert np.any(isi.side_features["kind"] == 0)  # WAIT tokens
+    assert np.any(burst.side_features["kind"] == 1)  # BURST tokens
+    assert np.any(burst.side_features["kind"] == 2)  # PAUSE tokens
+    assert np.any(synchrony.side_features["kind"] == 1)  # population packets
+
+
+def test_fit_requiring_tokenizers_are_deterministic_and_noncollapsed():
+    train = generate_synthetic_session(seed=11)
+    test = generate_synthetic_session(seed=12)
+
+    vq_a = VQMotifTokenizer(codebook_size=8, seed=5).fit_events(train.events)
+    vq_b = VQMotifTokenizer(codebook_size=8, seed=5).fit_events(train.events)
+    np.testing.assert_allclose(vq_a.codebook_, vq_b.codebook_)
+    vq_batch = vq_a.encode_events(test.events)
+    assert vq_batch.metadata["active_codes"] > 1
+
+    assembly_a = AssemblyTokenizer(n_assemblies=3).fit_events(train.events)
+    assembly_b = AssemblyTokenizer(n_assemblies=3).fit_events(train.events)
+    np.testing.assert_allclose(assembly_a.components_, assembly_b.components_)
+    assert assembly_a.summaries_ == assembly_b.summaries_
+    assert len(assembly_a.summaries_) == 3
+    assembly_batch = assembly_a.encode_events(test.events)
+    assert len(assembly_batch.token_ids) > 0
+
+
+def test_synthetic_benchmark_scores_all_tokenizers_without_leakage(tmp_path: Path):
+    config = yaml.safe_load(Path("configs/orion/tokenization_smoke.yaml").read_text())
+    report = run_synthetic_benchmark(config)
+    scores = report["scores"]
+    assert {score["tokenizer"] for score in scores} == {
+        "event",
+        "binned_count",
+        "isi_relative",
+        "burst",
+        "synchrony",
+        "vq_motif",
+        "assembly",
+    }
+    for score in scores:
+        assert score["input_events"] > 0
+        assert score["token_count"] > 0
+        assert 0.0 <= score["motif_decoding_accuracy"] <= 1.0
+        assert 0.0 <= score["jitter_similarity"] <= 1.0
+        assert 0.0 <= score["unit_dropout_similarity"] <= 1.0
+        assert score["encode_ms"] >= 0.0
+
+    write_benchmark_reports(report, tmp_path)
+    assert (tmp_path / "metrics.json").exists()
+    assert (tmp_path / "comparison_table.csv").exists()
+    cards = (tmp_path / "tokenizer_cards.md").read_text()
+    assert "## event" in cards
+    assert "## vq_motif" in cards


### PR DESCRIPTION
## Stack

**Base:** PR #11 (`agent/quality-v3`)

This is stack layer 6. Review PR #1 → #8 → #9 → #10 → #11 → this PR.

## What changes

- adds explicit `SpikeEvent` / motif schemas and translation from provenance-rich neurOS `SignalFrame` spike representations
- implements five interpretable tokenizers: exact event, binned count, relative-ISI WAIT/SPIKE, burst/pause/rebound, and synchrony packets
- implements deterministic fit-requiring VQ motif and SVD assembly tokenizers
- refuses to infer spikes from arbitrary continuous signals
- adds deterministic synthetic sessions containing burst, synchrony, assembly, leader-chain, pause/rebound, and movement-volley motifs in Poisson background
- adds deterministic jitter and unit-dropout perturbations
- adds a common benchmark with compression, entropy, encode time, cross-session motif decoding, jitter similarity, and unit-dropout similarity
- keeps learned tokenizer fitting and motif centroids strictly on the training session, then evaluates a separately seeded test session
- captures benchmark provenance and emits `metrics.json`, `comparison_table.csv`, and `tokenizer_cards.md`
- registers all seven implementations through `neuros.tokenizers`
- adds a checked-in smoke config and benchmark runner
- adds semantic, determinism, learned-codebook non-collapse, assembly, and report-generation tests

## Scientific rule

This PR does not promote existing NeuroFM code by name. ORION implementations must earn promotion through controlled comparative evidence. The first VQ implementation is deliberately a small deterministic codebook baseline, not a large VQ-VAE, so representation hypotheses are tested before expensive model scaling.

## Review focus

1. explicit spike provenance boundary
2. train/test leakage prevention
3. stable token semantics and IDs
4. synthetic-ground-truth realism and limitations
5. fairness of the comparison harness
6. VQ/assembly determinism and non-collapse

## Validation

The ORION CI job runs contract/tokenization tests and the full seven-tokenizer synthetic smoke benchmark, then requires all three report artifacts to be non-empty.