### PR TITLE
repo: converge documentation, maturity boundaries, and qualification gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,62 @@
+## Purpose
+
+<!-- What user, scientific, runtime, or architectural problem does this change solve? -->
+
+## Architectural boundary
+
+- [ ] This change has one primary responsibility.
+- [ ] Dependency direction remains consistent with `docs/ARCHITECTURE.md`.
+- [ ] New hardware/model/research functionality enters through an existing contract/plugin/adapter boundary, or this PR explicitly justifies a contract change.
+- [ ] Stable kernel code does not gain an implicit dependency on research implementations.
+
+## Compatibility and migration
+
+<!-- Describe API/config/artifact compatibility, deprecations, migration behavior, and rollback. -->
+
+- [ ] Existing stable behavior is preserved or an explicit migration path is documented.
+- [ ] Configuration/schema changes are versioned rather than silently reinterpreted.
+- [ ] Model or representation changes preserve honest algorithm/capability identity.
+
+## Evidence tier
+
+Select the strongest evidence actually produced by this PR. Do not imply a stronger tier.
+
+- [ ] Unit
+- [ ] Contract
+- [ ] Integration
+- [ ] Replay
+- [ ] Scientific synthetic
+- [ ] Real dataset
+- [ ] Hardware qualification
+- [ ] Closed-loop qualification
+- [ ] Clinical evidence (normally outside this software repository)
+
+### Validation performed
+
+<!-- Exact commands, tests, datasets/fixtures, hardware if applicable, and important results. -->
+
+## Scientific and BCI claim boundary
+
+- [ ] Train/fit/adaptation and held-out evaluation data are separated where relevant.
+- [ ] Subject/session/site/device/montage split semantics are explicit where relevant.
+- [ ] Missing uncertainty/confidence is not fabricated.
+- [ ] Attribution/attention/sparse features are not described as causal mechanism without intervention evidence.
+- [ ] Synthetic/software evidence is not described as hardware, biological, clinical, or safety validation.
+
+## Reliability, replay, and provenance
+
+- [ ] Runtime changes expose failures, queue loss, timing, and overload behavior rather than hiding them.
+- [ ] Recording changes preserve canonical sequence/timing/quality/provenance semantics.
+- [ ] Promoted model/data/benchmark artifacts have immutable or reproducible identity where applicable.
+- [ ] A replay/regression path exists for consequential runtime/model changes where practical.
+
+## Documentation and developer experience
+
+- [ ] Current docs are updated in the same PR when public behavior changes.
+- [ ] Supported examples use current APIs and are executable.
+- [ ] Optional dependencies fail with actionable errors and do not silently alter algorithm identity.
+- [ ] `python scripts/check_repo_hygiene.py` passes for structural changes.
+
+## Known limitations / next layer
+
+<!-- What remains deliberately out of scope? What evidence or qualification is still missing? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,32 @@ jobs:
           neuros-models list --mechint-ready
           python packages/neuros-models/examples/01_inspect_eeg_conformer.py
 
+  foundation-models:
+    name: Foundation interoperability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install local foundation stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[dev]"
+      - name: Run foundation interoperability regressions
+        run: |
+          pytest -q \
+            packages/neuros-foundation/tests/test_registry_v2.py \
+            tests/test_foundation_registry_v2.py
+      - name: Exercise dependency-light foundation examples
+        run: |
+          python packages/neuros-foundation/examples/01_discover_landscape.py
+          python packages/neuros-foundation/examples/02_probe_embeddings.py
+          python packages/neuros-foundation/examples/04_neuros_bridge.py
+
   sourceweigher:
     name: Source reliability / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,40 @@ jobs:
       - name: Enforce active/product/research/archive boundaries
         run: python scripts/check_repo_hygiene.py
 
+  package-builds:
+    name: Workspace wheel builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install build frontend
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build every workspace distribution
+        run: |
+          DIST="${RUNNER_TEMP}/neuros-wheels"
+          mkdir -p "${DIST}"
+          for package in \
+            packages/neuros-core \
+            packages/neuros-drivers \
+            packages/neuros-models \
+            packages/neuros-foundation \
+            packages/neuros-ui \
+            packages/neuros-cloud \
+            packages/neuros \
+            packages/neuros-mechint \
+            packages/neuros-neurofm \
+            packages/neuros-sourceweigher \
+            packages/orion
+          do
+            python -m build --wheel --outdir "${DIST}" "${package}"
+          done
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 11
+
   kernel-contracts:
     name: Kernel contracts / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
 # Contributing to neurOS and ORION
 
-Contributions should strengthen the stable runtime/representation boundaries rather than add new cross-package coupling. The repository contains both product-oriented infrastructure and active research, so **where a change lives is part of its API contract**.
+Contributions should strengthen stable runtime, representation, and evidence boundaries rather than add new cross-package coupling. The repository contains product-oriented infrastructure and active research, so **where a change lives is part of its API contract**.
+
+Before making broad changes, read:
+
+- [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) for current package maturity;
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for dependency direction and ownership;
+- [`ROADMAP.md`](ROADMAP.md) for active qualification priorities.
 
 ## Development setup
 
@@ -37,11 +43,12 @@ Dependency direction should remain:
 ```text
 neural contracts
       <- runtime / config / recording / quality
-      <- drivers / conventional models / SDK
-      <- ORION and research packages
+      <- drivers / task models / SDK
+      <- ORION / foundation / transfer / mechanism integrations
+      <- experiments and studies
 ```
 
-A kernel package must not import a research implementation. New hardware, transforms, tokenizers, encoders, decoders, sinks, and monitors should normally enter through plugin interfaces.
+A kernel package must not import a research implementation. New hardware, transforms, tokenizers, encoders, decoders, sinks, and monitors should normally enter through plugin interfaces. Model/research ecosystems should use narrow adapters rather than making the runtime aware of their internals.
 
 ## Where changes belong
 
@@ -49,12 +56,12 @@ A kernel package must not import a research implementation. New hardware, transf
 
 Only functionality that must be shared across nearly all BCI systems:
 
-- neural data contracts,
-- runtime graph/execution semantics,
-- clock/synchronization primitives,
-- configuration contracts,
-- persistent replay semantics,
-- generic scientific/runtime quality infrastructure,
+- neural data contracts;
+- runtime graph/execution semantics;
+- clock/synchronization primitives;
+- configuration contracts;
+- persistent replay semantics;
+- generic scientific/runtime quality infrastructure;
 - plugin discovery abstractions.
 
 Avoid hardware SDKs, task-specific models, cloud vendors, large deep-learning frameworks, or research algorithms here.
@@ -63,17 +70,79 @@ Avoid hardware SDKs, task-specific models, cloud vendors, large deep-learning fr
 
 Maintained source integrations and simulated/data sources. Optional device dependencies belong in extras or external plugin distributions.
 
+A driver PR claiming hardware support should separate software contract tests from device qualification. Qualification evidence must identify the exact device, firmware, transport, OS, plugin revision, and protocol used.
+
 ### `packages/neuros-models`
 
-Conventional task-specific decoder implementations and adapters. Decoders should return `DecoderOutput`; unavailable confidence/uncertainty stays unavailable.
+Task-specific decoder implementations and model-side analysis contracts.
+
+A new or changed decoder should:
+
+1. execute the algorithm named by its public class/card;
+2. fail clearly when a required backend is unavailable rather than silently substituting another architecture;
+3. define its input axes/shape and preprocessing assumptions;
+4. return honest `DecoderOutput` capabilities;
+5. expose `encode(...)` only when the representation is well-defined;
+6. provide an `InterpretabilityManifest` if it is promoted as mechanistically inspectable;
+7. include regression tests for architecture identity and declared analysis paths.
+
+Attention maps, saliency, or sparse features must not be presented as causal mechanisms without intervention evidence.
+
+### `packages/neuros-foundation`
+
+External neural foundation-model discovery, adapters, representation probes, and fair benchmark protocols.
+
+A foundation integration should:
+
+- separate catalog metadata from locally runnable adapter status;
+- record upstream provenance/version/revision when available;
+- fail closed when a checkpoint, package, or capability is unavailable;
+- never use a different model as a silent stand-in;
+- make subject/session/site/device evaluation splits explicit;
+- distinguish upstream reported results from neurOS-reproduced evidence.
+
+Legacy wrappers may remain for compatibility, but new scientific comparisons should use verified registry/adaptor paths.
+
+### `packages/neuros-sourceweigher`
+
+Reliability-aware source/domain selection and fusion.
+
+New strategies should report more than normalized weights. Include appropriate stability, perturbation, effective-sample-size, held-out utility, or shift diagnostics. Distinguish domain similarity, predictive utility, signal quality, timing reliability, and calibrated uncertainty rather than collapsing them into an ambiguous trust score.
+
+Keep the numerical core dependency-light. HTTP/service deployment remains optional.
+
+### `packages/neuros-mechint`
+
+Causal mechanism experiments and reproducible evidence contracts.
+
+Changes should preserve the package distinction between:
+
+- software contract readiness;
+- candidate discovery;
+- causal intervention evidence;
+- held-out validation;
+- cross-deployment-unit stability;
+- empirical neuroscience/biological claims.
+
+A new adapter establishes an execution boundary, not truth about a discovered mechanism. Immutable model/data/config/artifact identity and held-out evidence are preferred over notebook-only conclusions.
 
 ### `packages/orion`
 
-Neural tokenization, representation, adaptation, and neural-intelligence interfaces/implementations that have a common evaluation path. New ORION methods require leakage-controlled comparative evidence.
+Neural tokenization, representation, adaptation, and neural-intelligence contracts/implementations that have a common evaluation path. New ORION methods require leakage-controlled comparative evidence.
 
-### Research packages and `experiments/`
+Fit, representation training, adaptation, and final evaluation partitions should remain explicit. New tokenizers or representations should be compared against simpler controls under matched downstream capacity and compute where practical.
 
-Exploratory work belongs here first. Research code can move quickly and does not automatically receive compatibility guarantees.
+### `packages/neuros-neurofm` and research packages
+
+Experimental neural foundation-model and related research belongs here before promotion. Research code may move quickly and does not automatically receive compatibility guarantees.
+
+A NeuroFM implementation moves behind a promoted ORION interface only after it satisfies the relevant contract, artifact, leakage-control, robustness, and comparative-evidence requirements.
+
+### `packages/neuros-ui` and `packages/neuros-cloud`
+
+Optional UI/API/distributed integration surfaces. These packages should consume the same config/runtime/event contracts as local execution rather than creating alternate orchestration semantics.
+
+Provider- or UI-specific claims require their own tests. Package version numbers alone do not imply kernel-level qualification.
 
 ### `examples/`
 
@@ -114,16 +183,18 @@ A plugin should:
 5. include a contract test;
 6. include real-hardware qualification evidence separately if hardware support is claimed.
 
+External plugins should not require edits to `neuros-core` unless they reveal a genuinely missing general contract.
+
 ## Runtime changes
 
-Changes to `RuntimeGraph`, `RuntimeExecutor`, queue policies, clocks, fusion, or lifecycle are foundational. They should include tests for the relevant combinations of:
+Changes to `RuntimeGraph`, `RuntimeExecutor`, queue policies, clocks, fusion, or lifecycle are foundational. They should include tests for relevant combinations of:
 
-- finite and live sources,
-- cancellation/draining,
-- failure propagation,
-- backpressure/overflow,
-- deterministic replay,
-- multimodal ordering/timing,
+- finite and live sources;
+- cancellation/draining;
+- failure propagation;
+- backpressure/overflow;
+- deterministic replay;
+- multimodal ordering/timing;
 - latency telemetry.
 
 Do not hide dropped data or runtime failures.
@@ -132,29 +203,33 @@ Do not hide dropped data or runtime failures.
 
 Recording changes must preserve or explicitly migrate:
 
-- sequence identity,
-- device/host/synchronized timestamps,
-- clock domain,
-- quality flags,
-- stream descriptors,
-- frame metadata/provenance,
+- sequence identity;
+- device/host/synchronized timestamps;
+- clock domain;
+- quality flags;
+- stream descriptors;
+- frame metadata/provenance;
 - integrity verification.
 
 NWB/Zarr interoperability should not weaken the canonical lossless replay contract.
 
 ## Scientific and ORION changes
 
