### PR TITLE
docs: make public package READMEs match the current platform

### DIFF
--- a/packages/neuros-cloud/README.md
+++ b/packages/neuros-cloud/README.md
@@ -1,87 +1,62 @@
 # neurOS Cloud
 
-Cloud infrastructure for neurOS - Kafka, AWS SageMaker, WebDataset, Zarr export.
+`neuros-cloud` contains optional distributed-data, storage, observability, and cloud-provider integrations for neurOS.
 
-## Features
-
-- **Kafka Integration**: Real-time data streaming at scale
-- **AWS SageMaker**: Cloud-based model training
-- **WebDataset Export**: Efficient dataset format for PyTorch
-- **Zarr Export**: Cloud-native chunked array storage
-- **Distributed Processing**: Multi-node data pipelines
-- **Monitoring**: Prometheus, MLflow, W&B integration
+> **Maturity boundary:** this package currently builds as part of the workspace, but it is not the neurOS real-time execution kernel and does not yet have provider-specific release qualification. Treat cloud integrations as optional infrastructure until their individual deployment paths have dedicated contract and reference-environment tests.
 
 ## Installation
 
 ```bash
-# Minimal installation
 pip install neuros-cloud
-
-# With Kafka support
-pip install neuros-cloud[kafka]
-
-# With AWS integration
-pip install neuros-cloud[aws]
-
-# With export formats
-pip install neuros-cloud[export]
-
-# Everything
-pip install neuros-cloud[all]
+pip install "neuros-cloud[kafka]"      # Kafka / ZeroMQ / Redis integrations
+pip install "neuros-cloud[aws]"        # AWS + SageMaker dependencies
+pip install "neuros-cloud[export]"     # WebDataset / OME-Zarr / Arrow
+pip install "neuros-cloud[monitoring]" # Prometheus / MLflow / W&B
+pip install "neuros-cloud[all]"
 ```
 
-## Quick Start
+## Architectural role
 
-### Kafka Streaming
+Cloud infrastructure should sit above stable neurOS runtime and artifact contracts:
 
-```python
-from neuros.cloud import KafkaWriter
-
-# Stream data to Kafka
-writer = KafkaWriter(
-    bootstrap_servers='localhost:9092',
-    topic='neuros-eeg'
-)
-
-writer.write(data, metadata={'session_id': '001'})
+```text
+local acquisition / RuntimeGraph / recording / replay
+                         |
+                         v
+              evidence + artifact boundary
+                         |
+                         v
+       registry / telemetry / orchestration / collaboration
 ```
 
-### WebDataset Export
+Real-time neural acquisition, queue semantics, timing, and safety behavior should remain local by default. A cloud outage must not silently alter the meaning of a running neural pipeline.
 
-```python
-from neuros.export import WebDatasetExporter
+High-value cloud/product work includes:
 
-# Export to WebDataset format
-exporter = WebDatasetExporter(output_dir='./data')
-exporter.export(samples, labels)
-```
+- immutable experiment/model/data/evidence artifact registry;
+- remote experiment configuration and launch requests over stable APIs;
+- qualification history for named hardware/model/config combinations;
+- fleet/device compatibility metadata;
+- aggregate observability and audit trails;
+- multi-site collaboration and permissions;
+- reproducible benchmark orchestration;
+- optional large-scale training jobs that return versioned artifacts to the local runtime.
 
-### SageMaker Training
+## Evidence rule
 
-```python
-from neuros.training import SageMakerLauncher
-
-# Launch training job on SageMaker
-launcher = SageMakerLauncher(
-    role='arn:aws:iam::...',
-    instance_type='ml.p3.2xlarge'
-)
-
-launcher.train(training_script='train.py', data_path='s3://...')
-```
-
-## Use Cases
-
-- Large-scale data collection
-- Distributed model training
-- Multi-site experiments
-- Cloud-based inference
-- Dataset publishing
+Provider availability is not BCI qualification. Any cloud path that participates in a scientific or operational claim should record provider/runtime versions, configuration, artifact hashes, failure behavior, and the strongest evidence tier actually tested.
 
 ## Documentation
 
-Full documentation: https://neuros.readthedocs.io
+Current platform documentation and package maturity live in:
+
+- `docs/PROJECT_STATUS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/API_REFERENCE.md`
+- `ROADMAP.md`
+
+Repository: https://github.com/sidhulyalkar/neurOS-v1
 
 ## License
 
-MIT License
+MIT License.

--- a/packages/neuros-core/README.md
+++ b/packages/neuros-core/README.md
@@ -1,14 +1,18 @@
 # neurOS Core
 
-Core functionality for neurOS - a modular operating system for brain-computer interfaces.
+`neuros-core` is the dependency-light kernel for the neurOS BCI runtime. It owns the contracts and execution semantics that hardware, models, ORION, recording, and higher-level applications share.
 
-## Features
+## What belongs here
 
-- **Pipeline Architecture**: Composable pipelines for data processing
-- **Multi-Modal Orchestration**: Synchronize and process heterogeneous data streams
-- **Agent Framework**: DeviceAgent, ProcessingAgent, ModelAgent, FusionAgent
-- **Configuration Management**: Unified config system with YAML support
-- **Signal Processing**: Base processing utilities and feature extraction
+- canonical `SignalFrame`, `StreamDescriptor`, and `DecoderOutput` contracts;
+- `RuntimeGraph`, bounded edges, overflow policies, lifecycle, and supervised execution;
+- configuration schemas and plugin discovery;
+- clock synchronization primitives;
+- processing transforms;
+- canonical recording/replay semantics and integrity/provenance support;
+- generic scientific/runtime quality gates.
+
+Concrete device SDKs, task-specific neural networks, cloud vendors, UI frameworks, and research implementations should remain outside the kernel.
 
 ## Installation
 
@@ -16,35 +20,67 @@ Core functionality for neurOS - a modular operating system for brain-computer in
 pip install neuros-core
 ```
 
