### PR TITLE
evidence: run fixed-evaluation longitudinal EEG calibration curves

### DIFF
--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -7,6 +7,7 @@ on:
       - "scripts/evidence/**"
       - "docs/REAL_WORLD_EVIDENCE.md"
       - "docs/EVIDENCE_SOURCE_MAP.md"
+      - "docs/LONGITUDINAL_EEG_SHOWCASE.md"
       - ".github/workflows/evidence-ci.yml"
   push:
     branches:
@@ -17,6 +18,7 @@ on:
       - "scripts/evidence/**"
       - "docs/REAL_WORLD_EVIDENCE.md"
       - "docs/EVIDENCE_SOURCE_MAP.md"
+      - "docs/LONGITUDINAL_EEG_SHOWCASE.md"
       - ".github/workflows/evidence-ci.yml"
 
 permissions:
@@ -97,5 +99,6 @@ jobs:
           PY
           pytest -q \
             packages/neuros-foundation/tests/test_real_world.py \
-            packages/neuros-foundation/tests/test_longitudinal.py
+            packages/neuros-foundation/tests/test_longitudinal.py \
+            packages/neuros-foundation/tests/test_longitudinal_runner.py
           python scripts/evidence/run_moabb_longitudinal.py --help

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - "packages/neuros-foundation/**"
+      - "scripts/evidence/**"
       - "docs/REAL_WORLD_EVIDENCE.md"
+      - "docs/EVIDENCE_SOURCE_MAP.md"
       - ".github/workflows/evidence-ci.yml"
   push:
     branches:
@@ -12,7 +14,9 @@ on:
       - "agent/**"
     paths:
       - "packages/neuros-foundation/**"
+      - "scripts/evidence/**"
       - "docs/REAL_WORLD_EVIDENCE.md"
+      - "docs/EVIDENCE_SOURCE_MAP.md"
       - ".github/workflows/evidence-ci.yml"
 
 permissions:
@@ -38,13 +42,18 @@ jobs:
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[dev]"
-      - name: Verify grouped real-world evidence contracts
-        run: pytest -q packages/neuros-foundation/tests/test_real_world.py
-      - name: Exercise evidence discovery and manifest example
+      - name: Verify grouped and longitudinal evidence contracts
+        run: |
+          pytest -q \
+            packages/neuros-foundation/tests/test_real_world.py \
+            packages/neuros-foundation/tests/test_longitudinal.py
+      - name: Exercise evidence discovery, manifest example, and runner CLI
         run: |
           neuros-foundation evidence
           neuros-foundation evidence --role longitudinal_bci --json
+          neuros-foundation evidence --role cross_site_transfer --json
           python packages/neuros-foundation/examples/05_real_world_evidence.py
+          python scripts/evidence/run_moabb_longitudinal.py --help
 
   moabb-profile:
     name: MOABB evidence profile
@@ -61,15 +70,32 @@ jobs:
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[evidence,dev]"
-      - name: Verify external benchmark ecosystem is importable
+      - name: Verify external benchmark ecosystem and runner dependencies
         run: |
           python - <<'PY'
           import moabb
+          import moabb.datasets as datasets
+          from moabb.paradigms import LeftRightImagery, MotorImagery
           from neuros.foundation_models import find_evidence_sources
 
           major, minor, *_ = (int(part) for part in moabb.__version__.split(".") if part.isdigit())
           assert (major, minor) >= (1, 5), moabb.__version__
+          for name in ("Kumar2024", "Ma2020", "Lee2019_MI"):
+              assert getattr(datasets, name, None) is not None, name
+
+          assert LeftRightImagery().is_valid(datasets.Kumar2024())
+          assert LeftRightImagery().is_valid(datasets.Lee2019_MI())
+          assert MotorImagery(
+              n_classes=2,
+              events=["right_hand", "right_elbow"],
+          ).is_valid(datasets.Ma2020())
+          if getattr(datasets, "Wang2026", None) is not None:
+              assert LeftRightImagery().is_valid(datasets.Wang2026())
+
           assert find_evidence_sources(ecosystem="MOABB")
           print(f"MOABB {moabb.__version__} evidence profile OK")
           PY
-          pytest -q packages/neuros-foundation/tests/test_real_world.py
+          pytest -q \
+            packages/neuros-foundation/tests/test_real_world.py \
+            packages/neuros-foundation/tests/test_longitudinal.py
+          python scripts/evidence/run_moabb_longitudinal.py --help

