### PR TITLE
drivers: make BrainFlow hardware acquisition fail closed

### DIFF
--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -1,0 +1,39 @@
+name: neurOS driver contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "tests/test_brainflow_driver.py"
+      - ".github/workflows/drivers-ci.yml"
+  push:
+    branches:
+      - main
+      - "agent/**"
+    paths:
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "tests/test_brainflow_driver.py"
+      - ".github/workflows/drivers-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  brainflow-contracts:
+    name: BrainFlow fail-closed contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install driver test profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-drivers[test]"
+      - name: Verify hardware-boundary semantics without physical hardware
+        run: pytest -q tests/test_brainflow_driver.py

--- a/packages/neuros-drivers/README.md
+++ b/packages/neuros-drivers/README.md
@@ -1,57 +1,126 @@
 # neurOS Drivers
 
-Hardware drivers for neurOS - EEG, video, audio, and multi-modal data acquisition.
+Hardware, simulated, and dataset sources for neurOS.
 
-## Features
-
-- **EEG/BCI Devices**: BrainFlow integration for 20+ devices
-- **Lab Streaming Layer**: LSL for synchronized multi-modal capture
-- **Video Capture**: OpenCV-based video/camera drivers
-- **Audio Recording**: Microphone and audio driver support
-- **NWB I/O**: Neurodata Without Borders file format support
-- **Mock Drivers**: Simulation drivers for testing
+The driver layer adapts acquisition systems to the neurOS streaming contracts. Hardware support is deliberately separated from hardware **qualification**: a driver can satisfy its software contract without implying that every device, firmware, transport, operating system, or montage has been validated.
 
 ## Installation
 
 ```bash
-# Minimal installation
+# Minimal sources and simulated/data workflows
 pip install neuros-drivers
 
-# With specific hardware support
-pip install neuros-drivers[eeg]        # BrainFlow + LSL
-pip install neuros-drivers[video]      # Camera support
-pip install neuros-drivers[all]        # Everything
+# EEG acquisition through BrainFlow + LSL dependencies
+pip install "neuros-drivers[eeg]"
+
+# Other optional integrations
+pip install "neuros-drivers[video]"
+pip install "neuros-drivers[nwb]"
+pip install "neuros-drivers[all]"
 ```
 
-## Quick Start
+## Mock data
+
+Synthetic data is always explicit. neurOS does not silently replace a requested hardware source with a mock source.
 
 ```python
+import asyncio
+
 from neuros.drivers import MockDriver
 
-# Create a mock EEG driver
-driver = MockDriver(
-    n_channels=64,
-    sampling_rate=250,
-    modality='eeg'
-)
 
-# Start streaming
-driver.start_stream()
-data = driver.get_data(duration=1.0)
-driver.stop_stream()
+async def main() -> None:
+    driver = MockDriver(sampling_rate=250, channels=8)
+    await driver.start()
+    try:
+        async for frame in driver.frames():
+            print(frame.sequence_id, frame.data.shape, frame.timestamp_ns)
+            break
+    finally:
+        await driver.stop()
+
+
+asyncio.run(main())
 ```
 
-## Supported Devices
+## BrainFlow EEG
 
-- **EEG**: OpenBCI, BrainAmp, g.Nautilus, Muse, and more via BrainFlow
-- **Video**: Any OpenCV-compatible camera
-- **Audio**: System microphones via PyAudio
-- **Multi-modal**: LSL-compatible devices
+`BrainFlowDriver` uses BrainFlow's board metadata to select EEG rows, drains the BrainFlow ringbuffer so buffered samples are not repeatedly emitted, and validates the actual prepared-session sampling rate.
 