-Scientific comparisons must separate fit/train/adaptation/evaluation data. A new tokenizer or representation should include appropriate controls and report more than one convenient metric.
+Scientific comparisons must separate fit/train/adaptation/discovery/evaluation data where relevant. A new tokenizer, representation, transfer method, or mechanistic claim should include appropriate controls and report more than one convenient metric.
 
 At minimum consider:
 
-- compression/token budget,
-- entropy/codebook utilization,
-- behavior/motif/task decoding,
-- neural prediction where applicable,
-- cross-session transfer,
-- jitter/unit/channel dropout robustness,
-- runtime and memory,
+- compression/token budget;
+- entropy/codebook utilization;
+- behavior/motif/task decoding;
+- neural prediction where applicable;
+- subject/session/site/device transfer;
+- few-shot calibration cost;
+- jitter/unit/channel dropout robustness;
+- artifact/montage/session-drift sensitivity;
+- runtime and memory;
+- representation geometry/domain leakage;
+- mechanism intervention/faithfulness where claimed;
 - reproducibility seed/config/data/artifact manifests.
 
 Do not describe synthetic, software-only, or public-dataset evidence as hardware or clinical validation.
@@ -163,47 +238,51 @@ Do not describe synthetic, software-only, or public-dataset evidence as hardware
 
 Use the weakest accurate evidence label:
 
-1. unit,
-2. contract,
-3. integration,
-4. replay,
-5. scientific synthetic,
-6. real dataset,
-7. hardware qualification,
-8. closed-loop qualification,
+1. unit;
+2. contract;
+3. integration;
+4. replay;
+5. scientific synthetic;
+6. real dataset;
+7. hardware qualification;
+8. closed-loop qualification;
 9. clinical evidence.
 
-A passing unit test is not evidence for a device latency claim. A hardware smoke test is not clinical validation.
+A passing unit test is not evidence for a device latency claim. A hardware smoke test is not clinical validation. A model-level causal intervention is not automatically a biological mechanism.
 
 ## Pull requests
 
-Keep PRs reviewable and intentional:
+The repository includes `.github/pull_request_template.md` to keep architectural and evidence claims reviewable.
 
-- one architectural responsibility per PR;
+Keep PRs intentional:
+
+- one primary architectural responsibility per PR;
 - no unrelated formatting churn;
 - update tests and current docs in the same PR;
 - use draft PRs for foundational changes until CI is green;
 - for stacked PRs, state the base PR and merge order in the body;
+- use expected-head guards for consequential merges where possible;
 - do not commit generated coverage, build outputs, local recordings, benchmark reports, or model artifacts unless the artifact is itself a reviewed research fixture.
 
 For a foundational PR, describe:
 
-- what contract changes,
-- why the existing abstraction was insufficient,
-- compatibility/migration behavior,
-- scientific/runtime risks,
-- tests and evidence used,
+- what contract changes;
+- why the existing abstraction was insufficient;
+- compatibility/migration behavior;
+- scientific/runtime risks;
+- tests and evidence used;
+- the strongest accurate evidence tier;
 - known limitations and the next layer.
 
 ## Repository hygiene
 
 The repository deliberately keeps the root quiet. Do not reintroduce:
 
-- root `SESSION_SUMMARY*.md` files,
-- root cleanup/completion reports,
-- root `setup.py`,
-- tracked `.coverage`,
-- migration-only scripts in active `scripts/`,
+- root `SESSION_SUMMARY*.md` files;
+- root cleanup/completion reports;
+- root `setup.py`;
+- tracked `.coverage`;
+- migration-only scripts in active `scripts/`;
 - DINO/research notebooks under `notebooks/`.
 
 Run:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 The project is organized around a deliberately small kernel: explicit neural-data contracts, device-independent streaming, timing and synchronization, typed runtime graphs, processing, decoder execution, persistent recording/replay, observability, scientific quality gates, and extension points. Research packages can innovate quickly without owning the runtime architecture.
 
-**ORION** is the complementary neural-intelligence layer for neural tokenization, learned representations, adaptive decoding, personalization, and future neural foundation-model research.
+**ORION** is the complementary neural-intelligence layer for neural tokenization, learned representations, adaptive decoding, personalization, and neural foundation-model research.
 
 > **Status:** active research and engineering platform. APIs are being stabilized and tested, but hardware qualification, clinical validation, and safety certification are separate workstreams. This repository is not a medically validated BCI system.
+
+For the current package-by-package maturity and evidence map, see [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md).
 
 ## Architecture
 
@@ -23,16 +25,16 @@ SignalFrame + StreamDescriptor       stable neural data ABI
      RuntimeGraph
  source -> transform -> fusion -> decoder -> sink
           |                    |
-          |                    +-> DecoderOutput
+          |                    +-> DecoderOutput + embeddings
           |
  timing / queues / monitoring / recording / quality
           |
           +-----------------------------+
           |                             |
           v                             v
-   neuros-models                       ORION
- conventional decoders         neural tokens / representations /
-                               adaptive neural intelligence
+   model ecosystem                    ORION
+ models / foundation /         neural tokens / representations /
+ mechint / source trust        adaptive neural intelligence
 ```
 
 The architectural boundary is intentional:
@@ -48,22 +50,22 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the detailed design.
 packages/
   neuros-core/          kernel contracts, runtime, processing, timing, recording, quality
   neuros-drivers/       hardware, simulated, and dataset sources
-  neuros-models/        task-specific decoders and model adapters
-  neuros-foundation/    adapters for external neural representation/foundation models
+  neuros-models/        task-specific decoders and mechanistic analysis surfaces
+  neuros-foundation/    neural foundation-model discovery, adapters, probes, benchmarks
+  neuros-sourceweigher/ reliability-aware source/domain weighting and fusion
   neuros-ui/            dashboard/API/visualization surfaces
   neuros-cloud/         optional distributed/cloud integrations
   neuros/               user-facing SDK and CLI
   orion/                ORION tokenization and neural-intelligence interfaces
-  neuros-neurofm/       experimental neural foundation-model research
-  neuros-mechint/       mechanistic-interpretability research toolkit
-  neuros-sourceweigher/ focused service component
+  neuros-neurofm/       experimental native neural foundation-model research
+  neuros-mechint/       causal mechanism and reproducible evidence framework
 
 configs/                versioned runtime, quality, and ORION experiment configs
 examples/               supported executable examples; CI is required for promotion here
 tutorials/              maintained learning material
 notebooks/              transitional BCI notebooks; not automatically a stable API surface
 experiments/            research code, notebooks, papers, and exploratory evaluations
-docs/                   current architecture and guides
+docs/                   current architecture, maturity map, and guides
 docs/archive/           historical plans, migration reports, and session notes
 scripts/                current bootstrap, benchmark, quality, and developer utilities
 scripts/archive/        historical migration utilities
@@ -178,6 +180,39 @@ neuros.monitors
 
 This keeps the kernel independent of concrete hardware, decoder, storage, and ORION implementations.
 
+## Task-specific decoders and mechanistic analysis
+
+`neuros-models` provides classical baselines plus faithful PyTorch EEGNet, EEG Conformer, Transformer, CNN, LSTM, and multimodal fusion decoders. Maintained deep models expose structured probabilities/logits, pooled embeddings, and stable mechanistic-analysis manifests rather than changing algorithm identity based on which optional framework happens to be installed.
+
+```bash
+neuros-models list
+neuros-models list --mechint-ready
+neuros-models show eeg-conformer
+neuros-models doctor
+```
+
+An inspectable model can opt into the common `neuros-mechint` causal experiment layer through a manifest-validated adapter. A declared analysis surface identifies where an intervention can be performed; it does not itself establish biological or causal meaning.
+
+## Neural foundation-model interoperability
+
+`neuros-foundation` is the discovery, adapter, representation-probe, and benchmark boundary for external neural foundation-model ecosystems. It separates catalog metadata from locally runnable integrations and fails closed when an upstream implementation is unavailable.
+
+The package includes representation diagnostics such as effective rank, anisotropy, linear CKA, invariance, domain leakage, linear probing, pairwise similarity, sample-efficiency curves, and protocol fingerprints that make subject/session/site/device split semantics explicit.
+
+This package is for fair interoperability and evaluation. It does not turn third-party marketing claims into neurOS benchmark evidence.
+
+## Reliability-aware source transfer
+
+`neuros-sourceweigher` estimates how much a target should trust candidate subjects, sessions, sites, devices, models, or sensor streams. It includes constrained source-mixture estimation, transparent distance and Gibbs-risk baselines, online drift adaptation, representation-space weighting, MMD/Riemannian distribution methods, stability diagnostics, and a native runtime fusion operator.
+
+The core package is local-first and NumPy-only; its HTTP service is optional.
+
+## Mechanistic evidence
+
+`neuros-mechint` is a causal experiment and evidence framework for studying artificial and neural-data model mechanisms. It maintains intervention, faithfulness, held-out evidence, factorial comparison, correspondence, replication, dose-response, and artifact-provenance contracts.
+
+Its release status deliberately distinguishes **software contract readiness** from **empirical evidence completion**. Passing a software gate does not establish a real neural mechanism.
+
 ## ORION tokenization
 
 ORION begins at the representation boundary:
@@ -203,14 +238,18 @@ The benchmark emits `metrics.json`, `comparison_table.csv`, and `tokenizer_cards
 
 ## Quality and evidence
 
-GitHub Actions separates several evidence layers:
+GitHub Actions currently separates several software evidence layers:
 
 1. kernel contracts on Python 3.10, 3.11, and 3.12,
 2. installed BCI/config/CLI/runtime smoke execution,
 3. exact recording/replay plus NWB/Zarr interoperability,
 4. deterministic scientific and latency quality gates,
-5. ORION contracts and the controlled tokenizer benchmark,
-6. repository hygiene.
+5. task-model/mechanistic-analysis contracts,
+6. foundation-model interoperability regressions and dependency-light examples,
+7. SourceWeigher regression tests across Python 3.10, 3.11, and 3.12,
+8. ORION contracts and the controlled tokenizer benchmark,
+9. mech-int scientific software gates, ecosystem compatibility, and executed CPU tutorials,
+10. repository hygiene.
 
 Generic CI quality thresholds are intentionally distinct from hardware-specific qualification. Device/model/application latency and reliability claims require a recorded qualification profile with the relevant hardware, firmware, data, and artifact metadata.
 
@@ -230,7 +269,8 @@ Historical cleanup reports, migration plans, implementation notes, and session s
 
 ## Roadmap and contributing
 
-- [`ROADMAP.md`](ROADMAP.md) tracks the current architectural sequence and post-refactor gates.
+- [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) is the current capability/maturity map.
+- [`ROADMAP.md`](ROADMAP.md) tracks the next qualification and productization sequence.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) defines package boundaries, test expectations, plugin rules, and research-promotion requirements.
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,10 @@
 # neurOS + ORION Roadmap
 
-This roadmap describes the current architectural sequence and the evidence required to promote new capabilities. Historical plans and session reports live under `docs/archive/` and are not active roadmaps.
+This roadmap describes the active qualification and productization sequence for neurOS and ORION. Historical plans and session reports live under `docs/archive/` and are not active roadmaps. For the package-by-package maturity snapshot, see [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md).
 
-## Current refactor stack
+## Completed convergence foundation
 
-The current kernel-to-research refactor is intentionally split into reviewable stacked pull requests. Merge bottom-up only after reviewing and validating each layer:
+The 2026 architecture/refactor sequence is now merged into `main`:
 
 1. **PR #1: neurOS kernel and ORION contracts**
    - canonical `SignalFrame`, stream metadata, decoder outputs, queue policies, timing, config/plugin foundations, replay primitives, workspace packaging.