--- a/.github/workflows/longitudinal-evidence-study.yml
+++ b/.github/workflows/longitudinal-evidence-study.yml
@@ -1,0 +1,127 @@
+name: neurOS longitudinal EEG study
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: Public MOABB dataset key
+        required: true
+        type: choice
+        default: kumar2024
+        options:
+          - kumar2024
+          - ma2020
+          - lee2019-mi
+          - wang2026
+      subjects:
+        description: Comma-separated MOABB subject IDs
+        required: true
+        type: string
+        default: "1,2,3"
+      budgets:
+        description: Labeled calibration trials per class
+        required: true
+        type: string
+        default: "0,1,2,5,10"
+      history_policy:
+        description: Prior-only is prospective-style; all-other is symmetric cross-session
+        required: true
+        type: choice
+        default: prior
+        options:
+          - prior
+          - all-other
+      evaluation_fraction:
+        description: Fraction of each held-out class frozen for final evaluation
+        required: true
+        type: string
+        default: "0.5"
+      csp_components:
+        description: CSP component count for transparent baseline
+        required: true
+        type: string
+        default: "8"
+      seed:
+        description: Split/calibration seed
+        required: true
+        type: string
+        default: "2026"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: longitudinal-evidence-${{ github.ref }}-${{ inputs.dataset }}-${{ inputs.subjects }}
+  cancel-in-progress: false
+
+jobs:
+  study:
+    name: ${{ inputs.dataset }} / ${{ inputs.history_policy }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install pinned local evidence stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[evidence]"
+
+      - name: Record execution environment
+        run: |
+          mkdir -p evidence-run
+          python -VV > evidence-run/python.txt
+          python -m pip freeze > evidence-run/pip-freeze.txt
+          git rev-parse HEAD > evidence-run/git-revision.txt
+
+      - name: Run real-dataset evidence study
+        env:
+          MNE_DATA: ${{ runner.temp }}/mne-data
+        run: |
+          python scripts/evidence/run_moabb_longitudinal.py \
+            --dataset "${{ inputs.dataset }}" \
+            --subjects "${{ inputs.subjects }}" \
+            --budgets "${{ inputs.budgets }}" \
+            --history-policy "${{ inputs.history_policy }}" \
+            --evaluation-fraction "${{ inputs.evaluation_fraction }}" \
+            --csp-components "${{ inputs.csp_components }}" \
+            --seed "${{ inputs.seed }}" \
+            --output evidence-run/study
+
+      - name: Verify emitted evidence artifacts
+        run: |
+          test -s evidence-run/study/study_manifest.json
+          test -s evidence-run/study/results.csv
+          test -s evidence-run/study/summary.json
+          test -s evidence-run/study/report.md
+          test -s evidence-run/study/artifact_hashes.json
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          root = Path("evidence-run/study")
+          declared = json.loads((root / "artifact_hashes.json").read_text())["sha256"]
+          for name, expected in declared.items():
+              actual = hashlib.sha256((root / name).read_bytes()).hexdigest()
+              assert actual == expected, (name, actual, expected)
+          print("evidence artifact hashes verified")
+          PY
+
+      - name: Upload immutable evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: longitudinal-evidence-${{ inputs.dataset }}-${{ inputs.history_policy }}-${{ github.run_id }}
+          path: evidence-run/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/LONGITUDINAL_EEG_SHOWCASE.md
+++ b/docs/LONGITUDINAL_EEG_SHOWCASE.md
@@ -1,0 +1,290 @@
+# Longitudinal EEG Evidence Showcase
+
+This study is the first executable real-dataset showcase for the neurOS evidence plane.
+
+The goal is not to manufacture a flattering EEG accuracy number. The goal is to answer a deployment question that a BCI engineer, researcher, or buyer can understand immediately:
+
+> **If this decoder worked yesterday, how much data does it need tomorrow?**
+
+## First study: Kumar2024
+
+The recommended first run is the MOABB `Kumar2024` motor-imagery dataset because it contains repeated separate-day sessions and an offline-to-online training progression.
+
+Start with a small evidence run to validate the complete artifact chain:
+
+```bash
+python -m pip install -e "packages/neuros-foundation[evidence]"
+
+python scripts/evidence/run_moabb_longitudinal.py \
+  --dataset kumar2024 \
+  --subjects 1,2,3 \
+  --budgets 0,1,2,5,10 \
+  --history-policy prior \
+  --output evidence/kumar2024-csp-lda
+```
+
+Then scale to the predeclared subject set only after the artifact identities and dataset chronology have been inspected.
+
+## Two different questions, two explicit policies
+
+### `prior` — prospective-style longitudinal evidence
+
+This is the default.
+
+For a target session `S3`:
+
+```text
+S1          S2          S3                         S4          S5
+|-----------|-----------|--------------------------|-----------|
+   HISTORY      HISTORY     CALIBRATION + EVAL        EXCLUDED
+
+fit source data: S1 + S2
+calibration:     declared subset of S3
+final test:      frozen disjoint subset of S3
+future data:     S4 + S5 never enters fitting
+```
+
+The first observed session cannot be evaluated under this policy because no prior history exists.
+
+This is the appropriate default for claims such as:
+
+- next-session robustness;
+- next-day calibration burden;
+- prospective adaptation;
+- degradation as time since initial calibration grows.
+
+First-observed upstream metadata order is treated as chronology by the software. Before publishing or promoting a result, verify that ordering assumption against the dataset documentation and preserve the exact upstream data/version identity.
+
+### `all-other` — symmetric cross-session evaluation
+
+For the same target session `S3`:
+
+```text
+S1          S2          S3                         S4          S5
+|-----------|-----------|--------------------------|-----------|
+   TRAIN        TRAIN      CALIBRATION + EVAL          TRAIN       TRAIN
+```
+
+This mode is useful for conventional cross-session comparison, but it may learn from recordings collected after the target session. It must never be labeled as prospective or next-session deployment evidence.
+
+Run it explicitly:
+
+```bash
+python scripts/evidence/run_moabb_longitudinal.py \
+  --dataset kumar2024 \
+  --subjects 1,2,3 \
+  --history-policy all-other \
+  --output evidence/kumar2024-csp-lda-all-other
+```
+
+## Fixed evaluation identity
+
+Within the held-out session, neurOS freezes two disjoint sets once:
+
+```text
+held-out session
+      |
+      +--> ordered calibration pool
+      |
+      +--> frozen evaluation set
+```
+
+The evaluation set never changes when calibration budget changes.
+
+For a two-class task:
+
+```text
+0 / class   -> source history only
+1 / class   -> source history + 2 calibration trials
+2 / class   -> source history + 4 calibration trials
+5 / class   -> source history + 10 calibration trials
+10 / class  -> source history + 20 calibration trials
+```
+
+All five models are evaluated on exactly the same frozen held-out examples.
+
+This prevents a calibration curve from quietly becoming easier as more calibration examples are consumed.
+
+## Initial baseline
+
+The first benchmark intentionally uses:
+
+**CSP + Linear Discriminant Analysis**
+
+This gives neurOS a transparent floor before introducing higher-capacity models.
+
+The progression should be:
+
+```text
+CSP + LDA
+    |
+    +--> EEGNet
+    +--> EEG-Conformer
+    +--> frozen foundation representation + matched readout
+    +--> SourceWeigher transfer
+    +--> ORION EEG representation, only after an explicit EEG contract exists
+```
+
+Every method must consume the same frozen split and calibration identities.
+
+## Artifact contract
+
+A completed study emits:
+
+```text
+evidence/kumar2024-csp-lda/
+├── study_manifest.json
+├── results.csv
+├── summary.json
+├── report.md
+└── artifact_hashes.json
+```
+
+### `study_manifest.json`
+
+Contains the evidence authority:
+
+- dataset/source card;
+- Git/package/platform identity;
+- paradigm and event semantics;
+- chronological or symmetric history policy;
+- upstream-observed session order;
+- source sessions for every target session;
+- partition fingerprints;
+- fixed calibration/evaluation split fingerprints;
+- requested calibration budgets;
+- preprocessing and model identity;
+- explicit limitations.
+
+### `results.csv`
+
+One row per:
+
+```text
+subject × held-out session × calibration budget
+```
+
+with at least:
+
+- accuracy;
+- balanced accuracy;
+- ROC-AUC where valid;
+- fit time;
+- inference time per trial;
+- partition fingerprint;
+- calibration-split fingerprint.
+
+### `summary.json`
+
+Contains the aggregate calibration frontier used by the report/UI.
+
+### `report.md`
+
+Human-readable rendering of the same result rows. It is a view, not a second source of truth.
+
+### `artifact_hashes.json`
+
+SHA-256 identities for the evidence files.
+
+## Evidence Console design
+
+The public visualization should consume the artifact bundle directly.
+
+### Panel 1 — Session chronology
+
+Show a horizontal session timeline:
+
+```text
+PAST                              TARGET                         FUTURE
+S1 -------- S2 -------- S3 -------- S4 -------- S5 -------- S6
+history     history     history     held out      excluded    excluded
+                                      |
+                              calibration | evaluation
+```
+
+Selecting a target session should reveal:
+
+- which sessions were allowed into source training;
+- how many calibration examples were consumed;
+- the immutable evaluation fingerprint;
+- any excluded future sessions.
+
+The future-excluded region should be visibly different from train data. This makes leakage semantics inspectable rather than buried in a methods paragraph.
+
+### Panel 2 — Calibration frontier
+
+Primary chart:
+
+```text
+held-out balanced accuracy
+^
+|                         ORION / best validated method
+|                  *------*
+|            *-----
+|      *-----         foundation representation
+|  *---
+| *        CSP+LDA
++---------------------------------> labeled calibration / class
+ 0        1       2        5       10
+```
+
+Do not display only the final point.
+
+Useful derived quantities:
+
+- zero-calibration score;
+- largest-budget score;
+- area under the calibration frontier;
+- labels needed to reach a predeclared performance threshold;
+- adaptation wall-clock required to reach that threshold.
+
+The economically legible BCI metric is often **calibration saved**, not raw accuracy gained.
+
+### Panel 3 — Session drift
+
+Display zero-calibration performance versus session index/time.
+
+This reveals whether a method is actually stable or merely easy to recalibrate.
+
+### Panel 4 — Evidence identity
+
+Keep the following visible beside every chart:
+
+```text
+dataset revision
+Git revision
+method/model revision
+history policy
+partition fingerprint
+calibration split fingerprint
+artifact hash status
+```
+
+A screenshot without these identities should not be treated as promoted neurOS evidence.
+
+## Comparison promotion rules
+
+A new model may be added to the longitudinal figure only when:
+
+1. it consumes the exact same partition/calibration manifests;
+2. preprocessing fit boundaries are declared;
+3. hyperparameter/model selection does not inspect final evaluation examples;
+4. random seeds and uncertainty are reported where relevant;
+5. failures are retained in the artifact rather than filtered from the plot;
+6. model identity and weight/artifact hashes are pinned;
+7. the result is clearly labeled offline real-dataset evidence, not hardware or clinical qualification.
+
+## Next implementation sequence
+
+After the CSP+LDA runner is qualified:
+
+1. freeze one small Kumar2024 evidence bundle;
+2. add EEGNet and EEG-Conformer under identical manifests;
+3. add representation-only foundation-model comparisons using matched linear readouts;
+4. add SourceWeigher using prior sessions as candidate sources and the target-session calibration pool only for allowed adaptation;
+5. measure subject/session leakage and representation geometry;
+6. scale the predeclared study across participants;
+7. render the final evidence bundle in the neurOS Evidence Console;
+8. repeat the same calibration-frontier idea on FALCON with its native chronological day split.
+
+The showcase succeeds when a viewer can understand, in seconds, **what data the model was allowed to know, how badly it drifted, how much calibration recovered it, and whether every number can be reproduced.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Real-World Evidence:
       - Evidence Program: REAL_WORLD_EVIDENCE.md
       - Ranked Source Map: EVIDENCE_SOURCE_MAP.md
+      - Longitudinal EEG Showcase: LONGITUDINAL_EEG_SHOWCASE.md
   - Installation: getting-started/installation.md
   - Architecture: ARCHITECTURE.md
   - API Surface: API_REFERENCE.md

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -16,6 +16,10 @@ from neuros.foundation_models.benchmark import (
 )
 from neuros.foundation_models.catalog import DEFAULT_MODEL_CARDS, catalog_by_id
 from neuros.foundation_models.integration import FoundationEmbeddingDecoder
+from neuros.foundation_models.longitudinal import (
+    NestedCalibrationSplit,
+    make_nested_calibration_split,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -134,6 +138,8 @@ __all__ = [
     "EvaluationPartition",
     "collect_moabb",
     "hold_out_groups",
+    "NestedCalibrationSplit",
+    "make_nested_calibration_split",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -18,7 +18,9 @@ from neuros.foundation_models.catalog import DEFAULT_MODEL_CARDS, catalog_by_id
 from neuros.foundation_models.integration import FoundationEmbeddingDecoder
 from neuros.foundation_models.longitudinal import (
     NestedCalibrationSplit,
+    chronological_partition,
     make_nested_calibration_split,
+    ordered_group_values,
 )
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
@@ -138,6 +140,8 @@ __all__ = [
     "EvaluationPartition",
     "collect_moabb",
     "hold_out_groups",
+    "ordered_group_values",
+    "chronological_partition",
     "NestedCalibrationSplit",
     "make_nested_calibration_split",
     "FoundationEmbeddingDecoder",

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal.py
@@ -1,0 +1,217 @@
+"""Longitudinal calibration-budget contracts for real-world neural evaluation.
+
+The core invariant is simple but important: every point on a calibration curve
+must be evaluated on the *same held-out examples*. Calibration examples come
+from a separately frozen pool inside the held-out deployment unit and budgets
+are nested, so a larger budget is a strict superset of a smaller one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+from .real_world import EvaluationPartition
+
+
+@dataclass(frozen=True, slots=True)
+class NestedCalibrationSplit:
+    """Freeze one source-train / calibration-pool / evaluation partition.
+
+    This contract is intended for classification-style longitudinal studies
+    such as motor-imagery EEG. It is deliberately not used for FALCON-style
+    continuous decoding, where calibration windows and chronology should follow
+    the benchmark's native split semantics.
+    """
+
+    partition: EvaluationPartition
+    evaluation_indices: np.ndarray
+    calibration_order_by_class: Mapping[str, np.ndarray]
+    evaluation_fraction: float
+    seed: int
+
+    def __post_init__(self) -> None:
+        if not 0.0 < float(self.evaluation_fraction) < 1.0:
+            raise ValueError("evaluation_fraction must lie strictly between 0 and 1")
+
+        evaluation = np.asarray(self.evaluation_indices, dtype=np.int64).reshape(-1)
+        if len(evaluation) == 0:
+            raise ValueError("fixed evaluation set must be non-empty")
+
+        test_set = set(self.partition.test_indices.tolist())
+        if not set(evaluation.tolist()).issubset(test_set):
+            raise ValueError("evaluation indices must come from the held-out partition")
+        if np.intersect1d(evaluation, self.partition.train_indices).size:
+            raise ValueError("evaluation indices overlap source training data")
+
+        normalized: dict[str, np.ndarray] = {}
+        seen_calibration: set[int] = set()
+        for label, values in self.calibration_order_by_class.items():
+            key = str(label)
+            array = np.asarray(values, dtype=np.int64).reshape(-1)
+            if not set(array.tolist()).issubset(test_set):
+                raise ValueError(f"calibration pool for {key!r} leaves held-out partition")
+            if np.intersect1d(array, evaluation).size:
+                raise ValueError(f"calibration pool for {key!r} overlaps evaluation")
+            if np.intersect1d(array, self.partition.train_indices).size:
+                raise ValueError(f"calibration pool for {key!r} overlaps source training")
+            duplicate = seen_calibration.intersection(array.tolist())
+            if duplicate:
+                raise ValueError(f"calibration pools overlap at indices {sorted(duplicate)}")
+            seen_calibration.update(array.tolist())
+            normalized[key] = array
+
+        if not normalized:
+            raise ValueError("at least one class calibration pool is required")
+
+        covered = set(evaluation.tolist()).union(seen_calibration)
+        if covered != test_set:
+            missing = sorted(test_set - covered)
+            extra = sorted(covered - test_set)
+            raise ValueError(
+                "calibration/evaluation split must cover the held-out partition exactly; "
+                f"missing={missing}, extra={extra}"
+            )
+
+        object.__setattr__(self, "evaluation_indices", evaluation)
+        object.__setattr__(self, "calibration_order_by_class", normalized)
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return tuple(sorted(self.calibration_order_by_class))
+
+    @property
+    def source_train_indices(self) -> np.ndarray:
+        return self.partition.train_indices
+
+    @property
+    def max_budget_per_class(self) -> int:
+        """Largest balanced per-class budget supported by every class."""
+        return min(len(values) for values in self.calibration_order_by_class.values())
+
+    def calibration_indices(self, per_class: int) -> np.ndarray:
+        """Return a deterministic nested balanced calibration subset.
+
+        Budgets larger than the smallest class pool fail closed instead of
+        silently becoming class-imbalanced.
+        """
+        budget = int(per_class)
+        if budget < 0:
+            raise ValueError("calibration budget must be non-negative")
+        if budget > self.max_budget_per_class:
+            raise ValueError(
+                f"budget {budget} exceeds balanced maximum {self.max_budget_per_class}"
+            )
+        if budget == 0:
+            return np.asarray([], dtype=np.int64)
+        selected = [
+            values[:budget]
+            for _, values in sorted(self.calibration_order_by_class.items())
+        ]
+        return np.sort(np.concatenate(selected).astype(np.int64, copy=False))
+
+    def train_indices_for_budget(self, per_class: int) -> np.ndarray:
+        """Historical source data plus the requested held-out calibration data."""
+        calibration = self.calibration_indices(per_class)
+        if len(calibration) == 0:
+            return self.source_train_indices.copy()
+        return np.sort(np.concatenate([self.source_train_indices, calibration]))
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "partition_fingerprint": self.partition.fingerprint,
+            "evaluation_indices": self.evaluation_indices.tolist(),
+            "calibration_order_by_class": {
+                label: values.tolist()
+                for label, values in sorted(self.calibration_order_by_class.items())
+            },
+            "evaluation_fraction": float(self.evaluation_fraction),
+            "seed": int(self.seed),
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def manifest(self) -> dict[str, Any]:
+        y = np.asarray(self.partition.data.y)
+        return {
+            "schema_version": 1,
+            "kind": "nested_calibration_split",
+            "dataset_id": self.partition.data.dataset_id,
+            "split_unit": self.partition.split_unit,
+            "held_out_values": list(self.partition.held_out_values),
+            "source_train_samples": int(len(self.source_train_indices)),
+            "calibration_pool_samples": int(
+                sum(len(values) for values in self.calibration_order_by_class.values())
+            ),
+            "evaluation_samples": int(len(self.evaluation_indices)),
+            "evaluation_fraction_requested": float(self.evaluation_fraction),
+            "max_balanced_budget_per_class": int(self.max_budget_per_class),
+            "calibration_pool_by_class": {
+                label: int(len(values))
+                for label, values in sorted(self.calibration_order_by_class.items())
+            },
+            "evaluation_by_class": {
+                label: int(np.sum(y[self.evaluation_indices].astype(str) == label))
+                for label in self.labels
+            },
+            "seed": int(self.seed),
+            "partition_fingerprint": self.partition.fingerprint,
+            "calibration_split_fingerprint": self.fingerprint,
+            "invariants": [
+                "evaluation indices are fixed across calibration budgets",
+                "calibration budgets are nested within each class",
+                "calibration/evaluation indices are disjoint",
+                "source training data contains no held-out deployment unit",
+            ],
+        }
+
+
+def make_nested_calibration_split(
+    partition: EvaluationPartition,
+    *,
+    evaluation_fraction: float = 0.5,
+    seed: int = 0,
+) -> NestedCalibrationSplit:
+    """Freeze a class-stratified calibration pool and fixed evaluation set.
+
+    At least one held-out example per class is reserved for evaluation. If a
+    class contains only one held-out example it contributes no calibration
+    examples, making the balanced maximum budget zero. This is preferable to
+    silently evaluating on different class support across budgets.
+    """
+    fraction = float(evaluation_fraction)
+    if not 0.0 < fraction < 1.0:
+        raise ValueError("evaluation_fraction must lie strictly between 0 and 1")
+
+    y = np.asarray(partition.data.y)
+    held_out = partition.test_indices
+    held_labels = y[held_out].astype(str)
+    labels = tuple(sorted(np.unique(held_labels).tolist()))
+    if len(labels) < 2:
+        raise ValueError("nested calibration split requires at least two held-out classes")
+
+    rng = np.random.default_rng(int(seed))
+    evaluation: list[np.ndarray] = []
+    calibration: dict[str, np.ndarray] = {}
+
+    for label in labels:
+        class_indices = held_out[held_labels == label].copy()
+        rng.shuffle(class_indices)
+        n_class = len(class_indices)
+        n_evaluation = max(1, int(np.ceil(n_class * fraction)))
+        n_evaluation = min(n_class, n_evaluation)
+        evaluation.append(class_indices[:n_evaluation])
+        calibration[label] = class_indices[n_evaluation:]
+
+    return NestedCalibrationSplit(
+        partition=partition,
+        evaluation_indices=np.sort(np.concatenate(evaluation)),
+        calibration_order_by_class=calibration,
+        evaluation_fraction=fraction,
+        seed=int(seed),
+    )

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal.py
@@ -1,9 +1,14 @@
 """Longitudinal calibration-budget contracts for real-world neural evaluation.
 
-The core invariant is simple but important: every point on a calibration curve
-must be evaluated on the *same held-out examples*. Calibration examples come
-from a separately frozen pool inside the held-out deployment unit and budgets
-are nested, so a larger budget is a strict superset of a smaller one.
+The core invariants are simple but important:
+
+1. every point on a calibration curve is evaluated on the *same* held-out examples;
+2. deployment-realistic longitudinal evidence must not train on future sessions.
+
+Calibration examples come from a separately frozen pool inside the held-out
+deployment unit and budgets are nested, so a larger budget is a strict superset
+of a smaller one. Chronological partitions preserve the upstream row order as
+the default session chronology unless an explicit complete order is supplied.
 """
 
 from __future__ import annotations
@@ -11,11 +16,100 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 import numpy as np
 
-from .real_world import EvaluationPartition
+from .benchmark import SplitUnit
+from .real_world import EvaluationPartition, GroupedEvaluationData
+
+
+def ordered_group_values(
+    data: GroupedEvaluationData,
+    *,
+    split_unit: SplitUnit,
+) -> tuple[str, ...]:
+    """Return unique group values in first-observed order.
+
+    For MOABB-shaped data this preserves the upstream metadata order instead of
+    lexicographically sorting labels such as ``session_10`` before ``session_2``.
+    The function does not claim that arbitrary source ordering is chronology;
+    promoted studies must document why their upstream order is chronological.
+    """
+    if split_unit == "sample":
+        raise ValueError("sample is not a deployment-unit group")
+    if split_unit not in data.groups:
+        raise ValueError(
+            f"dataset has no {split_unit!r} group; available={sorted(data.groups)}"
+        )
+    return tuple(dict.fromkeys(np.asarray(data.groups[split_unit]).astype(str).tolist()))
+
+
+def chronological_partition(
+    data: GroupedEvaluationData,
+    *,
+    split_unit: SplitUnit,
+    held_out_value: Any,
+    order: Sequence[Any] | None = None,
+) -> EvaluationPartition:
+    """Train only on deployment units preceding one held-out unit.
+
+    Samples from deployment units *after* the held-out value are intentionally
+    excluded from both training and evaluation. This differs from symmetric
+    leave-one-group-out cross-validation and is the appropriate default for a
+    claim such as "performance on the next session/day".
+
+    When ``order`` is omitted, first-observed metadata order is used. Supplying
+    an explicit order requires each observed group exactly once, preventing a
+    partial or duplicated chronology from silently changing the evidence set.
+    """
+    if split_unit == "sample":
+        raise ValueError("chronological_partition requires a deployment-unit group")
+    if split_unit not in data.groups:
+        raise ValueError(
+            f"dataset has no {split_unit!r} group; available={sorted(data.groups)}"
+        )
+
+    observed = ordered_group_values(data, split_unit=split_unit)
+    if order is None:
+        chronology = observed
+    else:
+        chronology = tuple(str(value) for value in order)
+        if len(set(chronology)) != len(chronology):
+            raise ValueError("chronology order contains duplicate values")
+        if set(chronology) != set(observed):
+            missing = sorted(set(observed) - set(chronology))
+            extra = sorted(set(chronology) - set(observed))
+            raise ValueError(
+                "chronology order must contain every observed group exactly once; "
+                f"missing={missing}, extra={extra}"
+            )
+
+    held = str(held_out_value)
+    if held not in chronology:
+        raise ValueError(
+            f"unknown held-out {split_unit} value {held!r}; available={list(chronology)}"
+        )
+    position = chronology.index(held)
+    if position == 0:
+        raise ValueError(
+            f"held-out {split_unit} {held!r} has no prior {split_unit} data"
+        )
+
+    prior_values = chronology[:position]
+    group = np.asarray(data.groups[split_unit]).astype(str)
+    train = np.flatnonzero(np.isin(group, np.asarray(prior_values, dtype=str)))
+    test = np.flatnonzero(group == held)
+    if len(train) == 0 or len(test) == 0:  # defensive; position/known checks should prevent this
+        raise ValueError("chronological partition produced an empty train or test set")
+
+    return EvaluationPartition(
+        data=data,
+        split_unit=split_unit,
+        train_indices=train,
+        test_indices=test,
+        held_out_values=(held,),
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/neuros-foundation/tests/test_longitudinal.py
+++ b/packages/neuros-foundation/tests/test_longitudinal.py
@@ -5,12 +5,14 @@ import pytest
 
 from neuros.foundation_models import (
     GroupedEvaluationData,
+    chronological_partition,
     hold_out_groups,
     make_nested_calibration_split,
+    ordered_group_values,
 )
 
 
-def _fixture_partition():
+def _fixture_data():
     rng = np.random.default_rng(41)
     X = []
     y = []
@@ -27,11 +29,87 @@ def _fixture_partition():
                         "run": f"run-{trial // 6}",
                     }
                 )
-    data = GroupedEvaluationData.from_moabb_result(
+    return GroupedEvaluationData.from_moabb_result(
         (np.asarray(X), np.asarray(y), metadata),
         dataset_id="fixture",
     )
-    return hold_out_groups(data, split_unit="session", held_out_values=["2"])
+
+
+def _fixture_partition():
+    return hold_out_groups(_fixture_data(), split_unit="session", held_out_values=["2"])
+
+
+def test_chronological_partition_uses_prior_only_and_excludes_future():
+    data = _fixture_data()
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="1",
+    )
+
+    sessions = np.asarray(data.groups["session"])
+    assert set(sessions[partition.train_indices]) == {"0"}
+    assert set(sessions[partition.test_indices]) == {"1"}
+    assert len(partition.train_indices) == 24
+    assert len(partition.test_indices) == 24
+
+    future = set(np.flatnonzero(sessions == "2").tolist())
+    assert future.isdisjoint(partition.train_indices.tolist())
+    assert future.isdisjoint(partition.test_indices.tolist())
+
+
+def test_chronological_partition_fails_when_no_history_exists():
+    data = _fixture_data()
+    with pytest.raises(ValueError, match="no prior"):
+        chronological_partition(data, split_unit="session", held_out_value="0")
+
+
+def test_first_observed_order_is_not_lexicographically_resorted():
+    rng = np.random.default_rng(2)
+    sessions = ("session_1", "session_2", "session_10")
+    X = []
+    y = []
+    metadata = []
+    for session in sessions:
+        for label in ("left", "right"):
+            for trial in range(2):
+                X.append(rng.normal(size=(2, 4)))
+                y.append(label)
+                metadata.append(
+                    {"subject": "1", "session": session, "run": f"r-{trial}"}
+                )
+    data = GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata), dataset_id="ordered"
+    )
+
+    assert ordered_group_values(data, split_unit="session") == sessions
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="session_10",
+    )
+    assert set(data.groups["session"][partition.train_indices]) == {
+        "session_1",
+        "session_2",
+    }
+
+
+def test_explicit_chronology_must_cover_each_observed_group_once():
+    data = _fixture_data()
+    with pytest.raises(ValueError, match="every observed group"):
+        chronological_partition(
+            data,
+            split_unit="session",
+            held_out_value="2",
+            order=("0", "2"),
+        )
+    with pytest.raises(ValueError, match="duplicate"):
+        chronological_partition(
+            data,
+            split_unit="session",
+            held_out_value="2",
+            order=("0", "1", "1", "2"),
+        )
 
 
 def test_nested_calibration_uses_fixed_evaluation_examples():

--- a/packages/neuros-foundation/tests/test_longitudinal.py
+++ b/packages/neuros-foundation/tests/test_longitudinal.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    hold_out_groups,
+    make_nested_calibration_split,
+)
+
+
+def _fixture_partition():
+    rng = np.random.default_rng(41)
+    X = []
+    y = []
+    metadata = []
+    for session in ("0", "1", "2"):
+        for label in ("left", "right"):
+            for trial in range(12):
+                X.append(rng.normal(size=(4, 16)))
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"run-{trial // 6}",
+                    }
+                )
+    data = GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="fixture",
+    )
+    return hold_out_groups(data, split_unit="session", held_out_values=["2"])
+
+
+def test_nested_calibration_uses_fixed_evaluation_examples():
+    partition = _fixture_partition()
+    split = make_nested_calibration_split(
+        partition,
+        evaluation_fraction=0.5,
+        seed=7,
+    )
+
+    assert len(split.source_train_indices) == 48
+    assert len(split.evaluation_indices) == 12
+    assert split.max_budget_per_class == 6
+
+    y = partition.data.y.astype(str)
+    assert set(y[split.evaluation_indices]) == {"left", "right"}
+    assert np.sum(y[split.evaluation_indices] == "left") == 6
+    assert np.sum(y[split.evaluation_indices] == "right") == 6
+
+    evaluation_identity = split.evaluation_indices.copy()
+    for budget in (0, 1, 3, 6):
+        calibration = split.calibration_indices(budget)
+        assert len(calibration) == budget * 2
+        assert np.array_equal(split.evaluation_indices, evaluation_identity)
+        assert np.intersect1d(calibration, split.evaluation_indices).size == 0
+        assert np.intersect1d(calibration, split.source_train_indices).size == 0
+
+
+def test_calibration_budgets_are_strictly_nested_per_class():
+    split = make_nested_calibration_split(_fixture_partition(), seed=9)
+    one = set(split.calibration_indices(1).tolist())
+    three = set(split.calibration_indices(3).tolist())
+    six = set(split.calibration_indices(6).tolist())
+
+    assert one < three < six
+    assert len(one) == 2
+    assert len(three) == 6
+    assert len(six) == 12
+
+
+def test_split_fingerprint_and_manifest_are_deterministic():
+    partition = _fixture_partition()
+    first = make_nested_calibration_split(partition, seed=17)
+    second = make_nested_calibration_split(partition, seed=17)
+    changed = make_nested_calibration_split(partition, seed=18)
+
+    assert first.fingerprint == second.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert np.array_equal(first.evaluation_indices, second.evaluation_indices)
+
+    manifest = first.manifest()
+    assert manifest["source_train_samples"] == 48
+    assert manifest["calibration_pool_samples"] == 12
+    assert manifest["evaluation_samples"] == 12
+    assert manifest["max_balanced_budget_per_class"] == 6
+    assert manifest["calibration_pool_by_class"] == {"left": 6, "right": 6}
+    assert manifest["evaluation_by_class"] == {"left": 6, "right": 6}
+    assert manifest["calibration_split_fingerprint"] == first.fingerprint
+
+
+def test_budget_above_balanced_pool_fails_closed():
+    split = make_nested_calibration_split(_fixture_partition(), seed=3)
+    with pytest.raises(ValueError, match="balanced maximum"):
+        split.calibration_indices(split.max_budget_per_class + 1)
+    with pytest.raises(ValueError, match="non-negative"):
+        split.calibration_indices(-1)
+
+
+def test_smallest_class_controls_balanced_budget():
+    rng = np.random.default_rng(5)
+    X = rng.normal(size=(16, 3, 8))
+    y = np.asarray(["left"] * 12 + ["right"] * 4)
+    metadata = [
+        {"subject": "1", "session": "held", "run": f"r-{i}"}
+        for i in range(16)
+    ]
+    X = np.concatenate([rng.normal(size=(8, 3, 8)), X], axis=0)
+    y = np.concatenate([np.asarray(["left", "right"] * 4), y])
+    metadata = [
+        {"subject": "1", "session": "source", "run": f"s-{i}"}
+        for i in range(8)
+    ] + metadata
+    data = GroupedEvaluationData.from_moabb_result(
+        (X, y, metadata),
+        dataset_id="imbalanced",
+    )
+    partition = hold_out_groups(data, split_unit="session", held_out_values=["held"])
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=1)
+
+    assert split.max_budget_per_class == 2
+
+
+def test_invalid_fraction_and_single_class_fail_closed():
+    partition = _fixture_partition()
+    for invalid in (0.0, 1.0, -0.1, 1.1):
+        with pytest.raises(ValueError, match="strictly between"):
+            make_nested_calibration_split(partition, evaluation_fraction=invalid)
+
+    data = partition.data
+    single_class = GroupedEvaluationData(
+        dataset_id="single",
+        X=data.X,
+        y=np.asarray(["left"] * len(data.X)),
+        groups=data.groups,
+        metadata=data.metadata,
+    )
+    held = hold_out_groups(single_class, split_unit="session", held_out_values=["2"])
+    with pytest.raises(ValueError, match="at least two"):
+        make_nested_calibration_split(held)

--- a/packages/neuros-foundation/tests/test_longitudinal_runner.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_runner.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from neuros.foundation_models import GroupedEvaluationData
 
@@ -46,12 +47,19 @@ def _synthetic_longitudinal_eeg() -> GroupedEvaluationData:
     )
 
 
+def _patch_data_sources(runner, monkeypatch, bundle):
+    monkeypatch.setattr(
+        runner,
+        "_dataset_and_paradigm",
+        lambda *args, **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(runner, "collect_moabb", lambda *args, **kwargs: bundle)
+
+
 def test_runner_writes_consistent_prior_only_evidence_bundle(tmp_path, monkeypatch):
     runner = _load_runner()
     bundle = _synthetic_longitudinal_eeg()
-
-    monkeypatch.setattr(runner, "_dataset_and_paradigm", lambda *args, **kwargs: (object(), object()))
-    monkeypatch.setattr(runner, "collect_moabb", lambda *args, **kwargs: bundle)
+    _patch_data_sources(runner, monkeypatch, bundle)
 
     output = tmp_path / "evidence"
     code = runner.main(
@@ -80,6 +88,7 @@ def test_runner_writes_consistent_prior_only_evidence_bundle(tmp_path, monkeypat
         rows = list(csv.DictReader(handle))
 
     assert manifest["history_policy"] == "prior"
+    assert manifest["allow_incomplete_budgets"] is False
     assert [item["held_out_session"] for item in manifest["splits"]] == ["1", "2"]
     assert manifest["splits"][0]["source_sessions"] == ["0"]
     assert manifest["splits"][1]["source_sessions"] == ["0", "1"]
@@ -88,10 +97,19 @@ def test_runner_writes_consistent_prior_only_evidence_bundle(tmp_path, monkeypat
     assert len(rows) == 4  # two eligible held-out sessions x two budgets
     assert {row["history_policy"] for row in rows} == {"prior"}
     assert {row["calibration_per_class"] for row in rows} == {"0", "1"}
-    assert len({row["calibration_split_fingerprint"] for row in rows if row["held_out_session"] == "1"}) == 1
+    assert len(
+        {
+            row["calibration_split_fingerprint"]
+            for row in rows
+            if row["held_out_session"] == "1"
+        }
+    ) == 1
 
+    assert summary["paired_case_sets_identical"] is True
     assert [point["calibration_per_class"] for point in summary["curve"]] == [0, 1]
+    assert len({point["case_set_fingerprint"] for point in summary["curve"]}) == 1
     assert "future sessions excluded" in report
+    assert "paired across identical subject-session cases" in report
     assert set(hashes["sha256"]) == {
         "results.csv",
         "summary.json",
@@ -101,3 +119,30 @@ def test_runner_writes_consistent_prior_only_evidence_bundle(tmp_path, monkeypat
 
     for name in hashes["sha256"]:
         assert len(hashes["sha256"][name]) == 64
+
+
+def test_runner_fails_closed_if_requested_frontier_would_be_unpaired(tmp_path, monkeypatch):
+    runner = _load_runner()
+    bundle = _synthetic_longitudinal_eeg()
+    _patch_data_sources(runner, monkeypatch, bundle)
+
+    # With 10 examples per class and a 0.5 frozen evaluation fraction, the
+    # balanced calibration maximum is 5/class. A promoted 6/class point must
+    # fail instead of dropping this subject/session from the right side of the curve.
+    with pytest.raises(RuntimeError, match="not paired"):
+        runner.main(
+            [
+                "--dataset",
+                "kumar2024",
+                "--subjects",
+                "1",
+                "--budgets",
+                "0,6",
+                "--history-policy",
+                "prior",
+                "--csp-components",
+                "2",
+                "--output",
+                str(tmp_path / "strict-failure"),
+            ]
+        )

--- a/packages/neuros-foundation/tests/test_longitudinal_runner.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_runner.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+
+from neuros.foundation_models import GroupedEvaluationData
+
+
+def _load_runner():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts" / "evidence" / "run_moabb_longitudinal.py"
+    spec = importlib.util.spec_from_file_location("neuros_longitudinal_runner", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synthetic_longitudinal_eeg() -> GroupedEvaluationData:
+    rng = np.random.default_rng(77)
+    X = []
+    y = []
+    metadata = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left_hand", "right_hand")):
+            for trial in range(10):
+                signal = rng.normal(scale=0.8, size=(4, 128))
+                # Give the transparent baseline a stable but session-shifted signal.
+                signal[0, 24:72] += (1.0 if label_index else -1.0) + 0.08 * session_index
+                X.append(signal)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"run-{trial // 5}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X, dtype=np.float64), np.asarray(y), metadata),
+        dataset_id="moabb-kumar2024",
+    )
+
+
+def test_runner_writes_consistent_prior_only_evidence_bundle(tmp_path, monkeypatch):
+    runner = _load_runner()
+    bundle = _synthetic_longitudinal_eeg()
+
+    monkeypatch.setattr(runner, "_dataset_and_paradigm", lambda *args, **kwargs: (object(), object()))
+    monkeypatch.setattr(runner, "collect_moabb", lambda *args, **kwargs: bundle)
+
+    output = tmp_path / "evidence"
+    code = runner.main(
+        [
+            "--dataset",
+            "kumar2024",
+            "--subjects",
+            "1",
+            "--budgets",
+            "0,1",
+            "--history-policy",
+            "prior",
+            "--csp-components",
+            "2",
+            "--output",
+            str(output),
+        ]
+    )
+    assert code == 0
+
+    manifest = json.loads((output / "study_manifest.json").read_text())
+    summary = json.loads((output / "summary.json").read_text())
+    hashes = json.loads((output / "artifact_hashes.json").read_text())
+    report = (output / "report.md").read_text()
+    with (output / "results.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert manifest["history_policy"] == "prior"
+    assert [item["held_out_session"] for item in manifest["splits"]] == ["1", "2"]
+    assert manifest["splits"][0]["source_sessions"] == ["0"]
+    assert manifest["splits"][1]["source_sessions"] == ["0", "1"]
+    assert manifest["splits"][0]["observed_session_order"] == ["0", "1", "2"]
+
+    assert len(rows) == 4  # two eligible held-out sessions x two budgets
+    assert {row["history_policy"] for row in rows} == {"prior"}
+    assert {row["calibration_per_class"] for row in rows} == {"0", "1"}
+    assert len({row["calibration_split_fingerprint"] for row in rows if row["held_out_session"] == "1"}) == 1
+
+    assert [point["calibration_per_class"] for point in summary["curve"]] == [0, 1]
+    assert "future sessions excluded" in report
+    assert set(hashes["sha256"]) == {
+        "results.csv",
+        "summary.json",
+        "study_manifest.json",
+        "report.md",
+    }
+
+    for name in hashes["sha256"]:
+        assert len(hashes["sha256"][name]) == 64

--- a/scripts/evidence/run_moabb_longitudinal.py
+++ b/scripts/evidence/run_moabb_longitudinal.py
@@ -5,11 +5,12 @@ The first goal is a transparent evidence floor, not a state-of-the-art claim.
 For each subject and held-out session this runner:
 
 1. creates a neurOS deployment-unit-disjoint pre-model partition;
-2. freezes one class-stratified evaluation set inside the held-out session;
-3. freezes the remaining held-out trials as an ordered calibration pool;
-4. refits the same CSP+LDA baseline at nested per-class calibration budgets;
-5. evaluates every budget on the exact same held-out examples;
-6. writes machine-readable manifests, results, summary, hashes, and a report.
+2. by default trains only on sessions observed *before* the held-out session;
+3. freezes one class-stratified evaluation set inside the held-out session;
+4. freezes the remaining held-out trials as an ordered calibration pool;
+5. refits the same CSP+LDA baseline at nested per-class calibration budgets;
+6. evaluates every budget on the exact same held-out examples;
+7. writes machine-readable manifests, results, summary, hashes, and a report.
 
 Large public datasets are downloaded by MOABB when this script is run. CI does
 not download them; contract behavior is tested with synthetic MOABB-shaped data.
@@ -32,10 +33,12 @@ from typing import Any, Iterable
 import numpy as np
 
 from neuros.foundation_models import (
+    chronological_partition,
     collect_moabb,
     get_evidence_source,
     hold_out_groups,
     make_nested_calibration_split,
+    ordered_group_values,
 )
 
 
@@ -284,12 +287,18 @@ def _render_report(
     summary: dict[str, Any],
     split_records: list[dict[str, Any]],
 ) -> str:
+    history_text = (
+        "prior sessions only; future sessions excluded"
+        if args.history_policy == "prior"
+        else "all other sessions; symmetric cross-session evaluation"
+    )
     lines = [
         "# neurOS Longitudinal EEG Evidence Report",
         "",
         f"- Dataset: **{source.title}** (`{source.id}`)",
         f"- Baseline: **CSP({args.csp_components}) + LDA**",
         f"- Band: **{args.fmin:g}-{args.fmax:g} Hz**",
+        f"- History policy: **{history_text}**",
         f"- Fixed held-out evaluation fraction: **{args.evaluation_fraction:.2f}**",
         f"- Subjects requested: **{', '.join(str(v) for v in args.subjects)}**",
         f"- Subject-session cases: **{len(split_records)}**",
@@ -323,15 +332,37 @@ def _render_report(
             "Within that session, the evaluation examples are frozen once and never change "
             "as calibration budget grows. Calibration subsets are nested per class.",
             "",
-            "The zero-calibration row is therefore a genuine historical-session baseline; "
-            "larger budgets add held-out-session calibration examples but are scored on the "
-            "same evaluation trials.",
+        ]
+    )
+    if args.history_policy == "prior":
+        lines.extend(
+            [
+                "The default chronological policy trains only on sessions preceding the "
+                "held-out session in upstream metadata order. Later sessions are excluded "
+                "from both fitting and evaluation, preventing future-data leakage.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "The `all-other` policy is symmetric leave-one-session-out evaluation and "
+                "may include sessions recorded after the held-out session. It must not be "
+                "described as next-session or prospective deployment evidence.",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "The zero-calibration row uses source-history data only; larger budgets add "
+            "held-out-session calibration examples but are scored on the same evaluation trials.",
             "",
             "## Limits",
             "",
             "- This report is a transparent baseline, not an ORION or neurOS superiority claim.",
             "- Dataset files/checksums remain governed by MOABB/upstream repositories; pin those identities for promoted evidence.",
             "- CSP+LDA is refit when calibration examples are added; it is not an online-update algorithm.",
+            "- Upstream metadata order is treated as chronology under `prior`; promoted studies must verify that assumption against dataset documentation.",
             "- Hardware/closed-loop/clinical evidence is outside this offline real-dataset tier.",
             "",
             f"Raw result rows: {len(rows)}. See `results.csv`, `study_manifest.json`, and `artifact_hashes.json`.",
@@ -356,7 +387,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--held-out-sessions",
         type=_parse_text_list,
         default=None,
-        help="Optional comma-separated session IDs. Default: evaluate every session.",
+        help="Optional comma-separated session IDs. Default: evaluate every eligible session.",
+    )
+    parser.add_argument(
+        "--history-policy",
+        choices=("prior", "all-other"),
+        default="prior",
+        help=(
+            "Source-session policy. 'prior' (default) trains only on earlier sessions; "
+            "'all-other' is symmetric leave-one-session-out and may use future sessions."
+        ),
     )
     parser.add_argument(
         "--budgets",
@@ -422,27 +462,46 @@ def main(argv: list[str] | None = None) -> int:
             subjects=[int(subject)],
             dataset_id=source_id,
         )
-        sessions = sorted(set(bundle.groups.get("session", np.asarray([], dtype=str)).tolist()))
+        sessions = ordered_group_values(bundle, split_unit="session")
         if len(sessions) < 2:
             raise RuntimeError(
                 f"subject {subject} has fewer than two sessions after MOABB preprocessing"
             )
-        selected_sessions = sessions
+
         if args.held_out_sessions is not None:
-            missing = sorted(set(args.held_out_sessions) - set(sessions))
+            missing = [value for value in args.held_out_sessions if value not in sessions]
             if missing:
                 raise RuntimeError(
                     f"subject {subject} does not expose requested session(s) {missing}; "
-                    f"available={sessions}"
+                    f"available={list(sessions)}"
                 )
             selected_sessions = list(args.held_out_sessions)
+        elif args.history_policy == "prior":
+            selected_sessions = list(sessions[1:])
+        else:
+            selected_sessions = list(sessions)
 
         for session in selected_sessions:
-            partition = hold_out_groups(
-                bundle,
-                split_unit="session",
-                held_out_values=[session],
-            )
+            if args.history_policy == "prior":
+                try:
+                    partition = chronological_partition(
+                        bundle,
+                        split_unit="session",
+                        held_out_value=session,
+                        order=sessions,
+                    )
+                except ValueError as exc:
+                    raise RuntimeError(
+                        f"cannot construct prior-only evidence for subject {subject}, "
+                        f"session {session}: {exc}"
+                    ) from exc
+            else:
+                partition = hold_out_groups(
+                    bundle,
+                    split_unit="session",
+                    held_out_values=[session],
+                )
+
             split_seed = _stable_int_seed(args.seed, source_id, subject, session)
             calibration = make_nested_calibration_split(
                 partition,
@@ -460,17 +519,28 @@ def main(argv: list[str] | None = None) -> int:
                 preprocessing=(
                     f"MOABB {dataset_spec['paradigm']} events={events_text}; "
                     f"bandpass {args.fmin:g}-{args.fmax:g} Hz; CSP+LDA fit only on "
-                    "historical sessions plus declared calibration"
+                    "declared source sessions plus held-out calibration examples"
                 ),
                 notes=(
+                    f"history_policy={args.history_policy}",
                     "fixed evaluation subset inside held-out session",
                     "nested balanced calibration budgets per class",
                 ),
                 seed=split_seed,
             )
             record = partition.manifest(protocol=protocol)
+            source_sessions = tuple(
+                dict.fromkeys(
+                    np.asarray(bundle.groups["session"])[partition.train_indices]
+                    .astype(str)
+                    .tolist()
+                )
+            )
             record["subject"] = int(subject)
             record["held_out_session"] = str(session)
+            record["history_policy"] = args.history_policy
+            record["observed_session_order"] = list(sessions)
+            record["source_sessions"] = list(source_sessions)
             record["calibration"] = calibration.manifest()
             split_records.append(record)
 
@@ -503,6 +573,7 @@ def main(argv: list[str] | None = None) -> int:
                         "dataset_id": source_id,
                         "subject": int(subject),
                         "held_out_session": str(session),
+                        "history_policy": args.history_policy,
                         "partition_fingerprint": partition.fingerprint,
                         "calibration_split_fingerprint": calibration.fingerprint,
                         "calibration_per_class": int(budget),
@@ -535,6 +606,7 @@ def main(argv: list[str] | None = None) -> int:
             "kind": dataset_spec["paradigm"],
             "events": list(dataset_spec["events"] or ("left_hand", "right_hand")),
         },
+        "history_policy": args.history_policy,
         "subjects": [int(value) for value in args.subjects],
         "held_out_sessions_requested": args.held_out_sessions,
         "requested_calibration_per_class": [int(value) for value in args.budgets],
@@ -551,6 +623,8 @@ def main(argv: list[str] | None = None) -> int:
         "limitations": [
             "upstream MOABB/data-file checksums are not yet captured by this runner",
             "CSP+LDA is a transparent baseline, not an ORION superiority claim",
+            "prior policy assumes first-observed upstream session metadata order is chronological and must be verified before promotion",
+            "all-other policy is symmetric cross-session evaluation and is not prospective next-session evidence",
             "offline real-dataset evidence is not hardware or closed-loop qualification",
         ],
     }
@@ -586,6 +660,7 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "output": str(output),
                 "dataset": source_id,
+                "history_policy": args.history_policy,
                 "rows": len(rows),
                 "subject_session_cases": len(split_records),
                 "artifacts": [path.name for path in controlled],

--- a/scripts/evidence/run_moabb_longitudinal.py
+++ b/scripts/evidence/run_moabb_longitudinal.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Run a leakage-resistant longitudinal EEG calibration benchmark on MOABB.
+
+The first goal is a transparent evidence floor, not a state-of-the-art claim.
+For each subject and held-out session this runner:
+
+1. creates a neurOS deployment-unit-disjoint pre-model partition;
+2. freezes one class-stratified evaluation set inside the held-out session;
+3. freezes the remaining held-out trials as an ordered calibration pool;
+4. refits the same CSP+LDA baseline at nested per-class calibration budgets;
+5. evaluates every budget on the exact same held-out examples;
+6. writes machine-readable manifests, results, summary, hashes, and a report.
+
+Large public datasets are downloaded by MOABB when this script is run. CI does
+not download them; contract behavior is tested with synthetic MOABB-shaped data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.metadata
+import json
+import platform
+import subprocess
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+from neuros.foundation_models import (
+    collect_moabb,
+    get_evidence_source,
+    hold_out_groups,
+    make_nested_calibration_split,
+)
+
+
+_DATASETS = {
+    "kumar2024": {
+        "class": "Kumar2024",
+        "source_id": "moabb-kumar2024",
+        "description": "18 participants x 6 separate-day MI sessions",
+        "paradigm": "left_right",
+        "events": None,
+    },
+    "ma2020": {
+        "class": "Ma2020",
+        "source_id": "moabb-ma2020",
+        "description": "25 participants x 15 right-hand/right-elbow MI sessions",
+        "paradigm": "motor_imagery",
+        "events": ("right_hand", "right_elbow"),
+    },
+    "lee2019-mi": {
+        "class": "Lee2019_MI",
+        "source_id": "moabb-lee2019-family",
+        "description": "OpenBMI motor-imagery member of the 54-person shared cohort",
+        "paradigm": "left_right",
+        "events": None,
+    },
+    "wang2026": {
+        "class": "Wang2026",
+        "source_id": "moabb-wang2026",
+        "description": "39 participants x 5 sessions with online cursor-control study",
+        "paradigm": "left_right",
+        "events": None,
+    },
+}
+
+
+def _json_dump(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stable_int_seed(base: int, *parts: Any) -> int:
+    payload = "|".join([str(base), *(str(part) for part in parts)])
+    return int.from_bytes(hashlib.sha256(payload.encode("utf-8")).digest()[:4], "big")
+
+
+def _git_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _versions() -> dict[str, str | None]:
+    result: dict[str, str | None] = {}
+    for distribution in (
+        "neuros-foundation",
+        "neuros-core",
+        "neuros-models",
+        "moabb",
+        "mne",
+        "scikit-learn",
+        "numpy",
+    ):
+        try:
+            result[distribution] = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            result[distribution] = None
+    return result
+
+
+def _parse_int_list(value: str) -> list[int]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated integer")
+    try:
+        parsed = [int(item) for item in values]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("values must be integers") from exc
+    return parsed
+
+
+def _parse_text_list(value: str) -> list[str]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated value")
+    return values
+
+
+def _dataset_and_paradigm(dataset_key: str, *, fmin: float, fmax: float):
+    try:
+        import moabb.datasets as datasets
+        from moabb.paradigms import LeftRightImagery, MotorImagery
+    except ImportError as exc:  # pragma: no cover - exercised by real environment
+        raise RuntimeError(
+            "This benchmark requires the optional evidence stack. Install "
+            "`neuros-foundation[evidence]`."
+        ) from exc
+
+    spec = _DATASETS[dataset_key]
+    dataset_cls = getattr(datasets, spec["class"], None)
+    if dataset_cls is None:
+        raise RuntimeError(
+            f"Installed MOABB does not expose {spec['class']}. Pin a MOABB release "
+            "that contains this dataset or choose another --dataset."
+        )
+    dataset = dataset_cls()
+    if spec["paradigm"] == "left_right":
+        paradigm = LeftRightImagery(fmin=float(fmin), fmax=float(fmax))
+    elif spec["paradigm"] == "motor_imagery":
+        events = list(spec["events"] or ())
+        paradigm = MotorImagery(
+            n_classes=len(events),
+            events=events,
+            fmin=float(fmin),
+            fmax=float(fmax),
+        )
+    else:  # pragma: no cover - internal registry invariant
+        raise RuntimeError(f"unsupported paradigm kind {spec['paradigm']!r}")
+
+    try:
+        valid = paradigm.is_valid(dataset)
+    except Exception as exc:
+        raise RuntimeError(
+            f"MOABB rejected {spec['class']} for declared paradigm {spec['paradigm']}"
+        ) from exc
+    if valid is False:
+        raise RuntimeError(
+            f"MOABB rejected {spec['class']} for declared paradigm {spec['paradigm']}"
+        )
+    return dataset, paradigm
+
+
+def _build_csp_lda(*, components: int):
+    try:
+        from mne.decoding import CSP
+        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+        from sklearn.pipeline import make_pipeline
+    except ImportError as exc:  # pragma: no cover - real environment boundary
+        raise RuntimeError("CSP+LDA baseline requires MNE and scikit-learn") from exc
+    return make_pipeline(CSP(n_components=int(components), reg=None), LDA())
+
+
+def _score_binary(model: Any, X: np.ndarray, y: np.ndarray) -> dict[str, float]:
+    from sklearn.metrics import accuracy_score, balanced_accuracy_score, roc_auc_score
+
+    started = time.perf_counter()
+    prediction = model.predict(X)
+    inference_s = time.perf_counter() - started
+    metrics = {
+        "accuracy": float(accuracy_score(y, prediction)),
+        "balanced_accuracy": float(balanced_accuracy_score(y, prediction)),
+        "inference_s": float(inference_s),
+        "inference_ms_per_trial": float(1000.0 * inference_s / max(len(y), 1)),
+    }
+    classes = np.asarray(getattr(model, "classes_", []))
+    if len(classes) == 2 and hasattr(model, "predict_proba"):
+        probability = np.asarray(model.predict_proba(X), dtype=np.float64)
+        positive = classes[1]
+        y_binary = (np.asarray(y) == positive).astype(np.int64)
+        metrics["roc_auc"] = float(roc_auc_score(y_binary, probability[:, 1]))
+    else:
+        metrics["roc_auc"] = float("nan")
+    return metrics
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(np.mean(array))
+
+
+def _std(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(np.std(array, ddof=1)) if len(array) > 1 else 0.0
+
+
+def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_budget: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_budget[int(row["calibration_per_class"])].append(row)
+
+    curve = []
+    for budget in sorted(by_budget):
+        group = by_budget[budget]
+        curve.append(
+            {
+                "calibration_per_class": budget,
+                "n_subject_session_cases": len(group),
+                "mean_balanced_accuracy": _mean(row["balanced_accuracy"] for row in group),
+                "std_balanced_accuracy": _std(row["balanced_accuracy"] for row in group),
+                "mean_roc_auc": _mean(row["roc_auc"] for row in group),
+                "mean_fit_s": _mean(row["fit_s"] for row in group),
+                "mean_inference_ms_per_trial": _mean(
+                    row["inference_ms_per_trial"] for row in group
+                ),
+            }
+        )
+
+    improvement = None
+    if len(curve) >= 2 and curve[0]["calibration_per_class"] == 0:
+        start = curve[0]["mean_balanced_accuracy"]
+        end = curve[-1]["mean_balanced_accuracy"]
+        if start is not None and end is not None:
+            improvement = float(end - start)
+
+    return {
+        "schema_version": 1,
+        "primary_metric": "balanced_accuracy",
+        "curve": curve,
+        "largest_budget_minus_zero_balanced_accuracy": improvement,
+        "interpretation": (
+            "Descriptive baseline summary only. Statistical comparison and model "
+            "promotion require repeated subjects/sessions and a predeclared analysis plan."
+        ),
+    }
+
+
+def _write_results_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("cannot write empty benchmark results")
+    fieldnames = list(rows[0].keys())
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _render_report(
+    *,
+    source: Any,
+    args: argparse.Namespace,
+    rows: list[dict[str, Any]],
+    summary: dict[str, Any],
+    split_records: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "# neurOS Longitudinal EEG Evidence Report",
+        "",
+        f"- Dataset: **{source.title}** (`{source.id}`)",
+        f"- Baseline: **CSP({args.csp_components}) + LDA**",
+        f"- Band: **{args.fmin:g}-{args.fmax:g} Hz**",
+        f"- Fixed held-out evaluation fraction: **{args.evaluation_fraction:.2f}**",
+        f"- Subjects requested: **{', '.join(str(v) for v in args.subjects)}**",
+        f"- Subject-session cases: **{len(split_records)}**",
+        "",
+        "## Calibration frontier",
+        "",
+        "| calibration / class | cases | balanced accuracy mean | std | ROC-AUC mean | fit s | inference ms/trial |",
+        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for point in summary["curve"]:
+        def fmt(value: Any, digits: int = 4) -> str:
+            return "n/a" if value is None else f"{float(value):.{digits}f}"
+
+        lines.append(
+            "| {calibration_per_class} | {n_subject_session_cases} | {ba} | {std} | "
+            "{auc} | {fit} | {infer} |".format(
+                **point,
+                ba=fmt(point["mean_balanced_accuracy"]),
+                std=fmt(point["std_balanced_accuracy"]),
+                auc=fmt(point["mean_roc_auc"]),
+                fit=fmt(point["mean_fit_s"], 3),
+                infer=fmt(point["mean_inference_ms_per_trial"], 3),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Evidence contract",
+            "",
+            "Every subject-session case freezes the held-out session before model fitting. "
+            "Within that session, the evaluation examples are frozen once and never change "
+            "as calibration budget grows. Calibration subsets are nested per class.",
+            "",
+            "The zero-calibration row is therefore a genuine historical-session baseline; "
+            "larger budgets add held-out-session calibration examples but are scored on the "
+            "same evaluation trials.",
+            "",
+            "## Limits",
+            "",
+            "- This report is a transparent baseline, not an ORION or neurOS superiority claim.",
+            "- Dataset files/checksums remain governed by MOABB/upstream repositories; pin those identities for promoted evidence.",
+            "- CSP+LDA is refit when calibration examples are added; it is not an online-update algorithm.",
+            "- Hardware/closed-loop/clinical evidence is outside this offline real-dataset tier.",
+            "",
+            f"Raw result rows: {len(rows)}. See `results.csv`, `study_manifest.json`, and `artifact_hashes.json`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a fixed-evaluation longitudinal MOABB calibration benchmark."
+    )
+    parser.add_argument("--dataset", choices=sorted(_DATASETS), default="kumar2024")
+    parser.add_argument(
+        "--subjects",
+        type=_parse_int_list,
+        default=[1],
+        help="Comma-separated MOABB subject IDs (default: 1).",
+    )
+    parser.add_argument(
+        "--held-out-sessions",
+        type=_parse_text_list,
+        default=None,
+        help="Optional comma-separated session IDs. Default: evaluate every session.",
+    )
+    parser.add_argument(
+        "--budgets",
+        type=_parse_int_list,
+        default=[0, 1, 2, 5, 10],
+        help="Nested labeled calibration trials per class.",
+    )
+    parser.add_argument("--evaluation-fraction", type=float, default=0.5)
+    parser.add_argument("--fmin", type=float, default=8.0)
+    parser.add_argument("--fmax", type=float, default=30.0)
+    parser.add_argument("--csp-components", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=2026)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.fmin <= 0 or args.fmax <= args.fmin:
+        raise SystemExit("require 0 < --fmin < --fmax")
+    if args.csp_components <= 0:
+        raise SystemExit("--csp-components must be positive")
+    if not 0.0 < args.evaluation_fraction < 1.0:
+        raise SystemExit("--evaluation-fraction must lie strictly between 0 and 1")
+    if any(budget < 0 for budget in args.budgets):
+        raise SystemExit("--budgets must be non-negative")
+    args.budgets = sorted(set(args.budgets))
+    if 0 not in args.budgets:
+        args.budgets.insert(0, 0)
+
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    controlled = [
+        output / "study_manifest.json",
+        output / "results.csv",
+        output / "summary.json",
+        output / "report.md",
+        output / "artifact_hashes.json",
+    ]
+    existing = [path for path in controlled if path.exists()]
+    if existing and not args.overwrite:
+        names = ", ".join(path.name for path in existing)
+        raise SystemExit(f"refusing to overwrite existing artifacts: {names}")
+
+    dataset, paradigm = _dataset_and_paradigm(
+        args.dataset,
+        fmin=args.fmin,
+        fmax=args.fmax,
+    )
+    dataset_spec = _DATASETS[args.dataset]
+    source_id = dataset_spec["source_id"]
+    source = get_evidence_source(source_id)
+
+    rows: list[dict[str, Any]] = []
+    split_records: list[dict[str, Any]] = []
+    skipped_budgets: list[dict[str, Any]] = []
+
+    for subject in args.subjects:
+        bundle = collect_moabb(
+            dataset,
+            paradigm,
+            subjects=[int(subject)],
+            dataset_id=source_id,
+        )
+        sessions = sorted(set(bundle.groups.get("session", np.asarray([], dtype=str)).tolist()))
+        if len(sessions) < 2:
+            raise RuntimeError(
+                f"subject {subject} has fewer than two sessions after MOABB preprocessing"
+            )
+        selected_sessions = sessions
+        if args.held_out_sessions is not None:
+            missing = sorted(set(args.held_out_sessions) - set(sessions))
+            if missing:
+                raise RuntimeError(
+                    f"subject {subject} does not expose requested session(s) {missing}; "
+                    f"available={sessions}"
+                )
+            selected_sessions = list(args.held_out_sessions)
+
+        for session in selected_sessions:
+            partition = hold_out_groups(
+                bundle,
+                split_unit="session",
+                held_out_values=[session],
+            )
+            split_seed = _stable_int_seed(args.seed, source_id, subject, session)
+            calibration = make_nested_calibration_split(
+                partition,
+                evaluation_fraction=args.evaluation_fraction,
+                seed=split_seed,
+            )
+            events_text = (
+                "left_hand/right_hand"
+                if dataset_spec["events"] is None
+                else "/".join(dataset_spec["events"])
+            )
+            protocol = partition.protocol(
+                name=f"{source_id}-subject-{subject}-session-{session}",
+                transfer_regime="few_shot",
+                preprocessing=(
+                    f"MOABB {dataset_spec['paradigm']} events={events_text}; "
+                    f"bandpass {args.fmin:g}-{args.fmax:g} Hz; CSP+LDA fit only on "
+                    "historical sessions plus declared calibration"
+                ),
+                notes=(
+                    "fixed evaluation subset inside held-out session",
+                    "nested balanced calibration budgets per class",
+                ),
+                seed=split_seed,
+            )
+            record = partition.manifest(protocol=protocol)
+            record["subject"] = int(subject)
+            record["held_out_session"] = str(session)
+            record["calibration"] = calibration.manifest()
+            split_records.append(record)
+
+            X = np.asarray(bundle.X)
+            y = np.asarray(bundle.y)
+            eval_idx = calibration.evaluation_indices
+
+            for budget in args.budgets:
+                if budget > calibration.max_budget_per_class:
+                    skipped_budgets.append(
+                        {
+                            "subject": int(subject),
+                            "held_out_session": str(session),
+                            "requested_per_class": int(budget),
+                            "max_balanced_per_class": int(calibration.max_budget_per_class),
+                        }
+                    )
+                    continue
+
+                train_idx = calibration.train_indices_for_budget(budget)
+                cal_idx = calibration.calibration_indices(budget)
+                model = _build_csp_lda(components=args.csp_components)
+                started = time.perf_counter()
+                model.fit(X[train_idx], y[train_idx])
+                fit_s = time.perf_counter() - started
+                metrics = _score_binary(model, X[eval_idx], y[eval_idx])
+
+                rows.append(
+                    {
+                        "dataset_id": source_id,
+                        "subject": int(subject),
+                        "held_out_session": str(session),
+                        "partition_fingerprint": partition.fingerprint,
+                        "calibration_split_fingerprint": calibration.fingerprint,
+                        "calibration_per_class": int(budget),
+                        "source_train_samples": int(len(calibration.source_train_indices)),
+                        "calibration_samples": int(len(cal_idx)),
+                        "evaluation_samples": int(len(eval_idx)),
+                        "total_fit_samples": int(len(train_idx)),
+                        "accuracy": metrics["accuracy"],
+                        "balanced_accuracy": metrics["balanced_accuracy"],
+                        "roc_auc": metrics["roc_auc"],
+                        "fit_s": float(fit_s),
+                        "inference_s": metrics["inference_s"],
+                        "inference_ms_per_trial": metrics["inference_ms_per_trial"],
+                    }
+                )
+
+    if not rows:
+        raise RuntimeError("benchmark produced no evaluable rows")
+
+    summary = _summarize(rows)
+    manifest = {
+        "schema_version": 1,
+        "evidence_tier": "real_dataset",
+        "study": "longitudinal_eeg_calibration_baseline",
+        "method": "CSP+LDA refit with nested held-out-session calibration",
+        "source": source.to_dict(),
+        "dataset_key": args.dataset,
+        "dataset_class": dataset_spec["class"],
+        "paradigm": {
+            "kind": dataset_spec["paradigm"],
+            "events": list(dataset_spec["events"] or ("left_hand", "right_hand")),
+        },
+        "subjects": [int(value) for value in args.subjects],
+        "held_out_sessions_requested": args.held_out_sessions,
+        "requested_calibration_per_class": [int(value) for value in args.budgets],
+        "evaluation_fraction": float(args.evaluation_fraction),
+        "band_hz": [float(args.fmin), float(args.fmax)],
+        "csp_components": int(args.csp_components),
+        "seed": int(args.seed),
+        "git_revision": _git_revision(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "package_versions": _versions(),
+        "splits": split_records,
+        "skipped_budgets": skipped_budgets,
+        "limitations": [
+            "upstream MOABB/data-file checksums are not yet captured by this runner",
+            "CSP+LDA is a transparent baseline, not an ORION superiority claim",
+            "offline real-dataset evidence is not hardware or closed-loop qualification",
+        ],
+    }
+
+    results_path = output / "results.csv"
+    summary_path = output / "summary.json"
+    manifest_path = output / "study_manifest.json"
+    report_path = output / "report.md"
+    hashes_path = output / "artifact_hashes.json"
+
+    _write_results_csv(results_path, rows)
+    _json_dump(summary_path, summary)
+    _json_dump(manifest_path, manifest)
+    report_path.write_text(
+        _render_report(
+            source=source,
+            args=args,
+            rows=rows,
+            summary=summary,
+            split_records=split_records,
+        ),
+        encoding="utf-8",
+    )
+
+    hashes = {
+        path.name: _sha256(path)
+        for path in (results_path, summary_path, manifest_path, report_path)
+    }
+    _json_dump(hashes_path, {"sha256": hashes})
+
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "dataset": source_id,
+                "rows": len(rows),
+                "subject_session_cases": len(split_records),
+                "artifacts": [path.name for path in controlled],
+                "summary": summary,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evidence/run_moabb_longitudinal.py
+++ b/scripts/evidence/run_moabb_longitudinal.py
@@ -10,7 +10,8 @@ For each subject and held-out session this runner:
 4. freezes the remaining held-out trials as an ordered calibration pool;
 5. refits the same CSP+LDA baseline at nested per-class calibration budgets;
 6. evaluates every budget on the exact same held-out examples;
-7. writes machine-readable manifests, results, summary, hashes, and a report.
+7. keeps the public calibration frontier paired across subject-session cases;
+8. writes machine-readable manifests, results, summary, hashes, and a report.
 
 Large public datasets are downloaded by MOABB when this script is run. CI does
 not download them; contract behavior is tested with synthetic MOABB-shaped data.
@@ -228,18 +229,31 @@ def _std(values: Iterable[float]) -> float | None:
     return None if len(array) == 0 else float(np.std(array, ddof=1)) if len(array) > 1 else 0.0
 
 
+def _case_key(row: dict[str, Any]) -> tuple[str, str]:
+    return str(row["subject"]), str(row["held_out_session"])
+
+
+def _case_set_fingerprint(cases: set[tuple[str, str]]) -> str:
+    raw = json.dumps(sorted([list(case) for case in cases]), separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
 def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     by_budget: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
         by_budget[int(row["calibration_per_class"])].append(row)
 
     curve = []
+    case_sets: dict[int, set[tuple[str, str]]] = {}
     for budget in sorted(by_budget):
         group = by_budget[budget]
+        cases = {_case_key(row) for row in group}
+        case_sets[budget] = cases
         curve.append(
             {
                 "calibration_per_class": budget,
-                "n_subject_session_cases": len(group),
+                "n_subject_session_cases": len(cases),
+                "case_set_fingerprint": _case_set_fingerprint(cases),
                 "mean_balanced_accuracy": _mean(row["balanced_accuracy"] for row in group),
                 "std_balanced_accuracy": _std(row["balanced_accuracy"] for row in group),
                 "mean_roc_auc": _mean(row["roc_auc"] for row in group),
@@ -249,6 +263,11 @@ def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
                 ),
             }
         )
+
+    paired = True
+    if case_sets:
+        reference = next(iter(case_sets.values()))
+        paired = all(cases == reference for cases in case_sets.values())
 
     improvement = None
     if len(curve) >= 2 and curve[0]["calibration_per_class"] == 0:
@@ -260,6 +279,7 @@ def _summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "primary_metric": "balanced_accuracy",
+        "paired_case_sets_identical": paired,
         "curve": curve,
         "largest_budget_minus_zero_balanced_accuracy": improvement,
         "interpretation": (
@@ -292,6 +312,11 @@ def _render_report(
         if args.history_policy == "prior"
         else "all other sessions; symmetric cross-session evaluation"
     )
+    pairing_text = (
+        "paired across identical subject-session cases"
+        if summary["paired_case_sets_identical"]
+        else "UNPAIRED exploratory curve; case set changes by budget"
+    )
     lines = [
         "# neurOS Longitudinal EEG Evidence Report",
         "",
@@ -299,22 +324,23 @@ def _render_report(
         f"- Baseline: **CSP({args.csp_components}) + LDA**",
         f"- Band: **{args.fmin:g}-{args.fmax:g} Hz**",
         f"- History policy: **{history_text}**",
+        f"- Calibration frontier: **{pairing_text}**",
         f"- Fixed held-out evaluation fraction: **{args.evaluation_fraction:.2f}**",
         f"- Subjects requested: **{', '.join(str(v) for v in args.subjects)}**",
         f"- Subject-session cases: **{len(split_records)}**",
         "",
         "## Calibration frontier",
         "",
-        "| calibration / class | cases | balanced accuracy mean | std | ROC-AUC mean | fit s | inference ms/trial |",
-        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        "| calibration / class | cases | case-set fp | balanced accuracy mean | std | ROC-AUC mean | fit s | inference ms/trial |",
+        "| ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |",
     ]
     for point in summary["curve"]:
         def fmt(value: Any, digits: int = 4) -> str:
             return "n/a" if value is None else f"{float(value):.{digits}f}"
 
         lines.append(
-            "| {calibration_per_class} | {n_subject_session_cases} | {ba} | {std} | "
-            "{auc} | {fit} | {infer} |".format(
+            "| {calibration_per_class} | {n_subject_session_cases} | {case_set_fingerprint} | "
+            "{ba} | {std} | {auc} | {fit} | {infer} |".format(
                 **point,
                 ba=fmt(point["mean_balanced_accuracy"]),
                 std=fmt(point["std_balanced_accuracy"]),
@@ -349,6 +375,15 @@ def _render_report(
                 "The `all-other` policy is symmetric leave-one-session-out evaluation and "
                 "may include sessions recorded after the held-out session. It must not be "
                 "described as next-session or prospective deployment evidence.",
+                "",
+            ]
+        )
+    if not summary["paired_case_sets_identical"]:
+        lines.extend(
+            [
+                "**Exploratory warning:** calibration budgets do not contain identical "
+                "subject-session cases. Do not interpret changes in the aggregate curve as "
+                "a paired calibration effect.",
                 "",
             ]
         )
@@ -403,6 +438,15 @@ def build_parser() -> argparse.ArgumentParser:
         type=_parse_int_list,
         default=[0, 1, 2, 5, 10],
         help="Nested labeled calibration trials per class.",
+    )
+    parser.add_argument(
+        "--allow-incomplete-budgets",
+        action="store_true",
+        help=(
+            "Exploratory only: allow cases that cannot support a requested balanced budget "
+            "to drop from that budget. Default promoted behavior fails closed to keep the "
+            "calibration frontier paired."
+        ),
     )
     parser.add_argument("--evaluation-fraction", type=float, default=0.5)
     parser.add_argument("--fmin", type=float, default=8.0)
@@ -550,14 +594,21 @@ def main(argv: list[str] | None = None) -> int:
 
             for budget in args.budgets:
                 if budget > calibration.max_budget_per_class:
-                    skipped_budgets.append(
-                        {
-                            "subject": int(subject),
-                            "held_out_session": str(session),
-                            "requested_per_class": int(budget),
-                            "max_balanced_per_class": int(calibration.max_budget_per_class),
-                        }
-                    )
+                    detail = {
+                        "subject": int(subject),
+                        "held_out_session": str(session),
+                        "requested_per_class": int(budget),
+                        "max_balanced_per_class": int(calibration.max_budget_per_class),
+                    }
+                    if not args.allow_incomplete_budgets:
+                        raise RuntimeError(
+                            "requested calibration frontier is not paired: "
+                            f"subject={subject}, session={session} supports at most "
+                            f"{calibration.max_budget_per_class}/class but {budget}/class "
+                            "was requested. Choose a common smaller budget or pass "
+                            "--allow-incomplete-budgets for explicitly exploratory output."
+                        )
+                    skipped_budgets.append(detail)
                     continue
 
                 train_idx = calibration.train_indices_for_budget(budget)
@@ -571,6 +622,7 @@ def main(argv: list[str] | None = None) -> int:
                 rows.append(
                     {
                         "dataset_id": source_id,
+                        "case_id": f"subject-{subject}/session-{session}",
                         "subject": int(subject),
                         "held_out_session": str(session),
                         "history_policy": args.history_policy,
@@ -594,6 +646,9 @@ def main(argv: list[str] | None = None) -> int:
         raise RuntimeError("benchmark produced no evaluable rows")
 
     summary = _summarize(rows)
+    if not args.allow_incomplete_budgets and not summary["paired_case_sets_identical"]:
+        raise RuntimeError("internal error: strict calibration frontier is not paired")
+
     manifest = {
         "schema_version": 1,
         "evidence_tier": "real_dataset",
@@ -607,6 +662,7 @@ def main(argv: list[str] | None = None) -> int:
             "events": list(dataset_spec["events"] or ("left_hand", "right_hand")),
         },
         "history_policy": args.history_policy,
+        "allow_incomplete_budgets": bool(args.allow_incomplete_budgets),
         "subjects": [int(value) for value in args.subjects],
         "held_out_sessions_requested": args.held_out_sessions,
         "requested_calibration_per_class": [int(value) for value in args.budgets],
@@ -625,6 +681,7 @@ def main(argv: list[str] | None = None) -> int:
             "CSP+LDA is a transparent baseline, not an ORION superiority claim",
             "prior policy assumes first-observed upstream session metadata order is chronological and must be verified before promotion",
             "all-other policy is symmetric cross-session evaluation and is not prospective next-session evidence",
+            "allow-incomplete-budgets produces an unpaired exploratory frontier and is not promotion-ready",
             "offline real-dataset evidence is not hardware or closed-loop qualification",
         ],
     }
@@ -661,6 +718,7 @@ def main(argv: list[str] | None = None) -> int:
                 "output": str(output),
                 "dataset": source_id,
                 "history_policy": args.history_policy,
+                "paired_case_sets_identical": summary["paired_case_sets_identical"],
                 "rows": len(rows),
                 "subject_session_cases": len(split_records),
                 "artifacts": [path.name for path in controlled],


### PR DESCRIPTION
## Purpose

Turn the merged real-world evidence contracts into the first executable longitudinal EEG study while keeping the baseline transparent, the history clean, and the calibration frontier scientifically paired.

This PR is rebuilt directly from current `main` after #23 was squash-merged. It replaces the contaminated stacked history in #24 and contains only longitudinal-benchmark/showcase work.

## Scientific invariants

### 1. Future sessions cannot leak into a prospective claim

`--history-policy prior` is the default. For held-out session `S3`, fitting may use only sessions preceding `S3`; later sessions are excluded from both fitting and evaluation.

`--history-policy all-other` remains available for conventional symmetric leave-one-session-out evaluation, but the manifest/report explicitly state that it may use future sessions and therefore is **not** prospective next-session evidence.

The runner preserves first-observed upstream metadata order rather than lexicographically sorting session labels. Promoted studies must still verify that metadata order against the dataset documentation.

### 2. Calibration budgets must use one immutable final evaluation set

The held-out session is frozen once into:

```text
held-out session -> ordered balanced calibration pool + frozen evaluation set
```

Calibration subsets are deterministic and nested per class. The evaluation indices never change as budget grows.

### 3. Aggregate calibration curves must remain paired

A right-hand calibration point must not silently drop difficult subject/session cases simply because they lack enough balanced calibration examples.

By default, if any requested calibration budget cannot be supported by every selected subject/session case, the run fails closed. This keeps every plotted budget paired across the same cases.

`--allow-incomplete-budgets` is an explicit exploratory escape hatch. Such curves are labeled **unpaired**, carry per-budget case-set fingerprints, and are not promotion-ready.

## First executable benchmark

```bash
python scripts/evidence/run_moabb_longitudinal.py \
  --dataset kumar2024 \
  --subjects 1,2,3 \
  --budgets 0,1,2,5,10 \
  --history-policy prior \
  --output evidence/kumar2024
```

Supported dataset keys:

- `kumar2024` — primary first study;
- `ma2020` — high-session-count right-hand/right-elbow drift stress test;
- `lee2019-mi` — OpenBMI MI member of the cross-paradigm cohort;
- `wang2026` — supported when the installed MOABB release exposes that upstream class.

## Dataset-specific paradigm correctness

The runner does **not** pretend every motor-imagery dataset is left-vs-right:

- Kumar2024 / Lee2019_MI / Wang2026 use `LeftRightImagery`;
- Ma2020 uses `MotorImagery(events=["right_hand", "right_elbow"])`.

The MOABB qualification lane checks these declared paradigm/dataset combinations against the installed upstream API.

## Baseline

The first method is deliberately simple:

**CSP + Linear Discriminant Analysis**

For each subject and eligible held-out session:

1. MOABB creates trial arrays and subject/session/run metadata.
2. neurOS freezes the deployment-unit partition before fitting.
3. under `prior`, future sessions are excluded.
4. neurOS freezes a balanced held-out-session calibration pool and fixed evaluation set.
5. CSP+LDA is fit on declared source history only at budget 0.
6. At larger budgets, the same pipeline is refit on source history plus declared calibration examples.
7. Every budget is scored on the exact same evaluation trials.
8. The aggregate curve is checked for identical subject/session case membership at every budget.

This establishes a transparent evidence floor, not an ORION claim.

## Evidence artifacts

Each real run emits:

- `study_manifest.json`
- `results.csv`
- `summary.json`
- `report.md`
- `artifact_hashes.json`

The manifest records history policy, observed session order, source sessions, deployment-unit fingerprints, calibration split identity, paired/unpaired budget policy, model/preprocessing identity, environment, and limitations.

Each summary calibration point records a `case_set_fingerprint`, and `summary.json` records whether all case sets are identical.

The report is rendered from the same result rows rather than maintained as a separate result surface.

## End-to-end qualification

The path-scoped evidence workflow now:

- runs grouped + longitudinal contract tests on Python 3.10 / 3.11 / 3.12;
- verifies prior-only chronological partition behavior and exclusion of future sessions;
- verifies first-observed ordering rather than lexicographic session sorting;
- verifies fixed evaluation identity and nested calibration budgets;
- verifies strict paired calibration-frontier behavior;
- tests imbalanced/small-class failure behavior;
- installs the actual MOABB evidence profile on Python 3.11;
- verifies `Kumar2024`, `Ma2020`, `Lee2019_MI`, and their declared paradigms against MOABB;
- executes the **entire artifact pipeline** on synthetic MOABB-shaped EEG using real MNE CSP + sklearn LDA;
- verifies generated manifests, rows, paired case fingerprints, report semantics, and SHA-256 artifact identities.

Large public dataset downloads remain explicit study execution, not CI side effects.

## Explicit real-study workflow

Adds `.github/workflows/longitudinal-evidence-study.yml` as a **manual `workflow_dispatch` only** study runner.

A user can select dataset, subjects, calibration budgets, history policy, evaluation fraction, CSP size and seed from GitHub Actions. The workflow records Python/pip/Git identity, runs the public dataset study, recomputes every artifact hash, and uploads the complete evidence bundle.

It never downloads large public datasets as a normal push/PR side effect.

## Showcase

Adds `docs/LONGITUDINAL_EEG_SHOWCASE.md`, defining the Evidence Console visual language:

- session chronology with history / target / future-excluded regions;
- calibration-pool versus immutable evaluation identity;
- performance-versus-calibration frontier;
- paired-case identity per calibration point;
- zero-calibration drift by session;
- dataset/Git/model/split/artifact identities kept visible beside every chart.

The economically legible BCI metric is treated as **calibration saved**, not merely raw accuracy gained.

## Next comparison layer

Issue #26 specifies the next method ladder under the exact same split/calibration authority:

- EEGNet;
- EEG-Conformer;
- frozen representations + matched readout;
- SourceWeigher using target **calibration examples only** for target-distribution estimation;
- eventually a faithful foundation-model representation adapter and an explicit ORION EEG representation if scientifically justified.

No method gets to select a different final test set, learn from future sessions under a prospective claim, or use final evaluation examples for SourceWeigher/adaptation/model selection.