-## Documentation
+```python
+import asyncio
 
-Full documentation: https://neuros.readthedocs.io
+from neuros.drivers import BrainFlowDriver
+
+
+async def main() -> None:
+    driver = BrainFlowDriver(
+        board_id=0,
+        # serial_port="/dev/ttyUSB0",  # when required by the selected board
+    )
+    await driver.start()
+    try:
+        print(driver.descriptor)
+        async for frame in driver.frames():
+            print(frame.data)
+            break
+    finally:
+        await driver.stop()
+
+
+asyncio.run(main())
+```
+
+If BrainFlow is not installed, construction fails with an actionable error directing the user to install `neuros-drivers[eeg]`. Use `MockDriver` explicitly when simulation is intended.
+
+The optional `sampling_rate=` argument is an **assertion about the expected prepared-session rate**, not a software resampler. If the hardware reports a different rate, startup fails rather than publishing incorrect timing metadata.
+
+## BrainFlow safety semantics
+
+BrainFlow matrices are board-specific. The driver therefore:
+
+- selects channels through `BoardShim.get_eeg_channels(...)` rather than assuming EEG occupies rows `0..N-1`;
+- uses BrainFlow's timestamp row when one is available;
+- drains data with `get_board_data()` so one buffered sample is not replayed on every polling cycle;
+- rejects misspelled/unknown `BrainFlowInputParams` fields;
+- rejects impossible requested channel counts;
+- validates the actual prepared-session sampling rate when BrainFlow exposes it;
+- propagates acquisition and cleanup failures instead of turning them into plausible synthetic data.
+
+These are software safety properties, not evidence that a physical device is qualified. Device qualification still requires measured packet loss, synchronization uncertainty, drift, reconnect behavior, sustained recording reliability, and end-to-end latency for the exact hardware/firmware/software combination.
+
+## Supported acquisition families
+
+Current package surfaces include:
+
+- BrainFlow-compatible EEG/biosignal devices;
+- simulated/mock sources;
+- dataset playback;
+- ECG, ECoG, EMG, EOG, fNIRS, GSR, respiration, and other research-oriented source modules;
+- optional video/audio dependencies;
+- NWB-related integration dependencies.
+
+Lab Streaming Layer support is part of the broader neurOS interoperability stack. New hardware integrations should prefer the neurOS source/plugin contract rather than adding device-specific behavior to `neuros-core`.
+
+## Contributor rule
+
+A hardware PR should distinguish three different claims:
+
+1. **software contract:** the driver behaves correctly against deterministic fakes/fixtures;
+2. **integration:** the real SDK/device can stream through neurOS;
+3. **hardware qualification:** a named hardware/firmware/transport/software combination passes a recorded qualification protocol.
+
+Only claim the strongest tier actually tested.
+
+## Project documentation
+
+See the repository's current documentation and maturity map:
+
+- `docs/PROJECT_STATUS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/API_REFERENCE.md`
+- `ROADMAP.md`
 
 ## License
 
-MIT License
+MIT License.

--- a/packages/neuros-drivers/src/neuros/drivers/brainflow_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/brainflow_driver.py
@@ -1,34 +1,54 @@
-"""
-BrainFlow driver for neurOS.
+"""Fail-closed BrainFlow EEG source for neurOS.
 
-This module provides integration with the BrainFlow library for acquiring
-data from a wide variety of consumer and research-grade biosignal devices.
-If the optional ``brainflow`` package is not installed, the driver will
-gracefully fall back to the :class:`MockDriver`.  Users can specify a
-board ID and optional parameters such as serial port or IP address.  In
-production, this driver enables neurOS to support dozens of devices
-uniformly.
+BrainFlow's returned matrix is board-specific. This driver therefore uses
+BrainFlow's channel metadata instead of assuming EEG occupies the first rows,
+drains the board ringbuffer so samples are emitted once, and never silently
+substitutes synthetic data when hardware support is unavailable.
 """
 
 from __future__ import annotations
 
 import asyncio
+import math
 from typing import AsyncIterator, Optional
 
+import numpy as np
+
+from neuros.contracts import ClockDomain, StreamDescriptor
 from neuros.drivers.base_driver import BaseDriver
-from neuros.drivers.mock_driver import MockDriver
+from neuros.runtime import OverflowPolicy
 
 
 class BrainFlowDriver(BaseDriver):
-    """Driver that uses BrainFlow to stream neural data.
+    """Stream EEG samples from a BrainFlow-supported board.
 
-    This driver wraps the optional BrainFlow library.  When BrainFlow is
-    available, it will stream data from the specified board.  If
-    BrainFlow cannot be imported, a :class:`MockDriver` is used as a
-    fallback so that pipelines can still run without hardware.  The
-    driver exposes the standard :class:`BaseDriver` interface by
-    implementing the `_stream` coroutine which is invoked by the
-    base class to produce timestamped samples.
+    Parameters
+    ----------
+    board_id:
+        BrainFlow board identifier.
+    sampling_rate:
+        Optional *expected* prepared-session sampling rate. BrainFlow controls
+        the hardware sampling rate; neurOS does not pretend this argument can
+        resample the device. If supplied, startup fails when the actual rate
+        differs.
+    channels:
+        Optional number of EEG channels to expose, selected from BrainFlow's
+        declared EEG row indices. It must not exceed the board's EEG channel
+        count.
+    stream_id:
+        neurOS stream identifier.
+    overflow_policy:
+        Queue overload behavior inherited from :class:`BaseDriver`.
+    **params:
+        BrainFlow ``BrainFlowInputParams`` fields such as ``serial_port``,
+        ``ip_address``, or ``master_board``. Unknown fields are rejected so a
+        misspelled hardware parameter cannot be ignored silently.
+
+    Notes
+    -----
+    BrainFlow is an optional dependency. Constructing this driver without it
+    installed raises an actionable :class:`ImportError`. Use ``MockDriver``
+    explicitly for synthetic data.
     """
 
     def __init__(
@@ -36,121 +56,242 @@ class BrainFlowDriver(BaseDriver):
         board_id: int = 0,
         sampling_rate: Optional[float] = None,
         channels: Optional[int] = None,
+        *,
+        stream_id: str | None = None,
+        overflow_policy: OverflowPolicy = OverflowPolicy.DROP_OLDEST,
         **params,
     ) -> None:
-        """Initialise a BrainFlow driver.
-
-        Parameters
-        ----------
-        board_id : int, optional
-            Identifier of the BrainFlow board.  Defaults to 0 (synthetic).
-        sampling_rate : float, optional
-            Desired sampling rate.  If omitted, the board's native rate is
-            used.
-        channels : int, optional
-            Number of channels to acquire.  If omitted, the number of EEG
-            channels reported by the board is used.
-        **params
-            Additional keyword arguments are passed through to the
-            BrainFlow ``BrainFlowInputParams`` object.  These allow
-            specifying serial port, IP address, etc.  Unknown keys are
-            ignored.
-        """
-        # Attempt to import BrainFlow.  If it fails, fall back to the mock
-        # driver.  We defer importing BrainFlow until runtime so that
-        # neurOS does not require it as a hard dependency.
         try:
             from brainflow.board_shim import BoardShim, BrainFlowInputParams  # type: ignore
-        except ImportError:
-            # no brainflow: set up a mock driver and inherit its config
-            mock = MockDriver(
-                sampling_rate=sampling_rate or 250.0,
-                channels=channels or 8,
-            )
-            # call BaseDriver constructor to initialise queues and state
-            super().__init__(sampling_rate=mock.sampling_rate, channels=mock.channels)
-            self._delegate: Optional[BaseDriver] = mock
-            self._board: Optional[object] = None
-            return
+        except ImportError as exc:
+            raise ImportError(
+                "BrainFlowDriver requires the optional BrainFlow dependency. "
+                "Install `neuros-drivers[eeg]` or use MockDriver explicitly "
+                "for synthetic data."
+            ) from exc
 
-        # brainflow available: configure the board
-        # instantiate input parameters and assign any provided values
+        if channels is not None and int(channels) <= 0:
+            raise ValueError("channels must be positive when provided")
+        if sampling_rate is not None and float(sampling_rate) <= 0:
+            raise ValueError("sampling_rate must be positive when provided")
+
         input_params = BrainFlowInputParams()
-        for k, v in params.items():
-            if hasattr(input_params, k):
-                setattr(input_params, k, v)
-        # determine channel count and sampling rate from board if not given
-        # BrainFlow provides functions to query these properties
-        board_fs = BoardShim.get_sampling_rate(board_id)
-        eeg_chans = BoardShim.get_eeg_channels(board_id)
-        n_ch = channels or len(eeg_chans)
-        fs = sampling_rate or board_fs
-        # initialise base driver
-        super().__init__(sampling_rate=fs, channels=n_ch)
-        # store BrainFlow board
-        self._board_id = board_id
+        unknown_params: list[str] = []
+        for key, value in params.items():
+            if not hasattr(input_params, key):
+                unknown_params.append(key)
+                continue
+            setattr(input_params, key, value)
+        if unknown_params:
+            joined = ", ".join(sorted(unknown_params))
+            raise ValueError(f"Unknown BrainFlowInputParams field(s): {joined}")
+
+        self._BoardShim = BoardShim
+        self._board_id = int(board_id)
         self._params = input_params