@@ -20,8 +20,16 @@ The current kernel-to-research refactor is intentionally split into reviewable s
    - seven tokenizer families, synthetic motif ground truth, fit/test separation, robustness benchmarks, tokenizer evidence reports.
 7. **PR #13: Repository v3**
    - product/research/archive separation, historical cleanup, current documentation, and repository-hygiene enforcement.
+8. **PR #14: neuros-mechint v1**
+   - reproducible causal-evidence contracts, artifact schemas, held-out evidence, replication and explicit software-vs-empirical release status.
+9. **PR #16: neural foundation-model interoperability**
+   - capability registry, fail-closed adapters, representation probes, protocol fingerprints, and fair cross-model benchmark surfaces.
+10. **PR #17: SourceWeigher reliability engine**
+    - constrained source mixtures, distribution/reliability methods, online drift adaptation, diagnostics, and runtime fusion.
+11. **PR #18: mechanistically inspectable task models**
+    - faithful PyTorch decoder implementations, analysis manifests, model embeddings, neurOS-to-mech-int adapter, and dedicated model/mech-int CI.
 
-The stack is complete only when the exact head of every PR has green CI and each PR remains reviewable relative to the branch immediately below it.
+The repository therefore no longer needs another broad architectural rewrite. The next phase is **qualification, release discipline, evidence on real data/hardware, and a sharper public developer experience**.
 
 ---
 
@@ -41,22 +49,19 @@ SignalFrame + StreamDescriptor
         |
         v
 RuntimeGraph
-  acquisition
-  synchronization
-  processing
-  fusion
-  inference
-  sinks
+ acquisition | synchronization | transforms | fusion | inference | sinks
         |
-        +---------------> recording / replay / quality evidence
+        +---------------------> recording / replay / quality evidence
+        |
+        +---------------------> task models / embeddings
+        |                           |
+        |                           +-> foundation-model interoperability
+        |                           +-> SourceWeigher transfer reliability
+        |                           +-> mech-int causal evidence
         |
         v
 ORION representation boundary
-  tokenization
-  neural encoders
-  adaptation
-  personalization
-  interpretable state
+ tokenization | neural encoders | adaptation | personalization
         |
         v
 application / closed-loop controller
@@ -66,7 +71,31 @@ neurOS should make neural computation operationally predictable. ORION should ma
 
 ---
 
-# Post-stack Phase A: hardware qualification
+# Priority 0: public developer preview and release discipline
+
+## Goal
+
+Turn the monorepo from a sophisticated internal platform into something an external BCI researcher or engineer can install, understand, test, extend, and trust within one session.
+
+## Work
+
+- keep `docs/PROJECT_STATUS.md` as the canonical package maturity map;
+- add clean-install build/wheel checks for every package promoted as maintained;
+- verify local workspace installs separately from published-package installs;
+- define semantic-versioning and deprecation policy for stable contracts;
+- publish a package compatibility matrix for `neuros-core`, `neuros`, `neuros-models`, `neuros-foundation`, `neuros-sourceweigher`, `neuros-mechint`, and `neuros-orion`;
+- add a generated or tested configuration/schema reference;
+- provide one supported end-to-end developer journey covering install -> validate -> run -> record -> replay -> inspect;
+- provide one plugin-author journey that creates an external source/transform/decoder without kernel edits;
+- add dedicated qualification lanes before `neuros-ui` or `neuros-cloud` are presented as equally mature with the kernel.
+
+## Exit gates
+
+A clean external environment can install the documented profile, run the supported examples, build the maintained distributions, and reproduce the same contract checks without relying on an editable monorepo checkout.
+
+---
+
+# Priority 1: hardware qualification
 
 ## Goal
 
@@ -87,75 +116,82 @@ A device is called **qualified** only when its exact hardware/firmware/software 
 
 ---
 
-# Post-stack Phase B: model artifacts and decoder safety
+# Priority 2: durable model artifacts and decoder deployment safety
 
 ## Goal
 
-Make model deployment reproducible, inspectable, and safe enough for long-lived BCI experiments.
+Make model deployment reproducible, inspectable, rollbackable, and safe enough for long-lived BCI experiments.
 
 ## Work
 
-- replace arbitrary trusted-environment pickle loading in production paths with backend-specific artifacts plus stable manifests;
-- include architecture/input contract, training dataset hashes, subject/session scope, calibration state, metrics, Git SHA, package versions, and artifact SHA-256;
+- replace trusted-environment pickle persistence in promoted paths with backend-specific artifacts plus stable manifests;
+- store architecture/configuration, input contract, `state_dict` or backend-native weights, preprocessing, training dataset hashes, subject/session scope, calibration state, metrics, Git SHA, package versions, and artifact SHA-256;
+- bind the `InterpretabilityManifest` fingerprint to the artifact so layer/path changes cannot silently invalidate mechanistic evidence;
 - add decoder compatibility checks against stream/representation schemas before runtime start;
 - add probability/calibration capability tests and preserve `confidence=None` when uncertainty is unavailable;
-- implement immutable model registry identifiers and explicit promotion stages such as experimental, validated, qualified;
+- implement immutable model registry identifiers and explicit stages such as experimental, validated, and qualified;
 - add rollback and replay-based regression tests for every promoted artifact.
 
 ## Exit gates
 
-A promoted decoder must be reproducibly loadable, schema-compatible, replay-tested, and associated with a complete provenance manifest.
+A promoted decoder is reproducibly loadable, schema-compatible, replay-tested, mechanism-manifest-compatible where applicable, and associated with a complete provenance manifest.
 
 ---
 
-# Post-stack Phase C: real multimodal timing and fusion
+# Priority 3: ORION and model benchmarks on real neural datasets
 
 ## Goal
 
-Turn explicit clock semantics into best-in-class multimodal BCI synchronization.
+Determine which tokenization, representation, transfer, and mechanistic ideas survive contact with real deployment-unit variation.
+
+## Work
+
+- add NWB/data adapters using the canonical replay/data contracts;
+- evaluate across multiple preparations, sessions, animals/subjects, sites, devices/montages, and behavioral tasks where scientifically appropriate;
+- benchmark task decoders and foundation representations under the same subject/session-disjoint protocols;
+- include held-out neural prediction, behavior/state decoding, cross-session transfer, few-shot calibration, and compute-normalized metrics;
+- evaluate robustness to jitter, unit/channel dropout, sorting instability, rate shifts, artifacts, montage changes, and session drift;
+- keep tokenizer fit data, representation-model training data, adaptation data, mechanistic-discovery data, and final held-out evaluation data distinct;
+- compare ORION tokenization against event, count, rate-summary, randomized, and architecture-matched controls;
+- integrate SourceWeigher as an explicitly evaluated transfer strategy rather than an unconditional preprocessing step;
+- test whether candidate mechanisms remain causal and stable across subjects/sessions/devices instead of only within one trained model distribution.
+
+## NeuroFM promotion rule
+
+Existing `neuros-neurofm` implementations are research candidates, not automatically ORION components. A NeuroFM component moves behind a promoted ORION interface only when it:
+
+1. satisfies interface and artifact contracts;
+2. has leakage-controlled evidence;
+3. improves a meaningful metric or offers a clear efficiency/interpretability advantage;
+4. remains stable under perturbation and cross-session tests;
+5. has reproducible compute/data manifests;
+6. is compared against simpler baselines under matched budgets.
+
+---
+
+# Priority 4: multimodal timing and reliability-aware fusion
+
+## Goal
+
+Turn explicit clock and source-reliability semantics into best-in-class multimodal BCI synchronization and fusion.
 
 ## Work
 
 - extend the affine clock estimator to multiple hardware clock domains and intermittent synchronization observations;
 - propagate synchronization uncertainty through fusion decisions;
-- add fusion policies that can reject stale or temporally incompatible frames rather than blindly reuse the latest sample;
+- add fusion policies that reject stale or temporally incompatible frames rather than blindly reuse the latest sample;
+- attach contributing-frame provenance and timing uncertainty to fusion outputs;
+- combine timing/quality evidence with SourceWeigher reliability without conflating domain similarity, task utility, signal quality, and predictive uncertainty;
 - benchmark synthetic known-offset/drift scenarios and recorded multimodal sessions;
-- expose timing uncertainty to ORION so learned representations can distinguish neural uncertainty from biological variation.
+- expose timing/reliability uncertainty to ORION so learned representations can distinguish system uncertainty from biological variation.
 
 ## Exit gates
 
-Fusion outputs must report which source frames contributed, their synchronized timestamps, and the uncertainty under which the fusion decision was made.
+Fusion outputs report contributing source frames, synchronized timestamps, quality/reliability evidence, and the uncertainty under which the fusion decision was made.
 
 ---
 
-# Post-stack Phase D: ORION on real neural datasets
-
-## Goal
-
-Determine which neural tokenization and representation strategies survive contact with real data.
-
-## Work
-
-- add NWB spike-event adapters using the canonical replay/data contracts;
-- evaluate tokenizers on multiple preparations, sessions, animals/subjects, and behavioral tasks;
-- add held-out-unit prediction, next-window neural prediction, behavior/state decoding, cross-session transfer, few-shot adaptation, and compute-normalized metrics;
-- evaluate robustness to jitter, unit dropout, sorting instability, rate shifts, and session drift;
-- separate tokenizer fit data, representation-model training data, adaptation data, and held-out evaluation data;
-- compare ORION tokenization against event, count, rate-summary, and randomized controls under matched model budgets.
-
-## NeuroFM promotion rule
-
-Existing `neuros-neurofm` implementations are research candidates, not automatically ORION components. A NeuroFM component moves behind an ORION interface only when it:
-
-1. satisfies the interface and artifact contracts;
-2. has leakage-controlled evidence;
-3. improves a meaningful metric or offers a clear efficiency/interpretability advantage;
-4. remains stable under perturbation and cross-session tests;
-5. has reproducible compute and data manifests.
-
----
-
-# Post-stack Phase E: adaptive and personalized BCI intelligence
+# Priority 5: adaptive and personalized BCI intelligence
 
 ## Goal
 
@@ -166,17 +202,18 @@ Make adaptation explicit, constrained, reversible, and scientifically measurable
 - implement adaptation proposal/review/apply lifecycle rather than hidden online mutation;
 - distinguish calibration, unsupervised domain adaptation, supervised online learning, and user-specific personalization;
 - maintain baseline and candidate model states with rollback;
-- evaluate adaptation under simulated nonstationarity, electrode/channel degradation, and behavioral drift;
+- evaluate adaptation under simulated and real nonstationarity, electrode/channel degradation, and behavioral drift;
 - log every adaptation trigger, training window, objective, resulting artifact, and before/after metrics;
-- add mechanistic-interpretability hooks for explaining what state changed and which channels/tokens drove a decision.
+- use mechanistic evidence as an additional stability signal only after its predictive value is validated;
+- measure calibration cost and time-to-usable-control as first-class user-facing metrics.
 
 ## Exit gates
 
-No adaptive component may silently alter a promoted decoder. Every update must be attributable, replayable, bounded, and reversible.
+No adaptive component silently alters a promoted decoder. Every update is attributable, replayable, bounded, reversible, and evaluated against a no-adaptation baseline.
 
 ---
 
-# Post-stack Phase F: closed-loop safety plane
+# Priority 6: closed-loop safety plane
 
 ## Goal
 
@@ -185,7 +222,7 @@ Make neurOS suitable as a research substrate for increasingly consequential clos
 ## Work
 
 - introduce a first-class safety/constraint node type or equivalent policy layer;
-- add action-rate limits, deadman states, confidence/quality gating, stale-data rejection, and emergency stop semantics;
+- add action-rate limits, deadman states, confidence/quality gating, stale-data rejection, and emergency-stop semantics;
 - distinguish advisory decoder outputs from commands sent to an actuator;
 - create hardware-in-the-loop simulation before physical closed-loop control;
 - record proposed actions, accepted actions, rejected actions, reasons, neural quality, decoder state, and timing;
@@ -193,29 +230,29 @@ Make neurOS suitable as a research substrate for increasingly consequential clos
 
 ## Exit gates
 