-## Quick Start
+Optional extras:
 
-```python
-from neuros.core.pipeline import Pipeline
-from neuros.core.agents import DeviceAgent, ModelAgent
-
-# Create a simple pipeline
-pipeline = Pipeline(
-    driver=my_driver,
-    model=my_model
-)
-
-# Process data
-predictions = pipeline.predict(data)
+```bash
+pip install "neuros-core[evaluation]"
+pip install "neuros-core[recording]"  # NWB + Zarr interoperability
+pip install "neuros-core[test]"
 ```
 
-## Dependencies
+## Runtime graph
 
-Minimal dependencies for fast, lightweight installations:
-- numpy>=1.24.0
-- scipy>=1.11.0
-- pyyaml>=6.0
-- python-dotenv>=1.0.0
-- pydantic>=1.10.10
+A maintained neurOS execution path is a typed graph:
+
+```text
+SOURCE -> TRANSFORM -> FUSION -> DECODER -> SINK
+                  \              /
+                   --- MONITOR ---
+```
+
+Every runtime edge has explicit capacity and overflow policy. Runtime snapshots expose accepted/dropped items, queue high-water marks, node failures, and bounded latency summaries.
+
+```python
+from neuros.runtime import OverflowPolicy, RuntimeGraph
+
+# Concrete operators are supplied by installed packages/plugins.
+graph = RuntimeGraph()
+print(OverflowPolicy.DROP_OLDEST)
+```
+
+For a complete runnable workflow, install the user-facing `neuros` package and use the checked-in mock configuration.
+
+## Recording and replay
+
+The canonical archive preserves the neurOS neural-data contract rather than flattening it to a generic array. Exact sequence identity, timing fields, quality flags, stream descriptors, metadata/provenance, and payload integrity can therefore be replayed through the same runtime used by live sources.
+
+NWB and Zarr are optional interoperability exports. They do not replace neurOS' authoritative replay representation.
+
+## Architectural guarantee
+
+The intended dependency direction is:
+
+```text
+neuros-core
+    <- drivers / task models / user SDK
+    <- ORION / foundation / transfer / mechanism integrations
+    <- experiments and applications
+```
+
+A kernel change should be general enough to support multiple concrete devices/models and should arrive with contract, replay, failure, and overload tests appropriate to its impact.
 
 ## Documentation
 
-Full documentation: https://neuros.readthedocs.io
+Current documentation lives in the repository:
+
+- `docs/PROJECT_STATUS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/API_REFERENCE.md`
+- `ROADMAP.md`
+- `CONTRIBUTING.md`
+
+Repository: https://github.com/sidhulyalkar/neurOS-v1
 
 ## License
 
-MIT License
+MIT License.

--- a/packages/neuros-neurofm/README.md
+++ b/packages/neuros-neurofm/README.md
@@ -1,407 +1,132 @@
-# NeuroFM-X: Neural Foundation Model
+# neurOS NeuroFM
 
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![PyTorch 2.0+](https://img.shields.io/badge/PyTorch-2.0+-ee4c2c.svg)](https://pytorch.org/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+`neuros-neurofm` is the **alpha research package** for native neural foundation-model experiments inside neurOS.
 
-**A foundation model for neural population dynamics using selective state-space models (Mamba), multi-modal fusion (Perceiver-IO), and population transformers (PopT).**
+It contains exploratory architectures and utilities for neural population modeling, including state-space backbones, population-level aggregation, multimodal fusion, adaptation, continual-learning, evaluation, and mechanistic-analysis integration.
 
----
+> **Maturity boundary:** this package is research software. It is not a promoted ORION implementation, a hardware-qualified decoder, or a source of production/clinical claims. Model quality, latency, transfer, and mechanism claims require an immutable model artifact plus a leakage-controlled evaluation manifest on named data and hardware where applicable.
 
-## 🎯 Overview
+See [`../../docs/PROJECT_STATUS.md`](../../docs/PROJECT_STATUS.md) for the repository-wide maturity map.
 
-NeuroFM-X is designed for:
-- **Cross-task learning** (navigation, vision, decision-making)
-- **Cross-species generalization** (mouse, NHP, human)
-- **Multi-modal fusion** (Neuropixels, 2-photon, calcium imaging, LFP)
-- **Transfer learning** with few-shot adaptation
-- **Efficient training** with linear-complexity SSMs
+## Why this package exists
 
-### Key Features
+neurOS deliberately separates three concerns:
 
-- 🧠 **State-Space Models (Mamba):** O(L) complexity for long sequences
-- 🎨 **Perceiver-IO Fusion:** Handles variable-size inputs across modalities
-- 🔄 **Population Transformer (PopT):** Population-level aggregation
-- 🎯 **Multi-Task Heads:** Reconstruction, decoding, contrastive learning
-- ⚡ **Production-Ready:** Docker deployment, cloud training, monitoring
+- `neuros-foundation` catalogs and evaluates external neural foundation-model ecosystems behind common protocols.
+- `neuros-neurofm` is the sandbox for **native** neurOS foundation-model R&D.
+- `neuros-orion` is the representation/adaptation plane that receives research components only after comparative evidence justifies promotion.
 
-### Architecture
+That separation lets the project explore ambitious architectures without making experimental code part of the deployment contract by accident.
 
-```
-Neural Data → Tokenizers → Mamba Backbone → Perceiver-IO → PopT → Task Heads
-   (B,S,N)       ↓            (B,S,d)         (B,L,d)      (B,d)     (B,Y)
-              [Binned]      [4 blocks]      [32 latents]  [2 layers] [Decoder]
-              [Calcium]     [Multi-rate]    [Cross-attn]             [Encoder]
-              [LFP]                                                   [Contrast]
-```
+## Current research surface
 
-**Parameters:** 3-10M (efficient!)
-**Inference:** <10ms per sample
-**GPU Memory:** 2-6 GB (fits RTX 3070 Ti)
+The source tree includes work on:
 
----
+- neural population and state-space models;
+- modality-specific tokenization and dataset adapters;
+- multimodal fusion;
+- continual/adaptive learning;
+- augmentation and diffusion experiments;
+- evaluation utilities;
+- inference and integration helpers;
+- mechanistic-interpretability integration.
 
-## 🚀 Quick Start
+The presence of a module means the implementation is available for research. It does **not** imply that the method has beaten a baseline, generalized across subjects/sessions/devices, or passed a hardware qualification profile.
 
-### Installation
+## Installation from this monorepo
+
+From the repository root:
 
 ```bash
