### PR TITLE
evidence: run fixed-evaluation longitudinal EEG calibration curves

### DIFF
--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -75,12 +75,23 @@ jobs:
           python - <<'PY'
           import moabb
           import moabb.datasets as datasets
+          from moabb.paradigms import LeftRightImagery, MotorImagery
           from neuros.foundation_models import find_evidence_sources
 
           major, minor, *_ = (int(part) for part in moabb.__version__.split(".") if part.isdigit())
           assert (major, minor) >= (1, 5), moabb.__version__
           for name in ("Kumar2024", "Ma2020", "Lee2019_MI"):
               assert getattr(datasets, name, None) is not None, name
+
+          assert LeftRightImagery().is_valid(datasets.Kumar2024())
+          assert LeftRightImagery().is_valid(datasets.Lee2019_MI())
+          assert MotorImagery(
+              n_classes=2,
+              events=["right_hand", "right_elbow"],
+          ).is_valid(datasets.Ma2020())
+          if getattr(datasets, "Wang2026", None) is not None:
+              assert LeftRightImagery().is_valid(datasets.Wang2026())
+
           assert find_evidence_sources(ecosystem="MOABB")
           print(f"MOABB {moabb.__version__} evidence profile OK")
           PY

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -1,0 +1,75 @@
+name: neurOS real-world evidence
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-foundation/**"
+      - "docs/REAL_WORLD_EVIDENCE.md"
+      - ".github/workflows/evidence-ci.yml"
+  push:
+    branches:
+      - main
+      - "agent/**"
+    paths:
+      - "packages/neuros-foundation/**"
+      - "docs/REAL_WORLD_EVIDENCE.md"
+      - ".github/workflows/evidence-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  evidence-contracts:
+    name: Evidence contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install local evidence contract stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[dev]"
+      - name: Verify grouped real-world evidence contracts
+        run: pytest -q packages/neuros-foundation/tests/test_real_world.py
+      - name: Exercise evidence discovery and manifest example
+        run: |
+          neuros-foundation evidence
+          neuros-foundation evidence --role longitudinal_bci --json
+          python packages/neuros-foundation/examples/05_real_world_evidence.py
+
+  moabb-profile:
+    name: MOABB evidence profile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install MOABB-backed evidence profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[evidence,dev]"
+      - name: Verify external benchmark ecosystem is importable
+        run: |
+          python - <<'PY'
+          import moabb
+          from neuros.foundation_models import find_evidence_sources
+
+          major, minor, *_ = (int(part) for part in moabb.__version__.split(".") if part.isdigit())
+          assert (major, minor) >= (1, 5), moabb.__version__
+          assert find_evidence_sources(ecosystem="MOABB")
+          print(f"MOABB {moabb.__version__} evidence profile OK")
+          PY
+          pytest -q packages/neuros-foundation/tests/test_real_world.py

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - "packages/neuros-foundation/**"
+      - "scripts/evidence/**"
       - "docs/REAL_WORLD_EVIDENCE.md"
+      - "docs/EVIDENCE_SOURCE_MAP.md"
       - ".github/workflows/evidence-ci.yml"
   push:
     branches:
@@ -12,7 +14,9 @@ on:
       - "agent/**"
     paths:
       - "packages/neuros-foundation/**"
+      - "scripts/evidence/**"
       - "docs/REAL_WORLD_EVIDENCE.md"
+      - "docs/EVIDENCE_SOURCE_MAP.md"
       - ".github/workflows/evidence-ci.yml"
 
 permissions:
@@ -38,13 +42,18 @@ jobs:
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[dev]"
-      - name: Verify grouped real-world evidence contracts
-        run: pytest -q packages/neuros-foundation/tests/test_real_world.py
-      - name: Exercise evidence discovery and manifest example
+      - name: Verify grouped and longitudinal evidence contracts
+        run: |
+          pytest -q \
+            packages/neuros-foundation/tests/test_real_world.py \
+            packages/neuros-foundation/tests/test_longitudinal.py
+      - name: Exercise evidence discovery, manifest example, and runner CLI
         run: |
           neuros-foundation evidence
           neuros-foundation evidence --role longitudinal_bci --json
+          neuros-foundation evidence --role cross_site_transfer --json
           python packages/neuros-foundation/examples/05_real_world_evidence.py
+          python scripts/evidence/run_moabb_longitudinal.py --help
 
   moabb-profile:
     name: MOABB evidence profile
@@ -61,15 +70,21 @@ jobs:
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[evidence,dev]"
-      - name: Verify external benchmark ecosystem is importable
+      - name: Verify external benchmark ecosystem and runner dependencies
         run: |
           python - <<'PY'
           import moabb
+          import moabb.datasets as datasets
           from neuros.foundation_models import find_evidence_sources
 
           major, minor, *_ = (int(part) for part in moabb.__version__.split(".") if part.isdigit())
           assert (major, minor) >= (1, 5), moabb.__version__
+          for name in ("Kumar2024", "Ma2020", "Lee2019_MI"):
+              assert getattr(datasets, name, None) is not None, name
           assert find_evidence_sources(ecosystem="MOABB")
           print(f"MOABB {moabb.__version__} evidence profile OK")
           PY
-          pytest -q packages/neuros-foundation/tests/test_real_world.py
+          pytest -q \
+            packages/neuros-foundation/tests/test_real_world.py \
+            packages/neuros-foundation/tests/test_longitudinal.py
+          python scripts/evidence/run_moabb_longitudinal.py --help

--- a/docs/EVIDENCE_SOURCE_MAP.md
+++ b/docs/EVIDENCE_SOURCE_MAP.md
@@ -1,0 +1,157 @@
+# Evidence Source Map
+
+This page answers a narrower question than the general roadmap: **which public datasets should neurOS use, and what can each one actually prove?**
+
+A large dataset is not automatically strong evidence. The best source is the one whose variation matches the failure mode we want to test.
+
+## Recommended portfolio
+
+| Priority | Source | Modality / scale | What it can test | Best neurOS / ORION use |
+| --- | --- | --- | --- | --- |
+| **A1** | [Kumar2024 / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Kumar2024.html) | EEG, 18 participants, 6 separate-day sessions | Longitudinal drift, offline-to-online transition, adaptation/calibration cost | First executable longitudinal benchmark; SourceWeigher + task decoders + foundation representations |
+| **A1** | [FALCON H1/H2](https://snel-repo.github.io/falcon/datasets.html) | Human intracortical Utah arrays, multiple days | Real iBCI cross-day stability with deliberately small new-day calibration | Primary ORION few-shot/zero-shot adaptation benchmark |
+| **A1** | [IBL Repeated Site](https://docs.internationalbrainlab.org/notebooks_external/2024_data_release_repro_ephys.html) | 91 Neuropixels sessions across 12 labs | Cross-lab/site reproducibility with a standardized task and repeated target | SourceWeigher site reliability; representation invariance; mechanism replication |
+| **A2** | [Wang2026 / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Wang2026.html) | EEG, 39 participants, 5 sessions, online 1D/2D cursor | Repeated-session generalization in a real online control paradigm | Flagship non-invasive BCI evidence once exact upstream adapter/data version is pinned |
+| **A2** | [Ma2020 / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Ma2020.html) | EEG, 25 participants, 15 MI sessions | Dense session drift | Stress-test representation geometry, calibration burden, and mechanism stability |
+| **A2** | [Lee2019 OpenBMI family / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Lee2019_MI.html) | EEG, same 54-person cohort across MI, ERP/P300, SSVEP | Cross-paradigm reuse while holding participant cohort relatively controlled | Test whether a foundation representation is useful beyond one BCI paradigm |
+| **B1** | [Neural Latents Benchmark](https://neurallatents.github.io/datasets.html) | Macaque neural population spikes across motor, sensory, timing tasks | Canonical latent/population modeling | Validate ORION population representations against established neural-modeling baselines |
+| **B1** | [IBL Brain Wide Map](https://docs.internationalbrainlab.org/notebooks_external/2025_data_release_brainwidemap.html) | 459 sessions, 699 insertions, 139 mice, 12 labs | Large cross-lab / cross-region population-neural generalization | Pretraining, source reliability, cross-region representation and mechanism replication |
+| **B2** | [EEGDash](https://eegdash.org/) | BIDS-first corpus spanning hundreds of electrophysiology datasets | Scale, dataset diversity, external-corpus transfer | Dataset discovery and pretraining reservoir; broad stress tests after focused benchmarks are stable |
+
+## Why Kumar2024 should be first
+
+Kumar2024 is a particularly clean first longitudinal study because it has a natural product narrative:
+
+```text
+first day / offline calibration
+        -> later days / online feedback
+        -> neural distribution changes
+        -> how much new-day calibration does each method need?
+```
+
+The headline output should therefore be a **calibration-efficiency curve**, not only a final accuracy:
+
+```text
+held-out-session score
+^
+|                       best adaptive method
+|                    ___/
+|              _____/
+|        _____/        task decoder
+|   ____/
+|__/ fixed decoder
++----------------------------------> labeled calibration examples / seconds
+  0
+```
+
+The most interesting number is the amount of new-session calibration needed to reach a predefined performance target, with uncertainty across subjects and sessions.
+
+## Why FALCON is the strongest ORION product benchmark
+
+FALCON explicitly separates early held-in sessions from later held-out sessions and intentionally provides only a small calibration subset on held-out days. That makes it unusually difficult to hide the recalibration problem behind random train/test splits.
+
+The comparison ladder should be:
+
+```text
+fixed historical decoder
+  -> recent-session-only calibration
+  -> pooled historical sessions
+  -> SourceWeigher
+  -> representation adaptation
+  -> ORION
+```
+
+For each point report:
+
+- official FALCON task metric;
+- zero-calibration intercept;
+- score at matched calibration budgets;
+- area under the calibration-efficiency curve;
+- adaptation time and memory;
+- run-to-run uncertainty;
+- failure behavior when a new day differs substantially from prior days.
+
+Do not modify FALCON's chronological split to make neurOS easier to evaluate.
+
+## Why IBL Repeated Site matters to neurOS even though it is not a human BCI
+
+Human BCI evidence and neural-systems evidence answer different questions.
+
+The IBL repeated-site release is valuable because multiple laboratories used a standardized behavioral task and repeatedly targeted the same brain location. That lets us ask:
+
+- Does a learned representation carry lab identity more strongly than task information?
+- Does SourceWeigher learn to discount an outlying lab/session for defensible reasons?
+- Does a candidate circuit/mechanism replicate when the same experimental idea is repeated elsewhere?
+- Are mechanism claims stable to spike-sorting / unit-set / recording differences?
+- Which results are truly cross-site rather than artifacts of one acquisition pipeline?
+
+This is a much stronger mechanistic-interpretability stress test than repeatedly splitting a single recording.
+
+## Why NLB should be a secondary ORION benchmark
+
+NLB remains a useful canonical neural-population benchmark and its former hidden test data are now available for local evaluation. Its MC_Maze, MC_RTT, Area2_Bump, and DMFC_RSG tasks span different cortical systems and dynamical regimes.
+
+Use NLB to test whether ORION is a good **neural population model**, but not as the sole evidence of deployment stability. Several NLB datasets are single-session, so they cannot answer the same cross-day question as FALCON.
+
+Because the test data are now public, neurOS reports should emphasize repeated random seeds and avoid repeated manual tuning on the released test split.
+
+## Why EEGDash should not be the first benchmark
+
+The live EEGDash catalogue is extraordinarily valuable because it standardizes BIDS entities such as subject, session, task, run, montage/acquisition information, and participant metadata across a very large corpus.
+
+But a giant heterogeneous corpus creates many degrees of freedom:
+
+- which datasets were selected;
+- which tasks were mapped together;
+- which labels were harmonized;
+- which montages/sample rates were accepted;
+- which recordings were excluded;
+- which subjects/sites entered pretraining versus evaluation.
+
+Therefore EEGDash should initially be used for:
+
+1. metadata-first dataset discovery;
+2. pretraining corpus construction with an immutable corpus manifest;
+3. external-corpus transfer after a model is frozen;
+4. leave-dataset-out stress tests;
+5. identifying datasets with the exact longitudinal/site/device structure required by a new evidence question.
+
+Every corpus build should emit the full selected recording IDs and BIDS entities before training.
+
+## Evidence matrix
+
+The system should eventually maintain an evidence matrix rather than a single leaderboard:
+
+| Claim dimension | Kumar / Wang / Ma | Lee2019 family | FALCON H1/H2 | NLB | IBL repeated site | EEGDash |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Cross-session | **strong** | strong | **strong** | limited | moderate | source-dependent |
+| Cross-subject | strong | **strong** | not H1/H2 | limited | strong | **very strong** |
+| Cross-paradigm | limited | **strong** | movement vs communication across datasets | strong task diversity | fixed task | **very strong** |
+| Cross-site/lab | limited | limited | limited | limited | **excellent** | strong if selected explicitly |
+| Online BCI relevance | **strong** | strong | **excellent** | indirect | indirect | source-dependent |
+| Few-shot adaptation | **strong** | possible | **benchmark-defining** | not primary | possible | source-dependent |
+| Population tokenization | not current ORION contract | not current ORION contract | **strong candidate** | **excellent** | **excellent** | iEEG/EEG need separate contracts |
+| Mechanism replication | session-level | paradigm-level | day-level | task/session-level | **excellent** | possible at scale |
+| Pretraining scale | modest | modest | modest | modest | large | **excellent** |
+
+## Showcase order
+
+The public showcase should progress in this order:
+
+1. **Reproducibility:** mock/live run -> record -> verify -> replay.
+2. **Longitudinal EEG:** Kumar2024 held-out-session calibration curve.
+3. **BCI adaptation:** FALCON H1/H2 later-day calibration frontier.
+4. **Scientific trust:** IBL repeated-site cross-lab representation / SourceWeigher / mechanism replication.
+5. **Scale:** freeze the selected representation, then test it on a manifest-defined EEGDash or Brain Wide Map corpus.
+
+Each stage answers a different objection an external user may have:
+
+```text
+"Can I reproduce it?"
+        -> "Does it survive tomorrow?"
+        -> "Does it adapt with little new data?"
+        -> "Does the mechanism replicate elsewhere?"
+        -> "Does it generalize at scale?"
+```
+
+That sequence is the neurOS story.

--- a/docs/REAL_WORLD_EVIDENCE.md
+++ b/docs/REAL_WORLD_EVIDENCE.md
@@ -1,0 +1,284 @@
+# Real-World Evidence Program
+
+neurOS should be showcased by the **quality of the evidence chain**, not by one favorable accuracy number.
+
+The public story should answer three progressively harder questions:
+
+1. **Does the software reproduce exactly?** Can a run be recorded, verified, replayed, and tied to the same config/model/data identity?
+2. **Does the decoder survive deployment shift?** What happens on a new subject, session, day, or recording, and how much calibration is needed to recover performance?
+3. **Does the physical system behave as claimed?** On named hardware/firmware/transports, what are packet loss, clock uncertainty, queue loss, latency, reconnect behavior, and sustained recording reliability?
+
+A result is valuable only if the evidence tier and unsupported claims are explicit.
+
+## Source selection principles
+
+Prefer public sources that have at least one of these properties:
+
+- repeated sessions/days from the same participant;
+- actual online BCI feedback rather than only offline classification;
+- a benchmark-defined chronological held-in/held-out split;
+- enough subjects to test cross-subject transfer;
+- standardized metadata such as BIDS or NWB;
+- stable DOI/version identity and a redistributable or clearly documented license;
+- an external benchmark ecosystem so neurOS does not grade its own homework.
+
+Large corpora without a clear deployment question belong in pretraining/discovery, not in the headline benchmark.
+
+## Recommended evidence sources
+
+The machine-readable subset of this table is exposed by:
+
+```bash
+neuros-foundation evidence
+neuros-foundation evidence --role longitudinal_bci
+neuros-foundation evidence --modality intracortical --json
+```
+
+### Tier A: longitudinal non-invasive BCI
+
+| Source | Why it matters | Primary neurOS question |
+| --- | --- | --- |
+| [Wang2026 / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Wang2026.html) | 39 participants, 5 sessions, 62-channel EEG, four MI classes, online 1D/2D cursor control and multiple training/control cohorts | Can a decoder/representation remain useful across sessions in a real online BCI training protocol? |
+| [Kumar2024 / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Kumar2024.html) | 18 BCI-naive participants over 6 separate-day sessions; first session offline, later sessions use continuous online feedback | How much labeled or unlabeled calibration is required on a new day, and does transfer reduce it? |
+| [Ma2020 / MOABB](https://moabb.neurotechx.com/docs/generated/moabb.datasets.Ma2020.html) | 25 participants and 15 MI sessions per participant across three days | Does representation geometry, decoding utility, and candidate mechanism stability survive dense session drift? |
+
+**Use:** this should be the primary non-invasive benchmark family. MOABB supplies an external, reproducibility-focused evaluation ecosystem rather than a neurOS-specific dataset loader.
+
+### Tier A: invasive BCI adaptation
+
+[FALCON](https://snel-repo.github.io/falcon/) is especially aligned with ORION because its central question is stable neural decoding on later days with very little new-day calibration.
+
+| Source | Public identity | neurOS role |
+| --- | --- | --- |
+| [FALCON H1](https://snel-repo.github.io/falcon/datasets.html) | DANDI `000954`; human Utah-array reach/grasp iBCI | Cross-day continuous decoding and few-shot adaptation |
+| [FALCON H2](https://snel-repo.github.io/falcon/datasets.html) | DANDI `000950`; human handwriting / brain-to-text iBCI | Cross-day communication decoding and calibration efficiency |
+
+FALCON already defines chronological held-in and later held-out sets. Preserve those splits exactly. Do not create an easier random neurOS split and compare it to FALCON results.
+
+Before applying current ORION event/tokenization methods, inspect the released neural representation for each task and record any conversion from source features to neurOS `SignalFrame`/token contracts. A tokenization benchmark is meaningful only when the source representation supports that interpretation.
+
+### Tier B: scale and representation pretraining
+
+[EEGDash](https://eegdash.org/) exposes 700+ BIDS-first electrophysiology datasets through standardized subject/session/task/run metadata and interoperates with MNE/Braindecode.
+
+Use EEGDash for:
+
+- corpus discovery;
+- pretraining dataset mixtures;
+- external-dataset stress tests;
+- checking whether a representation transfers beyond the benchmark it was tuned on.
+
+Do **not** reduce EEGDash to one aggregate accuracy number. Dataset composition, task distribution, licenses, preprocessing, and subject/site leakage must remain visible.
+
+### Tier C: canonical fast regression
+
+Keep one small, established MOABB motor-imagery dataset as a quick developer/CI benchmark. Its job is not to prove a product claim; its job is to catch benchmark-pipeline regressions before expensive longitudinal runs.
+
+## Evidence tracks
+
+### Track 1 — Longitudinal EEG: “Does it still work next session?”
+
+Start with Kumar2024 because the offline-to-online progression maps naturally onto calibration/adaptation experiments. Run Ma2020 as the high-session-count stress test. Use Wang2026 as the flagship online-control study once the exact adapter/data version used by the run is pinned.
+
+For every dataset, compare the same split and downstream capacity across:
+
+1. transparent classical baseline (for example CSP + linear classifier where appropriate);
+2. task-specific neurOS decoder such as EEGNet / EEG-Conformer;
+3. frozen foundation-model representation + matched linear readout;
+4. optional SourceWeigher transfer strategy;
+5. any future ORION EEG representation only after it has an explicit EEG input/token contract.
+
+Report more than task score:
+
+- balanced accuracy / ROC-AUC or task-appropriate primary metric;
+- per-session degradation from the source/calibration domain;
+- calibration samples or seconds required to reach target performance;
+- performance-vs-calibration curve and area under that curve;
+- expected calibration error / Brier score where probabilistic output exists;
+- subject/session leakage probe on learned representations;
+- representation effective rank / anisotropy / CKA;
+- channel-dropout and montage perturbation robustness;
+- repeated-seed uncertainty;
+- training/adaptation wall-clock and inference latency measured separately.
+
+### Track 2 — FALCON: “Can ORION reduce recalibration burden?”
+
+Respect the benchmark's chronological held-in/held-out days. Evaluate a ladder rather than only the best method:
+
+```text
+fixed decoder
+  -> simple recent-session recalibration
+  -> pooled-source transfer
+  -> SourceWeigher
+  -> representation adaptation
+  -> ORION strategy
+```
+
+The central x-axis is **new-day calibration budget**, not model size.
+
+A strong figure is performance against calibration examples/minutes, with the fixed decoder as the zero-calibration intercept. For methods that update online, report both final score and the adaptation trajectory.
+
+For H1/H2, keep the official FALCON task metric and latency definition alongside any neurOS diagnostics. neurOS-specific representation or mechanism metrics are supplementary evidence, not replacement leaderboard metrics.
+
+### Track 3 — Hardware: “Can I trust what actually ran?”
+
+Use one accessible reference configuration first, for example an OpenBCI Cyton-class EEG board through the hardened BrainFlow source, plus an LSL marker/event stream once LSL is promoted to a first-class neurOS source.
+
+A hardware qualification profile should pin:
+
+- physical device and board ID;
+- firmware and acquisition library versions;
+- operating system and transport (USB/Bluetooth/Wi-Fi/serial as applicable);
+- channel names/types/units and actual device sampling rate;
+- timestamp source and clock domain;
+- LSL clock-offset measurements if LSL is used;
+- packet/sample loss and neurOS queue loss;
+- clock drift/uncertainty;
+- reconnect/recovery behavior;
+- sustained run duration;
+- source-to-decision p50/p95/p99 latency;
+- recording integrity and successful deterministic replay;
+- exact config, package, Git, model, and artifact identity.
+
+Run at least a short interactive demo and a longer soak test. The long test is what turns “it worked on my laptop” into hardware evidence.
+
+## Leakage-resistant partition contract
+
+`neuros-foundation` now provides a pre-model split contract:
+
+```python
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    hold_out_groups,
+)
+
+# Conventional MOABB output: X, labels, metadata
+bundle = GroupedEvaluationData.from_moabb_result(
+    (X, labels, metadata),
+    dataset_id="moabb-kumar2024",
+)
+
+partition = hold_out_groups(
+    bundle,
+    split_unit="session",
+    held_out_values=["5"],
+)
+protocol = partition.protocol(
+    name="kumar2024-held-out-session",
+    transfer_regime="few_shot",
+)
+manifest = partition.manifest(protocol=protocol)
+```
+
+The manifest is emitted **before model fitting** and records the deployment-unit split, protocol fingerprint, sample counts, source card, and partition fingerprint. It cannot prove that downstream code avoided every leakage route, but it makes accidental subject/session mixing substantially harder to hide.
+
+For an installed MOABB object/paradigm:
+
+```python
+from neuros.foundation_models import collect_moabb
+
+bundle = collect_moabb(dataset, paradigm, subjects=[1, 2, 3])
+```
+
+Install the optional evidence ecosystem with:
+
+```bash
+python -m pip install -e "packages/neuros-foundation[evidence]"
+```
+
+Pin the exact MOABB/data version in promoted benchmark artifacts. The curated source registry may describe a dataset available in current upstream documentation before that adapter appears in a particular installed release.
+
+## The showcase: neurOS Evidence Console
+
+The eventual UI should not look like a generic ML dashboard. It should look like an **evidence console** with a single run identity and four linked panels.
+
+### 1. Reproducibility
+
+Show:
+
+- run / artifact fingerprint;
+- Git and package identity;
+- dataset DOI/version;
+- config hash;
+- replay integrity status;
+- exact train/calibration/test split.
+
+Headline: **“Can this result be reproduced?”**
+
+### 2. Generalization
+
+Show:
+
+- held-out subject/session/day score;
+- source-domain score beside it;
+- degradation across time;
+- calibration-efficiency curve;
+- comparison to simple baselines.
+
+Headline: **“What happens when the neural distribution moves?”**
+
+### 3. Trust / mechanism
+
+Show separately:
+
+- domain leakage;
+- SourceWeigher weights and stability;
+- channel/unit perturbation sensitivity;
+- candidate mechanism intervention effect;
+- mechanism replication/stability across deployment units.
+
+Headline: **“Why should we trust the transfer?”**
+
+Do not collapse attribution, causal faithfulness, and biological interpretation into one “explainability” score.
+
+### 4. Runtime / hardware
+
+Show:
+
+- live stream/device descriptors;
+- queue loss;
+- clock uncertainty/drift;
+- p50/p95/p99 latency;
+- reconnect events;
+- recording/replay integrity.
+
+Headline: **“Did the physical system satisfy its contract?”**
+
+## Recommended first public demo
+
+A compelling public demo can be run as a three-act sequence:
+
+### Act I — Exactness
+
+```text
+mock/live source -> neurOS graph -> record -> verify -> replay
+```
+
+Show that replay preserves the same signal/runtime contract and evidence identity.
+
+### Act II — Shift
+
+Load one longitudinal MOABB dataset. Fit only on allowed sessions, then reveal a held-out session. Compare a transparent baseline, a neurOS decoder, a foundation representation, and SourceWeigher. Move a calibration-budget slider and redraw performance.
+
+### Act III — Adaptation
+
+Switch to a FALCON cross-day task. Show the official early-day/later-day boundary and the performance-vs-calibration curve. If ORION improves the frontier, the visual claim becomes extremely concrete: **the same neural interface needs less recalibration on a later day**.
+
+That is a much stronger product demonstration than “our transformer got 2% more accuracy.”
+
+## Promotion gates
+
+A result may be featured publicly only when the artifact includes:
+
+- immutable source identity/version;
+- explicit split unit and held-out identities;
+- preprocessing fit boundary;
+- model/representation identity and hash;
+- calibration/adaptation budget;
+- repeated-seed uncertainty or justified deterministic protocol;
+- primary task metric plus relevant robustness/calibration metrics;
+- exact code/package environment;
+- limitations and unsupported claims;
+- replay/reproduction instructions where applicable.
+
+Hardware claims additionally require a named qualification manifest. Closed-loop or clinical claims require separate evidence tiers and must never be inferred from offline benchmark success.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ neurOS is a modular runtime and SDK for building reproducible brain-computer int
 ## Start here
 
 - [Project status and maturity](PROJECT_STATUS.md)
+- [Real-world evidence program](REAL_WORLD_EVIDENCE.md)
 - [Installation](getting-started/installation.md)
 - [Architecture](ARCHITECTURE.md)
 - [API surface](API_REFERENCE.md)
@@ -80,7 +81,12 @@ neuros-models list --mechint-ready
 neuros-models show eeg-conformer
 ```
 
-`neuros-foundation` owns discovery, adapter capability metadata, representation probes, and split/protocol-aware comparisons across neural foundation-model ecosystems. Catalog presence is not treated as proof that a model is locally runnable or independently reproduced.
+`neuros-foundation` owns discovery, adapter capability metadata, representation probes, split/protocol-aware comparisons, and pre-model real-world evidence manifests across neural foundation-model ecosystems. Catalog presence is not treated as proof that a model is locally runnable or independently reproduced.
+
+```bash
+neuros-foundation evidence
+neuros-foundation evidence --role longitudinal_bci
+```
 
 `neuros-sourceweigher` owns source/domain reliability estimation and transfer-risk-aware fusion. It can consume representations without making model packages depend on its algorithms.
 
@@ -100,6 +106,8 @@ ORION is the neural-intelligence layer. Its initial tokenization work uses expli
 
 The synthetic benchmark uses separately seeded train/test sessions, labeled neural motifs, timing jitter, and unit dropout. Fit-requiring tokenizers never auto-fit during evaluation.
 
+Real-world promotion is intentionally modality-specific. Current event/spike tokenizers should first be evaluated on population-neural sources whose released representation supports those semantics; EEG requires its own explicit ORION input/token contract rather than an implicit translation from spike tokens.
+
 ## Quality and evidence
 
 The repository separates evidence rather than collapsing it into one green badge:
@@ -110,11 +118,12 @@ The repository separates evidence rather than collapsing it into one green badge
 - deterministic scientific/latency gates,
 - model/mechanistic-analysis contracts,
 - foundation-model interoperability regressions,
+- deployment-unit-disjoint real-world evidence contracts,
 - SourceWeigher regressions,
 - ORION tokenization contracts and synthetic benchmark evidence,
 - mech-int scientific software gates and executed tutorials.
 
-Hardware qualification, real-dataset evidence, closed-loop qualification, and clinical evidence remain stronger and separate tiers.
+Hardware qualification, completed real-dataset benchmark results, closed-loop qualification, and clinical evidence remain stronger and separate tiers.
 
 ## Repository organization
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,9 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Project Status: PROJECT_STATUS.md
-  - Real-World Evidence: REAL_WORLD_EVIDENCE.md
+  - Real-World Evidence:
+      - Evidence Program: REAL_WORLD_EVIDENCE.md
+      - Ranked Source Map: EVIDENCE_SOURCE_MAP.md
   - Installation: getting-started/installation.md
   - Architecture: ARCHITECTURE.md
   - API Surface: API_REFERENCE.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Project Status: PROJECT_STATUS.md
+  - Real-World Evidence: REAL_WORLD_EVIDENCE.md
   - Installation: getting-started/installation.md
   - Architecture: ARCHITECTURE.md
   - API Surface: API_REFERENCE.md

--- a/packages/neuros-foundation/examples/05_real_world_evidence.py
+++ b/packages/neuros-foundation/examples/05_real_world_evidence.py
@@ -1,0 +1,60 @@
+"""Build a deployment-unit-disjoint evidence manifest without downloading data.
+
+The arrays are synthetic so this example stays deterministic and CI-friendly.
+The metadata shape mirrors the conventional MOABB (X, labels, metadata) boundary;
+replace the fixture with a real MOABB paradigm result for an actual study.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    find_evidence_sources,
+    hold_out_groups,
+)
+
+rng = np.random.default_rng(11)
+records = []
+labels = []
+trials = []
+for subject in ("1", "2", "3"):
+    for session in ("0", "1", "2"):
+        for trial in range(6):
+            label = trial % 2
+            signal = rng.normal(size=(8, 64))
+            signal[0] += 0.25 * label
+            trials.append(signal)
+            labels.append(label)
+            records.append(
+                {
+                    "subject": subject,
+                    "session": session,
+                    "run": "0",
+                }
+            )
+
+bundle = GroupedEvaluationData.from_moabb_result(
+    (np.asarray(trials), np.asarray(labels), records),
+    dataset_id="example-longitudinal-eeg",
+)
+partition = hold_out_groups(
+    bundle,
+    split_unit="session",
+    held_out_values=["2"],
+)
+protocol = partition.protocol(
+    name="example-held-out-session",
+    transfer_regime="linear_probe",
+    notes=("synthetic example only; replace with a pinned public dataset",),
+)
+
+print("Curated longitudinal EEG sources")
+for source in find_evidence_sources(role="longitudinal_bci"):
+    print(f"  {source.id}: {source.title}")
+
+print("\nPre-model evidence manifest")
+print(json.dumps(partition.manifest(protocol=protocol), indent=2, sort_keys=True))

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -44,6 +44,7 @@ cebra = ["cebra>=0.3.0"]
 allen = ["allensdk>=2.15.0"]
 legacy = ["torch>=2.1.0"]
 eeg = ["mne>=1.6.0"]
+evidence = ["moabb>=1.5.0,<2"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
@@ -54,6 +55,7 @@ all = [
     "cebra>=0.3.0",
     "zuna",
     "mne>=1.6.0",
+    "moabb>=1.5.0,<2",
     "allensdk>=2.15.0",
 ]
 

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -26,6 +26,16 @@ from neuros.foundation_models.probes import (
     pairwise_cka,
     representation_report,
 )
+from neuros.foundation_models.real_world import (
+    REAL_WORLD_EVIDENCE_SOURCES,
+    EvaluationPartition,
+    EvidenceSource,
+    GroupedEvaluationData,
+    collect_moabb,
+    find_evidence_sources,
+    get_evidence_source,
+    hold_out_groups,
+)
 from neuros.foundation_models.registry import (
     DEFAULT_REGISTRY,
     AdapterUnavailableError,
@@ -116,6 +126,14 @@ __all__ = [
     "BenchmarkReport",
     "benchmark_embeddings",
     "sample_efficiency_curve",
+    "EvidenceSource",
+    "REAL_WORLD_EVIDENCE_SOURCES",
+    "get_evidence_source",
+    "find_evidence_sources",
+    "GroupedEvaluationData",
+    "EvaluationPartition",
+    "collect_moabb",
+    "hold_out_groups",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -16,6 +16,10 @@ from neuros.foundation_models.benchmark import (
 )
 from neuros.foundation_models.catalog import DEFAULT_MODEL_CARDS, catalog_by_id
 from neuros.foundation_models.integration import FoundationEmbeddingDecoder
+from neuros.foundation_models.longitudinal import (
+    NestedCalibrationSplit,
+    make_nested_calibration_split,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -134,6 +138,8 @@ __all__ = [
     "EvaluationPartition",
     "collect_moabb",
     "hold_out_groups",
+    "NestedCalibrationSplit",
+    "make_nested_calibration_split",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/cli.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/cli.py
@@ -1,4 +1,4 @@
-"""Command-line discovery tools for the neural foundation-model landscape."""
+"""Command-line discovery tools for neural models and real-world evidence sources."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import argparse
 import json
 from typing import Any
 
+from .real_world import find_evidence_sources
 from .registry import DEFAULT_REGISTRY
 
 
@@ -48,10 +49,38 @@ def _print_cards(cards: tuple[Any, ...]) -> None:
         print("  ".join(value.ljust(widths[index]) for index, value in enumerate(row)))
 
 
+def _print_evidence_sources(sources: tuple[Any, ...]) -> None:
+    if not sources:
+        print("No evidence sources matched the requested filters.")
+        return
+    rows = [
+        (
+            source.id,
+            source.ecosystem,
+            source.modality,
+            _compact(source.roles, limit=3),
+            source.title,
+        )
+        for source in sources
+    ]
+    header = ("ID", "ECOSYSTEM", "MODALITY", "ROLES", "TITLE")
+    widths = [
+        max(len(row[index]) for row in rows + [header])
+        for index in range(len(header))
+    ]
+    print("  ".join(value.ljust(widths[index]) for index, value in enumerate(header)))
+    print("  ".join("-" * width for width in widths))
+    for row in rows:
+        print("  ".join(value.ljust(widths[index]) for index, value in enumerate(row)))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="neuros-foundation",
-        description="Discover, compare, and inspect neural foundation models across modalities.",
+        description=(
+            "Discover, compare, and inspect neural foundation models and curated "
+            "real-world evidence sources."
+        ),
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -76,6 +105,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor_parser = subparsers.add_parser("doctor", help="Check local execution adapters")
     doctor_parser.add_argument("--json", action="store_true")
+
+    evidence_parser = subparsers.add_parser(
+        "evidence",
+        help="List curated public sources selected for real-world neurOS evidence",
+    )
+    evidence_parser.add_argument("--modality")
+    evidence_parser.add_argument("--ecosystem")
+    evidence_parser.add_argument("--role")
+    evidence_parser.add_argument("--json", action="store_true")
 
     return parser
 
@@ -132,6 +170,18 @@ def main(argv: list[str] | None = None) -> int:
             for row in rows:
                 mark = "OK" if row["available"] else "MISSING"
                 print(f"[{mark}] {row['model_id']}: {row['reason']}")
+        return 0
+
+    if args.command == "evidence":
+        sources = find_evidence_sources(
+            modality=args.modality,
+            ecosystem=args.ecosystem,
+            role=args.role,
+        )
+        if args.json:
+            _emit_json([source.to_dict() for source in sources])
+        else:
+            _print_evidence_sources(sources)
         return 0
 
     return 2

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal.py
@@ -1,0 +1,217 @@
+"""Longitudinal calibration-budget contracts for real-world neural evaluation.
+
+The core invariant is simple but important: every point on a calibration curve
+must be evaluated on the *same held-out examples*. Calibration examples come
+from a separately frozen pool inside the held-out deployment unit and budgets
+are nested, so a larger budget is a strict superset of a smaller one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+from .real_world import EvaluationPartition
+
+
+@dataclass(frozen=True, slots=True)
+class NestedCalibrationSplit:
+    """Freeze one source-train / calibration-pool / evaluation partition.
+
+    This contract is intended for classification-style longitudinal studies
+    such as motor-imagery EEG. It is deliberately not used for FALCON-style
+    continuous decoding, where calibration windows and chronology should follow
+    the benchmark's native split semantics.
+    """
+
+    partition: EvaluationPartition
+    evaluation_indices: np.ndarray
+    calibration_order_by_class: Mapping[str, np.ndarray]
+    evaluation_fraction: float
+    seed: int
+
+    def __post_init__(self) -> None:
+        if not 0.0 < float(self.evaluation_fraction) < 1.0:
+            raise ValueError("evaluation_fraction must lie strictly between 0 and 1")
+
+        evaluation = np.asarray(self.evaluation_indices, dtype=np.int64).reshape(-1)
+        if len(evaluation) == 0:
+            raise ValueError("fixed evaluation set must be non-empty")
+
+        test_set = set(self.partition.test_indices.tolist())
+        if not set(evaluation.tolist()).issubset(test_set):
+            raise ValueError("evaluation indices must come from the held-out partition")
+        if np.intersect1d(evaluation, self.partition.train_indices).size:
+            raise ValueError("evaluation indices overlap source training data")
+
+        normalized: dict[str, np.ndarray] = {}
+        seen_calibration: set[int] = set()
+        for label, values in self.calibration_order_by_class.items():
+            key = str(label)
+            array = np.asarray(values, dtype=np.int64).reshape(-1)
+            if not set(array.tolist()).issubset(test_set):
+                raise ValueError(f"calibration pool for {key!r} leaves held-out partition")
+            if np.intersect1d(array, evaluation).size:
+                raise ValueError(f"calibration pool for {key!r} overlaps evaluation")
+            if np.intersect1d(array, self.partition.train_indices).size:
+                raise ValueError(f"calibration pool for {key!r} overlaps source training")
+            duplicate = seen_calibration.intersection(array.tolist())
+            if duplicate:
+                raise ValueError(f"calibration pools overlap at indices {sorted(duplicate)}")
+            seen_calibration.update(array.tolist())
+            normalized[key] = array
+
+        if not normalized:
+            raise ValueError("at least one class calibration pool is required")
+
+        covered = set(evaluation.tolist()).union(seen_calibration)
+        if covered != test_set:
+            missing = sorted(test_set - covered)
+            extra = sorted(covered - test_set)
+            raise ValueError(
+                "calibration/evaluation split must cover the held-out partition exactly; "
+                f"missing={missing}, extra={extra}"
+            )
+
+        object.__setattr__(self, "evaluation_indices", evaluation)
+        object.__setattr__(self, "calibration_order_by_class", normalized)
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return tuple(sorted(self.calibration_order_by_class))
+
+    @property
+    def source_train_indices(self) -> np.ndarray:
+        return self.partition.train_indices
+
+    @property
+    def max_budget_per_class(self) -> int:
+        """Largest balanced per-class budget supported by every class."""
+        return min(len(values) for values in self.calibration_order_by_class.values())
+
+    def calibration_indices(self, per_class: int) -> np.ndarray:
+        """Return a deterministic nested balanced calibration subset.
+
+        Budgets larger than the smallest class pool fail closed instead of
+        silently becoming class-imbalanced.
+        """
+        budget = int(per_class)
+        if budget < 0:
+            raise ValueError("calibration budget must be non-negative")
+        if budget > self.max_budget_per_class:
+            raise ValueError(
+                f"budget {budget} exceeds balanced maximum {self.max_budget_per_class}"
+            )
+        if budget == 0:
+            return np.asarray([], dtype=np.int64)
+        selected = [
+            values[:budget]
+            for _, values in sorted(self.calibration_order_by_class.items())
+        ]
+        return np.sort(np.concatenate(selected).astype(np.int64, copy=False))
+
+    def train_indices_for_budget(self, per_class: int) -> np.ndarray:
+        """Historical source data plus the requested held-out calibration data."""
+        calibration = self.calibration_indices(per_class)
+        if len(calibration) == 0:
+            return self.source_train_indices.copy()
+        return np.sort(np.concatenate([self.source_train_indices, calibration]))
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "partition_fingerprint": self.partition.fingerprint,
+            "evaluation_indices": self.evaluation_indices.tolist(),
+            "calibration_order_by_class": {
+                label: values.tolist()
+                for label, values in sorted(self.calibration_order_by_class.items())
+            },
+            "evaluation_fraction": float(self.evaluation_fraction),
+            "seed": int(self.seed),
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def manifest(self) -> dict[str, Any]:
+        y = np.asarray(self.partition.data.y)
+        return {
+            "schema_version": 1,
+            "kind": "nested_calibration_split",
+            "dataset_id": self.partition.data.dataset_id,
+            "split_unit": self.partition.split_unit,
+            "held_out_values": list(self.partition.held_out_values),
+            "source_train_samples": int(len(self.source_train_indices)),
+            "calibration_pool_samples": int(
+                sum(len(values) for values in self.calibration_order_by_class.values())
+            ),
+            "evaluation_samples": int(len(self.evaluation_indices)),
+            "evaluation_fraction_requested": float(self.evaluation_fraction),
+            "max_balanced_budget_per_class": int(self.max_budget_per_class),
+            "calibration_pool_by_class": {
+                label: int(len(values))
+                for label, values in sorted(self.calibration_order_by_class.items())
+            },
+            "evaluation_by_class": {
+                label: int(np.sum(y[self.evaluation_indices].astype(str) == label))
+                for label in self.labels
+            },
+            "seed": int(self.seed),
+            "partition_fingerprint": self.partition.fingerprint,
+            "calibration_split_fingerprint": self.fingerprint,
+            "invariants": [
+                "evaluation indices are fixed across calibration budgets",
+                "calibration budgets are nested within each class",
+                "calibration/evaluation indices are disjoint",
+                "source training data contains no held-out deployment unit",
+            ],
+        }
+
+
+def make_nested_calibration_split(
+    partition: EvaluationPartition,
+    *,
+    evaluation_fraction: float = 0.5,
+    seed: int = 0,
+) -> NestedCalibrationSplit:
+    """Freeze a class-stratified calibration pool and fixed evaluation set.
+
+    At least one held-out example per class is reserved for evaluation. If a
+    class contains only one held-out example it contributes no calibration
+    examples, making the balanced maximum budget zero. This is preferable to
+    silently evaluating on different class support across budgets.
+    """
+    fraction = float(evaluation_fraction)
+    if not 0.0 < fraction < 1.0:
+        raise ValueError("evaluation_fraction must lie strictly between 0 and 1")
+
+    y = np.asarray(partition.data.y)
+    held_out = partition.test_indices
+    held_labels = y[held_out].astype(str)
+    labels = tuple(sorted(np.unique(held_labels).tolist()))
+    if len(labels) < 2:
+        raise ValueError("nested calibration split requires at least two held-out classes")
+
+    rng = np.random.default_rng(int(seed))
+    evaluation: list[np.ndarray] = []
+    calibration: dict[str, np.ndarray] = {}
+
+    for label in labels:
+        class_indices = held_out[held_labels == label].copy()
+        rng.shuffle(class_indices)
+        n_class = len(class_indices)
+        n_evaluation = max(1, int(np.ceil(n_class * fraction)))
+        n_evaluation = min(n_class, n_evaluation)
+        evaluation.append(class_indices[:n_evaluation])
+        calibration[label] = class_indices[n_evaluation:]
+
+    return NestedCalibrationSplit(
+        partition=partition,
+        evaluation_indices=np.sort(np.concatenate(evaluation)),
+        calibration_order_by_class=calibration,
+        evaluation_fraction=fraction,
+        seed=int(seed),
+    )

--- a/packages/neuros-foundation/src/neuros/foundation_models/real_world.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/real_world.py
@@ -25,9 +25,12 @@ EvidenceRole = Literal[
     "cross_subject_transfer",
     "cross_session_transfer",
     "cross_paradigm_transfer",
+    "cross_site_transfer",
     "cross_day_adaptation",
     "few_shot_adaptation",
     "foundation_pretraining",
+    "population_modeling",
+    "mechanism_replication",
     "representation_stress_test",
 ]
 
@@ -210,6 +213,80 @@ REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
         external_id="DANDI:000950",
         notes=(
             "Communication iBCI target with a long chronological held-in period followed by later held-out days.",
+        ),
+    ),
+    EvidenceSource(
+        id="nlb-mc-maze",
+        title="Neural Latents Benchmark MC_Maze",
+        ecosystem="NLB / DANDI",
+        modality="macaque motor-cortex spikes",
+        task="delayed center-out reaching with straight and curved trajectories",
+        access_url="https://neurallatents.github.io/datasets.html",
+        citation="Neural Latents Benchmark (NLB'21)",
+        license=None,
+        subjects=None,
+        sessions=None,
+        roles=(
+            "canonical_benchmark",
+            "population_modeling",
+            "representation_stress_test",
+        ),
+        external_id="NLB:MC_Maze",
+        notes=(
+            "Canonical population-modeling benchmark with motor and premotor cortex spiking plus kinematics.",
+            "The former EvalAI test data became public for local evaluation in January 2026; report multiple seeds and avoid tuning directly on the released test split.",
+        ),
+    ),
+    EvidenceSource(
+        id="ibl-repeated-site",
+        title="IBL Reproducible Ephys repeated-site release",
+        ecosystem="IBL / ONE",
+        modality="mouse Neuropixels spikes/LFP",
+        task="standardized decision-making task at the same repeated brain site across laboratories",
+        access_url=(
+            "https://docs.internationalbrainlab.org/notebooks_external/"
+            "2024_data_release_repro_ephys.html"
+        ),
+        citation="International Brain Laboratory Reproducible Ephys data release",
+        license=None,
+        subjects=None,
+        sessions=91,
+        roles=(
+            "cross_site_transfer",
+            "population_modeling",
+            "mechanism_replication",
+            "representation_stress_test",
+        ),
+        external_id="IBL:RepeatedSite",
+        notes=(
+            "Ninety-one released Neuropixels sessions across 12 laboratories target the same repeated site.",
+            "High-value SourceWeigher and mechanistic-stability benchmark because lab/site effects can be tested without deliberately changing the task and target location.",
+        ),
+    ),
+    EvidenceSource(
+        id="ibl-brain-wide-map",
+        title="IBL Brain Wide Map 2025",
+        ecosystem="IBL / ONE",
+        modality="mouse Neuropixels spikes/LFP + behavior/video",
+        task="standardized decision-making task sampled across the brain and laboratories",
+        access_url=(
+            "https://docs.internationalbrainlab.org/notebooks_external/"
+            "2025_data_release_brainwidemap.html"
+        ),
+        citation="International Brain Laboratory Brain Wide Map; doi:10.1038/s41586-025-09235-0",
+        license=None,
+        subjects=139,
+        sessions=459,
+        roles=(
+            "cross_site_transfer",
+            "foundation_pretraining",
+            "population_modeling",
+            "mechanism_replication",
+        ),
+        external_id="IBL:Brainwidemap",
+        notes=(
+            "The current release spans 459 sessions, 699 probe insertions, 139 subjects, and 12 laboratories.",
+            "Use for cross-lab/brain-region representation and mechanism replication, not as a direct human BCI efficacy claim.",
         ),
     ),
     EvidenceSource(

--- a/packages/neuros-foundation/src/neuros/foundation_models/real_world.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/real_world.py
@@ -24,6 +24,7 @@ EvidenceRole = Literal[
     "online_bci",
     "cross_subject_transfer",
     "cross_session_transfer",
+    "cross_paradigm_transfer",
     "cross_day_adaptation",
     "few_shot_adaptation",
     "foundation_pretraining",
@@ -33,11 +34,11 @@ EvidenceRole = Literal[
 
 @dataclass(frozen=True, slots=True)
 class EvidenceSource:
-    """A public data source selected for a specific neurOS evidence question.
+    """A public source selected for one or more neurOS evidence questions.
 
     Counts are descriptive metadata, not benchmark results. ``sessions`` may be
-    ``None`` for sources whose natural unit is a day/set rather than a uniform
-    per-subject session count.
+    ``None`` when the natural unit is a day/set rather than a uniform per-subject
+    session count.
     """
 
     id: str
@@ -70,9 +71,9 @@ class EvidenceSource:
         return asdict(self)
 
 
-# Stable public datasets selected because they expose deployment-relevant shift,
-# not because neurOS claims state-of-the-art performance on them. The catalog is
-# intentionally small: each source must answer a distinct falsifiable question.
+# Stable public sources selected because they expose deployment-relevant shift,
+# not because neurOS claims state-of-the-art performance on them. Each source
+# should answer a distinct falsifiable question.
 REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
     EvidenceSource(
         id="moabb-wang2026",
@@ -80,7 +81,10 @@ REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
         ecosystem="MOABB",
         modality="EEG",
         task="4-class motor imagery with online 1D/2D cursor control",
-        access_url="https://moabb.neurotechx.com/docs/generated/moabb.datasets.Wang2026.html",
+        access_url=(
+            "https://moabb.neurotechx.com/docs/generated/"
+            "moabb.datasets.Wang2026.html"
+        ),
         citation="doi:10.1038/s41467-026-75435-5; data doi:10.1184/R1/32293995.v1",
         license="CC BY-NC 4.0",
         subjects=39,
@@ -103,7 +107,10 @@ REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
         ecosystem="MOABB",
         modality="EEG",
         task="2-class motor imagery with repeated online visual feedback",
-        access_url="https://moabb.neurotechx.com/docs/generated/moabb.datasets.Kumar2024.html",
+        access_url=(
+            "https://moabb.neurotechx.com/docs/generated/"
+            "moabb.datasets.Kumar2024.html"
+        ),
         citation="doi:10.1093/pnasnexus/pgae076; data doi:10.5281/zenodo.10694880",
         license="CC BY 4.0",
         subjects=18,
@@ -126,7 +133,10 @@ REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
         ecosystem="MOABB",
         modality="EEG",
         task="2-class right-hand versus right-elbow motor imagery",
-        access_url="https://moabb.neurotechx.com/docs/generated/moabb.datasets.Ma2020.html",
+        access_url=(
+            "https://moabb.neurotechx.com/docs/generated/"
+            "moabb.datasets.Ma2020.html"
+        ),
         citation="doi:10.1038/s41597-020-0535-2; data doi:10.7910/DVN/RBN3XG",
         license="CC BY 4.0",
         subjects=25,
@@ -139,6 +149,32 @@ REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
         external_id="Ma2020",
         notes=(
             "Fifteen motor-imagery sessions per subject make this a strong drift/stability stress test.",
+        ),
+    ),
+    EvidenceSource(
+        id="moabb-lee2019-family",
+        title="Lee2019 OpenBMI MI / ERP / SSVEP family",
+        ecosystem="MOABB",
+        modality="EEG",
+        task="three BCI paradigms in a shared 54-participant cohort",
+        access_url=(
+            "https://moabb.neurotechx.com/docs/generated/"
+            "moabb.datasets.Lee2019_MI.html"
+        ),
+        citation="doi:10.1093/gigascience/giz002; data doi:10.5524/100542",
+        license="GPL 3.0 dataset/toolbox distribution",
+        subjects=54,
+        sessions=2,
+        roles=(
+            "online_bci",
+            "cross_subject_transfer",
+            "cross_session_transfer",
+            "cross_paradigm_transfer",
+        ),
+        external_id="Lee2019",
+        notes=(
+            "The same OpenBMI study includes MI, ERP/P300, and SSVEP variants.",
+            "Use this family to test cross-paradigm representation reuse without mixing paradigm-specific labels or metrics.",
         ),
     ),
     EvidenceSource(
@@ -200,6 +236,12 @@ _SOURCE_BY_ID = {source.id: source for source in REAL_WORLD_EVIDENCE_SOURCES}
 if len(_SOURCE_BY_ID) != len(REAL_WORLD_EVIDENCE_SOURCES):  # pragma: no cover
     raise RuntimeError("duplicate real-world evidence source id")
 
+_EXTERNAL_TO_SOURCE_ID = {
+    source.external_id: source.id
+    for source in REAL_WORLD_EVIDENCE_SOURCES
+    if source.external_id is not None
+}
+
 
 def get_evidence_source(source_id: str) -> EvidenceSource:
     """Return one curated evidence source by stable neurOS id."""
@@ -248,10 +290,37 @@ def _metadata_records(metadata: Any) -> tuple[dict[str, Any], ...]:
     return normalized
 
 
-def _string_group(records: Sequence[Mapping[str, Any]], key: str) -> np.ndarray | None:
+def _string_group(
+    records: Sequence[Mapping[str, Any]],
+    key: str,
+) -> np.ndarray | None:
     if not records or any(key not in row for row in records):
         return None
     return np.asarray([str(row[key]) for row in records], dtype=str)
+
+
+def _recording_group(groups: Mapping[str, np.ndarray]) -> np.ndarray | None:
+    """Derive MOABB's contiguous-recording identity as subject/session/run."""
+    if "subject" not in groups or "session" not in groups:
+        return None
+    subject = groups["subject"]
+    session = groups["session"]
+    run = groups.get("run")
+    if run is None:
+        return np.asarray(
+            [
+                f"{sub}/{ses}"
+                for sub, ses in zip(subject, session, strict=True)
+            ],
+            dtype=str,
+        )
+    return np.asarray(
+        [
+            f"{sub}/{ses}/{run_id}"
+            for sub, ses, run_id in zip(subject, session, run, strict=True)
+        ],
+        dtype=str,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -323,11 +392,9 @@ class GroupedEvaluationData:
             values = _string_group(records, key)
             if values is not None:
                 groups[key] = values
-        if "subject" in groups and "session" in groups:
-            groups["recording"] = np.asarray(
-                [f"{subject}/{session}" for subject, session in zip(groups["subject"], groups["session"], strict=True)],
-                dtype=str,
-            )
+        recording = _recording_group(groups)
+        if recording is not None:
+            groups["recording"] = recording
         if not groups:
             raise ValueError(
                 "MOABB metadata must contain at least one of subject/session/run"
@@ -361,8 +428,14 @@ def collect_moabb(
     if not callable(getter):
         raise TypeError("paradigm must provide a callable get_data method")
     result = getter(dataset=dataset, subjects=subjects, **get_data_kwargs)
-    resolved_id = dataset_id or getattr(dataset, "code", None) or dataset.__class__.__name__
-    return GroupedEvaluationData.from_moabb_result(result, dataset_id=str(resolved_id))
+    upstream_id = str(
+        getattr(dataset, "code", None) or dataset.__class__.__name__
+    )
+    resolved_id = dataset_id or _EXTERNAL_TO_SOURCE_ID.get(upstream_id, upstream_id)
+    return GroupedEvaluationData.from_moabb_result(
+        result,
+        dataset_id=str(resolved_id),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -428,7 +501,7 @@ class EvaluationPartition:
 
     @property
     def fingerprint(self) -> str:
-        """Fingerprint the split assignment, labels, and group identities.
+        """Fingerprint split assignment, labels, and deployment identities.
 
         This is not a raw-data checksum. A promoted benchmark artifact must also
         preserve the upstream dataset/version checksum supplied by its data
@@ -453,7 +526,8 @@ class EvaluationPartition:
         """Emit a machine-readable pre-model evidence manifest."""
         if protocol.split_unit != self.split_unit:
             raise ValueError(
-                f"protocol split_unit={protocol.split_unit!r} does not match partition {self.split_unit!r}"
+                "protocol split unit does not match partition: "
+                f"{protocol.split_unit!r} != {self.split_unit!r}"
             )
         group = self.data.groups[self.split_unit]
         train_values = sorted(set(group[self.train_indices].tolist()))
@@ -494,7 +568,8 @@ def hold_out_groups(
     """Create a strict held-out subject/session/site/device/recording split."""
     if split_unit == "sample":
         raise ValueError(
-            "hold_out_groups is for deployment-unit evaluation; use an explicit sample split elsewhere"
+            "hold_out_groups is for deployment-unit evaluation; "
+            "use an explicit sample split elsewhere"
         )
     if split_unit not in data.groups:
         raise ValueError(

--- a/packages/neuros-foundation/src/neuros/foundation_models/real_world.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/real_world.py
@@ -1,0 +1,522 @@
+"""Real-world evidence sources and leakage-resistant grouped evaluation contracts.
+
+This module deliberately stops before model fitting. Its job is to make the
+*evidence boundary* explicit: what public source is being used, which deployment
+unit is held out, and which examples are allowed to influence fitting or
+calibration. Model/representation benchmarks can then consume the resulting
+partition under :class:`~neuros.foundation_models.benchmark.EvaluationProtocol`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Literal, Mapping, Sequence
+
+import numpy as np
+
+from .benchmark import EvaluationProtocol, SplitUnit, TransferRegime
+
+EvidenceRole = Literal[
+    "canonical_benchmark",
+    "longitudinal_bci",
+    "online_bci",
+    "cross_subject_transfer",
+    "cross_session_transfer",
+    "cross_day_adaptation",
+    "few_shot_adaptation",
+    "foundation_pretraining",
+    "representation_stress_test",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSource:
+    """A public data source selected for a specific neurOS evidence question.
+
+    Counts are descriptive metadata, not benchmark results. ``sessions`` may be
+    ``None`` for sources whose natural unit is a day/set rather than a uniform
+    per-subject session count.
+    """
+
+    id: str
+    title: str
+    ecosystem: str
+    modality: str
+    task: str
+    access_url: str
+    citation: str
+    license: str | None = None
+    subjects: int | None = None
+    sessions: int | None = None
+    roles: tuple[EvidenceRole, ...] = ()
+    external_id: str | None = None
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.id.strip():
+            raise ValueError("evidence source id must be non-empty")
+        if not self.title.strip():
+            raise ValueError("evidence source title must be non-empty")
+        if not self.access_url.startswith("https://"):
+            raise ValueError("evidence source access_url must use https")
+        if self.subjects is not None and self.subjects <= 0:
+            raise ValueError("subjects must be positive when provided")
+        if self.sessions is not None and self.sessions <= 0:
+            raise ValueError("sessions must be positive when provided")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# Stable public datasets selected because they expose deployment-relevant shift,
+# not because neurOS claims state-of-the-art performance on them. The catalog is
+# intentionally small: each source must answer a distinct falsifiable question.
+REAL_WORLD_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
+    EvidenceSource(
+        id="moabb-wang2026",
+        title="Wang2026 sensory-guided motor-imagery BCI",
+        ecosystem="MOABB",
+        modality="EEG",
+        task="4-class motor imagery with online 1D/2D cursor control",
+        access_url="https://moabb.neurotechx.com/docs/generated/moabb.datasets.Wang2026.html",
+        citation="doi:10.1038/s41467-026-75435-5; data doi:10.1184/R1/32293995.v1",
+        license="CC BY-NC 4.0",
+        subjects=39,
+        sessions=5,
+        roles=(
+            "longitudinal_bci",
+            "online_bci",
+            "cross_subject_transfer",
+            "cross_session_transfer",
+        ),
+        external_id="Wang2026",
+        notes=(
+            "Primary non-invasive flagship: repeated sessions plus real online cursor feedback.",
+            "Use cohort/group metadata explicitly; do not collapse experimental conditions silently.",
+        ),
+    ),
+    EvidenceSource(
+        id="moabb-kumar2024",
+        title="Kumar2024 longitudinal motor-imagery training",
+        ecosystem="MOABB",
+        modality="EEG",
+        task="2-class motor imagery with repeated online visual feedback",
+        access_url="https://moabb.neurotechx.com/docs/generated/moabb.datasets.Kumar2024.html",
+        citation="doi:10.1093/pnasnexus/pgae076; data doi:10.5281/zenodo.10694880",
+        license="CC BY 4.0",
+        subjects=18,
+        sessions=6,
+        roles=(
+            "longitudinal_bci",
+            "online_bci",
+            "cross_session_transfer",
+            "few_shot_adaptation",
+        ),
+        external_id="Kumar2024",
+        notes=(
+            "Useful for calibration-cost/adaptation studies because session 1 is offline and later sessions include online feedback.",
+            "MOABB includes the bar-feedback runs and excludes the car-racing runs.",
+        ),
+    ),
+    EvidenceSource(
+        id="moabb-ma2020",
+        title="Ma2020 same-limb motor-imagery longitudinal EEG",
+        ecosystem="MOABB",
+        modality="EEG",
+        task="2-class right-hand versus right-elbow motor imagery",
+        access_url="https://moabb.neurotechx.com/docs/generated/moabb.datasets.Ma2020.html",
+        citation="doi:10.1038/s41597-020-0535-2; data doi:10.7910/DVN/RBN3XG",
+        license="CC BY 4.0",
+        subjects=25,
+        sessions=15,
+        roles=(
+            "longitudinal_bci",
+            "cross_session_transfer",
+            "representation_stress_test",
+        ),
+        external_id="Ma2020",
+        notes=(
+            "Fifteen motor-imagery sessions per subject make this a strong drift/stability stress test.",
+        ),
+    ),
+    EvidenceSource(
+        id="falcon-h1",
+        title="FALCON H1 human reach-and-grasp iBCI",
+        ecosystem="FALCON / DANDI",
+        modality="intracortical",
+        task="reach and grasp kinematic decoding across days",
+        access_url="https://snel-repo.github.io/falcon/datasets.html",
+        citation="FALCON benchmark; DANDI 000954",
+        license=None,
+        subjects=1,
+        sessions=None,
+        roles=("cross_day_adaptation", "few_shot_adaptation"),
+        external_id="DANDI:000954",
+        notes=(
+            "Human Utah-array data with explicit early-day held-in and later-day held-out benchmark sets.",
+            "Primary invasive ORION adaptation target after verifying the released neural representation contract.",
+        ),
+    ),
+    EvidenceSource(
+        id="falcon-h2",
+        title="FALCON H2 human handwriting iBCI",
+        ecosystem="FALCON / DANDI",
+        modality="intracortical",
+        task="handwriting / brain-to-text decoding across days",
+        access_url="https://snel-repo.github.io/falcon/datasets.html",
+        citation="FALCON benchmark; DANDI 000950",
+        license=None,
+        subjects=1,
+        sessions=None,
+        roles=("cross_day_adaptation", "few_shot_adaptation"),
+        external_id="DANDI:000950",
+        notes=(
+            "Communication iBCI target with a long chronological held-in period followed by later held-out days.",
+        ),
+    ),
+    EvidenceSource(
+        id="eegdash-corpus",
+        title="EEGDash BIDS-first electrophysiology corpus",
+        ecosystem="EEGDash",
+        modality="EEG/MEG/iEEG/fNIRS/EMG",
+        task="large-scale corpus discovery and representation pretraining",
+        access_url="https://eegdash.org/",
+        citation="EEGDash project",
+        license=None,
+        subjects=None,
+        sessions=None,
+        roles=("foundation_pretraining", "cross_subject_transfer"),
+        external_id="EEGDash",
+        notes=(
+            "Use as a scale/discovery corpus, not as a single leaderboard score.",
+            "Preserve BIDS subject/session/task/run entities in every downstream split.",
+        ),
+    ),
+)
+
+_SOURCE_BY_ID = {source.id: source for source in REAL_WORLD_EVIDENCE_SOURCES}
+if len(_SOURCE_BY_ID) != len(REAL_WORLD_EVIDENCE_SOURCES):  # pragma: no cover
+    raise RuntimeError("duplicate real-world evidence source id")
+
+
+def get_evidence_source(source_id: str) -> EvidenceSource:
+    """Return one curated evidence source by stable neurOS id."""
+    try:
+        return _SOURCE_BY_ID[source_id]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown evidence source {source_id!r}; available={sorted(_SOURCE_BY_ID)}"
+        ) from exc
+
+
+def find_evidence_sources(
+    *,
+    modality: str | None = None,
+    ecosystem: str | None = None,
+    role: EvidenceRole | None = None,
+) -> tuple[EvidenceSource, ...]:
+    """Filter the curated evidence catalog without downloading any data."""
+    values = REAL_WORLD_EVIDENCE_SOURCES
+    if modality is not None:
+        needle = modality.strip().lower()
+        values = tuple(source for source in values if needle in source.modality.lower())
+    if ecosystem is not None:
+        needle = ecosystem.strip().lower()
+        values = tuple(source for source in values if needle in source.ecosystem.lower())
+    if role is not None:
+        values = tuple(source for source in values if role in source.roles)
+    return values
+
+
+def _metadata_records(metadata: Any) -> tuple[dict[str, Any], ...]:
+    """Normalize pandas-style or sequence metadata into plain dictionaries."""
+    if hasattr(metadata, "to_dict"):
+        try:
+            records = metadata.to_dict(orient="records")
+        except TypeError:
+            records = metadata.to_dict("records")
+    else:
+        records = metadata
+    if isinstance(records, Mapping) or isinstance(records, (str, bytes)):
+        raise TypeError("metadata must be a table/sequence of row mappings")
+    try:
+        normalized = tuple(dict(row) for row in records)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("metadata rows must be mapping-like") from exc
+    return normalized
+
+
+def _string_group(records: Sequence[Mapping[str, Any]], key: str) -> np.ndarray | None:
+    if not records or any(key not in row for row in records):
+        return None
+    return np.asarray([str(row[key]) for row in records], dtype=str)
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedEvaluationData:
+    """Array data plus explicit deployment-unit identities.
+
+    ``groups`` is the critical field. A benchmark that cannot state which
+    subject/session/site/device/recording each sample belongs to cannot claim a
+    deployment-unit-disjoint result through this contract.
+    """
+
+    dataset_id: str
+    X: np.ndarray
+    y: np.ndarray
+    groups: Mapping[str, np.ndarray]
+    metadata: tuple[dict[str, Any], ...] = ()
+
+    def __post_init__(self) -> None:
+        x = np.asarray(self.X)
+        y = np.asarray(self.y)
+        if x.ndim == 0:
+            raise ValueError("X must have a sample dimension")
+        if y.ndim == 0:
+            raise ValueError("y must have a sample dimension")
+        if len(x) != len(y):
+            raise ValueError("X and y must contain the same number of samples")
+        if len(x) < 2:
+            raise ValueError("real-world evaluation requires at least two samples")
+        normalized_groups: dict[str, np.ndarray] = {}
+        for key, values in self.groups.items():
+            name = str(key).strip()
+            if not name:
+                raise ValueError("group names must be non-empty")
+            array = np.asarray(values).reshape(-1).astype(str)
+            if len(array) != len(x):
+                raise ValueError(f"group {name!r} length must match X")
+            normalized_groups[name] = array
+        if not normalized_groups:
+            raise ValueError("at least one deployment-unit group is required")
+        if self.metadata and len(self.metadata) != len(x):
+            raise ValueError("metadata row count must match X")
+        object.__setattr__(self, "X", x)
+        object.__setattr__(self, "y", y)
+        object.__setattr__(self, "groups", normalized_groups)
+
+    @classmethod
+    def from_moabb_result(
+        cls,
+        result: tuple[Any, Any, Any],
+        *,
+        dataset_id: str,
+    ) -> "GroupedEvaluationData":
+        """Build from MOABB's conventional ``(X, labels, metadata)`` result.
+
+        No MOABB import is required here, which keeps the core foundation
+        package light and makes the metadata/split contract independently
+        testable. Install ``neuros-foundation[evidence]`` to obtain MOABB 1.5+
+        for actual dataset loading.
+        """
+        if not isinstance(result, tuple) or len(result) != 3:
+            raise TypeError("MOABB result must be a 3-tuple: (X, labels, metadata)")
+        X, y, metadata = result
+        records = _metadata_records(metadata)
+        if len(records) != len(np.asarray(X)):
+            raise ValueError("MOABB metadata row count must match X")
+
+        groups: dict[str, np.ndarray] = {}
+        for key in ("subject", "session", "run"):
+            values = _string_group(records, key)
+            if values is not None:
+                groups[key] = values
+        if "subject" in groups and "session" in groups:
+            groups["recording"] = np.asarray(
+                [f"{subject}/{session}" for subject, session in zip(groups["subject"], groups["session"], strict=True)],
+                dtype=str,
+            )
+        if not groups:
+            raise ValueError(
+                "MOABB metadata must contain at least one of subject/session/run"
+            )
+        return cls(
+            dataset_id=dataset_id,
+            X=np.asarray(X),
+            y=np.asarray(y),
+            groups=groups,
+            metadata=records,
+        )
+
+
+def collect_moabb(
+    dataset: Any,
+    paradigm: Any,
+    *,
+    subjects: Sequence[int] | None = None,
+    dataset_id: str | None = None,
+    **get_data_kwargs: Any,
+) -> GroupedEvaluationData:
+    """Collect one MOABB paradigm result through a tiny, testable adapter.
+
+    ``dataset`` and ``paradigm`` are intentionally duck-typed. With MOABB 1.5+
+    this corresponds to ``paradigm.get_data(dataset=dataset, subjects=...)``.
+    The function performs no implicit preprocessing beyond whatever paradigm is
+    supplied by the caller; preprocessing identity belongs in the benchmark
+    manifest/protocol.
+    """
+    getter = getattr(paradigm, "get_data", None)
+    if not callable(getter):
+        raise TypeError("paradigm must provide a callable get_data method")
+    result = getter(dataset=dataset, subjects=subjects, **get_data_kwargs)
+    resolved_id = dataset_id or getattr(dataset, "code", None) or dataset.__class__.__name__
+    return GroupedEvaluationData.from_moabb_result(result, dataset_id=str(resolved_id))
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationPartition:
+    """Train/test indices for one explicit held-out deployment unit."""
+
+    data: GroupedEvaluationData
+    split_unit: SplitUnit
+    train_indices: np.ndarray
+    test_indices: np.ndarray
+    held_out_values: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        train = np.asarray(self.train_indices, dtype=np.int64).reshape(-1)
+        test = np.asarray(self.test_indices, dtype=np.int64).reshape(-1)
+        if len(train) == 0 or len(test) == 0:
+            raise ValueError("both train and test partitions must be non-empty")
+        if np.intersect1d(train, test).size:
+            raise ValueError("train and test indices overlap")
+        if np.any(train < 0) or np.any(test < 0):
+            raise ValueError("partition indices must be non-negative")
+        if np.any(train >= len(self.data.X)) or np.any(test >= len(self.data.X)):
+            raise ValueError("partition indices exceed dataset length")
+        object.__setattr__(self, "train_indices", train)
+        object.__setattr__(self, "test_indices", test)
+
+    @property
+    def train(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.data.X[self.train_indices], self.data.y[self.train_indices]
+
+    @property
+    def test(self) -> tuple[np.ndarray, np.ndarray]:
+        return self.data.X[self.test_indices], self.data.y[self.test_indices]
+
+    def protocol(
+        self,
+        *,
+        name: str,
+        transfer_regime: TransferRegime = "linear_probe",
+        preprocessing: str = "fit preprocessing on train partition only",
+        notes: Iterable[str] = (),
+        seed: int = 0,
+    ) -> EvaluationProtocol:
+        """Create the shared foundation-model protocol for this partition."""
+        held = ",".join(self.held_out_values)
+        return EvaluationProtocol(
+            name=name,
+            split_unit=self.split_unit,
+            transfer_regime=transfer_regime,
+            preprocessing=preprocessing,
+            seed=seed,
+            leakage_controls=(
+                f"no {self.split_unit} overlap between train/test",
+                "fit normalization/preprocessing on train partition only",
+                "adaptation/calibration examples are excluded from final evaluation examples",
+            ),
+            notes=(
+                f"dataset={self.data.dataset_id}",
+                f"held_out_{self.split_unit}={held}",
+                *tuple(notes),
+            ),
+        )
+
+    @property
+    def fingerprint(self) -> str:
+        """Fingerprint the split assignment, labels, and group identities.
+
+        This is not a raw-data checksum. A promoted benchmark artifact must also
+        preserve the upstream dataset/version checksum supplied by its data
+        ecosystem. The partition fingerprint prevents accidental split drift.
+        """
+        payload = {
+            "dataset_id": self.data.dataset_id,
+            "split_unit": self.split_unit,
+            "held_out_values": self.held_out_values,
+            "train_indices": self.train_indices.tolist(),
+            "test_indices": self.test_indices.tolist(),
+            "labels": np.asarray(self.data.y).astype(str).tolist(),
+            "groups": {
+                key: np.asarray(values).astype(str).tolist()
+                for key, values in sorted(self.data.groups.items())
+            },
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def manifest(self, *, protocol: EvaluationProtocol) -> dict[str, Any]:
+        """Emit a machine-readable pre-model evidence manifest."""
+        if protocol.split_unit != self.split_unit:
+            raise ValueError(
+                f"protocol split_unit={protocol.split_unit!r} does not match partition {self.split_unit!r}"
+            )
+        group = self.data.groups[self.split_unit]
+        train_values = sorted(set(group[self.train_indices].tolist()))
+        test_values = sorted(set(group[self.test_indices].tolist()))
+        overlap = sorted(set(train_values).intersection(test_values))
+        if overlap:
+            raise ValueError(f"deployment-unit leakage detected: {overlap}")
+        source = _SOURCE_BY_ID.get(self.data.dataset_id)
+        return {
+            "schema_version": 1,
+            "evidence_tier": "real_dataset",
+            "dataset_id": self.data.dataset_id,
+            "source": source.to_dict() if source is not None else None,
+            "n_samples": int(len(self.data.X)),
+            "train_samples": int(len(self.train_indices)),
+            "test_samples": int(len(self.test_indices)),
+            "input_shape": list(self.data.X.shape),
+            "target_shape": list(self.data.y.shape),
+            "split_unit": self.split_unit,
+            "held_out_values": list(self.held_out_values),
+            "train_group_values": train_values,
+            "test_group_values": test_values,
+            "partition_fingerprint": self.fingerprint,
+            "protocol": protocol.to_dict(),
+            "limitations": [
+                "partition fingerprint is not a raw-dataset checksum",
+                "this manifest establishes split/provenance semantics, not model superiority",
+            ],
+        }
+
+
+def hold_out_groups(
+    data: GroupedEvaluationData,
+    *,
+    split_unit: SplitUnit,
+    held_out_values: Iterable[Any],
+) -> EvaluationPartition:
+    """Create a strict held-out subject/session/site/device/recording split."""
+    if split_unit == "sample":
+        raise ValueError(
+            "hold_out_groups is for deployment-unit evaluation; use an explicit sample split elsewhere"
+        )
+    if split_unit not in data.groups:
+        raise ValueError(
+            f"dataset has no {split_unit!r} group; available={sorted(data.groups)}"
+        )
+    held = tuple(sorted({str(value) for value in held_out_values}))
+    if not held:
+        raise ValueError("held_out_values must be non-empty")
+    group = np.asarray(data.groups[split_unit]).astype(str)
+    known = set(group.tolist())
+    missing = sorted(set(held) - known)
+    if missing:
+        raise ValueError(f"unknown held-out {split_unit} values: {missing}")
+    test_mask = np.isin(group, np.asarray(held, dtype=str))
+    train = np.flatnonzero(~test_mask)
+    test = np.flatnonzero(test_mask)
+    if len(train) == 0:
+        raise ValueError("held-out values consume the entire dataset")
+    return EvaluationPartition(
+        data=data,
+        split_unit=split_unit,
+        train_indices=train,
+        test_indices=test,
+        held_out_values=held,
+    )

--- a/packages/neuros-foundation/tests/test_longitudinal.py
+++ b/packages/neuros-foundation/tests/test_longitudinal.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    hold_out_groups,
+    make_nested_calibration_split,
+)
+
+
+def _fixture_partition():
+    # Two historical sessions + one held-out session. The held-out session has
+    # 12 examples/class so a 50% evaluation split leaves 6/class calibration.
+    rng = np.random.default_rng(41)
+    X = []
+    y = []
+    metadata = []
+    for session in ("0", "1", "2"):
+        for label in ("left", "right"):
+            for trial in range(12):
+                X.append(rng.normal(size=(4, 16)))
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"run-{trial // 6}",
+                    }
+                )
+    data = GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="fixture",
+    )
+    return hold_out_groups(data, split_unit="session", held_out_values=["2"])
+
+
+def test_nested_calibration_uses_fixed_evaluation_examples():
+    partition = _fixture_partition()
+    split = make_nested_calibration_split(
+        partition,
+        evaluation_fraction=0.5,
+        seed=7,
+    )
+
+    assert len(split.source_train_indices) == 48
+    assert len(split.evaluation_indices) == 12
+    assert split.max_budget_per_class == 6
+
+    y = partition.data.y.astype(str)
+    assert set(y[split.evaluation_indices]) == {"left", "right"}
+    assert np.sum(y[split.evaluation_indices] == "left") == 6
+    assert np.sum(y[split.evaluation_indices] == "right") == 6
+
+    evaluation_identity = split.evaluation_indices.copy()
+    for budget in (0, 1, 3, 6):
+        calibration = split.calibration_indices(budget)
+        assert len(calibration) == budget * 2
+        assert np.array_equal(split.evaluation_indices, evaluation_identity)
+        assert np.intersect1d(calibration, split.evaluation_indices).size == 0
+        assert np.intersect1d(calibration, split.source_train_indices).size == 0
+
+
+def test_calibration_budgets_are_strictly_nested_per_class():
+    split = make_nested_calibration_split(_fixture_partition(), seed=9)
+    one = set(split.calibration_indices(1).tolist())
+    three = set(split.calibration_indices(3).tolist())
+    six = set(split.calibration_indices(6).tolist())
+
+    assert one < three < six
+    assert len(one) == 2
+    assert len(three) == 6
+    assert len(six) == 12
+
+
+def test_split_fingerprint_and_manifest_are_deterministic():
+    partition = _fixture_partition()
+    first = make_nested_calibration_split(partition, seed=17)
+    second = make_nested_calibration_split(partition, seed=17)
+    changed = make_nested_calibration_split(partition, seed=18)
+
+    assert first.fingerprint == second.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert np.array_equal(first.evaluation_indices, second.evaluation_indices)
+
+    manifest = first.manifest()
+    assert manifest["source_train_samples"] == 48
+    assert manifest["calibration_pool_samples"] == 12
+    assert manifest["evaluation_samples"] == 12
+    assert manifest["max_balanced_budget_per_class"] == 6
+    assert manifest["calibration_pool_by_class"] == {"left": 6, "right": 6}
+    assert manifest["evaluation_by_class"] == {"left": 6, "right": 6}
+    assert manifest["calibration_split_fingerprint"] == first.fingerprint
+
+
+def test_budget_above_balanced_pool_fails_closed():
+    split = make_nested_calibration_split(_fixture_partition(), seed=3)
+    with pytest.raises(ValueError, match="balanced maximum"):
+        split.calibration_indices(split.max_budget_per_class + 1)
+    with pytest.raises(ValueError, match="non-negative"):
+        split.calibration_indices(-1)
+
+
+def test_smallest_class_controls_balanced_budget():
+    rng = np.random.default_rng(5)
+    X = rng.normal(size=(16, 3, 8))
+    y = np.asarray(["left"] * 12 + ["right"] * 4)
+    metadata = [
+        {"subject": "1", "session": "held", "run": f"r-{i}"}
+        for i in range(16)
+    ]
+    # Add source data so holding out the only test session does not consume all data.
+    X = np.concatenate([rng.normal(size=(8, 3, 8)), X], axis=0)
+    y = np.concatenate([np.asarray(["left", "right"] * 4), y])
+    metadata = [
+        {"subject": "1", "session": "source", "run": f"s-{i}"}
+        for i in range(8)
+    ] + metadata
+    data = GroupedEvaluationData.from_moabb_result(
+        (X, y, metadata),
+        dataset_id="imbalanced",
+    )
+    partition = hold_out_groups(data, split_unit="session", held_out_values=["held"])
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=1)
+
+    # right: 4 examples -> 2 fixed evaluation + 2 calibration.
+    assert split.max_budget_per_class == 2
+
+
+def test_invalid_fraction_and_single_class_fail_closed():
+    partition = _fixture_partition()
+    for invalid in (0.0, 1.0, -0.1, 1.1):
+        with pytest.raises(ValueError, match="strictly between"):
+            make_nested_calibration_split(partition, evaluation_fraction=invalid)
+
+    data = partition.data
+    single_class = GroupedEvaluationData(
+        dataset_id="single",
+        X=data.X,
+        y=np.asarray(["left"] * len(data.X)),
+        groups=data.groups,
+        metadata=data.metadata,
+    )
+    held = hold_out_groups(single_class, split_unit="session", held_out_values=["2"])
+    with pytest.raises(ValueError, match="at least two"):
+        make_nested_calibration_split(held)

--- a/packages/neuros-foundation/tests/test_real_world.py
+++ b/packages/neuros-foundation/tests/test_real_world.py
@@ -53,6 +53,18 @@ def test_curated_catalog_answers_distinct_real_world_questions():
     assert lee.subjects == 54
     assert lee.sessions == 2
 
+    canonical = find_evidence_sources(role="canonical_benchmark")
+    assert {source.id for source in canonical} == {"nlb-mc-maze"}
+
+    cross_site = find_evidence_sources(role="cross_site_transfer")
+    assert {source.id for source in cross_site} == {
+        "ibl-repeated-site",
+        "ibl-brain-wide-map",
+    }
+    repeated = get_evidence_source("ibl-repeated-site")
+    assert repeated.sessions == 91
+    assert "mechanism_replication" in repeated.roles
+
 
 def test_from_moabb_result_preserves_subject_session_run_and_recording_identity():
     data = GroupedEvaluationData.from_moabb_result(

--- a/packages/neuros-foundation/tests/test_real_world.py
+++ b/packages/neuros-foundation/tests/test_real_world.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    collect_moabb,
+    find_evidence_sources,
+    get_evidence_source,
+    hold_out_groups,
+)
+
+
+def _moabb_like_result():
+    X = np.arange(12 * 3 * 8, dtype=np.float64).reshape(12, 3, 8)
+    y = np.asarray(["left", "right"] * 6)
+    metadata = []
+    for subject in ("1", "2"):
+        for session in ("0", "1", "2"):
+            for trial in range(2):
+                metadata.append(
+                    {
+                        "subject": subject,
+                        "session": session,
+                        "run": f"run-{trial}",
+                    }
+                )
+    return X, y, metadata
+
+
+def test_curated_catalog_answers_distinct_real_world_questions():
+    wang = get_evidence_source("moabb-wang2026")
+    assert wang.subjects == 39
+    assert wang.sessions == 5
+    assert "online_bci" in wang.roles
+
+    invasive = find_evidence_sources(modality="intracortical")
+    assert {source.id for source in invasive} == {"falcon-h1", "falcon-h2"}
+
+    longitudinal = find_evidence_sources(role="longitudinal_bci")
+    assert {source.id for source in longitudinal} == {
+        "moabb-wang2026",
+        "moabb-kumar2024",
+        "moabb-ma2020",
+    }
+
+
+def test_from_moabb_result_preserves_subject_session_and_recording_identity():
+    data = GroupedEvaluationData.from_moabb_result(
+        _moabb_like_result(),
+        dataset_id="fixture",
+    )
+    assert data.X.shape == (12, 3, 8)
+    assert set(data.groups) == {"subject", "session", "run", "recording"}
+    assert data.groups["recording"][0] == "1/0"
+    assert data.groups["recording"][-1] == "2/2"
+
+
+def test_session_holdout_is_disjoint_and_manifest_is_deterministic():
+    data = GroupedEvaluationData.from_moabb_result(
+        _moabb_like_result(),
+        dataset_id="fixture",
+    )
+    partition = hold_out_groups(data, split_unit="session", held_out_values=["2"])
+    assert len(partition.train_indices) == 8
+    assert len(partition.test_indices) == 4
+    assert set(data.groups["session"][partition.train_indices]) == {"0", "1"}
+    assert set(data.groups["session"][partition.test_indices]) == {"2"}
+
+    protocol = partition.protocol(
+        name="fixture-cross-session",
+        transfer_regime="few_shot",
+        preprocessing="8-30 Hz fit/transform parameters learned from train only",
+    )
+    manifest = partition.manifest(protocol=protocol)
+
+    assert manifest["evidence_tier"] == "real_dataset"
+    assert manifest["train_group_values"] == ["0", "1"]
+    assert manifest["test_group_values"] == ["2"]
+    assert manifest["partition_fingerprint"] == partition.fingerprint
+    assert manifest["protocol"]["fingerprint"] == protocol.fingerprint
+    json.dumps(manifest, sort_keys=True)
+
+    repeat = hold_out_groups(data, split_unit="session", held_out_values=[2])
+    assert repeat.fingerprint == partition.fingerprint
+
+
+def test_unknown_or_total_holdout_fails_closed():
+    data = GroupedEvaluationData.from_moabb_result(
+        _moabb_like_result(),
+        dataset_id="fixture",
+    )
+    with pytest.raises(ValueError, match="unknown held-out"):
+        hold_out_groups(data, split_unit="session", held_out_values=["9"])
+    with pytest.raises(ValueError, match="entire dataset"):
+        hold_out_groups(data, split_unit="subject", held_out_values=["1", "2"])
+    with pytest.raises(ValueError, match="deployment-unit"):
+        hold_out_groups(data, split_unit="sample", held_out_values=[0])
+
+
+def test_moabb_metadata_without_deployment_identity_is_rejected():
+    X, y, _ = _moabb_like_result()
+    metadata = [{"condition": "left"} for _ in range(len(X))]
+    with pytest.raises(ValueError, match="subject/session/run"):
+        GroupedEvaluationData.from_moabb_result(
+            (X, y, metadata),
+            dataset_id="bad",
+        )
+
+
+class _FakeDataset:
+    code = "FakeMOABB"
+
+
+class _FakeParadigm:
+    def __init__(self):
+        self.calls = []
+
+    def get_data(self, *, dataset, subjects, **kwargs):
+        self.calls.append((dataset, subjects, kwargs))
+        return _moabb_like_result()
+
+
+def test_collect_moabb_is_a_thin_explicit_adapter():
+    dataset = _FakeDataset()
+    paradigm = _FakeParadigm()
+    data = collect_moabb(
+        dataset,
+        paradigm,
+        subjects=[1, 2],
+        return_epochs=False,
+    )
+    assert data.dataset_id == "FakeMOABB"
+    assert paradigm.calls == [(dataset, [1, 2], {"return_epochs": False})]
+
+
+def test_moabb_result_shape_and_metadata_contracts_fail_closed():
+    X, y, metadata = _moabb_like_result()
+    with pytest.raises(TypeError, match="3-tuple"):
+        GroupedEvaluationData.from_moabb_result((X, y), dataset_id="bad")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="metadata row count"):
+        GroupedEvaluationData.from_moabb_result(
+            (X, y, metadata[:-1]),
+            dataset_id="bad",
+        )

--- a/packages/neuros-foundation/tests/test_real_world.py
+++ b/packages/neuros-foundation/tests/test_real_world.py
@@ -47,16 +47,37 @@ def test_curated_catalog_answers_distinct_real_world_questions():
         "moabb-ma2020",
     }
 
+    cross_paradigm = find_evidence_sources(role="cross_paradigm_transfer")
+    assert {source.id for source in cross_paradigm} == {"moabb-lee2019-family"}
+    lee = cross_paradigm[0]
+    assert lee.subjects == 54
+    assert lee.sessions == 2
 
-def test_from_moabb_result_preserves_subject_session_and_recording_identity():
+
+def test_from_moabb_result_preserves_subject_session_run_and_recording_identity():
     data = GroupedEvaluationData.from_moabb_result(
         _moabb_like_result(),
         dataset_id="fixture",
     )
     assert data.X.shape == (12, 3, 8)
     assert set(data.groups) == {"subject", "session", "run", "recording"}
-    assert data.groups["recording"][0] == "1/0"
-    assert data.groups["recording"][-1] == "2/2"
+    assert data.groups["recording"][0] == "1/0/run-0"
+    assert data.groups["recording"][-1] == "2/2/run-1"
+
+
+def test_recording_holdout_targets_one_contiguous_moabb_run():
+    data = GroupedEvaluationData.from_moabb_result(
+        _moabb_like_result(),
+        dataset_id="fixture",
+    )
+    partition = hold_out_groups(
+        data,
+        split_unit="recording",
+        held_out_values=["2/2/run-1"],
+    )
+    assert len(partition.test_indices) == 1
+    assert data.groups["recording"][partition.test_indices].tolist() == ["2/2/run-1"]
+    assert "2/2/run-0" in data.groups["recording"][partition.train_indices]
 
 
 def test_session_holdout_is_disjoint_and_manifest_is_deterministic():
@@ -115,6 +136,10 @@ class _FakeDataset:
     code = "FakeMOABB"
 
 
+class _KnownDataset:
+    code = "Kumar2024"
+
+
 class _FakeParadigm:
     def __init__(self):
         self.calls = []
@@ -135,6 +160,19 @@ def test_collect_moabb_is_a_thin_explicit_adapter():
     )
     assert data.dataset_id == "FakeMOABB"
     assert paradigm.calls == [(dataset, [1, 2], {"return_epochs": False})]
+
+
+def test_collect_moabb_resolves_known_upstream_code_to_curated_source():
+    dataset = _KnownDataset()
+    paradigm = _FakeParadigm()
+    data = collect_moabb(dataset, paradigm, subjects=[1])
+    assert data.dataset_id == "moabb-kumar2024"
+
+    partition = hold_out_groups(data, split_unit="session", held_out_values=["2"])
+    protocol = partition.protocol(name="known-source")
+    manifest = partition.manifest(protocol=protocol)
+    assert manifest["source"]["external_id"] == "Kumar2024"
+    assert manifest["source"]["license"] == "CC BY 4.0"
 
 
 def test_moabb_result_shape_and_metadata_contracts_fail_closed():

--- a/scripts/evidence/run_moabb_longitudinal.py
+++ b/scripts/evidence/run_moabb_longitudinal.py
@@ -24,7 +24,6 @@ import importlib.metadata
 import json
 import platform
 import subprocess
-import sys
 import time
 from collections import defaultdict
 from pathlib import Path
@@ -45,21 +44,29 @@ _DATASETS = {
         "class": "Kumar2024",
         "source_id": "moabb-kumar2024",
         "description": "18 participants x 6 separate-day MI sessions",
+        "paradigm": "left_right",
+        "events": None,
     },
     "ma2020": {
         "class": "Ma2020",
         "source_id": "moabb-ma2020",
-        "description": "25 participants x 15 MI sessions",
+        "description": "25 participants x 15 right-hand/right-elbow MI sessions",
+        "paradigm": "motor_imagery",
+        "events": ("right_hand", "right_elbow"),
     },
     "lee2019-mi": {
         "class": "Lee2019_MI",
         "source_id": "moabb-lee2019-family",
         "description": "OpenBMI motor-imagery member of the 54-person shared cohort",
+        "paradigm": "left_right",
+        "events": None,
     },
     "wang2026": {
         "class": "Wang2026",
         "source_id": "moabb-wang2026",
         "description": "39 participants x 5 sessions with online cursor-control study",
+        "paradigm": "left_right",
+        "events": None,
     },
 }
 
@@ -132,7 +139,7 @@ def _parse_text_list(value: str) -> list[str]:
 def _dataset_and_paradigm(dataset_key: str, *, fmin: float, fmax: float):
     try:
         import moabb.datasets as datasets
-        from moabb.paradigms import LeftRightImagery
+        from moabb.paradigms import LeftRightImagery, MotorImagery
     except ImportError as exc:  # pragma: no cover - exercised by real environment
         raise RuntimeError(
             "This benchmark requires the optional evidence stack. Install "
@@ -147,7 +154,29 @@ def _dataset_and_paradigm(dataset_key: str, *, fmin: float, fmax: float):
             "that contains this dataset or choose another --dataset."
         )
     dataset = dataset_cls()
-    paradigm = LeftRightImagery(fmin=float(fmin), fmax=float(fmax))
+    if spec["paradigm"] == "left_right":
+        paradigm = LeftRightImagery(fmin=float(fmin), fmax=float(fmax))
+    elif spec["paradigm"] == "motor_imagery":
+        events = list(spec["events"] or ())
+        paradigm = MotorImagery(
+            n_classes=len(events),
+            events=events,
+            fmin=float(fmin),
+            fmax=float(fmax),
+        )
+    else:  # pragma: no cover - internal registry invariant
+        raise RuntimeError(f"unsupported paradigm kind {spec['paradigm']!r}")
+
+    try:
+        valid = paradigm.is_valid(dataset)
+    except Exception as exc:
+        raise RuntimeError(
+            f"MOABB rejected {spec['class']} for declared paradigm {spec['paradigm']}"
+        ) from exc
+    if valid is False:
+        raise RuntimeError(
+            f"MOABB rejected {spec['class']} for declared paradigm {spec['paradigm']}"
+        )
     return dataset, paradigm
 
 
@@ -338,7 +367,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--evaluation-fraction", type=float, default=0.5)
     parser.add_argument("--fmin", type=float, default=8.0)
     parser.add_argument("--fmax", type=float, default=30.0)
-    parser.add_argument("--csp-components", type=int, default=6)
+    parser.add_argument("--csp-components", type=int, default=8)
     parser.add_argument("--seed", type=int, default=2026)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--overwrite", action="store_true")
@@ -378,7 +407,8 @@ def main(argv: list[str] | None = None) -> int:
         fmin=args.fmin,
         fmax=args.fmax,
     )
-    source_id = _DATASETS[args.dataset]["source_id"]
+    dataset_spec = _DATASETS[args.dataset]
+    source_id = dataset_spec["source_id"]
     source = get_evidence_source(source_id)
 
     rows: list[dict[str, Any]] = []
@@ -419,12 +449,18 @@ def main(argv: list[str] | None = None) -> int:
                 evaluation_fraction=args.evaluation_fraction,
                 seed=split_seed,
             )
+            events_text = (
+                "left_hand/right_hand"
+                if dataset_spec["events"] is None
+                else "/".join(dataset_spec["events"])
+            )
             protocol = partition.protocol(
                 name=f"{source_id}-subject-{subject}-session-{session}",
                 transfer_regime="few_shot",
                 preprocessing=(
-                    f"MOABB LeftRightImagery bandpass {args.fmin:g}-{args.fmax:g} Hz; "
-                    "CSP+LDA fit only on historical sessions plus declared calibration"
+                    f"MOABB {dataset_spec['paradigm']} events={events_text}; "
+                    f"bandpass {args.fmin:g}-{args.fmax:g} Hz; CSP+LDA fit only on "
+                    "historical sessions plus declared calibration"
                 ),
                 notes=(
                     "fixed evaluation subset inside held-out session",
@@ -494,6 +530,11 @@ def main(argv: list[str] | None = None) -> int:
         "method": "CSP+LDA refit with nested held-out-session calibration",
         "source": source.to_dict(),
         "dataset_key": args.dataset,
+        "dataset_class": dataset_spec["class"],
+        "paradigm": {
+            "kind": dataset_spec["paradigm"],
+            "events": list(dataset_spec["events"] or ("left_hand", "right_hand")),
+        },
         "subjects": [int(value) for value in args.subjects],
         "held_out_sessions_requested": args.held_out_sessions,
         "requested_calibration_per_class": [int(value) for value in args.budgets],
@@ -540,14 +581,20 @@ def main(argv: list[str] | None = None) -> int:
     }
     _json_dump(hashes_path, {"sha256": hashes})
 
-    print(json.dumps({
-        "output": str(output),
-        "dataset": source_id,
-        "rows": len(rows),
-        "subject_session_cases": len(split_records),
-        "artifacts": [path.name for path in controlled],
-        "summary": summary,
-    }, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "dataset": source_id,
+                "rows": len(rows),
+                "subject_session_cases": len(split_records),
+                "artifacts": [path.name for path in controlled],
+                "summary": summary,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/scripts/evidence/run_moabb_longitudinal.py
+++ b/scripts/evidence/run_moabb_longitudinal.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Run a leakage-resistant longitudinal EEG calibration benchmark on MOABB.
+
+The first goal is a transparent evidence floor, not a state-of-the-art claim.
+For each subject and held-out session this runner:
+
+1. creates a neurOS deployment-unit-disjoint pre-model partition;
+2. freezes one class-stratified evaluation set inside the held-out session;
+3. freezes the remaining held-out trials as an ordered calibration pool;
+4. refits the same CSP+LDA baseline at nested per-class calibration budgets;
+5. evaluates every budget on the exact same held-out examples;
+6. writes machine-readable manifests, results, summary, hashes, and a report.
+
+Large public datasets are downloaded by MOABB when this script is run. CI does
+not download them; contract behavior is tested with synthetic MOABB-shaped data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.metadata
+import json
+import platform
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+from neuros.foundation_models import (
+    collect_moabb,
+    get_evidence_source,
+    hold_out_groups,
+    make_nested_calibration_split,
+)
+
+
+_DATASETS = {
+    "kumar2024": {
+        "class": "Kumar2024",
+        "source_id": "moabb-kumar2024",
+        "description": "18 participants x 6 separate-day MI sessions",
+    },
+    "ma2020": {
+        "class": "Ma2020",
+        "source_id": "moabb-ma2020",
+        "description": "25 participants x 15 MI sessions",
+    },
+    "lee2019-mi": {
+        "class": "Lee2019_MI",
+        "source_id": "moabb-lee2019-family",
+        "description": "OpenBMI motor-imagery member of the 54-person shared cohort",
+    },
+    "wang2026": {
+        "class": "Wang2026",
+        "source_id": "moabb-wang2026",
+        "description": "39 participants x 5 sessions with online cursor-control study",
+    },
+}
+
+
+def _json_dump(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stable_int_seed(base: int, *parts: Any) -> int:
+    payload = "|".join([str(base), *(str(part) for part in parts)])
+    return int.from_bytes(hashlib.sha256(payload.encode("utf-8")).digest()[:4], "big")
+
+
+def _git_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _versions() -> dict[str, str | None]:
+    result: dict[str, str | None] = {}
+    for distribution in (
+        "neuros-foundation",
+        "neuros-core",
+        "neuros-models",
+        "moabb",
+        "mne",
+        "scikit-learn",
+        "numpy",
+    ):
+        try:
+            result[distribution] = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            result[distribution] = None
+    return result
+
+
+def _parse_int_list(value: str) -> list[int]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated integer")
+    try:
+        parsed = [int(item) for item in values]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("values must be integers") from exc
+    return parsed
+
+
+def _parse_text_list(value: str) -> list[str]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated value")
+    return values
+
+
+def _dataset_and_paradigm(dataset_key: str, *, fmin: float, fmax: float):
+    try:
+        import moabb.datasets as datasets
+        from moabb.paradigms import LeftRightImagery
+    except ImportError as exc:  # pragma: no cover - exercised by real environment
+        raise RuntimeError(
+            "This benchmark requires the optional evidence stack. Install "
+            "`neuros-foundation[evidence]`."
+        ) from exc
+
+    spec = _DATASETS[dataset_key]
+    dataset_cls = getattr(datasets, spec["class"], None)
+    if dataset_cls is None:
+        raise RuntimeError(
+            f"Installed MOABB does not expose {spec['class']}. Pin a MOABB release "
+            "that contains this dataset or choose another --dataset."
+        )
+    dataset = dataset_cls()
+    paradigm = LeftRightImagery(fmin=float(fmin), fmax=float(fmax))
+    return dataset, paradigm
+
+
+def _build_csp_lda(*, components: int):
+    try:
+        from mne.decoding import CSP
+        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+        from sklearn.pipeline import make_pipeline
+    except ImportError as exc:  # pragma: no cover - real environment boundary
+        raise RuntimeError("CSP+LDA baseline requires MNE and scikit-learn") from exc
+    return make_pipeline(CSP(n_components=int(components), reg=None), LDA())
+
+
+def _score_binary(model: Any, X: np.ndarray, y: np.ndarray) -> dict[str, float]:
+    from sklearn.metrics import accuracy_score, balanced_accuracy_score, roc_auc_score
+
+    started = time.perf_counter()
+    prediction = model.predict(X)
+    inference_s = time.perf_counter() - started
+    metrics = {
+        "accuracy": float(accuracy_score(y, prediction)),
+        "balanced_accuracy": float(balanced_accuracy_score(y, prediction)),
+        "inference_s": float(inference_s),
+        "inference_ms_per_trial": float(1000.0 * inference_s / max(len(y), 1)),
+    }
+    classes = np.asarray(getattr(model, "classes_", []))
+    if len(classes) == 2 and hasattr(model, "predict_proba"):
+        probability = np.asarray(model.predict_proba(X), dtype=np.float64)
+        positive = classes[1]
+        y_binary = (np.asarray(y) == positive).astype(np.int64)
+        metrics["roc_auc"] = float(roc_auc_score(y_binary, probability[:, 1]))
+    else:
+        metrics["roc_auc"] = float("nan")
+    return metrics
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(np.mean(array))
+
+
+def _std(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(np.std(array, ddof=1)) if len(array) > 1 else 0.0
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_budget: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_budget[int(row["calibration_per_class"])].append(row)
+
+    curve = []
+    for budget in sorted(by_budget):
+        group = by_budget[budget]
+        curve.append(
+            {
+                "calibration_per_class": budget,
+                "n_subject_session_cases": len(group),
+                "mean_balanced_accuracy": _mean(row["balanced_accuracy"] for row in group),
+                "std_balanced_accuracy": _std(row["balanced_accuracy"] for row in group),
+                "mean_roc_auc": _mean(row["roc_auc"] for row in group),
+                "mean_fit_s": _mean(row["fit_s"] for row in group),
+                "mean_inference_ms_per_trial": _mean(
+                    row["inference_ms_per_trial"] for row in group
+                ),
+            }
+        )
+
+    improvement = None
+    if len(curve) >= 2 and curve[0]["calibration_per_class"] == 0:
+        start = curve[0]["mean_balanced_accuracy"]
+        end = curve[-1]["mean_balanced_accuracy"]
+        if start is not None and end is not None:
+            improvement = float(end - start)
+
+    return {
+        "schema_version": 1,
+        "primary_metric": "balanced_accuracy",
+        "curve": curve,
+        "largest_budget_minus_zero_balanced_accuracy": improvement,
+        "interpretation": (
+            "Descriptive baseline summary only. Statistical comparison and model "
+            "promotion require repeated subjects/sessions and a predeclared analysis plan."
+        ),
+    }
+
+
+def _write_results_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("cannot write empty benchmark results")
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _render_report(
+    *,
+    source: Any,
+    args: argparse.Namespace,
+    rows: list[dict[str, Any]],
+    summary: dict[str, Any],
+    split_records: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "# neurOS Longitudinal EEG Evidence Report",
+        "",
+        f"- Dataset: **{source.title}** (`{source.id}`)",
+        f"- Baseline: **CSP({args.csp_components}) + LDA**",
+        f"- Band: **{args.fmin:g}-{args.fmax:g} Hz**",
+        f"- Fixed held-out evaluation fraction: **{args.evaluation_fraction:.2f}**",
+        f"- Subjects requested: **{', '.join(str(v) for v in args.subjects)}**",
+        f"- Subject-session cases: **{len(split_records)}**",
+        "",
+        "## Calibration frontier",
+        "",
+        "| calibration / class | cases | balanced accuracy mean | std | ROC-AUC mean | fit s | inference ms/trial |",
+        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for point in summary["curve"]:
+        def fmt(value: Any, digits: int = 4) -> str:
+            return "n/a" if value is None else f"{float(value):.{digits}f}"
+
+        lines.append(
+            "| {calibration_per_class} | {n_subject_session_cases} | {ba} | {std} | "
+            "{auc} | {fit} | {infer} |".format(
+                **point,
+                ba=fmt(point["mean_balanced_accuracy"]),
+                std=fmt(point["std_balanced_accuracy"]),
+                auc=fmt(point["mean_roc_auc"]),
+                fit=fmt(point["mean_fit_s"], 3),
+                infer=fmt(point["mean_inference_ms_per_trial"], 3),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Evidence contract",
+            "",
+            "Every subject-session case freezes the held-out session before model fitting. "
+            "Within that session, the evaluation examples are frozen once and never change "
+            "as calibration budget grows. Calibration subsets are nested per class.",
+            "",
+            "The zero-calibration row is therefore a genuine historical-session baseline; "
+            "larger budgets add held-out-session calibration examples but are scored on the "
+            "same evaluation trials.",
+            "",
+            "## Limits",
+            "",
+            "- This report is a transparent baseline, not an ORION or neurOS superiority claim.",
+            "- Dataset files/checksums remain governed by MOABB/upstream repositories; pin those identities for promoted evidence.",
+            "- CSP+LDA is refit when calibration examples are added; it is not an online-update algorithm.",
+            "- Hardware/closed-loop/clinical evidence is outside this offline real-dataset tier.",
+            "",
+            f"Raw result rows: {len(rows)}. See `results.csv`, `study_manifest.json`, and `artifact_hashes.json`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a fixed-evaluation longitudinal MOABB calibration benchmark."
+    )
+    parser.add_argument("--dataset", choices=sorted(_DATASETS), default="kumar2024")
+    parser.add_argument(
+        "--subjects",
+        type=_parse_int_list,
+        default=[1],
+        help="Comma-separated MOABB subject IDs (default: 1).",
+    )
+    parser.add_argument(
+        "--held-out-sessions",
+        type=_parse_text_list,
+        default=None,
+        help="Optional comma-separated session IDs. Default: evaluate every session.",
+    )
+    parser.add_argument(
+        "--budgets",
+        type=_parse_int_list,
+        default=[0, 1, 2, 5, 10],
+        help="Nested labeled calibration trials per class.",
+    )
+    parser.add_argument("--evaluation-fraction", type=float, default=0.5)
+    parser.add_argument("--fmin", type=float, default=8.0)
+    parser.add_argument("--fmax", type=float, default=30.0)
+    parser.add_argument("--csp-components", type=int, default=6)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.fmin <= 0 or args.fmax <= args.fmin:
+        raise SystemExit("require 0 < --fmin < --fmax")
+    if args.csp_components <= 0:
+        raise SystemExit("--csp-components must be positive")
+    if not 0.0 < args.evaluation_fraction < 1.0:
+        raise SystemExit("--evaluation-fraction must lie strictly between 0 and 1")
+    if any(budget < 0 for budget in args.budgets):
+        raise SystemExit("--budgets must be non-negative")
+    args.budgets = sorted(set(args.budgets))
+    if 0 not in args.budgets:
+        args.budgets.insert(0, 0)
+
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    controlled = [
+        output / "study_manifest.json",
+        output / "results.csv",
+        output / "summary.json",
+        output / "report.md",
+        output / "artifact_hashes.json",
+    ]
+    existing = [path for path in controlled if path.exists()]
+    if existing and not args.overwrite:
+        names = ", ".join(path.name for path in existing)
+        raise SystemExit(f"refusing to overwrite existing artifacts: {names}")
+
+    dataset, paradigm = _dataset_and_paradigm(
+        args.dataset,
+        fmin=args.fmin,
+        fmax=args.fmax,
+    )
+    source_id = _DATASETS[args.dataset]["source_id"]
+    source = get_evidence_source(source_id)
+
+    rows: list[dict[str, Any]] = []
+    split_records: list[dict[str, Any]] = []
+    skipped_budgets: list[dict[str, Any]] = []
+
+    for subject in args.subjects:
+        bundle = collect_moabb(
+            dataset,
+            paradigm,
+            subjects=[int(subject)],
+            dataset_id=source_id,
+        )
+        sessions = sorted(set(bundle.groups.get("session", np.asarray([], dtype=str)).tolist()))
+        if len(sessions) < 2:
+            raise RuntimeError(
+                f"subject {subject} has fewer than two sessions after MOABB preprocessing"
+            )
+        selected_sessions = sessions
+        if args.held_out_sessions is not None:
+            missing = sorted(set(args.held_out_sessions) - set(sessions))
+            if missing:
+                raise RuntimeError(
+                    f"subject {subject} does not expose requested session(s) {missing}; "
+                    f"available={sessions}"
+                )
+            selected_sessions = list(args.held_out_sessions)
+
+        for session in selected_sessions:
+            partition = hold_out_groups(
+                bundle,
+                split_unit="session",
+                held_out_values=[session],
+            )
+            split_seed = _stable_int_seed(args.seed, source_id, subject, session)
+            calibration = make_nested_calibration_split(
+                partition,
+                evaluation_fraction=args.evaluation_fraction,
+                seed=split_seed,
+            )
+            protocol = partition.protocol(
+                name=f"{source_id}-subject-{subject}-session-{session}",
+                transfer_regime="few_shot",
+                preprocessing=(
+                    f"MOABB LeftRightImagery bandpass {args.fmin:g}-{args.fmax:g} Hz; "
+                    "CSP+LDA fit only on historical sessions plus declared calibration"
+                ),
+                notes=(
+                    "fixed evaluation subset inside held-out session",
+                    "nested balanced calibration budgets per class",
+                ),
+                seed=split_seed,
+            )
+            record = partition.manifest(protocol=protocol)
+            record["subject"] = int(subject)
+            record["held_out_session"] = str(session)
+            record["calibration"] = calibration.manifest()
+            split_records.append(record)
+
+            X = np.asarray(bundle.X)
+            y = np.asarray(bundle.y)
+            eval_idx = calibration.evaluation_indices
+
+            for budget in args.budgets:
+                if budget > calibration.max_budget_per_class:
+                    skipped_budgets.append(
+                        {
+                            "subject": int(subject),
+                            "held_out_session": str(session),
+                            "requested_per_class": int(budget),
+                            "max_balanced_per_class": int(calibration.max_budget_per_class),
+                        }
+                    )
+                    continue
+
+                train_idx = calibration.train_indices_for_budget(budget)
+                cal_idx = calibration.calibration_indices(budget)
+                model = _build_csp_lda(components=args.csp_components)
+                started = time.perf_counter()
+                model.fit(X[train_idx], y[train_idx])
+                fit_s = time.perf_counter() - started
+                metrics = _score_binary(model, X[eval_idx], y[eval_idx])
+
+                rows.append(
+                    {
+                        "dataset_id": source_id,
+                        "subject": int(subject),
+                        "held_out_session": str(session),
+                        "partition_fingerprint": partition.fingerprint,
+                        "calibration_split_fingerprint": calibration.fingerprint,
+                        "calibration_per_class": int(budget),
+                        "source_train_samples": int(len(calibration.source_train_indices)),
+                        "calibration_samples": int(len(cal_idx)),
+                        "evaluation_samples": int(len(eval_idx)),
+                        "total_fit_samples": int(len(train_idx)),
+                        "accuracy": metrics["accuracy"],
+                        "balanced_accuracy": metrics["balanced_accuracy"],
+                        "roc_auc": metrics["roc_auc"],
+                        "fit_s": float(fit_s),
+                        "inference_s": metrics["inference_s"],
+                        "inference_ms_per_trial": metrics["inference_ms_per_trial"],
+                    }
+                )
+
+    if not rows:
+        raise RuntimeError("benchmark produced no evaluable rows")
+
+    summary = _summarize(rows)
+    manifest = {
+        "schema_version": 1,
+        "evidence_tier": "real_dataset",
+        "study": "longitudinal_eeg_calibration_baseline",
+        "method": "CSP+LDA refit with nested held-out-session calibration",
+        "source": source.to_dict(),
+        "dataset_key": args.dataset,
+        "subjects": [int(value) for value in args.subjects],
+        "held_out_sessions_requested": args.held_out_sessions,
+        "requested_calibration_per_class": [int(value) for value in args.budgets],
+        "evaluation_fraction": float(args.evaluation_fraction),
+        "band_hz": [float(args.fmin), float(args.fmax)],
+        "csp_components": int(args.csp_components),
+        "seed": int(args.seed),
+        "git_revision": _git_revision(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "package_versions": _versions(),
+        "splits": split_records,
+        "skipped_budgets": skipped_budgets,
+        "limitations": [
+            "upstream MOABB/data-file checksums are not yet captured by this runner",
+            "CSP+LDA is a transparent baseline, not an ORION superiority claim",
+            "offline real-dataset evidence is not hardware or closed-loop qualification",
+        ],
+    }
+
+    results_path = output / "results.csv"
+    summary_path = output / "summary.json"
+    manifest_path = output / "study_manifest.json"
+    report_path = output / "report.md"
+    hashes_path = output / "artifact_hashes.json"
+
+    _write_results_csv(results_path, rows)
+    _json_dump(summary_path, summary)
+    _json_dump(manifest_path, manifest)
+    report_path.write_text(
+        _render_report(
+            source=source,
+            args=args,
+            rows=rows,
+            summary=summary,
+            split_records=split_records,
+        ),
+        encoding="utf-8",
+    )
+
+    hashes = {
+        path.name: _sha256(path)
+        for path in (results_path, summary_path, manifest_path, report_path)
+    }
+    _json_dump(hashes_path, {"sha256": hashes})
+
+    print(json.dumps({
+        "output": str(output),
+        "dataset": source_id,
+        "rows": len(rows),
+        "subject_session_cases": len(split_records),
+        "artifacts": [path.name for path in controlled],
+        "summary": summary,
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded by clean PR #25.

#24 was originally stacked on `agent/real-world-evidence-v1`. After #23 was squash-merged, GitHub could no longer represent the stack as a clean five-file delta and the retargeted PR appeared to carry already-merged evidence-history commits.

Rather than merge a misleading history, the genuinely new longitudinal work was rebuilt directly from the exact merged `main` boundary in `agent/longitudinal-eeg-benchmark-v2` and opened as #25. No functionality is intentionally dropped; #25 is the canonical review/qualification surface.