-A closed-loop demo must fail safe under source loss, runtime overload, decoder failure, stale synchronization, and explicit user/operator stop.
+A closed-loop demo fails safe under source loss, runtime overload, decoder failure, stale synchronization, policy rejection, and explicit user/operator stop.
 
 ---
 
-# Post-stack Phase G: developer ecosystem and productization
+# Priority 7: ecosystem and productization
 
 ## Goal
 
-Make the platform useful to researchers and BCI developers beyond this repository.
+Make the platform valuable to researchers, neurotechnology teams, and BCI developers beyond this repository while preserving an open, inspectable core.
 
 ## Work
 
 - stabilize versioned plugin APIs and compatibility policy;
-- publish a small set of independently installable, well-tested device and decoder plugins;
-- provide supported examples for motor imagery, replay analysis, multimodal fusion, and ORION tokenization;
-- generate schema-aware configuration documentation and editor support;
-- add package build/wheel/clean-install release gates;
-- establish semantic versioning and deprecation periods for stable contracts;
-- build UI surfaces from the same config/runtime/event APIs rather than separate orchestration logic.
+- publish independently installable, well-tested device and decoder plugins;
+- provide supported examples for motor imagery, replay analysis, multimodal fusion, model/mechanism auditing, foundation representations, SourceWeigher transfer, and ORION tokenization;
+- build UI surfaces from the same config/runtime/event APIs rather than separate orchestration logic;
+- define a remote experiment/telemetry control plane without moving core real-time execution into the cloud;
+- create machine-readable qualification and benchmark artifacts suitable for CI, papers, and enterprise audit trails;
+- keep optional commercial integrations above open kernel contracts rather than forking the architecture.
 
 ## Exit gates
 
-A new contributor should be able to install a standard profile, validate a config, run a mock experiment, record/replay it, inspect metrics, and add a plugin without modifying kernel code.
+A new contributor can add a plugin without kernel changes, and a team can reproduce the same experiment/qualification artifact on another machine or site with explicit compatibility/provenance information.
 
 ---
 
@@ -237,16 +274,17 @@ No lower tier should be described using language that implies a higher tier.
 
 ---
 
-# Near-term priority after merging the stack
+# Immediate execution sequence
 
 The highest-value next sequence is:
 
-1. hardware qualification manifests and one real EEG device pipeline;
-2. durable model-artifact loading and replay regression;
-3. real NWB spike dataset adapter for ORION tokenization;
-4. cross-session ORION tokenizer benchmark;
-5. multimodal synchronization uncertainty and stale-frame-aware fusion;
-6. adaptation lifecycle with rollback and provenance;
-7. closed-loop safety policy layer.
+1. finish the public developer-preview/release gates;
+2. define the model artifact v1 format and remove pickle from promoted deployment paths;
+3. qualify one real EEG device end to end using a machine-readable hardware manifest;
+4. add one real public neural dataset to the ORION/model benchmark harness;
+5. run subject/session-disjoint decoder + foundation + SourceWeigher + mechanism-stability comparisons;
+6. add uncertainty-aware multimodal fusion;
+7. build adaptation lifecycle with rollback and provenance;
+8. add a closed-loop safety policy layer before more consequential demos.
 
-The guiding question remains: **what are the smallest stable abstractions from which serious BCI systems can be built, measured, replayed, and improved?**
+The guiding question remains: **what are the smallest stable abstractions from which serious BCI systems can be built, measured, replayed, falsified, and improved?**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,8 +1,8 @@
 # neurOS API Surface
 
-This document is a maintained map of the stable architectural surfaces. It is intentionally smaller than the historical hand-written API catalog, which is preserved under `docs/archive/development/API_REFERENCE_PRE_KERNEL.md`.
+This document is a maintained map of the stable and promoted architectural surfaces. It is intentionally smaller than a generated symbol catalog. For exact signatures, use the package source/docstrings for the installed version.
 
-For exact signatures, use the package source/docstrings for the installed version. The purpose of this page is to make ownership and dependency direction unambiguous.
+The purpose of this page is to make ownership, dependency direction, and evidence boundaries unambiguous.
 
 ## `neuros.contracts`
 
@@ -31,6 +31,8 @@ Describes stream modality, sample rate, channel names/types/units, device/manufa
 
 Structured inference result. Confidence and uncertainty are optional. neurOS does not fabricate certainty when a decoder cannot supply it.
 
+A decoder may also expose probabilities, logits, pooled embeddings, model identity/version, inference timing, and structured metadata.
+
 ### Operator protocols
 
 The kernel defines structural contracts for sources, transforms, decoders, sinks, monitors, and synchronization-related behavior. Implementations live in plugin packages rather than the kernel.
@@ -39,9 +41,9 @@ The kernel defines structural contracts for sources, transforms, decoders, sinks
 
 ### `RuntimeGraph`
 
-Typed directed acyclic graph of `RuntimeNode` and `RuntimeEdge` objects.
+Maintained typed directed acyclic graph of `RuntimeNode` and `RuntimeEdge` objects.
 
-Node kinds:
+Node kinds include:
 
 - source
 - transform
@@ -54,9 +56,9 @@ Edges carry bounded queue capacity and explicit overflow policy.
 
 ### `RuntimeExecutor`
 
-Native execution engine shared by live, replay, single-stream, and multimodal paths.
+Native execution engine shared by live, replay, single-stream, and standard multimodal paths.
 
-Key methods:
+Key usage:
 
 ```python
 await executor.start()
@@ -64,11 +66,8 @@ async for output in executor.outputs():
     ...
 await executor.stop()
 
-# finite graph
-snapshot = await executor.run()
-
-# timed graph
-snapshot = await executor.run_for(2.0)
+snapshot = await executor.run()          # finite graph
+snapshot = await executor.run_for(2.0)   # timed graph
 ```
 
 Snapshots include runtime state, failures, per-node latency/activity, and per-edge accepted/dropped/high-water metrics.
@@ -114,7 +113,7 @@ neuros.sinks
 neuros.monitors
 ```
 
-Use the CLI to inspect the actual installed set:
+Inspect the actual installed set with:
 
 ```bash
 neuros plugins --json
@@ -137,16 +136,16 @@ Custom historical processing-agent classes remain an explicit migration escape h
 
 ### `SessionArchiveWriter`
 
-Dependency-free, lossless persistent session writer for `SignalFrame` streams.
+Dependency-light, lossless persistent session writer for `SignalFrame` streams.
 
-Records:
+Records can include:
 
-- exact frame timing and sequence fields,
-- stream descriptors,
-- quality flags and metadata,
-- per-frame payload SHA-256,
-- config hash,
-- Git SHA and package versions,
+- exact frame timing and sequence fields;
+- stream descriptors;
+- quality flags and metadata;
+- per-frame payload SHA-256;
+- config hash;
+- Git SHA and package versions;
 - runtime metrics and model-artifact references.
 
 ### `SessionArchiveReader`
@@ -183,7 +182,7 @@ Deterministic fault injection for packet loss, channel dropout, timestamp jitter
 
 Capture Git/config/data/artifact/package/host provenance for benchmark evidence.
 
-### scientific probes
+### Scientific probes
 
 Small deterministic known-ground-truth probes validate that processing behavior retains expected scientific semantics.
 
@@ -191,7 +190,7 @@ Small deterministic known-ground-truth probes validate that processing behavior 
 
 Drivers implement the source boundary. Hardware-specific dependencies belong in driver extras or external plugin packages.
 
-All maintained drivers should expose or be adaptable to:
+Maintained drivers should expose or be adaptable to:
 
 ```python
 source.descriptor
@@ -203,17 +202,191 @@ await source.stop()
 
 Legacy tuple iteration may remain for compatibility but is not the long-term neural ABI.
 
+Importability is not hardware qualification. Named device/firmware/transport combinations require separate qualification evidence.
+
 ## `neuros.models`
 
-Conventional decoders live here. Maintained decoders should expose `infer(X) -> DecoderOutput` and capabilities describing probabilities, uncertainty, online fit, embeddings, or state when supported.
+`neuros-models` owns task-specific decoder implementations and the model-side contract for representation and mechanistic analysis.
 
-A training-free `ThresholdDecoder` exists for installation/config/runtime smoke tests. It is not a scientific BCI baseline.
+### `BaseModel`
+
+Maintains the familiar training/prediction surface and structured `infer(...) -> DecoderOutput` behavior.
+
+### Neural decoders
+
+Promoted deep families include:
+
+- `EEGNetModel`
+- `EEGConformerModel`
+- `TemporalTransformerModel` / `TransformerModel`
+- `CNNModel`
+- `LSTMModel`
+- `AttentionFusionModel`
+
+Classical baselines include SVM, random forest, k-NN, gradient-boosting, and simple-classifier surfaces.
+
+A model name is expected to match the algorithm actually executed. Optional backend absence should fail clearly rather than silently substitute another model family.
+
+### `InterpretabilityManifest`
+
+An explicit model-side declaration of stable analysis surfaces.
+
+Related types include:
+
+- `AnalysisCapability`
+- `AnalysisSurface`
+- `InterpretabilityManifest`
+- `MechanisticallyInspectable`
+- `validate_manifest_paths(...)`
+
+A manifest can describe architecture family, backend, input axes, component paths, semantic roles, tensor axes, supported operations, recommended analyses, and limitations.
+
+A manifest identifies valid intervention locations. It does **not** certify the meaning or biological interpretation of those components.
+
+### Representations
+
+Maintained neural decoders may expose `encode(X)` to return pooled representations. Structured inference can include the same embedding alongside logits/probabilities and a model/analysis-manifest fingerprint.
+
+This representation seam can be consumed by foundation probes, SourceWeigher, or mech-int without making those packages dependencies of the model layer.
+
+### Model discovery
+
+```bash
+neuros-models list
+neuros-models list --mechint-ready
+neuros-models show eeg-conformer
+neuros-models doctor
+```
+
+`DecoderCard`, `list_decoder_cards()`, and `get_decoder_card(...)` provide a programmatic catalog surface.
+
+### Mechanistic bridge
+
+Inspectable models can create a `neuros-mechint` adapter when the optional research package is installed. The bridge validates the model's declared manifest paths against the actual backend module graph before an experiment begins.
+
+## `neuros.foundation_models`
+
+`neuros-foundation` is a registry-first interoperability and evaluation layer for external neural foundation-model ecosystems.
+
+### Capability/catalog types
+
+Promoted schema types include:
+
+- `FoundationModelCard`
+- `NeuralModality`
+- `ModelTask`
+- `ModelStatus`
+- `AccessLevel`
+- `AdapterAvailability`
+- `IntegrationLevel`
+
+`DEFAULT_MODEL_CARDS` and `catalog_by_id(...)` expose curated model metadata.
+
+Catalog presence is not equivalent to local execution or reproduced upstream performance.
+
+### Adapter layer
+
+Key adapter interfaces/types include:
+
+- `FoundationAdapter`
+- `CallableAdapter`
+- `ZunaAdapter`
+- `NeuroFMXAdapter`
+- `ModelRegistry`
+- `DEFAULT_REGISTRY`
+- `build_default_registry()`
+
+Availability errors such as `AdapterUnavailableError` and `UnsupportedCapabilityError` provide fail-closed behavior when an integration or capability is unavailable.
+
+Historical wrappers such as POYO/NDT/CEBRA/Neuroformer classes remain for compatibility, but the modern registry/adapters should be preferred for scientific comparisons.
+
+### Representation probes
+
+Maintained probes include:
+
+- `effective_rank(...)`
+- `mean_pairwise_cosine(...)`
+- `linear_cka(...)`
+- `pairwise_cka(...)`
+- `invariance_score(...)`
+- `linear_probe(...)`
+- `domain_leakage_probe(...)`
+- `representation_report(...)`
+
+These characterize representation geometry or predictive utility. They are not by themselves causal mechanism tests.
+
+### Benchmark protocol
+
+`EvaluationProtocol`, `BenchmarkReport`, `benchmark_embeddings(...)`, and `sample_efficiency_curve(...)` provide protocol-stamped comparison surfaces so subject/session/site/device split semantics are explicit rather than buried in notebook code.
+
+### `FoundationEmbeddingDecoder`
+
+Wrap a frozen or callable representation encoder with a neurOS task readout so representation models can participate in standard decoder/runtime comparisons without being misrepresented as native task architectures.
+
+## `neuros_sourceweigher`
+
+`neuros-sourceweigher` owns reliability-aware source/domain selection and fusion.
+
+### Core weighting
+
+- `SourceWeigher`
+- `WeightingResult`
+- `WeightingDiagnostics`
+- `project_to_simplex(...)`
+
+### Strategies
+
+- `DistanceWeigher`
+- `GibbsRiskWeigher`
+- `OnlineSourceWeigher`
+- `MMDSourceWeigher`
+- `RiemannianCovarianceWeigher`
+
+Supporting distribution metrics include `rbf_mmd2(...)` and `spd_affine_invariant_distance(...)`.
+
+### Representation/runtime integration
+
+- `RepresentationSourceWeigher`
+- `ReliabilityWeightedFusion`
+- `RunningFeatureSummary`
+- `summarize_features(...)`
+
+The package can therefore weight subjects/sessions/sites/models in representation space or provide reliability-aware runtime fusion without moving the numerical core behind an HTTP dependency.
+
+### Diagnostics
+
+Diagnostics include effective sample size, leave-one-source-out stability, target perturbation sensitivity, and weight-shift measures. A plausible weighting result should be accompanied by stability evidence rather than only a normalized vector.
+
+The optional service boundary is installed separately with `neuros-sourceweigher[service]`.
+
+## `neuros_mechint`
+
+`neuros-mechint` is the causal mechanism and evidence layer.
+
+It owns research contracts for:
+
+- activation capture/replacement and causal intervention;
+- circuit/path faithfulness;
+- held-out evidence packs;
+- factorial comparisons;
+- feature correspondence and causal substitution;
+- replication and hierarchical uncertainty;
+- dose-response/intervention sweeps;
+- immutable model/data/config/artifact provenance.
+
+### `NeurOSModelAdapter`
+
+Native duck-typed bridge from an inspectable neurOS decoder to the generic PyTorch intervention machinery. It validates the decoder's complete analysis manifest before use and deliberately does not make `neuros-mechint` depend directly on `neuros-models`.
+
+External ecosystems such as TransformerLens, NNsight, and SAELens are integrated through similarly narrow adapters.
+
+**Claim boundary:** tool integration, attribution, sparse features, or a causal effect in one trained model do not establish a stable biological mechanism. Empirical claims require appropriate held-out and cross-deployment-unit evidence.
 
 ## `orion`
 
 ORION is intentionally separate from runtime execution.
 
-Core contracts:
+Core contracts include:
 
 - `NeuroTokenizer`
 - `NeuroTokenBatch`
@@ -222,7 +395,7 @@ Core contracts:
 - `AdaptiveDecoder`
 - `AdaptationProposal`
 
-Initial tokenizers:
+Initial tokenizers include:
 
 - `EventSpikeTokenizer`
 - `BinnedCountTokenizer`
@@ -236,7 +409,7 @@ Fit-requiring implementations must be fit explicitly on training data before enc
 
 ## CLI
 
-Primary commands:
+Primary neurOS commands:
 
 ```text
 neuros doctor