-# Clone repository
-git clone <repo-url>
-cd neuros-neurofm
-
-# Install package
-pip install -e .
-
-# Install Mamba (REQUIRED for fast training)
-pip install mamba-ssm causal-conv1d
+git clone https://github.com/sidhulyalkar/neurOS-v1.git
+cd neurOS-v1
+python -m pip install -e "packages/neuros-neurofm[dev]"
 ```
 
-### Run Training
-
-**Quick validation (2-3 hours):**
-```bash
-python training/train.py --config configs/quick_test.yaml
-```
-
-**Full training (8-12 hours on RTX 3070 Ti):**
-```bash
-python training/train.py --config configs/local_full.yaml
-```
-
-**Cloud training (24-40 hours, AWS A100):**
-```bash
-python training/train.py --config configs/cloud_aws_a100.yaml
-```
-
-### Monitor Progress
+Optional research profiles are declared in `pyproject.toml`:
 
 ```bash
-# Checkpoint analysis
-python scripts/monitor_training.py --checkpoint checkpoints/latest.pt
+# state-space / Mamba experiments
+python -m pip install -e "packages/neuros-neurofm[mamba]"
 
-# TensorBoard
-tensorboard --logdir=logs
+# training stack
+python -m pip install -e "packages/neuros-neurofm[training]"
 
-# Benchmark
-python benchmarks/benchmark_neurofmx.py --checkpoint checkpoints/best.pt
+# DANDI / NWB / Allen / IBL dataset tooling
+python -m pip install -e "packages/neuros-neurofm[datasets]"
+
+# mechanistic-analysis integration
+python -m pip install -e "packages/neuros-neurofm[mechint]"
 ```
 
----
+Install only the extras required by the experiment. GPU/CUDA compatibility depends on the selected PyTorch and optional backend versions.
 
-## 📦 Project Structure
+## Evidence requirements
 
-```
-neuros-neurofm/
-├── src/neuros_neurofm/       # Core library
-│   ├── models/                # Model architectures
-│   ├── tokenizers/            # Modality-specific tokenizers
-│   ├── fusion/                # Perceiver-IO fusion
-│   └── adapters/              # Transfer learning
-│
-├── training/                  # Training scripts
-│   ├── train.py               # Main training (YAML-based)
-│   ├── train_legacy.py        # Old training script
-│   └── train_legacy_logging.py
-│
-├── scripts/                   # Utilities
-│   ├── data_utils.py          # Data loading
-│   ├── monitor_training.py    # Training monitoring
-│   ├── prepare_full_dataset.py
-│   └── download_allen_data.py
-│
-├── configs/                   # Training configurations
-│   ├── quick_test.yaml        # Fast validation (4 sessions)
-│   ├── local_full.yaml        # Full local training
-│   └── cloud_aws_a100.yaml    # Cloud training
-│
-├── deployment/                # Production
-│   ├── Dockerfile
-│   ├── docker-compose.yml
-│   └── aws_setup.sh
-│
-├── benchmarks/                # Evaluation
-│   └── benchmark_neurofmx.py
-│
-└── docs/                      # Documentation
-    ├── QUICK_START.md
-    ├── SCALING_STRATEGY.md
-    ├── TRAINING_GUIDE.md
-    └── OPTIMAL_TRAINING_PLAN.md
+A NeuroFM experiment should not be promoted based on a single training curve or favorable held-out fold. At minimum, a comparative result should record:
+
+1. dataset identity and version;
+2. subject/session/site/device split unit;
+3. preprocessing and tokenization fingerprint;
+4. architecture and parameter-count identity;
+5. training/calibration budget;
+6. random seeds and repeated-run uncertainty;
+7. task utility metrics;
+8. representation diagnostics such as geometry and domain leakage;
+9. robustness to missing/noisy channels or units where relevant;
+10. artifact/checkpoint hashes and exact code/package versions.
+
+For transfer/adaptation studies, fit, adaptation, calibration, and evaluation partitions must be disjoint according to the declared protocol.
+
+For mechanistic studies, attribution alone is insufficient. Intervention, held-out faithfulness, replication, and cross-session/subject stability should be reported separately.
+
+## Recommended real-data progression
+
+The current roadmap is to test native NeuroFM ideas through shared neurOS benchmark protocols rather than maintain a private scoreboard inside this package:
+
+```text
+synthetic falsification
+  -> one real multi-session dataset
+  -> subject/session-disjoint comparison
+  -> cross-dataset/device transfer
+  -> few-shot adaptation/calibration-cost study
+  -> mechanism stability study
+  -> promoted ORION component only if evidence survives
 ```
 