-        self._board = BoardShim(board_id, input_params)
-        self._delegate = None
+        self._board = BoardShim(self._board_id, input_params)
+        self._requested_channels = int(channels) if channels is not None else None
+        self._expected_sampling_rate = (
+            float(sampling_rate) if sampling_rate is not None else None
+        )
+        self._session_prepared = False
+        self._board_streaming = False
+
+        self._master_board_id = self._resolve_master_board_id()
+        self._eeg_channels = self._resolve_eeg_channels(self._master_board_id)
+        initial_rate = float(BoardShim.get_sampling_rate(self._master_board_id))
+        self._timestamp_channel = self._resolve_timestamp_channel(self._master_board_id)
+        self._device_name = self._resolve_device_name(self._master_board_id)
+
+        super().__init__(
+            sampling_rate=initial_rate,
+            channels=len(self._eeg_channels),
+            stream_id=stream_id,
+            modality="eeg",
+            overflow_policy=overflow_policy,
+        )
+
+    def _resolve_master_board_id(self) -> int:
+        get_board_id = getattr(self._board, "get_board_id", None)
+        if callable(get_board_id):
+            return int(get_board_id())
+        return self._board_id
+
+    def _resolve_eeg_channels(self, board_id: int) -> tuple[int, ...]:
+        rows = tuple(int(row) for row in self._BoardShim.get_eeg_channels(board_id))
+        if not rows:
+            raise ValueError(f"BrainFlow board {board_id} exposes no EEG channels")
+        if self._requested_channels is not None:
+            if self._requested_channels > len(rows):
+                raise ValueError(
+                    f"Requested {self._requested_channels} EEG channels but BrainFlow "
+                    f"board {board_id} exposes {len(rows)}"
+                )
+            rows = rows[: self._requested_channels]
+        return rows
+
+    def _resolve_timestamp_channel(self, board_id: int) -> int | None:
+        try:
+            return int(self._BoardShim.get_timestamp_channel(board_id))
+        except Exception:
+            # Some BrainFlow-compatible streams do not expose a timestamp row.
+            # This is optional metadata; EEG row discovery is not optional.
+            return None
+
+    def _resolve_device_name(self, board_id: int) -> str:
+        getter = getattr(self._BoardShim, "get_device_name", None)
+        if callable(getter):
+            try:
+                return str(getter(board_id))
+            except Exception:
+                pass
+        return f"BrainFlow board {board_id}"
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        """Describe the actual BrainFlow EEG rows exposed by this source."""
+        return StreamDescriptor(
+            stream_id=self.stream_id,
+            modality="eeg",
+            sample_rate_hz=self.sampling_rate,
+            channel_names=tuple(f"eeg_{index}" for index in range(self.channels)),
+            channel_types=tuple("eeg" for _ in range(self.channels)),
+            device=self._device_name,
+            manufacturer="BrainFlow",
+            clock_domain=ClockDomain.UNKNOWN,
+            metadata={
+                "brainflow_board_id": self._board_id,
+                "brainflow_master_board_id": self._master_board_id,
+                "brainflow_eeg_rows": self._eeg_channels,
+                "brainflow_timestamp_row": self._timestamp_channel,
+            },
+        )
 
     async def start(self) -> None:
-        """Start streaming.
-
-        If BrainFlow is available, this prepares and starts the board.
-        Otherwise it delegates to the mock driver.  In all cases
-        ``BaseDriver.start`` is called to spawn the streaming task.
-        """
-        if self._delegate is not None:
-            # use mock driver
-            await self._delegate.start()
+        """Prepare the hardware session, validate it, and start acquisition."""
+        if self._running:
             return
-        # prepare and start the BrainFlow board
-        # BoardShim.prepare_session and start_stream are synchronous
-        self._board.prepare_session()  # type: ignore[attr-defined]
-        self._board.start_stream()  # type: ignore[attr-defined]
-        await super().start()
+
+        try:
+            self._board.prepare_session()
+            self._session_prepared = True
+
+            # Playback/streaming boards can resolve to a different master board.
+            self._master_board_id = self._resolve_master_board_id()
+            self._eeg_channels = self._resolve_eeg_channels(self._master_board_id)
+            self.channels = len(self._eeg_channels)
+            self._timestamp_channel = self._resolve_timestamp_channel(self._master_board_id)
+            self._device_name = self._resolve_device_name(self._master_board_id)
+
+            actual_rate_getter = getattr(self._board, "get_board_sampling_rate", None)
+            if callable(actual_rate_getter):
+                actual_rate = float(actual_rate_getter())
+            else:
+                actual_rate = float(self._BoardShim.get_sampling_rate(self._master_board_id))
+            if actual_rate <= 0:
+                raise RuntimeError(
+                    f"BrainFlow reported invalid prepared-session sampling rate {actual_rate}"
+                )
+            if self._expected_sampling_rate is not None and not math.isclose(
+                actual_rate,
+                self._expected_sampling_rate,
+                rel_tol=0.0,
+                abs_tol=1e-9,
+            ):
+                raise ValueError(
+                    "BrainFlow controls the device sampling rate: expected "
+                    f"{self._expected_sampling_rate:g} Hz but the prepared session "
+                    f"reports {actual_rate:g} Hz"
+                )
+            self.sampling_rate = actual_rate
+
+            self._board.start_stream()
+            self._board_streaming = True
+            await super().start()
+        except Exception:
+            await self._cleanup_board(raise_errors=False)
+            raise
 
     async def stop(self) -> None:
-        """Stop streaming and clean up resources."""
-        if self._delegate is not None:
-            await self._delegate.stop()
-            return
-        # call BaseDriver.stop to cancel the stream task and flush the queue
+        """Stop neurOS streaming and release the BrainFlow session."""
         await super().stop()
-        # stop the board and release resources
-        try:
-            self._board.stop_stream()  # type: ignore[attr-defined]
-            self._board.release_session()  # type: ignore[attr-defined]
-        except Exception:
-            pass
+        await self._cleanup_board(raise_errors=True)
+
+    async def _cleanup_board(self, *, raise_errors: bool) -> None:
+        errors: list[BaseException] = []
+
+        if self._board_streaming:
+            try:
+                self._board.stop_stream()
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                self._board_streaming = False
+
+        if self._session_prepared:
+            try:
+                self._board.release_session()
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                self._session_prepared = False
+
+        if errors and raise_errors:
+            raise RuntimeError(
+                "BrainFlow cleanup failed; the hardware session may require manual recovery"
+            ) from errors[0]
 
     async def _stream(self) -> AsyncIterator[tuple[float, list[float]]]:
-        """Internal coroutine that yields timestamped samples.
+        """Drain buffered BrainFlow samples exactly once using declared EEG rows."""
+        idle_sleep = min(max(1.0 / self.sampling_rate, 0.001), 0.02)
 
-        This implementation delegates to the mock driver when BrainFlow
-        is unavailable.  Otherwise it repeatedly queries the board for
-        the most recent sample and yields it along with a timestamp.
-        The loop runs until the driver is stopped.
-        """
-        # if fallback driver is present, delegate streaming
-        if self._delegate is not None:
-            async for ts, data in self._delegate:
-                yield ts, data
-            return
-        import time
-        # compute sleep interval based on sampling rate to reduce busy looping
-        period = 1.0 / (self.sampling_rate or 1.0)
-        while True:
+        while self._running:
             try:
-                # BrainFlow returns an array shape (n_channels_total, n_samples)
-                data = self._board.get_current_board_data(1)  # type: ignore[attr-defined]
-                if data.size != 0:
-                    # extract the latest sample for the configured channels
-                    ts = time.time()
-                    # data[:n_channels, -1] gives the last sample for each channel
-                    sample = data[: self.channels, -1]
-                    # convert to Python list for consistency with MockDriver
-                    yield ts, sample.tolist()
-                await asyncio.sleep(period)
+                available = int(self._board.get_board_data_count())
+                if available <= 0:
+                    await asyncio.sleep(idle_sleep)
+                    continue
+
+                # get_board_data removes returned samples from BrainFlow's ringbuffer.
+                # Using get_current_board_data here would repeatedly emit the same
+                # latest sample when neurOS polls faster than the device.
+                matrix = np.asarray(self._board.get_board_data(), dtype=np.float64)
+                if matrix.ndim != 2:
+                    raise RuntimeError(
+                        f"BrainFlow returned a non-matrix payload with shape {matrix.shape}"
+                    )
+                if matrix.shape[1] == 0:
+                    await asyncio.sleep(idle_sleep)
+                    continue
+
+                max_required_row = max(
+                    (*self._eeg_channels,)
+                    + ((self._timestamp_channel,) if self._timestamp_channel is not None else ())
+                )
+                if max_required_row >= matrix.shape[0]:
+                    raise RuntimeError(
+                        "BrainFlow payload row count does not match the board metadata: "
+                        f"required row {max_required_row}, received {matrix.shape[0]} rows"
+                    )
+
+                for column in range(matrix.shape[1]):
+                    if self._timestamp_channel is not None:
+                        timestamp = float(matrix[self._timestamp_channel, column])
+                        if not math.isfinite(timestamp):
+                            raise RuntimeError("BrainFlow emitted a non-finite timestamp")
+                    else:
+                        # A host wall-clock fallback is explicit only when the board
+                        # exposes no timestamp channel. Canonical host receipt timing is
+                        # still recorded by SignalFrame.from_legacy/BaseDriver.frames().
+                        import time
+
+                        timestamp = time.time()
+
+                    sample = matrix[np.asarray(self._eeg_channels, dtype=int), column]
+                    if not np.isfinite(sample).all():
+                        raise RuntimeError("BrainFlow emitted NaN or infinite EEG values")
+                    yield timestamp, sample.tolist()
+
+                await asyncio.sleep(0)
             except asyncio.CancelledError:
                 break