@@ -250,17 +423,28 @@ neuros inspect SESSION
 neuros replay SESSION --config CONFIG
 ```
 
+Additional package CLIs include:
+
+```text
+neuros-models ...
+neuros-foundation ...
+neuros-mechint ...
+```
+
 Legacy model-registry/demo commands remain for compatibility but should not become the architecture for new functionality.
 
-## Stability rule
+## Stability and dependency rule
 
-The stable direction is:
+The intended direction is:
 
 ```text
 contracts
-   <- runtime / config / quality
-   <- drivers / models / SDK
-   <- ORION and other research packages
+   <- runtime / config / recording / quality
+   <- drivers / task models / SDK
+   <- ORION and model/evidence integrations
+   <- experiments / research studies
 ```
 
-Kernel packages must not import research implementations. New capabilities should enter through contracts and plugin interfaces rather than new cross-package coupling.
+Kernel packages must not import research implementations. New capabilities should enter through contracts and plugin/adapter interfaces rather than new cross-package coupling.
+
+For the current maturity of each package, see [`PROJECT_STATUS.md`](PROJECT_STATUS.md). For the next qualification sequence, see [`../ROADMAP.md`](../ROADMAP.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,43 +1,56 @@
-# neurOS Kernel Architecture
+# neurOS + ORION Architecture
 
-This document is the architectural source of truth for the neurOS runtime.
+This document is the architectural source of truth for the maintained neurOS runtime and its boundaries with ORION and the research/model ecosystem.
 
 ## 1. Design objective
 
-neurOS should provide the smallest stable set of abstractions needed to construct reliable BCI systems across changing hardware, signal modalities, models, and research ideas.
+neurOS should provide the smallest stable set of abstractions needed to construct reliable, replayable, measurable brain-computer interface systems across changing hardware, signal modalities, models, and research ideas.
 
-The kernel is intentionally narrower than the repository. Research packages are allowed to move quickly. Kernel contracts should move slowly.
+The kernel is intentionally narrower than the repository. Research packages may move quickly. Runtime contracts should move slowly and accumulate evidence before they are broadened.
+
+The governing separation is:
+
+- **neurOS runtime plane:** reliable acquisition, timing, execution, recording, replay, configuration, quality, and observability;
+- **model and evidence plane:** task decoders, representation interoperability, source reliability, and causal/mechanistic analysis;
+- **ORION intelligence plane:** neural tokenization, learned representations, adaptation, and personalization;
+- **application/safety plane:** task behavior and, eventually, constrained closed-loop actions.
 
 ## 2. System boundary
 
 ```text
-┌──────────────────────────────────────────────────────────────────────┐
-│                         Applications                                 │
-│ communication | prosthetics | research | adaptive UX | experiments  │
-└───────────────────────────────┬──────────────────────────────────────┘
-                                │
-                         user-facing SDK
-                                │
-             ┌──────────────────┴──────────────────┐
-             │                                     │
-             ▼                                     ▼
-┌─────────────────────────┐           ┌──────────────────────────────┐
-│         neurOS          │           │            ORION             │
-│                         │           │                              │
-│ acquisition             │           │ tokenization                 │
-│ data contracts          │◀─────────▶│ learned representations      │
-│ synchronization         │           │ adaptive decoding            │
-│ processing/runtime      │           │ personalization              │
-│ recording/replay        │           │ foundation-model research    │
-│ observability           │           │                              │
-└────────────┬────────────┘           └──────────────┬───────────────┘
-             │                                       │
-             └─────────────────┬─────────────────────┘
-                               ▼
-                    Stable neural contracts
+┌────────────────────────────────────────────────────────────────────────────┐
+│                              Applications                                  │
+│ communication | prosthetics | research | adaptive UX | experiments        │
+└──────────────────────────────────┬─────────────────────────────────────────┘
+                                   │
+                            user-facing SDK
+                                   │
+                  ┌────────────────┴─────────────────┐
+                  │                                  │
+                  ▼                                  ▼
+┌────────────────────────────┐        ┌────────────────────────────────────┐
+│       neurOS runtime       │        │               ORION                │
+│                            │        │                                    │
+│ acquisition                │◀──────▶│ tokenization                       │
+│ data contracts             │        │ learned representations            │
+│ synchronization            │        │ adaptive decoding                  │
+│ graph execution            │        │ personalization                    │
+│ recording / replay         │        │ neural-intelligence research       │
+│ quality / observability    │        │                                    │
+└──────────────┬─────────────┘        └────────────────┬───────────────────┘
+               │                                       │
+               │              ┌────────────────────────┘
+               ▼              ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                      Model + evidence ecosystem                            │
+│ task decoders | foundation adapters | source trust | mechanistic evidence │
+└──────────────────────────────────┬─────────────────────────────────────────┘
+                                   │
+                                   ▼
+                        stable neural contracts
 ```
 
-neurOS owns reliable execution. ORION owns neural intelligence.
+neurOS owns reliable execution. ORION owns neural intelligence. Model/evidence packages may consume the same contracts without becoming hidden dependencies of the runtime kernel.
 
 ## 3. Package responsibilities
 
@@ -45,42 +58,84 @@ neurOS owns reliable execution. ORION owns neural intelligence.
 
 The kernel. It contains:
 
-- canonical data contracts,
-- runtime queue and lifecycle semantics,
-- processing primitives,
-- clock synchronization,
-- recording/replay primitives,
-- versioned configuration schemas,
-- plugin discovery,
-- orchestration compatibility APIs.
+- canonical neural data contracts;
+- runtime graph and executor semantics;
+- queue/backpressure and lifecycle behavior;
+- processing primitives;
+- clock synchronization;
+- recording/replay primitives and persistent archives;
+- versioned configuration schemas;
+- plugin discovery;
+- generic scientific/runtime quality infrastructure;
+- compatibility orchestration APIs.
 
-**Dependency rule:** `neuros-core` must not import concrete driver or decoder packages.
+**Dependency rule:** `neuros-core` must not import concrete driver, task-model, UI/cloud, ORION implementation, NeuroFM, or mechanistic-interpretability packages.
 
 ### `neuros-drivers`
 
-Concrete hardware and dataset sources. Drivers may depend on `neuros-core`; the reverse dependency is forbidden.
+Concrete hardware, simulated, and dataset sources. Drivers may depend on `neuros-core`; the reverse dependency is forbidden.
 
-Heavy or hardware-specific dependencies belong in extras such as EEG, video, audio, or NWB support.
+Heavy or hardware-specific dependencies belong in extras or external plugin distributions. A driver being importable does not mean a named hardware/firmware combination is qualified.
 
 ### `neuros-models`
 
-Conventional task-specific decoders and model adapters. Models implement the kernel decoder contracts while retaining legacy `train`/`predict` compatibility.
+Task-specific decoders and model-side analysis contracts.
+
+Maintained deep decoders use an explicit PyTorch backend and expose:
+
+- `DecoderOutput` compatible inference;
+- probabilities/logits when genuinely supported;
+- pooled embeddings through `encode(...)`;
+- stable model identity and metadata;
+- an `InterpretabilityManifest` describing named analysis surfaces;
+- an optional manifest-validated bridge into `neuros-mechint`.
+
+A model name must describe the algorithm actually executed. Missing optional dependencies must fail clearly rather than silently substitute another model family.
 
 ### `neuros-foundation`
 
-Adapters and integrations for external neural representation/foundation-model ecosystems. It is not the home of proprietary ORION intelligence.
+The interoperability/evaluation boundary for external neural foundation-model ecosystems.
+
+It owns:
+
+- model/capability catalog metadata;
+- locally runnable adapters where integrations are verified;
+- fail-closed availability semantics;
+- representation probes;
+- split/protocol-aware benchmark metadata and fingerprints;
+- bridges from frozen encoders into neurOS decoder contracts.
+
+Catalog presence is not equivalent to local execution, reproduced performance, or endorsement of an upstream claim.
+
+### `neuros-sourceweigher`
+
+The source/domain reliability layer. It owns algorithms for estimating which subjects, sessions, sites, devices, models, or streams a target should trust and by how much.
+
+It remains dependency-light and can integrate with neurOS runtime fusion or consume embeddings from model/foundation layers without forcing a reverse dependency into those packages.
+
+### `neuros-mechint`
+
+The causal mechanism/evidence framework. It owns intervention, faithfulness, held-out evidence, comparison, correspondence, replication, dose-response, provenance, and evidence-artifact contracts.
+
+Its software release status deliberately separates **software contract readiness** from **empirical evidence completion**. Adapter availability or passing software gates never establishes biological homology or a real neural mechanism.
+
+### `neuros-neurofm`
+
+Experimental native neural foundation-model research. NeuroFM work is a candidate source of ORION implementations, not an automatic dependency or promoted representation layer.
 
 ### `neuros`
 
-The user-facing meta-package and CLI. This composition layer is allowed to depend on core, drivers, and models.
+The user-facing meta-package and CLI. This composition layer may depend on core, drivers, and models and may expose optional profiles for research, recording, deployment, and ORION.
+
+### `neuros-ui` and `neuros-cloud`
+
+Optional presentation, API, distributed, export, and observability integrations. They must consume stable runtime/config/event contracts instead of becoming alternate orchestration systems.
+
+Until dedicated release/qualification lanes exist for these packages, their package versions should not be interpreted as equal evidence maturity with the kernel.
 
 ### `orion` / distribution `neuros-orion`
 
-The stable ORION contract surface. The package currently defines token, representation, encoder, adaptive-decoder, and adaptation-proposal interfaces. Research implementations should migrate behind these contracts once validated.
-
-### Research packages
-
-`neuros-neurofm`, `neuros-mechint`, and experimental notebooks are research surfaces. They may depend on stable runtime contracts but must not become implicit dependencies of the kernel.
+The stable ORION contract and current tokenization surface. ORION defines token, representation, encoder, adaptive-decoder, and adaptation-proposal interfaces. Research implementations move behind these contracts only after comparative evidence justifies promotion.
 
 ## 4. Canonical neural data
 
@@ -104,15 +159,15 @@ A separate `StreamDescriptor` describes relatively static stream metadata such a
 
 ### Timing rule
 
-A plain floating-point timestamp is insufficient as a long-term BCI interchange contract. The frame explicitly represents different clocks so latency, synchronization, and provenance are not conflated.
+A single floating-point timestamp is insufficient as a long-term BCI interchange contract. The frame explicitly represents different clocks so latency, synchronization, and provenance are not conflated.
 
 `SignalFrame.timestamp_ns` resolves in this order:
 
-1. synchronized time,
-2. device time,
+1. synchronized time;
+2. device time;
 3. host receive time.
 
-Legacy drivers can continue yielding `(timestamp_seconds, ndarray)` while they migrate. `BaseDriver.frames()` adapts that representation into `SignalFrame`.
+Legacy tuple-producing drivers can be adapted into frames at the source boundary while they migrate.
 
 ## 5. Clock synchronization
 
@@ -124,19 +179,19 @@ host_time = scale * device_time + offset
 
 from a bounded window of timestamp pairs. It reports:
 
-- offset,
-- scale,
-- drift in parts per million,
-- residual uncertainty,
-- number of observations.
+- offset;
+- scale;
+- drift in parts per million;
+- residual uncertainty;
+- observation count.
 
 The synchronizer can annotate a `SignalFrame` with synchronized time and `CLOCK_UNCERTAIN` quality state when residual timing error exceeds the configured threshold.
 
-This software estimator is a fallback/alignment primitive. Hardware synchronization remains preferable when available.
+This software estimator is an alignment primitive, not a substitute for hardware synchronization when tighter guarantees are required.
 
 ## 6. Decoder semantics
 
-The canonical model response is `DecoderOutput`:
+The canonical task-model response is `DecoderOutput`:
 
 ```text
 prediction