----
+Useful external sources include MOABB/MNE for EEG benchmarking and DANDI/FALCON/NLB-style NWB datasets for population/spiking studies. The exact supported benchmark bridge should live in maintained neurOS evaluation code, not be implied by this README.
 
-## 🎓 Usage
+## Development
 
-### Basic Training
-
-```python
-# Load configuration
-config = load_config("configs/quick_test.yaml")
-
-# Create model
-model = NeuroFMXMultiTask(
-    d_model=config['model']['d_model'],
-    n_mamba_blocks=config['model']['n_mamba_blocks'],
-    ...
-)
-
-# Train
-trainer = ConfigurableTrainer(config, model, train_loader, val_loader)
-trainer.train()
-```
-
-### Inference
-
-```python
-from neuros_neurofm.models import NeuroFMXComplete
-
-# Load trained model
-model = NeuroFMXComplete.from_pretrained("checkpoints/best.pt")
-
-# Decode behavior
-behavior = model.decode_behavior(neural_data)
-
-# Extract latents
-latents = model.encode(neural_data)
-```
-
-### Transfer Learning
-
-```python
-# Add adapter for new dataset
-model.add_unit_id_adapter(n_units=new_dataset.n_units, freeze_backbone=True)
-
-# Fine-tune (only adapter trains)
-trainer.fit(model, new_dataloader)
-```
-
----
-
-## 📊 Training Strategy
-
-We recommend **progressive scaling**:
-
-| Phase | Sessions | Duration | Cost | Purpose |
-|-------|----------|----------|------|---------|
-| 1. Validation | 4 | 2-3 hrs | $0 | Test architecture |
-| 2. Optimization | 10-20 | 4-8 hrs | $0-50 | Find best config |
-| 3. Baseline | 20-30 | 8-12 hrs | $30-50 | Publishable results |
-| 4. Foundation | 50-100 | 20-40 hrs | $100-200 | Strong model |
-| 5. Multi-Modal | 200+ | 40-80 hrs | $200-400 | Ultimate generalization |
-
-**Key insight:** Start small, optimize, then scale. See [docs/SCALING_STRATEGY.md](docs/SCALING_STRATEGY.md)
-
----
-
-## 🔧 Configuration
-
-All training is configured via YAML:
-
-```yaml
-# configs/my_experiment.yaml
-name: "my_experiment"
-
-data:
-  batch_size: 16
-  num_sessions: 20
-  max_units: 384
-
-model:
-  d_model: 128
-  n_mamba_blocks: 4
-  n_latents: 32
-
-training:
-  max_epochs: 50
-  learning_rate: 3.0e-4
-  use_amp: true
-```
-
-Templates: [configs/](configs/)
-
----
-
-## 🌐 Cloud Deployment
-
-### Docker
+From the repository root:
 
 ```bash
-# Build
-docker build -t neurofmx:latest -f deployment/Dockerfile .
-
-# Run
-docker run --gpus all \
-  -v $(pwd)/data:/data \
-  -v $(pwd)/checkpoints:/checkpoints \
-  neurofmx:latest --config configs/local_full.yaml
+python -m pip install -e "packages/neuros-neurofm[dev]"
+pytest -q packages/neuros-neurofm/tests
 ```
 
-### AWS
+Dataset- or GPU-dependent tests should remain explicitly marked so the default software contract suite does not silently depend on large downloads or specialized hardware.
 
-```bash
-# Setup instance
-./deployment/aws_setup.sh <instance-id>
+## Relationship to ORION
 
-# Start training
-python training/train.py --config configs/cloud_aws_a100.yaml
-```
+ORION should consume a NeuroFM idea only when the experiment answers a practical question such as:
 
-Cost monitoring and auto-shutdown included! See [deployment/](deployment/)
+- Does this representation reduce calibration cost on a new session or subject?
+- Does it improve robustness to channel/unit dropout or device drift?
+- Does it preserve task information while reducing subject/session leakage?
+- Does a proposed mechanism remain causally important under held-out interventions?
+- Does the benefit survive matched downstream capacity and matched training budgets?
 