--- a/packages/neuros-drivers/src/neuros/drivers/brainflow_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/brainflow_driver.py
@@ -213,9 +213,31 @@ class BrainFlowDriver(BaseDriver):
             raise
 
     async def stop(self) -> None:
-        """Stop neurOS streaming and release the BrainFlow session."""
-        await super().stop()
-        await self._cleanup_board(raise_errors=True)
+        """Stop neurOS streaming and release the BrainFlow session.
+
+        Hardware cleanup is attempted even if the background acquisition task
+        has already failed. The original acquisition failure remains the
+        primary exception unless cleanup is the only failure.
+        """
+        runtime_error: BaseException | None = None
+        cleanup_error: BaseException | None = None
+
+        try:
+            await super().stop()
+        except BaseException as exc:
+            runtime_error = exc
+
+        try:
+            await self._cleanup_board(raise_errors=True)
+        except BaseException as exc:
+            cleanup_error = exc
+
+        if runtime_error is not None:
+            if cleanup_error is not None:
+                runtime_error.add_note(f"BrainFlow cleanup also failed: {cleanup_error!r}")
+            raise runtime_error
+        if cleanup_error is not None:
+            raise cleanup_error
 
     async def _cleanup_board(self, *, raise_errors: bool) -> None:
         errors: list[BaseException] = []
@@ -264,10 +286,10 @@ class BrainFlowDriver(BaseDriver):
                     await asyncio.sleep(idle_sleep)
                     continue
 