@@ -150,13 +205,13 @@ inference_time_ns
 metadata
 ```
 
-**Critical rule:** absence of calibrated probability is represented as `confidence=None`. It must never be converted to artificial confidence such as `1.0`.
+**Critical rule:** absence of calibrated probability is represented as `confidence=None`. It must never be converted to artificial certainty such as `1.0`.
 
-`BaseModel` remains compatible with traditional `train(X, y)` / `predict(X)` APIs but now exposes `infer()` that returns `DecoderOutput`.
+Task-model embeddings create a shared but explicit seam for representation probes, source/domain weighting, and mechanistic analyses. Embedding availability does not imply that the representation is invariant, causal, or transferable until those properties are measured.
 
-## 7. Runtime graph
+## 7. Native runtime graph
 
-The target runtime is a typed directed graph:
+`RuntimeGraph` is the maintained execution representation:
 
 ```text
 SOURCE -> TRANSFORM -> ... -> FUSION -> DECODER -> SINK
@@ -164,95 +219,69 @@ SOURCE -> TRANSFORM -> ... -> FUSION -> DECODER -> SINK
                    ------ MONITOR -----
 ```
 
-`RuntimeNode` records:
+`RuntimeNode` records node identity, kind, operator, execution policy, optional latency budget, and metadata. `RuntimeEdge` records source/destination, bounded capacity, and overflow policy.
 
-- node ID,
-- node kind,
-- operator,
-- execution policy,
-- optional latency budget,
-- metadata.
+`RuntimeExecutor` natively executes this graph for finite replay and live streaming sources. It provides supervised failure propagation, draining/cancellation semantics, execution classes, queue telemetry, and bounded per-node latency statistics.
 
-`RuntimeEdge` records:
-
-- source and destination,
-- bounded capacity,
-- overflow policy.
-
-The current `Pipeline`/`Orchestrator` APIs remain as compatibility surfaces while execution progressively converges on this graph representation.
+`Pipeline` and `MultiModalPipeline` are compatibility/convenience facades. Standard paths compile to `RuntimeGraph` and execute through `RuntimeExecutor`. Historical custom processing-agent classes remain an explicit migration exception rather than a second preferred runtime architecture.
 
 ## 8. Backpressure
 
-Every bounded runtime edge must have explicit overload behavior:
+Every bounded runtime edge has explicit overload behavior:
 
 - `BLOCK`
 - `DROP_OLDEST`
 - `DROP_NEWEST`
 - `FAIL`
 
-`DROP_OLDEST` is the default for real-time compatibility because stale neural data is often less useful than fresh data, but applications should choose policy deliberately.
+`DROP_OLDEST` is useful for many real-time paths because stale neural data can be less useful than fresh data, but applications should choose policy deliberately.
 
-Queue telemetry includes:
+Queue telemetry includes accepted items, dropped items, and high-water mark. Dropped samples are therefore measurable system behavior, not a hidden implementation detail.
 
-- accepted items,
-- dropped items,
-- high-water mark.
+## 9. Lifecycle and failures
 
-Dropped samples are therefore measurable system behavior, not a hidden implementation detail.
+Runtime lifecycle states are explicit and failures are supervised rather than allowed to disappear inside worker tasks.
 
-## 9. Lifecycle
-
-Runtime lifecycle states are explicit:
-
-```text
-CREATED -> STARTING -> RUNNING -> DRAINING -> STOPPED
-                      |
-                      +-> DEGRADED / FAILED
-```
-
-The single-stream orchestrator exposes public:
+The maintained execution pattern is:
 
 ```python
-await runtime.start()
-async for result in runtime.stream_results():
+await executor.start()
+async for output in executor.outputs():
     ...
-await runtime.stop()
+await executor.stop()
 ```
 
-`run()` is a convenience wrapper over the same lifecycle rather than a separate execution implementation.
+Finite and timed convenience execution use the same engine. Runtime snapshots retain failures, per-node activity/latency, and per-edge queue evidence.
 
-## 10. Recording and replay
+## 10. Persistent recording and replay
 
-Canonical frames can be recorded and replayed without changing their timestamps.
+neurOS has a canonical dependency-light session archive for exact `SignalFrame` persistence.
 
-`FrameRecorder` provides a minimal sink for deterministic tests and experiments. `ReplaySource` implements the source contract and can replay either immediately or according to recorded timing at a configurable speed.
+The archive preserves:
 
-Long-term storage implementations such as NWB/Zarr should preserve these same contracts and provenance semantics.
+- sequence identity;
+- device, host, and synchronized timestamps;
+- clock domain and quality state;
+- stream descriptors;
+- frame metadata/provenance;
+- per-frame payload integrity hashes;
+- config hash;
+- Git/package/environment provenance;
+- model-artifact references and runtime metrics where supplied.
 
-Replay is a first-class requirement because it enables:
+`ArchiveReplaySource` exposes archived streams through the same source contract used by live hardware. `RecordingSource` can wrap a source so received frames are persisted before forwarding.
 
-- deterministic regression tests,
-- hardware-independent debugging,
-- latency experiments,
-- ORION training/evaluation,
-- fault injection,
-- reproducibility.
+NWB and Zarr are maintained optional interoperability exports. They do not replace neurOS' canonical lossless replay semantics.
+
+Replay is a first-class requirement because it supports deterministic regression, hardware-independent debugging, latency experiments, ORION/model evaluation, fault injection, and reproducibility.
 
 ## 11. Configuration
 
-The versioned `PipelineConfig` schema describes:
+The versioned `PipelineConfig` schema describes streams, source plugins, transforms, decoder, sinks, monitors, queue capacity, overflow policy, and metadata.
 
-- named streams,
-- source plugins,
-- per-stream transforms,
-- decoder plugin,
-- sinks,
-- monitors,
-- queue capacity,
-- overflow policy,
-- metadata.
+`resolve_config(...)` compiles the validated configuration into a `RuntimeGraph`. Source overrides allow archived sessions to replace live hardware plugins without instantiating the original device SDK.
 
-Config schema version 1 is deliberately small. Future migrations must be explicit rather than interpreting old experiment files differently without notice.
+Configuration schema changes require explicit migration. Old experiment files must not silently acquire new semantics.
 
 ## 12. Plugin architecture
 
@@ -268,13 +297,11 @@ neuros.sinks
 neuros.monitors
 ```
 
-`PluginRegistry` supports both programmatic registration and installed entry-point discovery.
-
-This allows hardware/model integrations to evolve independently from the kernel.
+This allows hardware/model integrations to evolve independently from the kernel. External plugins should be able to satisfy these contracts without modifying `neuros-core`.
 
 ## 13. ORION boundary
 
-ORION starts where raw/processed neural data becomes a machine-native neural representation:
+ORION starts where provenance-rich neural data becomes a machine-native neural representation:
 
 ```text
 SignalFrame(s)
@@ -300,89 +327,119 @@ DecoderOutput
 
 Online change is represented by `AdaptationProposal` containing a reason, requested changes, supporting evidence, and whether approval is required. Adaptation should be observable and auditable rather than an invisible side effect.
 
-## 14. Neurotokenization research
+## 14. ORION tokenization evidence
 
-The existing neurotokenization research plan should target `orion.NeuroTokenizer` rather than create a parallel runtime interface. Event, binned-count, ISI, burst, synchrony, VQ motif, and assembly tokenizers can then be compared behind one contract.
+The maintained initial ORION tokenizer layer includes:
 
-Scientific promotion criteria remain based on fair comparisons across downstream decoding, transfer, robustness, motif recovery, interpretability, compression, and sample efficiency rather than reconstruction alone.
+- exact event tokens;
+- binned counts;
+- relative-ISI WAIT/SPIKE tokens;
+- burst/pause/rebound tokens;
+- synchrony packets;
+- vector-quantized motifs;
+- population assemblies.
 
-## 15. Dependency direction
+The controlled synthetic benchmark uses known motifs, separately seeded train/test sessions, timing jitter, unit dropout, compression, entropy, motif decoding, robustness, and runtime metrics. Fit-requiring tokenizers are fit on the training side rather than auto-fitting during evaluation.
+
+This is **scientific synthetic evidence**, not proof that one tokenizer is superior on real human BCI data. Real-data promotion requires deployment-unit-disjoint evaluation.
+
+## 15. Model and evidence interoperability
+
+The maintained package direction allows one model representation to be studied through several orthogonal lenses:
+
+```text
+neuros-models / external verified encoder
+                |
+                +-> DecoderOutput / embedding
+                |
+                +-> neuros-foundation representation probes
+                |
+                +-> neuros-sourceweigher transfer reliability
+                |
+                +-> neuros-mechint causal interventions
+```
+
+These tools answer different questions and must not be collapsed into a single score:
+
+- representation similarity is not task utility;
+- domain similarity is not signal quality;
+- attention or attribution is not mechanism;
+- a causal effect in one model/session is not cross-subject stability;
+- synthetic robustness is not hardware qualification.
+
+## 16. Dependency direction
 
 Allowed:
 
 ```text