----
+Until then, the implementation remains research material by design.
 
-## 📈 Performance
+## Documentation
 
-### Benchmarks (20 Allen Neuropixels sessions)
+- [Project maturity map](../../docs/PROJECT_STATUS.md)
+- [Architecture](../../docs/ARCHITECTURE.md)
+- [Roadmap](../../ROADMAP.md)
+- [Contributing](../../CONTRIBUTING.md)
+- [Package documentation](docs/)
 
-| Metric | NeuroFM-X | CEBRA |
-|--------|-----------|-------|
-| Reconstruction R² | 0.65-0.75 | 0.55-0.65 |
-| Behavior Decoding R² | 0.45-0.60 | 0.40-0.50 |
-| Inference Speed | 8-12 ms | 15-20 ms |
-| Parameters | 3-10M | 5-15M |
+## License
 
-### With Foundation Training (200+ sessions, multi-modal):
-- Reconstruction R²: **0.75-0.85**
-- Transfer Learning: **90%+ with <10 examples**
-- Cross-Modal: **Zero-shot across modalities**
-
----
-
-## 🛠️ Development
-
-### Requirements
-
-- Python 3.10+
-- PyTorch 2.0+
-- CUDA 11.8+ (for GPU training)
-- `mamba-ssm` (REQUIRED for fast training)
-- `causal-conv1d`
-
-### Installation for Development
-
-```bash
-# Install in editable mode
-pip install -e ".[dev]"
-
-# Install pre-commit hooks
-pre-commit install
-
-# Run tests
-pytest tests/
-```
-
-### Project Dependencies
-
-```
-torch>=2.0.0
-numpy>=1.24.0
-scipy>=1.10.0
-scikit-learn>=1.2.0
-tqdm>=4.65.0
-pyyaml>=6.0
-tensorboard>=2.12.0
-mamba-ssm>=1.1.0
-causal-conv1d>=1.1.0
-allensdk  # For Allen data
-h5py
-pynwb
-```
-
----
-
-## 📚 Documentation
-
-### Getting Started
-- **[Quick Start](docs/QUICK_START.md)** - Get running in 5 minutes
-- **[Training Guide](docs/TRAINING_GUIDE.md)** - Detailed instructions
-
-### Advanced
-- **[Scaling Strategy](docs/SCALING_STRATEGY.md)** - Progressive training approach
-- **[Optimal Training Plan](docs/OPTIMAL_TRAINING_PLAN.md)** - Multi-dataset strategy
-
-### Reference
-- **Architecture:** [src/neuros_neurofm/models/](src/neuros_neurofm/models/)
-- **Configs:** [configs/](configs/)
-- **Deployment:** [deployment/](deployment/)
-
----
-
-## 🔬 Supported Datasets
-
-### Currently Integrated
-- Allen Brain Observatory - Neuropixels
-- Allen Brain Observatory - 2-Photon
-
-### Ready to Integrate (Public & Free)
-- International Brain Laboratory (IBL)
-- CRCNS Hippocampus
-- Miniscope
-- DANDI Archive
-- Neural Latents Benchmark (NHP)
-
-See [docs/OPTIMAL_TRAINING_PLAN.md](docs/OPTIMAL_TRAINING_PLAN.md) for multi-dataset training.
-
----
-
-## 🤝 Contributing
-
-Contributions welcome! Areas:
-- Additional tokenizers (ECoG, Utah arrays, EEG)
-- New task heads (RL, attention, sleep staging)
-- Optimization improvements
-- Multi-GPU training
-- Additional benchmarks
-
----
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) for details
-
----
-
-## 🙏 Acknowledgments
-
-- **Allen Institute** - Neuropixels & 2-photon datasets
-- **Mamba (Gu & Dao)** - Selective state-space models
-- **Perceiver (Jaegle et al.)** - Cross-attention architecture
-- **CEBRA** - Contrastive learning inspiration
-
----
-
-## 📧 Support
-
-- **Issues:** [GitHub Issues](issues)
-- **Documentation:** [docs/](docs/)
-- **Discussions:** [GitHub Discussions](discussions)
-
----
-
-## 🚀 Quick Commands
-
-```bash
-# Install
-pip install -e . && pip install mamba-ssm causal-conv1d
-
-# Train (quick test)
-python training/train.py --config configs/quick_test.yaml
-
-# Train (full)
-python training/train.py --config configs/local_full.yaml
-
-# Monitor
-python scripts/monitor_training.py --checkpoint checkpoints/latest.pt
-
-# Benchmark
-python benchmarks/benchmark_neurofmx.py --checkpoint checkpoints/best.pt
-
-# Docker
-docker-compose up neurofm-train
-```
-
----
-
-**Build neural foundation models. Start training now! 🧠✨**
+MIT. See the repository [`LICENSE`](../../LICENSE).

--- a/packages/neuros-ui/README.md
+++ b/packages/neuros-ui/README.md
@@ -1,82 +1,57 @@
 # neurOS UI
 
-User interfaces for neurOS - Streamlit dashboard, FastAPI server, and visualizations.
+`neuros-ui` contains optional dashboard, API, and visualization integrations for neurOS.
 