-                max_required_row = max(
-                    (*self._eeg_channels,)
-                    + ((self._timestamp_channel,) if self._timestamp_channel is not None else ())
-                )
+                required_rows = list(self._eeg_channels)
+                if self._timestamp_channel is not None:
+                    required_rows.append(self._timestamp_channel)
+                max_required_row = max(required_rows)
                 if max_required_row >= matrix.shape[0]:
                     raise RuntimeError(
                         "BrainFlow payload row count does not match the board metadata: "

--- a/packages/neuros-drivers/src/neuros/drivers/brainflow_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/brainflow_driver.py
@@ -217,7 +217,7 @@ class BrainFlowDriver(BaseDriver):
 
         Hardware cleanup is attempted even if the background acquisition task
         has already failed. The original acquisition failure remains the
-        primary exception unless cleanup is the only failure.
+        primary exception unless cleanup also fails.
         """
         runtime_error: BaseException | None = None
         cleanup_error: BaseException | None = None
@@ -232,9 +232,12 @@ class BrainFlowDriver(BaseDriver):
         except BaseException as exc:
             cleanup_error = exc
 
+        if runtime_error is not None and cleanup_error is not None:
+            raise RuntimeError(
+                "BrainFlow acquisition failed and hardware cleanup also failed: "
+                f"{cleanup_error!r}"
+            ) from runtime_error
         if runtime_error is not None:
-            if cleanup_error is not None:
-                runtime_error.add_note(f"BrainFlow cleanup also failed: {cleanup_error!r}")
             raise runtime_error
         if cleanup_error is not None:
             raise cleanup_error

--- a/tests/test_brainflow_driver.py
+++ b/tests/test_brainflow_driver.py
@@ -1,18 +1,167 @@
-import asyncio
+import builtins
+import sys
+import types
+
+import numpy as np
+import pytest
 
 from neuros.drivers.brainflow_driver import BrainFlowDriver
 
 
-async def test_brainflow_fallback():
-    driver = BrainFlowDriver()
-    # should either use brainflow if installed or fallback to mock
-    assert driver.sampling_rate > 0
-    assert driver.channels > 0
-    # start and stop driver
+class FakeBrainFlowInputParams:
+    def __init__(self) -> None:
+        self.serial_port = ""
+        self.ip_address = ""
+        self.master_board = 0
+
+
+class FakeBoardShim:
+    instances = []
+
+    def __init__(self, board_id, params) -> None:
+        self.board_id = int(board_id)
+        self.params = params
+        self.prepared = False
+        self.streaming = False
+        self.released = False
+        self._consumed = False
+        FakeBoardShim.instances.append(self)
+
+    @staticmethod
+    def get_sampling_rate(board_id):
+        return 250
+
+    @staticmethod
+    def get_eeg_channels(board_id):
+        # BrainFlow matrices are board-specific. Deliberately choose rows that
+        # are not the first N rows to catch accidental data[:channels] slicing.
+        return [1, 3]
+
+    @staticmethod
+    def get_timestamp_channel(board_id):
+        return 5
+
+    @staticmethod
+    def get_device_name(board_id):
+        return "Fake EEG Board"
+
+    def get_board_id(self):
+        return self.board_id
+
+    def prepare_session(self):
+        self.prepared = True
+
+    def start_stream(self):
+        assert self.prepared
+        self.streaming = True
+
+    def get_board_sampling_rate(self):
+        # Exercise the actual prepared-session rate rather than static metadata.
+        return 200
+
+    def get_board_data_count(self):
+        return 0 if self._consumed else 2
+
+    def get_board_data(self):
+        self._consumed = True
+        return np.asarray(
+            [
+                [100.0, 101.0],  # package/other row
+                [11.0, 12.0],    # EEG row 1
+                [20.0, 21.0],    # non-EEG row
+                [31.0, 32.0],    # EEG row 3
+                [40.0, 41.0],    # non-EEG row
+                [1000.25, 1000.255],  # timestamp row
+            ]
+        )
+
+    def stop_stream(self):
+        self.streaming = False
+
+    def release_session(self):
+        self.released = True
+        self.prepared = False
+
+
+def install_fake_brainflow(monkeypatch):
+    FakeBoardShim.instances.clear()
+    package = types.ModuleType("brainflow")
+    board_shim = types.ModuleType("brainflow.board_shim")
+    board_shim.BoardShim = FakeBoardShim
+    board_shim.BrainFlowInputParams = FakeBrainFlowInputParams
+    package.board_shim = board_shim
+    monkeypatch.setitem(sys.modules, "brainflow", package)
+    monkeypatch.setitem(sys.modules, "brainflow.board_shim", board_shim)
+
+
+def test_brainflow_missing_dependency_fails_closed(monkeypatch):
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "brainflow.board_shim" or name.startswith("brainflow"):
+            raise ImportError("brainflow intentionally unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    with pytest.raises(ImportError, match=r"neuros-drivers\[eeg\].*MockDriver explicitly"):
+        BrainFlowDriver()
+
+
+def test_brainflow_rejects_unknown_hardware_parameters(monkeypatch):
+    install_fake_brainflow(monkeypatch)
+
+    with pytest.raises(ValueError, match="Unknown BrainFlowInputParams field.*seral_port"):
+        BrainFlowDriver(seral_port="/dev/ttyUSB0")
+
+
+@pytest.mark.asyncio
+async def test_brainflow_uses_declared_eeg_rows_and_drains_samples_once(monkeypatch):
+    install_fake_brainflow(monkeypatch)
+    driver = BrainFlowDriver(board_id=7, serial_port="/dev/fake")
+
+    # Static metadata is available before the session is prepared.
+    assert driver.sampling_rate == 250
+    assert driver.channels == 2
+    assert driver.descriptor.metadata["brainflow_eeg_rows"] == (1, 3)
+
     await driver.start()
-    # obtain a few samples
-    async for ts, data in driver:
-        assert isinstance(data, list)
-        assert len(data) == driver.channels
-        break
+    assert driver.sampling_rate == 200
+
+    received = []
+    async for timestamp, data in driver:
+        received.append((timestamp, data))
+        if len(received) == 2:
+            break
+
     await driver.stop()
+
+    assert received == [
+        (1000.25, [11.0, 31.0]),
+        (1000.255, [12.0, 32.0]),
+    ]
+    board = FakeBoardShim.instances[-1]
+    assert board._consumed is True
+    assert board.streaming is False
+    assert board.released is True
+
+
+@pytest.mark.asyncio
+async def test_brainflow_sampling_rate_is_an_assertion_not_fake_resampling(monkeypatch):
+    install_fake_brainflow(monkeypatch)
+    driver = BrainFlowDriver(board_id=7, sampling_rate=250)
+
+    with pytest.raises(ValueError, match="controls the device sampling rate.*200 Hz"):
+        await driver.start()
+
+    board = FakeBoardShim.instances[-1]
+    assert board.streaming is False
+    assert board.released is True
+    assert driver._running is False
+
+
+def test_brainflow_channel_count_cannot_exceed_declared_eeg_rows(monkeypatch):
+    install_fake_brainflow(monkeypatch)
+
+    with pytest.raises(ValueError, match="Requested 3 EEG channels.*exposes 2"):
+        BrainFlowDriver(board_id=7, channels=3)

--- a/tests/test_brainflow_driver.py
+++ b/tests/test_brainflow_driver.py
@@ -1,3 +1,4 @@
+import asyncio
 import builtins
 import sys
 import types
@@ -165,3 +166,26 @@ def test_brainflow_channel_count_cannot_exceed_declared_eeg_rows(monkeypatch):
 
     with pytest.raises(ValueError, match="Requested 3 EEG channels.*exposes 2"):
         BrainFlowDriver(board_id=7, channels=3)
+
+
+@pytest.mark.asyncio
+async def test_brainflow_acquisition_failure_still_releases_session(monkeypatch):
+    install_fake_brainflow(monkeypatch)
+    driver = BrainFlowDriver(board_id=7)
+    board = FakeBoardShim.instances[-1]
+
+    def malformed_payload():
+        board._consumed = True
+        # Metadata requires rows 1, 3, and 5, so this payload must fail.
+        return np.zeros((2, 1), dtype=float)
+
+    board.get_board_data = malformed_payload
+
+    await driver.start()
+    await asyncio.sleep(0.02)
+
+    with pytest.raises(RuntimeError, match="payload row count does not match"):
+        await driver.stop()
+
+    assert board.streaming is False
+    assert board.released is True


### PR DESCRIPTION
## Purpose

Harden the BrainFlow hardware boundary so a requested physical EEG source cannot silently become synthetic data or emit the wrong matrix rows.

During the repository convergence audit, the existing driver exposed several correctness risks:

- missing `brainflow` silently instantiated `MockDriver`;
- EEG samples were selected with `data[:channels]` even though BrainFlow matrices are board-specific and expose the correct rows through `get_eeg_channels(...)`;
- polling used `get_current_board_data(1)`, which does not remove the sample from BrainFlow's ringbuffer and can therefore emit the same latest sample repeatedly;
- `sampling_rate=` changed neurOS timing metadata/polling without configuring the hardware;
- cleanup errors were swallowed;
- the old regression test explicitly accepted hidden mock fallback.

## Changes

### Fail-closed hardware semantics

`BrainFlowDriver` now raises an actionable import error when BrainFlow is unavailable. Simulation requires an explicit `MockDriver`.

Unknown `BrainFlowInputParams` fields are rejected so misspelled serial/IP/device configuration cannot be ignored silently.

### Correct board-specific channel selection

The driver resolves the BrainFlow master board and uses `BoardShim.get_eeg_channels(...)`. Optional `channels=` limits that declared EEG set rather than slicing arbitrary matrix rows.

The descriptor records the board ID, resolved master board ID, EEG row indices, timestamp row, and EEG modality.

### Prepared-session timing truth

When BrainFlow exposes `get_board_sampling_rate()`, neurOS uses the actual prepared-session sampling rate. `sampling_rate=` is now an assertion about the expected rate rather than fake software resampling. A mismatch fails startup.

### Exactly-once buffer draining

Acquisition checks BrainFlow's ringbuffer count and drains buffered samples with `get_board_data()`. It no longer repeatedly polls the non-destructive `get_current_board_data(1)` API.

BrainFlow's timestamp row is used when available. Payload geometry and finite EEG/timestamp values are validated before emission.

### Cleanup under failure

Hardware stop/release is attempted even if the neurOS acquisition task has already failed. Cleanup failures propagate instead of being swallowed.

### Release-blocking driver contract tests

Adds a dedicated path-scoped driver workflow and deterministic fake-BrainFlow tests covering:

- missing dependency fail-closed behavior;
- typo/unknown hardware-parameter rejection;
- non-contiguous EEG row selection;
- exact buffered sample draining;
- prepared-session rate validation;
- impossible channel-count rejection;
- hardware cleanup after acquisition failure.

No physical-device performance or qualification claim is made by these tests.

## Compatibility

This intentionally removes the unsafe implicit mock fallback. Code that wants simulation must construct/configure `MockDriver` explicitly.

Existing callers that used `sampling_rate=` as if it configured BrainFlow hardware will now receive a clear error if the prepared session reports a different rate.

## Evidence tier

**Contract** and software-level integration using deterministic BrainFlow fakes. Real device/firmware/transport qualification remains a separate next step.

## External API basis

BrainFlow documents that returned matrix layout is board-specific, that `get_eeg_channels(...)` and `get_timestamp_channel(...)` identify the relevant rows, that `get_board_data()` flushes collected data from the internal buffer, and that prepared sessions can expose their actual sampling rate. This PR aligns neurOS with those semantics rather than relying on positional assumptions.