-neuros-drivers ----> neuros-core
-neuros-models -----> neuros-core
-neuros-ui ---------> neuros-core
-neuros-cloud ------> neuros-core
-orion ------------> neuros-core
-neuros ------------> core + drivers + models
-research ----------> stable packages
+neuros-drivers --------> neuros-core
+neuros-models ---------> neuros-core
+neuros-ui -------------> neuros-core
+neuros-cloud ----------> neuros-core
+orion -----------------> neuros-core
+neuros ----------------> core + drivers + models
+foundation ------------> core + model contracts
+sourceweigher ---------> dependency-light / optional runtime integration
+mechint ---------------> core + optional model/ORION/research adapters
+research --------------> stable packages
 ```
 
-Forbidden:
+Forbidden without an explicit architectural proposal:
 
 ```text
 neuros-core -> concrete drivers
-neuros-core -> concrete models
+neuros-core -> concrete task models
 neuros-core -> UI/cloud
 neuros-core -> NeuroFM/mechint/ORION implementations
 ```
 
-A PR that adds one of the forbidden dependencies must justify an architectural change, not merely an import convenience.
+Convenient imports are not sufficient justification for reversing dependency direction.
 
-## 16. Quality gates
+## 17. Quality and evidence gates
 
-The repository CI is organized into three initial layers:
+Current repository CI separates multiple software evidence surfaces:
 
-1. kernel contract tests across supported Python versions,
-2. BCI end-to-end mock pipeline smoke tests,
-3. ORION contract tests.
+1. repository hygiene;
+2. kernel contracts across Python 3.10, 3.11, and 3.12;
+3. installed BCI/config/CLI/runtime smoke execution;
+4. scientific and latency quality gates;
+5. recording/replay plus NWB/Zarr interoperability;
+6. task-model/mechanistic-analysis contracts;
+7. foundation-model interoperability regressions;
+8. SourceWeigher regressions across supported Python versions;
+9. ORION contracts and controlled tokenizer benchmark;
+10. dedicated mech-int software/evidence gates, CPU tutorial execution, and ecosystem import compatibility.
 
-The intended expansion is:
+These remain below hardware qualification, real-dataset evidence, closed-loop qualification, and clinical evidence in the project evidence hierarchy.
 
-```text
-unit
-contract
-integration
-replay
-scientific validity
-performance regression
-hardware qualification
-```
+## 18. Completed convergence and remaining architecture work
 
-Hardware qualification should remain separate from generic CI and record exact device/firmware/runtime metadata.
+The following migrations are complete on `main`:
 
-## 17. Migration strategy
+- canonical `SignalFrame` / `DecoderOutput` contracts;
+- config compilation to `RuntimeGraph`;
+- native graph execution for standard single/multimodal paths;
+- config-first CLI operation;
+- persistent lossless recording/replay with integrity verification;
+- NWB/Zarr exports;
+- plugin entry-point discovery;
+- product/research/archive repository separation;
+- deterministic scientific/runtime quality gates;
+- ORION tokenizer contracts and benchmark;
+- foundation-model interoperability layer;
+- SourceWeigher reliability layer;
+- mechanistic-evidence v1 contracts;
+- faithful inspectable task-model layer.
 
-This architecture is being adopted incrementally to protect working research code.
+The highest-value remaining architectural work is now narrower and more consequential:
 
-### Compatibility kept now
+1. clean-install/package compatibility and release gates;
+2. explicit hardware qualification manifests and one real-device reference pipeline;
+3. durable, non-pickle promoted model artifacts bound to input and analysis-manifest fingerprints;
+4. real-dataset ORION/model/transfer/mechanism benchmarks with subject/session/device-disjoint protocols;
+5. uncertainty-aware multimodal fusion;
+6. auditable adaptation with rollback;
+7. a first-class closed-loop safety/constraint plane;
+8. externally maintained plugins and reference deployments built without kernel forks.
 
-- existing `BaseDriver` subclasses,
-- tuple-based driver iteration,
-- `BaseModel.train/predict`,
-- `Pipeline` and `MultiModalPipeline`,
-- existing CLI composition.
-
-### Preferred new APIs
-
-- `SignalFrame` / `StreamDescriptor`,
-- `DecoderOutput`,
-- versioned config,
-- plugin registry,
-- runtime overflow/lifecycle primitives,
-- ORION representation contracts.
-
-### Next migrations
-
-1. compile `PipelineConfig` directly to `RuntimeGraph`,
-2. make the native graph executor consume `SignalFrame` end to end,
-3. add production NWB/Zarr recorder/replay adapters,
-4. migrate built-in integrations to plugin entry points,
-5. separate supported examples from research experiments,
-6. archive historical migration/session documents,
-7. add scientific and latency regression suites,
-8. migrate validated NeuroFM/tokenization work behind ORION contracts.
-
-The desired endpoint is not maximum module count. It is a small, trustworthy kernel on which sophisticated BCI research can safely compound.
+The desired endpoint is not maximum module count. It is a small, trustworthy execution kernel connected to a rigorous neural-intelligence and evidence ecosystem on which serious BCI systems can safely compound.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,0 +1,152 @@
+# neurOS + ORION Project Status
+
+This page is the current capability and maturity map for the monorepo. It is intentionally stricter than a feature list: a package can contain useful code without being a qualified production surface.
+
+> **Evidence boundary:** software maturity, package version, and passing CI do not imply hardware qualification, clinical validation, biological correctness, or safety certification.
+
+## Platform shape
+
+neurOS is organized as three cooperating layers:
+
+```text
+neural hardware / datasets / replay
+              |
+              v
+      neurOS runtime plane
+ contracts | timing | graph execution | recording | quality
+              |
+              +-----------------------------+
+              |                             |
+              v                             v
+       model / transfer plane              ORION
+ task decoders | foundation adapters   tokenization | representations
+ mechanistic analysis | source trust   adaptation | personalization
+              |                             |
+              +--------------+--------------+
+                             v
+                     application layer
+```
+
+The runtime plane should remain small and conservative. Research and model layers may move faster, but they must cross explicit contracts before they become deployment dependencies.
+
+## Package maturity map
+
+| Surface | Role | Current evidence | Intended use now |
+| --- | --- | --- | --- |
+| `neuros-core` | data contracts, runtime graph, timing, recording/replay, config, quality | kernel contract matrix on Python 3.10-3.12; replay and recording tests | maintained kernel and integration substrate |
+| `neuros` | user-facing SDK and CLI composition | installed BCI/config/CLI/record/replay smoke execution | primary developer entry point |
+| `neuros-drivers` | hardware, simulated, and dataset sources | exercised through the BCI profile and plugin/config tests; device-specific qualification remains separate | maintained integration surface, not blanket hardware qualification |
+| `neuros-models` | task-specific classical and neural decoders | v2.1 model/mech-int contract job; faithful PyTorch model identity; analysis-manifest regression tests | maintained decoder layer; model artifacts still need stronger deployment serialization |
+| `neuros-foundation` | neural foundation-model catalog, adapters, probes, benchmark protocols | package regressions plus dependency-light examples in monorepo CI | maintained interoperability/evaluation layer; upstream-model claims remain provenance-sensitive |
+| `neuros-sourceweigher` | reliability-aware source/domain weighting and fusion | regression matrix on Python 3.10-3.12 plus dependency-light examples | maintained research/deployment-support component for transfer and source trust |
+| `neuros-orion` | tokenization and neural-intelligence contracts | ORION contract tests and controlled synthetic tokenizer benchmark | experimental representation layer with explicit promotion gates |
+| `neuros-mechint` | causal mechanism experiments, evidence artifacts, replication contracts | v1 software-contract gates, Python 3.10-3.12, executed CPU tutorials, ecosystem import checks | mature research software contract; empirical neuroscience evidence remains study-specific and incomplete by default |
+| `neuros-neurofm` | native neural foundation-model R&D | alpha research package and ORION/mech-int integration tests | experimental model research, not a promoted ORION implementation by default |
+| `neuros-ui` | dashboard/API/visualization surfaces | package metadata exists, but it is not yet a release-blocking qualification lane | integration/prototyping surface until dedicated product tests exist |
+| `neuros-cloud` | distributed/cloud/export/monitoring integrations | package metadata exists, but it is not yet a release-blocking qualification lane | optional integration surface until provider-specific tests and release gates exist |
+
+## What is genuinely usable today
+
+### 1. Build and execute a reproducible software BCI pipeline
+
+```bash
+python scripts/bootstrap.py --profile bci --test-tools
+neuros doctor --json
+neuros validate configs/examples/mock_bci.yaml --json
+neuros run configs/examples/mock_bci.yaml --duration 2 --json
+```
+
+The config path resolves plugins into the same native `RuntimeGraph` used by the Python pipeline facades.
+
+### 2. Record, verify, and replay the same neural contract
+
+```bash
+neuros record configs/examples/mock_bci.yaml --output /tmp/session --session-id demo --duration 2
+neuros inspect /tmp/session --verify --json
+neuros replay /tmp/session --config configs/examples/mock_bci.yaml --json
+```
+
+The canonical session archive preserves neurOS timing, quality, sequence, provenance, and integrity semantics. NWB and Zarr are interoperability exports rather than the authoritative replay format.
+
+### 3. Compare task-specific neural decoders without changing their algorithm identity
+
+```bash
+neuros-models list
+neuros-models list --mechint-ready
+neuros-models show eeg-conformer
+```
+
+The maintained deep decoders expose logits, embeddings, stable model identity, and explicit mechanistic-analysis surfaces. Missing optional backends fail closed instead of silently swapping in a different algorithm.
+
+### 4. Inspect neural representations and foundation-model integrations
+
+`neuros-foundation` separates catalog metadata from locally runnable adapters. Its probes and protocol fingerprints are intended to make cross-model comparisons explicit about subject/session/site/device split semantics and representation preprocessing.
+
+### 5. Estimate which sources should be trusted for a target domain
+
+`neuros-sourceweigher` provides constrained source mixtures, distribution-distance baselines, online drift adaptation, representation-space weighting, and neurOS runtime fusion without forcing the HTTP service into the core install.
+
+### 6. Run causal mechanism studies without confusing tooling with evidence
+
+`neuros-mechint` provides causal intervention, faithfulness, held-out evidence, replication, and artifact contracts. Its release status deliberately separates **software contract readiness** from **empirical evidence completion**.
+
+### 7. Benchmark neural tokenization behind one ORION contract
+
+The current ORION benchmark compares seven tokenizer families under controlled synthetic motifs, separately seeded train/test sessions, timing jitter, unit dropout, compression, entropy, decoding, robustness, and runtime measurements.
+
+## Important gaps before neurOS should be marketed as a broadly deployable BCI platform
+
+### Hardware qualification
+
+There is not yet a public qualification matrix showing reproducible packet loss, drift, synchronization uncertainty, reconnect behavior, sustained recording reliability, and latency for named hardware/firmware/software combinations.
+
+### Durable model artifacts
+
+The model layer still needs a production artifact format based on explicit architecture/configuration, `state_dict` or backend-native weights, input schema, calibration state, training/evaluation provenance, and immutable hashes. Trusted Python pickle should not be the long-term deployment boundary.
+
+### Real-data ORION evidence
+
+Synthetic known-ground-truth tokenization tests are valuable falsification tools, but ORION needs leakage-controlled multi-session real neural datasets before tokenizer or representation superiority claims should be made.
+
+### Cross-subject/session/device mechanism stability
+
+Mechanistic interpretability becomes strategically valuable for BCI only when candidate mechanisms remain predictive and causal across the deployment units that matter. Subject/session/montage/device robustness should be measured as a first-class benchmark dimension.
+
+### Closed-loop safety plane
+
+The runtime needs explicit action constraints, deadman behavior, stale-data rejection, quality/confidence gates, rate limits, emergency stop semantics, and hardware-in-the-loop qualification before consequential closed-loop control is treated as a product capability.
+
+### UI/cloud qualification
+
+`neuros-ui` and `neuros-cloud` should either gain dedicated contract/release tests and supported reference deployments or be labeled more explicitly as optional integration packages. Public package version numbers alone should not imply equal maturity with the kernel.
+
+## Contribution and promotion rule
+
+New work should enter at the weakest accurate maturity level:
+
+```text
+experiment
+   -> research package
+   -> stable contract adapter
+   -> integration/replay evidence
+   -> real-dataset evidence
+   -> hardware qualification
+   -> closed-loop qualification
+```
+
+Promotion should require evidence, not enthusiasm. A sophisticated method that cannot be replayed, versioned, falsified, or compared fairly is still research debt.
+
+## Near-term release objective
+
+The next coherent public milestone should be a **developer preview** in which an external contributor can:
+
+1. install from a clean environment;
+2. run and inspect a mock pipeline;
+3. record and replay it;
+4. select an inspectable decoder;
+5. compare or adapt representations through the foundation/SourceWeigher layers;
+6. run an ORION tokenizer benchmark;
+7. add an external plugin without modifying kernel code;
+8. understand exactly which claims are supported by software, dataset, hardware, or closed-loop evidence.
+
+That milestone is more valuable than simply adding more algorithms. It turns neurOS from a large repository into a legible platform.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,28 +1,46 @@
 # neurOS Documentation
 
-neurOS is a modular runtime and SDK for building reproducible brain-computer interface systems. The current architecture centers on explicit neural-data contracts, typed runtime graphs, deterministic recording/replay, real plugin discovery, measurable backpressure/latency, and a separate ORION neural-intelligence layer.
+neurOS is a modular runtime and SDK for building reproducible brain-computer interface systems. The architecture centers on explicit neural-data contracts, typed runtime graphs, deterministic recording/replay, plugin discovery, measurable timing/backpressure, task-specific decoder contracts, and a separate ORION neural-intelligence layer.
 
-> neurOS is an active research and engineering platform. Generic software tests are not hardware qualification, medical validation, or clinical evidence.
+> neurOS is an active research and engineering platform. Generic software tests are not hardware qualification, medical validation, biological evidence, or clinical certification.
 
 ## Start here
 
+- [Project status and maturity](PROJECT_STATUS.md)
 - [Installation](getting-started/installation.md)
 - [Architecture](ARCHITECTURE.md)
 - [API surface](API_REFERENCE.md)
 - [Repository roadmap](../ROADMAP.md)
 - [Contributing](../CONTRIBUTING.md)
 
-## The execution model
+## Platform at a glance
 
 ```text