-## Features
-
-- **Real-Time Dashboard**: Streamlit-based monitoring interface
-- **REST API**: FastAPI server for programmatic access
-- **Interactive Visualizations**: Plotly, Matplotlib, Seaborn
-- **Live Data Streaming**: WebSocket support for real-time updates
-- **Experiment Tracking**: Built-in visualization for training runs
+> **Maturity boundary:** this package currently builds as part of the workspace, but it does not yet have the same release-blocking behavioral qualification as `neuros-core`. Treat it as an integration/prototyping surface until dedicated dashboard/API contract tests and supported reference deployments are added.
 
 ## Installation
 
 ```bash
-# Minimal installation (visualization only)
 pip install neuros-ui
-
-# With Streamlit dashboard
-pip install neuros-ui[dashboard]
-
-# With FastAPI server
-pip install neuros-ui[api]
-
-# Everything
-pip install neuros-ui[all]
+pip install "neuros-ui[dashboard]"  # Streamlit
+pip install "neuros-ui[api]"        # FastAPI + Uvicorn
+pip install "neuros-ui[viz]"        # Plotly + Seaborn
+pip install "neuros-ui[all]"
 ```
 
-## Quick Start
+## Architectural role
 
-### Streamlit Dashboard
+UI code should consume the same neurOS configuration, runtime, recording, and event contracts used by local execution. It should **not** become a second orchestration engine with different lifecycle, timing, or model semantics.
 
-```bash
-# Launch dashboard
-streamlit run -m neuros.ui.dashboard
+The intended direction is:
+
+```text
+RuntimeGraph / recording / quality / model evidence
+                    |
+                    v
+              API / dashboard
 ```
 
-### FastAPI Server
+High-value UI work for the Developer Preview includes:
 
-```python
-from neuros.ui.api import create_app
+- runtime graph and stream health;
+- queue loss and latency distributions;
+- recording/replay inspection;
+- device/model/config provenance;
+- qualification/evidence history;
+- model/representation comparison artifacts;
+- explicit warning surfaces when a claim has only software, synthetic, or dataset-level evidence.
 
-# Create API server
-app = create_app()
+## Product rule
 
-# Run server
-# uvicorn neuros.ui.api:app --reload
-```
-
-### Visualization
-
-```python
-from neuros.viz import plot_eeg_signal, plot_confusion_matrix
-
-# Plot EEG signal
-plot_eeg_signal(data, sampling_rate=250)
-
-# Plot model evaluation
-plot_confusion_matrix(y_true, y_pred, labels=['Class A', 'Class B'])
-```
-
-## Features
-
-### Dashboard
-- Live signal monitoring
-- Model performance metrics
-- Training progress visualization
-- Multi-modal data display
-
-### API Endpoints
-- `/predict`: Real-time inference
-- `/train`: Model training
-- `/metrics`: Performance metrics
-- `/status`: System health
+Real-time BCI execution should remain local by default. A dashboard may observe, configure, or request actions through stable APIs, but UI availability must never become a hidden prerequisite for acquisition or safety-critical runtime behavior.
 
 ## Documentation
 
-Full documentation: https://neuros.readthedocs.io
+Current platform documentation and package maturity live in:
+
+- `docs/PROJECT_STATUS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/API_REFERENCE.md`
+- `ROADMAP.md`
+
+Repository: https://github.com/sidhulyalkar/neurOS-v1
 
 ## License
 
-MIT License
+MIT License.

--- a/packages/neuros/README.md
+++ b/packages/neuros/README.md
@@ -1,152 +1,110 @@
 # neurOS
 
-A modular operating system for brain-computer interfaces.
+`neuros` is the user-facing SDK and CLI composition package for the neurOS brain-computer interface runtime.
 
-## Overview
-
-neurOS is a comprehensive platform for building BCI applications, from hardware integration to deep learning models. This meta-package provides convenient installation options for common use cases.
+> **Project status:** active research and engineering platform. Software contract tests do not imply hardware qualification, clinical validation, or safety certification. See the repository's `docs/PROJECT_STATUS.md` for the current package-by-package maturity map.
 
 ## Installation
-
-### Standard Installation (Recommended)
-
-Includes core functionality, drivers, and models:
 
 ```bash
 pip install neuros
 ```
 
-### Minimal Installation
-
-Only core functionality (lightweight, ~50MB):
+Optional profiles declared by this distribution include:
 
 ```bash
-pip install neuros-core
+pip install "neuros[bci]"        # EEG driver dependencies, PyTorch models, dashboard
+pip install "neuros[recording]"  # NWB/Zarr recording interoperability
+pip install "neuros[research]"   # model/foundation/SourceWeigher research stack
+pip install "neuros[orion]"      # ORION contracts/tokenization package
+pip install "neuros[deployment]" # optional UI/cloud integrations
+pip install "neuros[all]"
 ```
 
-### Full Installation
+For monorepo development, prefer the version-controlled workspace profiles in `scripts/bootstrap.py` rather than treating the repository root as one Python package.
 
-Everything including foundation models, UI, and cloud:
+## Start with the CLI
 
 ```bash
-pip install neuros[all]
+neuros doctor --json
+neuros plugins --json
+neuros devices --json
+neuros validate configs/examples/mock_bci.yaml --json
+neuros run configs/examples/mock_bci.yaml --duration 2 --json
 ```
 
-### Custom Installations
+The checked-in mock configuration is deterministic and training-free, making it suitable for installation/runtime smoke testing.
+
+## Record and replay
 
 ```bash