-Source plugin
-   -> SignalFrame
-   -> RuntimeGraph
-      source -> transform -> fusion -> decoder -> sink
-   -> DecoderOutput
+hardware / datasets / replay
+          |
+          v
+      Source plugins
+          |
+          v
+       SignalFrame
+          |
+          v
+      RuntimeGraph
+ source -> transform -> fusion -> decoder -> sink
+          |                       |
+          |                       +-> DecoderOutput + embedding
+          |
+ timing / quality / recording / replay / provenance
+          |
+          +----------------------------+
+          |                            |
+          v                            v
+ model + transfer ecosystem           ORION
+ models | foundation | mechint     tokenization | representation
+ source reliability                adaptation | personalization
 ```
 
-Every edge has explicit capacity and overflow policy. Runtime snapshots expose queue loss/high-water metrics and node latency/failure statistics. Live sources and replay sources use the same executor.
+Every runtime edge has explicit capacity and overflow policy. Runtime snapshots expose queue loss/high-water metrics and node latency/failure statistics. Live and replay sources use the same executor.
 
 ## Config-first operation
 
@@ -50,20 +68,23 @@ neuros replay /tmp/session \
   --json
 ```
 
-The canonical neurOS archive preserves exact sequence/timing/quality semantics and provenance. NWB and Zarr are optional interoperability exports.
+The canonical neurOS archive preserves exact sequence, timing, quality, and provenance semantics. NWB and Zarr are optional interoperability exports.
 
-## Scientific quality
+## Decoder and representation ecosystem
 
-The repository separates several evidence layers rather than collapsing them into a single test count:
+`neuros-models` owns faithful task-specific decoders, logits/embeddings, stable analysis surfaces, and model-side metadata. Its deep decoders use an explicit PyTorch implementation rather than environment-dependent algorithm substitution.
 
-- kernel contract tests,
-- end-to-end BCI/config execution,
-- persistent replay and storage interoperability,
-- deterministic scientific/latency gates,
-- ORION representation benchmarks,
-- future hardware qualification profiles.
+```bash
+neuros-models list
+neuros-models list --mechint-ready
+neuros-models show eeg-conformer
+```
 
-Current generic quality thresholds are version-controlled under `configs/quality/`. Performance claims should always identify the evidence tier that produced them.
+`neuros-foundation` owns discovery, adapter capability metadata, representation probes, and split/protocol-aware comparisons across neural foundation-model ecosystems. Catalog presence is not treated as proof that a model is locally runnable or independently reproduced.
+
+`neuros-sourceweigher` owns source/domain reliability estimation and transfer-risk-aware fusion. It can consume representations without making model packages depend on its algorithms.
+
+`neuros-mechint` owns causal intervention, faithfulness, held-out evidence, replication, and evidence-artifact contracts. Its v1 release explicitly separates software readiness from empirical evidence completion.
 
 ## ORION
 
@@ -78,6 +99,22 @@ ORION is the neural-intelligence layer. Its initial tokenization work uses expli
 - population assemblies.
 
 The synthetic benchmark uses separately seeded train/test sessions, labeled neural motifs, timing jitter, and unit dropout. Fit-requiring tokenizers never auto-fit during evaluation.
+
+## Quality and evidence
+
+The repository separates evidence rather than collapsing it into one green badge:
+
+- kernel contracts across supported Python versions,
+- end-to-end BCI/config execution,
+- persistent replay and storage interoperability,
+- deterministic scientific/latency gates,
+- model/mechanistic-analysis contracts,
+- foundation-model interoperability regressions,
+- SourceWeigher regressions,
+- ORION tokenization contracts and synthetic benchmark evidence,
+- mech-int scientific software gates and executed tutorials.
+
+Hardware qualification, real-dataset evidence, closed-loop qualification, and clinical evidence remain stronger and separate tiers.
 
 ## Repository organization
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Project Status: PROJECT_STATUS.md
   - Installation: getting-started/installation.md
   - Architecture: ARCHITECTURE.md
   - API Surface: API_REFERENCE.md

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -44,7 +44,11 @@ cebra = ["cebra>=0.3.0"]
 allen = ["allensdk>=2.15.0"]
 legacy = ["torch>=2.1.0"]
 eeg = ["mne>=1.6.0"]
-dev = ["pytest>=8.0.0", "pytest-cov>=5.0.0"]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-cov>=5.0.0",
+]
 all = [
     "torch>=2.1.0",
     "cebra>=0.3.0",

--- a/packages/neuros-neurofm/pyproject.toml
+++ b/packages/neuros-neurofm/pyproject.toml
@@ -88,7 +88,7 @@ markers = [
 [tool.black]
 line-length = 100
 target-version = ["py39", "py310", "py311"]
-include = '\\.pyi?$'
+include = '\.pyi?$'
 
 [tool.isort]
 profile = "black"

--- a/packages/neuros-neurofm/pyproject.toml
+++ b/packages/neuros-neurofm/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "MIT"}
 authors = [
-    {name = "neurOS Team", email = "neuros@example.com"}
+    {name = "neurOS Development Team"}
 ]
 keywords = ["neuroscience", "BCI", "foundation-model", "SSM", "mamba"]
 classifiers = [
@@ -67,10 +67,10 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/shulyalk/neuros-v1"
-Documentation = "https://neuros-v1.readthedocs.io"
-Repository = "https://github.com/shulyalk/neuros-v1"
-Issues = "https://github.com/shulyalk/neuros-v1/issues"
+Homepage = "https://github.com/sidhulyalkar/neurOS-v1/tree/main/packages/neuros-neurofm"
+Documentation = "https://github.com/sidhulyalkar/neurOS-v1/tree/main/packages/neuros-neurofm/docs"
+Repository = "https://github.com/sidhulyalkar/neurOS-v1"
+Issues = "https://github.com/sidhulyalkar/neurOS-v1/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -88,7 +88,7 @@ markers = [
 [tool.black]
 line-length = 100
 target-version = ["py39", "py310", "py311"]
-include = '\.pyi?$'
+include = '\\.pyi?$'
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary

This is the repository convergence pass after the kernel/runtime/CLI/recording/quality/ORION, mech-int, foundation, SourceWeigher, and inspectable-model refactors have all landed on `main`.

It does **not** introduce another architecture rewrite. It makes the repository describe, qualify, package, and govern the platform that now actually exists.

## Agent-branch convergence

All historical `agent/*` branches were compared with `main`. The kernel, runtime, CLI, recording, quality, ORION-tokenization, repository-v3, mech-int-v1, foundation, and SourceWeigher branches are strictly behind `main` with no unique commits.

The only branch that contained unmerged work was `agent/models-mechint-integration`. PR #18 was repaired, fully qualified, and merged before this branch was created.

This PR therefore starts from the clean post-#18 merge boundary rather than attempting to re-cherry-pick historical agent work.

## What changes here

### Canonical maturity map

Adds `docs/PROJECT_STATUS.md` as the package-by-package capability/evidence source of truth. It explicitly distinguishes maintained kernel/runtime surfaces from experimental ORION/NeuroFM work and from UI/cloud packages that do not yet have equivalent runtime/product qualification.

### Current architecture and API documentation

Refreshes:

- `README.md`
- `docs/index.md`
- `docs/ARCHITECTURE.md`
- `docs/API_REFERENCE.md`
- `ROADMAP.md`
- `CONTRIBUTING.md`
- MkDocs navigation

The docs now describe the native graph executor, persistent session archive, NWB/Zarr exports, plugin architecture, task-model analysis manifests, neural foundation-model interoperability, SourceWeigher, mech-int v1, and ORION tokenization as implemented surfaces rather than future migrations.

### Foundation interoperability becomes release-blocking

Adds a dedicated `Foundation interoperability` CI job that:

- installs the local core/model/foundation stack;
- runs both foundation registry regression suites;
- executes the dependency-light discovery, representation-probe, and neurOS bridge examples.

This closes a qualification gap where `neuros-foundation` was publicly maintained but its regressions did not block root CI.

### Every workspace distribution must build

Adds a wheel-build job for all 11 workspace distributions. This catches broken package metadata/build configuration even when editable-source tests still pass.

This is deliberately a build gate, not yet a claim that every distribution has a fully qualified published-wheel deployment path. Clean-install compatibility is retained as the next release milestone.

### PR governance

Adds `.github/pull_request_template.md` with explicit architecture, compatibility, evidence-tier, scientific-claim, replay/provenance, and documentation checks.

### NeuroFM metadata cleanup

Fixes stale public package metadata that still pointed to an old repository owner/path and obsolete documentation host. No NeuroFM algorithm, dependency, or Python-support behavior is changed.

## Evidence and claim boundary

This PR deliberately does not promote software evidence into hardware or clinical claims.

The documentation now calls out the remaining stronger gates explicitly:

- clean-install/published-package compatibility qualification;
- named hardware/firmware qualification;
- durable promoted model artifacts;
- real-data subject/session/device-disjoint ORION/model benchmarks;
- cross-unit mechanism stability;
- uncertainty-aware multimodal fusion;
- reversible adaptation;
- closed-loop safety qualification.

## Validation target

This draft should remain unmerged until the exact PR head passes:

- repository hygiene;
- **all-workspace wheel builds**;
- kernel contract matrix;
- installed BCI smoke;
- scientific/latency gates;
- recording interoperability;
- model/mech-int contracts;
- **foundation interoperability**;
- SourceWeigher matrix;
- ORION contracts/tokenization;
- any path-triggered mech-int evidence workflow.

## Next layer

After this convergence PR, the highest-value engineering sequence is no longer broad refactoring. It is a developer-preview/release pass, model-artifact v1, one real hardware qualification pipeline, and one real-data cross-session benchmark that evaluates task decoders, foundation representations, SourceWeigher, ORION tokenization, and mechanism stability under the same deployment-unit-disjoint protocol.