-# BCI applications
-pip install neuros[bci]        # Core + EEG drivers + PyTorch models + Dashboard
+neuros record configs/examples/mock_bci.yaml \
+  --output /tmp/neuros-session \
+  --session-id demo \
+  --duration 2
 
-# Research with foundation models
-pip install neuros[research]   # Models + POYO/NDT/CEBRA
-
-# Production deployment
-pip install neuros[deployment] # UI + Cloud infrastructure
+neuros inspect /tmp/neuros-session --verify --json
+neuros replay /tmp/neuros-session \
+  --config configs/examples/mock_bci.yaml \
+  --json
 ```
 
-### Individual Packages
+The canonical neurOS archive preserves sequence, timing, quality, stream metadata, provenance, and integrity semantics. NWB and Zarr are interoperability exports rather than replacements for the lossless replay boundary.
 
-```bash
-pip install neuros-core        # Core pipeline and agents
-pip install neuros-drivers     # Hardware drivers (EEG, video, audio)
-pip install neuros-models      # Deep learning models
-pip install neuros-foundation  # Foundation models (POYO, NDT, CEBRA)
-pip install neuros-ui          # Dashboard and API
-pip install neuros-cloud       # Cloud infrastructure
-```
+## Python API
 
-## Quick Start
+The compatibility/convenience pipeline compiles standard paths to the native runtime graph:
 
 ```python
-from neuros.drivers import MockDriver
-from neuros.models import EEGNet
-from neuros.core.pipeline import Pipeline
+import asyncio
+import numpy as np
 
-# Create a simple BCI pipeline
-driver = MockDriver(n_channels=64, sampling_rate=250)
-model = EEGNet(n_classes=4, n_channels=64, sampling_rate=250)
-pipeline = Pipeline(driver=driver, model=model)
+from neuros.drivers.mock_driver import MockDriver
+from neuros.models.simple_classifier import SimpleClassifier
+from neuros.pipeline import Pipeline
 
-# Train
-pipeline.train(X_train, y_train)
+model = SimpleClassifier()
+model.train(np.random.randn(100, 40), np.random.randint(0, 2, 100))
 
-# Predict
-predictions = pipeline.predict(X_test)
+pipeline = Pipeline(
+    driver=MockDriver(sampling_rate=250, channels=8),
+    model=model,
+)
+
+metrics = asyncio.run(pipeline.run(duration=2.0))
+print(metrics)
 ```
 
-## Package Structure
+For new architecture work, prefer explicit neurOS contracts, `RuntimeGraph`, plugins, and persistent replay over adding another orchestration abstraction.
 
-neurOS is organized into focused packages:
+## Package ecosystem
 
-- **neuros-core**: Pipeline, orchestrator, agents, signal processing
-- **neuros-drivers**: BrainFlow, LSL, video, audio, NWB I/O
-- **neuros-models**: EEGNet, Transformers, LSTM, classical ML
-- **neuros-foundation**: POYO, NDT, CEBRA, Neuroformer
-- **neuros-ui**: Streamlit dashboard, FastAPI server, visualizations
-- **neuros-cloud**: Kafka, SageMaker, WebDataset, Zarr
+The meta-package composes several independently versioned distributions:
 
-## Features
+- `neuros-core`: runtime, contracts, config, processing, recording/replay, quality;
+- `neuros-drivers`: hardware/simulated/dataset sources;
+- `neuros-models`: task-specific decoders and model-side interpretability manifests;
+- `neuros-foundation`: foundation-model catalog/adapters/representation probes;
+- `neuros-sourceweigher`: source/domain reliability and transfer-aware fusion;
+- `neuros-mechint`: causal mechanism/evidence tooling;
+- `neuros-orion`: ORION tokenization and neural-intelligence contracts;
+- `neuros-ui` and `neuros-cloud`: optional integration surfaces with separate maturity boundaries.
 
-✅ **Multi-Modal**: Synchronize EEG, video, audio, and more
-✅ **Real-Time**: Low-latency processing for live BCI
-✅ **Foundation Models**: Pre-trained models for transfer learning
-✅ **Cloud-Ready**: Kafka, SageMaker, distributed processing
-✅ **Extensible**: Plugin system for custom components
+The architectural rule is simple: research and product integrations may depend on stable runtime contracts, but the runtime kernel must not depend on research implementations.
 
 ## Documentation
 
-- **Tutorials**: https://neuros.readthedocs.io/tutorials
-- **API Reference**: https://neuros.readthedocs.io/api
-- **User Guides**: https://neuros.readthedocs.io/guides
+Current documentation lives in the repository:
 
-## Command Line Interface
+- `README.md`
+- `docs/PROJECT_STATUS.md`
+- `docs/ARCHITECTURE.md`
+- `docs/API_REFERENCE.md`
+- `ROADMAP.md`
+- `CONTRIBUTING.md`
 
-```bash
-# List available devices
-neuros devices
-
-# Start a pipeline
-neuros run --config pipeline_config.yaml
-
-# Export data to NWB
-neuros export --input raw_data/ --output session.nwb
-```
-
-## Examples
-
-See the [notebooks/](https://github.com/<your-user>/neuros2/tree/main/notebooks) directory for tutorials:
-
-- Tutorial 1: Basic Pipelines
-- Tutorial 2: Real-Time Processing
-- Tutorial 3: Multi-Modal Processing
-- Tutorial 4: Custom Models
-- Tutorial 5: Benchmarking
-- Tutorial 6: NWB Integration
-
-## Contributing
-
-We welcome contributions! Please see [CONTRIBUTING.md](https://github.com/<your-user>/neuros2/blob/main/CONTRIBUTING.md) for guidelines.
+Repository: https://github.com/sidhulyalkar/neurOS-v1
 
 ## License
 
-MIT License
-
-## Citation
-
-If you use neurOS in your research, please cite:
-
-```bibtex
-@software{neuros2025,
-  title={neurOS: A Modular Operating System for Brain-Computer Interfaces},
-  author={neurOS Development Team},
-  year={2025},
-  url={https://github.com/<your-user>/neuros2}
-}
-```
-
-## Support
-
-- **Issues**: https://github.com/<your-user>/neuros2/issues
-- **Discussions**: https://github.com/<your-user>/neuros2/discussions
-- **Documentation**: https://neuros.readthedocs.io
+MIT License.

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -32,15 +32,28 @@ ACTIVE_DOCS = (
     "ROADMAP.md",
     "mkdocs.yml",
     "docs/index.md",
+    "docs/PROJECT_STATUS.md",
     "docs/ARCHITECTURE.md",
     "docs/API_REFERENCE.md",
     "docs/getting-started/installation.md",
+    "packages/neuros-core/README.md",
+    "packages/neuros-drivers/README.md",
+    "packages/neuros-models/README.md",
+    "packages/neuros-foundation/README.md",
+    "packages/neuros-ui/README.md",
+    "packages/neuros-cloud/README.md",
+    "packages/neuros/README.md",
+    "packages/orion/README.md",
+    "packages/neuros-neurofm/README.md",
+    "packages/neuros-mechint/README.md",
+    "packages/neuros-sourceweigher/README.md",
 )
 
 STALE_MARKERS = (
     "github.com/yourusername/neuros-v1",
     "github.com/shulyalk/neuros-v1",
     "github.com/<your-user>/neuros2",
+    "neuros.readthedocs.io",
     "pip install -e .",
 )
 


### PR DESCRIPTION
## Purpose

Complete the public documentation convergence at the distribution boundary. The root docs are now current, but several package READMEs that can become PyPI-facing metadata still taught pre-runtime-v3 APIs, advertised unqualified surfaces as production-ready, linked to an obsolete ReadTheDocs host, or even contained `<your-user>/neuros2` placeholders.

## Changes

### `packages/neuros/README.md`

- replaces obsolete `neuros.core.pipeline` / old EEGNet examples with the maintained CLI and compatibility `Pipeline` workflow;
- documents current extras and record/inspect/replay commands;
- describes the full package ecosystem, including SourceWeigher, mech-int, and ORION;
- removes placeholder repository URLs and obsolete documentation routes;
- links users to the canonical project maturity, architecture, API, roadmap, and contribution docs.

### `packages/neuros-core/README.md`

- replaces the old agent-framework description with the implemented contract/runtime/recording/config/quality kernel;
- documents `RuntimeGraph`, explicit overflow semantics, canonical replay, and dependency direction;
- removes obsolete imports and documentation links.

### `packages/neuros-ui/README.md`

- removes unverified endpoint/launch recipes from the public package landing page;
- explicitly marks UI as an integration/prototyping surface until it gains dedicated behavioral qualification;
- defines UI as a consumer of stable runtime/evidence contracts rather than a second orchestrator.

### `packages/neuros-cloud/README.md`

- removes unverified public recipes for cloud classes/import paths;
- explicitly separates optional control-plane infrastructure from local real-time execution;
- defines high-value cloud scope around artifact registry, telemetry, qualification history, collaboration, and reproducible orchestration.

### `packages/neuros-neurofm/README.md`

The expanded hygiene scan exposed a deeper evidence-boundary problem in the alpha NeuroFM README. It contained unsupported public claims such as production readiness, sub-10 ms inference, zero-shot cross-modal transfer, and benchmark ranges without an immutable model artifact/evaluation manifest.

The README is now explicitly an alpha R&D surface. It documents the separation between external foundation-model interoperability (`neuros-foundation`), native foundation-model R&D (`neuros-neurofm`), and promoted representation/adaptation work (`neuros-orion`), and defines the real-data/evidence gates required before promotion.

### Repository hygiene

The hygiene checker now scans all top-level public package READMEs and rejects stale repository placeholders, the obsolete `neuros.readthedocs.io` host, and the historical root editable-install path.

## Evidence tier

Documentation/repository hygiene. No runtime, model, hardware, or scientific behavior is changed.

## Qualification

The exact PR head passed:

- repository hygiene;
- all 11 workspace wheel builds;
- kernel contracts on Python 3.10/3.11/3.12;
- installed BCI run/record/inspect/replay smoke;
- scientific/latency gates;
- recording interoperability;
- model/mech-int contracts;
- foundation interoperability;
- SourceWeigher on Python 3.10/3.11/3.12;
- ORION contracts/tokenization;
- dedicated BrainFlow driver contracts.
