### PR TITLE
evidence: build authoritative longitudinal EEG model ladder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - "agent/**"
 
 permissions:
   contents: read

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -134,6 +134,7 @@ jobs:
             packages/neuros-foundation/tests/test_longitudinal_methods.py \
             packages/neuros-foundation/tests/test_longitudinal_transfer.py \
             packages/neuros-foundation/tests/test_longitudinal_zero_calibration.py \
+            packages/neuros-foundation/tests/test_longitudinal_model_identity.py \
             packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
       - name: Exercise ladder CLI
         run: |

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -8,7 +8,10 @@ on:
       - "docs/REAL_WORLD_EVIDENCE.md"
       - "docs/EVIDENCE_SOURCE_MAP.md"
       - "docs/LONGITUDINAL_EEG_SHOWCASE.md"
+      - "docs/LONGITUDINAL_MODEL_LADDER.md"
       - ".github/workflows/evidence-ci.yml"
+      - ".github/workflows/longitudinal-evidence-study.yml"
+      - ".github/workflows/longitudinal-model-ladder-study.yml"
   push:
     branches:
       - main
@@ -19,7 +22,10 @@ on:
       - "docs/REAL_WORLD_EVIDENCE.md"
       - "docs/EVIDENCE_SOURCE_MAP.md"
       - "docs/LONGITUDINAL_EEG_SHOWCASE.md"
+      - "docs/LONGITUDINAL_MODEL_LADDER.md"
       - ".github/workflows/evidence-ci.yml"
+      - ".github/workflows/longitudinal-evidence-study.yml"
+      - ".github/workflows/longitudinal-model-ladder-study.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -48,14 +48,16 @@ jobs:
         run: |
           pytest -q \
             packages/neuros-foundation/tests/test_real_world.py \
-            packages/neuros-foundation/tests/test_longitudinal.py
-      - name: Exercise evidence discovery, manifest example, and runner CLI
+            packages/neuros-foundation/tests/test_longitudinal.py \
+            packages/neuros-foundation/tests/test_longitudinal_authority.py
+      - name: Exercise evidence discovery and runner CLIs
         run: |
           neuros-foundation evidence
           neuros-foundation evidence --role longitudinal_bci --json
           neuros-foundation evidence --role cross_site_transfer --json
           python packages/neuros-foundation/examples/05_real_world_evidence.py
           python scripts/evidence/run_moabb_longitudinal.py --help
+          python scripts/evidence/run_moabb_model_ladder.py --help
 
   moabb-profile:
     name: MOABB evidence profile
@@ -72,7 +74,7 @@ jobs:
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[evidence,dev]"
-      - name: Verify external benchmark ecosystem and runner dependencies
+      - name: Verify external benchmark ecosystem and baseline runner
         run: |
           python - <<'PY'
           import moabb
@@ -102,3 +104,30 @@ jobs:
             packages/neuros-foundation/tests/test_longitudinal.py \
             packages/neuros-foundation/tests/test_longitudinal_runner.py
           python scripts/evidence/run_moabb_longitudinal.py --help
+
+  model-ladder-profile:
+    name: Longitudinal model ladder / Python 3.11
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install complete local ladder stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-models[dev]"
+          python -m pip install -e packages/neuros-sourceweigher
+          python -m pip install -e "packages/neuros-foundation[evidence,ladder,dev]"
+      - name: Verify authority, task decoders, frozen transfer, and full bundle
+        run: |
+          pytest -q \
+            packages/neuros-foundation/tests/test_longitudinal_authority.py \
+            packages/neuros-foundation/tests/test_longitudinal_methods.py \
+            packages/neuros-foundation/tests/test_longitudinal_transfer.py \
+            packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
+      - name: Exercise ladder CLI
+        run: |
+          python scripts/evidence/run_moabb_model_ladder.py --help

--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -127,6 +127,7 @@ jobs:
             packages/neuros-foundation/tests/test_longitudinal_authority.py \
             packages/neuros-foundation/tests/test_longitudinal_methods.py \
             packages/neuros-foundation/tests/test_longitudinal_transfer.py \
+            packages/neuros-foundation/tests/test_longitudinal_zero_calibration.py \
             packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
       - name: Exercise ladder CLI
         run: |

--- a/.github/workflows/longitudinal-model-ladder-study.yml
+++ b/.github/workflows/longitudinal-model-ladder-study.yml
@@ -1,0 +1,188 @@
+name: neurOS longitudinal EEG model ladder
+
+on:
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: Public MOABB dataset key
+        required: true
+        type: choice
+        default: kumar2024
+        options:
+          - kumar2024
+          - ma2020
+          - lee2019-mi
+          - wang2026
+      subjects:
+        description: Comma-separated MOABB subject IDs
+        required: true
+        type: string
+        default: "1,10"
+      held_out_sessions:
+        description: Optional comma-separated target sessions; blank uses all eligible targets
+        required: false
+        type: string
+        default: ""
+      methods:
+        description: Comma-separated method IDs
+        required: true
+        type: string
+        default: "csp-lda,eegnet,eeg-conformer,frozen-eegnet,frozen-eeg-conformer,sourceweigher-eegnet,sourceweigher-eeg-conformer"
+      model_seeds:
+        description: Comma-separated optimization seeds for neural methods
+        required: true
+        type: string
+        default: "101"
+      budgets:
+        description: Labeled target-session calibration examples per class
+        required: true
+        type: string
+        default: "0,1,2,5,10"
+      history_policy:
+        description: Prior-only is prospective-style; all-other is symmetric cross-session
+        required: true
+        type: choice
+        default: prior
+        options:
+          - prior
+          - all-other
+      split_seed:
+        description: Base split/calibration seed
+        required: true
+        type: string
+        default: "2026"
+      evaluation_fraction:
+        description: Fraction of each held-out class frozen for final evaluation
+        required: true
+        type: string
+        default: "0.5"
+      epochs:
+        description: Fixed training epochs for neural encoders/decoders
+        required: true
+        type: string
+        default: "20"
+      batch_size:
+        description: Neural training batch size
+        required: true
+        type: string
+        default: "32"
+      csp_components:
+        description: CSP component count for transparent baseline
+        required: true
+        type: string
+        default: "8"
+      readout_c:
+        description: Logistic readout inverse regularization strength
+        required: true
+        type: string
+        default: "1.0"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: longitudinal-model-ladder-${{ github.ref }}-${{ inputs.dataset }}-${{ inputs.subjects }}
+  cancel-in-progress: false
+
+jobs:
+  study:
+    name: ${{ inputs.dataset }} / ${{ inputs.history_policy }} / model ladder
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install complete local evidence ladder
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-models[pytorch]"
+          python -m pip install -e packages/neuros-sourceweigher
+          python -m pip install -e "packages/neuros-foundation[evidence,ladder]"
+
+      - name: Record execution environment
+        run: |
+          mkdir -p evidence-run
+          python -VV > evidence-run/python.txt
+          python -m pip freeze > evidence-run/pip-freeze.txt
+          git rev-parse HEAD > evidence-run/git-revision.txt
+          printf '%s\n' "${{ inputs.methods }}" > evidence-run/requested-methods.txt
+          printf '%s\n' "${{ inputs.model_seeds }}" > evidence-run/requested-model-seeds.txt
+
+      - name: Run real-dataset model ladder
+        env:
+          MNE_DATA: ${{ runner.temp }}/mne-data
+        shell: bash
+        run: |
+          EXTRA=()
+          if [[ -n "${{ inputs.held_out_sessions }}" ]]; then
+            EXTRA+=(--held-out-sessions "${{ inputs.held_out_sessions }}")
+          fi
+          python scripts/evidence/run_moabb_model_ladder.py \
+            --dataset "${{ inputs.dataset }}" \
+            --subjects "${{ inputs.subjects }}" \
+            --methods "${{ inputs.methods }}" \
+            --model-seeds "${{ inputs.model_seeds }}" \
+            --budgets "${{ inputs.budgets }}" \
+            --history-policy "${{ inputs.history_policy }}" \
+            --split-seed "${{ inputs.split_seed }}" \
+            --evaluation-fraction "${{ inputs.evaluation_fraction }}" \
+            --epochs "${{ inputs.epochs }}" \
+            --batch-size "${{ inputs.batch_size }}" \
+            --csp-components "${{ inputs.csp_components }}" \
+            --readout-c "${{ inputs.readout_c }}" \
+            --device cpu \
+            --output evidence-run/study \
+            "${EXTRA[@]}"
+
+      - name: Verify emitted authority and evidence artifacts
+        run: |
+          for name in \
+            study_manifest.json \
+            split_authority.json \
+            method_runs.json \
+            results.csv \
+            summary.json \
+            report.md \
+            artifact_hashes.json; do
+            test -s "evidence-run/study/$name"
+          done
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          root = Path("evidence-run/study")
+          declared = json.loads((root / "artifact_hashes.json").read_text())["sha256"]
+          for name, expected in declared.items():
+              actual = hashlib.sha256((root / name).read_bytes()).hexdigest()
+              assert actual == expected, (name, actual, expected)
+
+          manifest = json.loads((root / "study_manifest.json").read_text())
+          summary = json.loads((root / "summary.json").read_text())
+          authority = json.loads((root / "split_authority.json").read_text())
+          assert manifest["authority_fingerprints"] == [
+              item["authority_fingerprint"] for item in authority["cases"]
+          ]
+          assert summary["unexpected_unavailable_rows"] == 0
+          print(
+              "model ladder verified; descriptive promotion gate =",
+              summary["promotion_ready_descriptive"],
+          )
+          PY
+
+      - name: Upload immutable model-ladder evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: longitudinal-model-ladder-${{ inputs.dataset }}-${{ inputs.history_policy }}-${{ github.run_id }}
+          path: evidence-run/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/LONGITUDINAL_EEG_SHOWCASE.md
+++ b/docs/LONGITUDINAL_EEG_SHOWCASE.md
@@ -1,290 +1,341 @@
 # Longitudinal EEG Evidence Showcase
 
-This study is the first executable real-dataset showcase for the neurOS evidence plane.
+The longitudinal EEG showcase is the first public-facing demonstration of the neurOS evidence plane.
 
-The goal is not to manufacture a flattering EEG accuracy number. The goal is to answer a deployment question that a BCI engineer, researcher, or buyer can understand immediately:
+The central question remains deliberately concrete:
 
-> **If this decoder worked yesterday, how much data does it need tomorrow?**
+> **If this neural decoder worked on prior sessions, how much new target-session data does it need now?**
 
-## First study: Kumar2024
+The showcase now has two executable layers:
 
-The recommended first run is the MOABB `Kumar2024` motor-imagery dataset because it contains repeated separate-day sessions and an offline-to-online training progression.
+1. a transparent CSP + LDA evidence floor;
+2. an authoritative multi-method model ladder under the exact same deployment semantics.
 
-Start with a small evidence run to validate the complete artifact chain:
+For the implementation contract and seven comparison lanes, see [Longitudinal Model Ladder](LONGITUDINAL_MODEL_LADDER.md).
 
-```bash
-python -m pip install -e "packages/neuros-foundation[evidence]"
+## Flagship study: Kumar2024
 
-python scripts/evidence/run_moabb_longitudinal.py \
-  --dataset kumar2024 \
-  --subjects 1,2,3 \
-  --budgets 0,1,2,5,10 \
-  --history-policy prior \
-  --output evidence/kumar2024-csp-lda
-```
+Kumar2024 remains the recommended first longitudinal EEG study because it provides six separate-day sessions from 18 BCI-naive participants, with MOABB session `0` representing the offline session and sessions `1` through `5` the chronological online sessions.
 
-Then scale to the predeclared subject set only after the artifact identities and dataset chronology have been inspected.
+The original experiment also contains two different training/adaptation cohorts:
 
-## Two different questions, two explicit policies
+- MOABB subjects 1–9: `GR`;
+- MOABB subjects 10–18: `PAR`.
 
-### `prior` — prospective-style longitudinal evidence
+neurOS preserves that cohort identity in every promoted case rather than pooling the trajectories blindly.
 
-This is the default.
-
-For a target session `S3`:
+The preregistered promoted frontier in Issue #27 uses:
 
 ```text
-S1          S2          S3                         S4          S5
-|-----------|-----------|--------------------------|-----------|
-   HISTORY      HISTORY     CALIBRATION + EVAL        EXCLUDED
-
-fit source data: S1 + S2
-calibration:     declared subset of S3
-final test:      frozen disjoint subset of S3
-future data:     S4 + S5 never enters fitting
+0, 1, 2, 5, 10 labeled target examples / class
 ```
 
-The first observed session cannot be evaluated under this policy because no prior history exists.
+with prospective-style prior-session history.
 
-This is the appropriate default for claims such as:
+## Prospective chronology
 
-- next-session robustness;
-- next-day calibration burden;
-- prospective adaptation;
-- degradation as time since initial calibration grows.
+`history_policy = prior` is the primary policy.
 
-First-observed upstream metadata order is treated as chronology by the software. Before publishing or promoting a result, verify that ordering assumption against the dataset documentation and preserve the exact upstream data/version identity.
-
-### `all-other` — symmetric cross-session evaluation
-
-For the same target session `S3`:
+For target session `S3`:
 
 ```text
-S1          S2          S3                         S4          S5
-|-----------|-----------|--------------------------|-----------|
-   TRAIN        TRAIN      CALIBRATION + EVAL          TRAIN       TRAIN
+S0             S1             S2             S3             S4
+|--------------|--------------|--------------|--------------|
+  SOURCE          SOURCE         TARGET          FUTURE
+                                  |   |           EXCLUDED
+                            calibration eval
 ```
 
-This mode is useful for conventional cross-session comparison, but it may learn from recordings collected after the target session. It must never be labeled as prospective or next-session deployment evidence.
+Only sessions preceding the target may enter source fitting.
 
-Run it explicitly:
-
-```bash
-python scripts/evidence/run_moabb_longitudinal.py \
-  --dataset kumar2024 \
-  --subjects 1,2,3 \
-  --history-policy all-other \
-  --output evidence/kumar2024-csp-lda-all-other
-```
-
-## Fixed evaluation identity
-
-Within the held-out session, neurOS freezes two disjoint sets once:
+The target session is partitioned once into:
 
 ```text
-held-out session
-      |
-      +--> ordered calibration pool
-      |
-      +--> frozen evaluation set
+target session
+   |
+   +--> ordered calibration pool
+   |
+   +--> immutable final evaluation set
 ```
 
-The evaluation set never changes when calibration budget changes.
+Future sessions never enter fitting under a prospective claim.
 
-For a two-class task:
+`history_policy = all-other` remains available as a separately labeled symmetric cross-session sensitivity analysis. It may use sessions recorded after the target and therefore is not next-session deployment evidence.
+
+## One authority, every method
+
+The multi-method showcase no longer relies on each model recreating a split from configuration.
+
+For every subject/target-session case neurOS serializes a `LongitudinalCaseAuthority` containing the actual source, calibration and evaluation indices plus a hash of the processed EEG.
 
 ```text
-0 / class   -> source history only
-1 / class   -> source history + 2 calibration trials
-2 / class   -> source history + 4 calibration trials
-5 / class   -> source history + 10 calibration trials
-10 / class  -> source history + 20 calibration trials
+processed EEG + labels + groups
+             |
+             v
+ LongitudinalCaseAuthority
+             |
+    +--------+---------+----------+
+    |        |         |          |
+ CSP+LDA   EEGNet   Conformer   frozen transfer
+                                  |
+                             SourceWeigher
 ```
 
-All five models are evaluated on exactly the same frozen held-out examples.
+A method must restore this authority before fitting.
 
-This prevents a calibration curve from quietly becoming easier as more calibration examples are consumed.
+If processed samples or identity change, the benchmark fails before training rather than producing an incomparable result.
 
-## Initial baseline
+## Current executable ladder
 
-The first benchmark intentionally uses:
+The Evidence Console can now render:
 
-**CSP + Linear Discriminant Analysis**
+- CSP + LDA;
+- EEGNet;
+- EEG-Conformer;
+- frozen EEGNet + matched logistic readout;
+- frozen EEG-Conformer + matched logistic readout;
+- SourceWeigher on the exact frozen EEGNet representation;
+- SourceWeigher on the exact frozen EEG-Conformer representation.
 
-This gives neurOS a transparent floor before introducing higher-capacity models.
+The frozen and SourceWeigher versions of one encoder share the exact same trained encoder state and representation tensors. The evidence bundle records both the learned-state SHA-256 and representation SHA-256.
 
-The progression should be:
+That lets the weighted-vs-unweighted comparison isolate the transfer strategy instead of quietly retraining two different encoders.
+
+## SourceWeigher is not secretly transductive
+
+SourceWeigher may use:
 
 ```text
-CSP + LDA
-    |
-    +--> EEGNet
-    +--> EEG-Conformer
-    +--> frozen foundation representation + matched readout
-    +--> SourceWeigher transfer
-    +--> ORION EEG representation, only after an explicit EEG contract exists
+prior-session frozen embeddings
+              +
+declared target calibration embeddings
 ```
 
-Every method must consume the same frozen split and calibration identities.
+It may not inspect final evaluation embeddings when estimating target similarity.
 
-## Artifact contract
+At labeled calibration budget `0`, target-dependent SourceWeigher is therefore explicitly unavailable.
 
-A completed study emits:
+The UI should display that absence rather than drawing a fabricated zero-shot point.
+
+## Evidence identity stack
+
+Every promoted neural operating point should expose three different identities:
+
+### Data identity
+
+- dataset/version;
+- processed-data SHA-256;
+- source/calibration/evaluation indices;
+- authority, partition and calibration fingerprints.
+
+### Learned-model identity
+
+- method configuration;
+- model seed;
+- parameter count;
+- complete trained `state_dict` SHA-256;
+- analysis-manifest fingerprint.
+
+### Representation identity
+
+For frozen-transfer lanes:
+
+- exact source embedding SHA contribution;
+- exact target calibration-pool embedding SHA contribution;
+- exact final evaluation embedding SHA contribution;
+- combined `representation_sha256`;
+- `encoder_state_fingerprint`.
+
+A configuration hash is not presented as a substitute for a learned-model hash.
+
+## The Evidence Console
+
+The strongest public interface is not a generic leaderboard. It is a linked explanation of **chronology, recalibration burden, source trust and provenance**.
+
+### 1. Chronology ribbon
 
 ```text
-evidence/kumar2024-csp-lda/
-├── study_manifest.json
-├── results.csv
-├── summary.json
-├── report.md
-└── artifact_hashes.json
+PAST                               TARGET                        FUTURE
+S0 -------- S1 -------- S2 -------- S3 -------- S4 -------- S5
+source      source      source      held out     excluded    excluded
+                                     |
+                              calibration | eval
 ```
 
-### `study_manifest.json`
+Selecting a target should reveal:
 
-Contains the evidence authority:
+- source sessions;
+- excluded future sessions;
+- calibration examples consumed;
+- immutable evaluation fingerprint;
+- GR/PAR cohort for Kumar2024.
 
-- dataset/source card;
-- Git/package/platform identity;
-- paradigm and event semantics;
-- chronological or symmetric history policy;
-- upstream-observed session order;
-- source sessions for every target session;
-- partition fingerprints;
-- fixed calibration/evaluation split fingerprints;
-- requested calibration budgets;
-- preprocessing and model identity;
-- explicit limitations.
-
-### `results.csv`
-
-One row per:
+### 2. Calibration frontier
 
 ```text
-subject × held-out session × calibration budget
-```
-
-with at least:
-
-- accuracy;
-- balanced accuracy;
-- ROC-AUC where valid;
-- fit time;
-- inference time per trial;
-- partition fingerprint;
-- calibration-split fingerprint.
-
-### `summary.json`
-
-Contains the aggregate calibration frontier used by the report/UI.
-
-### `report.md`
-
-Human-readable rendering of the same result rows. It is a view, not a second source of truth.
-
-### `artifact_hashes.json`
-
-SHA-256 identities for the evidence files.
-
-## Evidence Console design
-
-The public visualization should consume the artifact bundle directly.
-
-### Panel 1 — Session chronology
-
-Show a horizontal session timeline:
-
-```text
-PAST                              TARGET                         FUTURE
-S1 -------- S2 -------- S3 -------- S4 -------- S5 -------- S6
-history     history     history     held out      excluded    excluded
-                                      |
-                              calibration | evaluation
-```
-
-Selecting a target session should reveal:
-
-- which sessions were allowed into source training;
-- how many calibration examples were consumed;
-- the immutable evaluation fingerprint;
-- any excluded future sessions.
-
-The future-excluded region should be visibly different from train data. This makes leakage semantics inspectable rather than buried in a methods paragraph.
-
-### Panel 2 — Calibration frontier
-
-Primary chart:
-
-```text
-held-out balanced accuracy
+balanced accuracy
 ^
-|                         ORION / best validated method
+|                         method A
 |                  *------*
-|            *-----
-|      *-----         foundation representation
-|  *---
-| *        CSP+LDA
-+---------------------------------> labeled calibration / class
- 0        1       2        5       10
+|             *----        method B
+|        *----
+|   *----                    CSP+LDA
++------------------------------------> labels / class
+   0    1    2       5          10
 ```
 
-Do not display only the final point.
+Do not reduce the result to the largest-budget endpoint.
 
-Useful derived quantities:
+The primary Kumar comparison for methods defined at zero target calibration is normalized area under the full `0 -> 10` frontier.
 
-- zero-calibration score;
-- largest-budget score;
-- area under the calibration frontier;
-- labels needed to reach a predeclared performance threshold;
-- adaptation wall-clock required to reach that threshold.
+Target-dependent adaptation methods additionally receive a separate **positive-budget adaptation AUC**. These two quantities must remain visibly distinct.
 
-The economically legible BCI metric is often **calibration saved**, not raw accuracy gained.
+### 3. Source trust panel
 
-### Panel 3 — Session drift
+For SourceWeigher show:
 
-Display zero-calibration performance versus session index/time.
+```text
+S0  ███████░  0.41
+S1  ███░░░░░  0.18
+S2  ████████  0.41
+```
 
-This reveals whether a method is actually stable or merely easy to recalibrate.
+alongside:
 
-### Panel 4 — Evidence identity
+- effective sample size;
+- entropy;
+- largest source weight;
+- moment-matching residual;
+- convergence diagnostics.
 
-Keep the following visible beside every chart:
+This turns adaptation from a black box into an inspectable statement about which historical neural states the system considered useful.
+
+### 4. Drift and cohort views
+
+The same artifact bundle should provide:
+
+- pooled frontier;
+- GR frontier;
+- PAR frontier;
+- zero-calibration performance by target-session index;
+- failure rate by method/session;
+- fit/adaptation time and inference latency.
+
+These are views of one authority, not separately maintained analyses.
+
+### 5. Model and representation diagnostics
+
+Beside task score expose:
+
+- model parameter count;
+- learned-state SHA;
+- training wall-clock;
+- trial inference latency;
+- representation effective rank;
+- feature variance;
+- mean norm;
+- anisotropy proxy.
+
+This is particularly important because the current EEGNet and EEG-Conformer baselines are not capacity matched. A performance difference must not automatically be narrated as an attention-vs-convolution mechanism.
+
+### 6. Reproducibility drawer
+
+Keep visible or one click away:
 
 ```text
 dataset revision
 Git revision
-method/model revision
+package versions
 history policy
-partition fingerprint
-calibration split fingerprint
-artifact hash status
+split seed
+model seed
+processed-data SHA
+model-state SHA
+representation SHA when applicable
+authority fingerprint
+artifact verification status
 ```
 
-A screenshot without these identities should not be treated as promoted neurOS evidence.
+A screenshot without evidence identity is a visualization, not a promoted neurOS result.
 
-## Comparison promotion rules
+## Artifact bundle
 
-A new model may be added to the longitudinal figure only when:
+The multi-method study emits:
 
-1. it consumes the exact same partition/calibration manifests;
-2. preprocessing fit boundaries are declared;
-3. hyperparameter/model selection does not inspect final evaluation examples;
-4. random seeds and uncertainty are reported where relevant;
-5. failures are retained in the artifact rather than filtered from the plot;
-6. model identity and weight/artifact hashes are pinned;
-7. the result is clearly labeled offline real-dataset evidence, not hardware or clinical qualification.
+```text
+study_manifest.json
+split_authority.json
+method_runs.json
+results.csv
+summary.json
+report.md
+artifact_hashes.json
+```
 
-## Next implementation sequence
+The `report.md` and eventual web Evidence Console must be rendered from these machine-readable artifacts.
 
-After the CSP+LDA runner is qualified:
+The scientific record and polished demonstration must not become two hand-maintained surfaces.
 
-1. freeze one small Kumar2024 evidence bundle;
-2. add EEGNet and EEG-Conformer under identical manifests;
-3. add representation-only foundation-model comparisons using matched linear readouts;
-4. add SourceWeigher using prior sessions as candidate sources and the target-session calibration pool only for allowed adaptation;
-5. measure subject/session leakage and representation geometry;
-6. scale the predeclared study across participants;
-7. render the final evidence bundle in the neurOS Evidence Console;
-8. repeat the same calibration-frontier idea on FALCON with its native chronological day split.
+## Failure preservation
 
-The showcase succeeds when a viewer can understand, in seconds, **what data the model was allowed to know, how badly it drifted, how much calibration recovered it, and whether every number can be reproduced.**
+Failures remain part of the evidence.
+
+If a model fails for a case/seed, the result table contains failed operating points instead of silently deleting that subject/session.
+
+A descriptive bundle passes its promotion gate only when:
+
+- method failures are absent;
+- unexpected unavailable points are absent;
+- every method preserves identical case membership across the calibration budgets it claims to support.
+
+## How to run the two layers
+
+### Transparent floor
+
+```bash
+python scripts/evidence/run_moabb_longitudinal.py \
+  --dataset kumar2024 \
+  --subjects 1,10 \
+  --budgets 0,1,2,5,10 \
+  --history-policy prior \
+  --output evidence/kumar-csp-pilot
+```
+
+### Full model ladder
+
+Install the sibling SourceWeigher workspace package explicitly, then the foundation evidence/ladder profile:
+
+```bash
+python -m pip install -e packages/neuros-core
+python -m pip install -e "packages/neuros-models[pytorch]"
+python -m pip install -e packages/neuros-sourceweigher
+python -m pip install -e "packages/neuros-foundation[evidence,ladder]"
+
+python scripts/evidence/run_moabb_model_ladder.py \
+  --dataset kumar2024 \
+  --subjects 1,10 \
+  --methods csp-lda,eegnet,eeg-conformer,frozen-eegnet,frozen-eeg-conformer,sourceweigher-eegnet,sourceweigher-eeg-conformer \
+  --model-seeds 101 \
+  --budgets 0,1,2,5,10 \
+  --history-policy prior \
+  --split-seed 2026 \
+  --output evidence/kumar-model-ladder-pilot
+```
+
+The GitHub Actions workflow **neurOS longitudinal EEG model ladder** provides the same real-dataset study as an explicit manual run and uploads the complete evidence bundle.
+
+## What comes next
+
+Once the Kumar provenance pilot is inspected and the exact study dependencies are frozen:
+
+1. execute the complete CSP floor across all preregistered cases;
+2. scale the task-decoder and frozen-transfer lanes under the same authorities;
+3. add subject/session leakage and cross-session CKA under those same frozen examples;
+4. add montage/channel perturbation robustness;
+5. connect the existing mechanistic evidence-pack format to the same case authority;
+6. move the calibration-frontier concept to FALCON's native chronological cross-day splits;
+7. admit an ORION EEG representation only after ORION has an explicit EEG input/token contract.
+
+The public claim should grow only as the evidence grows.
+
+The showcase succeeds when a viewer can understand in seconds **what the system was allowed to know, how the neural distribution moved, how much calibration was needed, which prior sources were trusted, and exactly what data/model/code produced the result.**

--- a/docs/LONGITUDINAL_MODEL_LADDER.md
+++ b/docs/LONGITUDINAL_MODEL_LADDER.md
@@ -1,234 +1,224 @@
 # Longitudinal EEG Model Ladder
 
-The longitudinal model ladder is the first neurOS benchmark where multiple neural decoding strategies are forced to answer the **same deployment question on the same samples**.
+This document defines the authoritative multi-method longitudinal EEG comparison layer built on the prospective split and calibration authority in neurOS.
 
-The benchmark is not a model zoo. It is a controlled comparison of how much useful decoding performance survives a session shift and how much target-session calibration is required to recover it.
+The governing rule is simple:
 
-## The authority comes before the model
+> One frozen data authority, many methods.
 
-For each subject and target session, neurOS first creates a `LongitudinalCaseAuthority`.
+Every method must consume the same serialized source-history, target-calibration and final-evaluation identity. Method-specific convenience is never allowed to silently redefine the scientific question.
 
-That object freezes:
+## Why this exists
 
-```text
-prior source indices
-        |
-        +----------------------+
-                               |
-target session                 |
-  +--> ordered calibration pool|
-  +--> immutable final eval    |
-                               v
-                    LongitudinalCaseAuthority
-                               |
-                 processed-data SHA-256
-                 partition fingerprint
-                 calibration fingerprint
-                 exact integer indices
-                               |
-          +--------------------+--------------------+
-          |                    |                    |
-        CSP+LDA              EEGNet          EEG-Conformer
-          |                    |                    |
-          +--------- frozen representation lanes --+
-                               |
-                         SourceWeigher
-```
+A longitudinal BCI benchmark becomes misleading quickly if each model is allowed to choose a different target test set, use future sessions under a prospective claim, estimate adaptation state from final evaluation samples, or recreate nominally identical frozen encoders independently.
 
-Every method restores and validates that authority before fitting.
+The ladder therefore separates three identities:
 
-A method cannot silently regenerate a convenient split. If processed EEG bytes, labels, group order, or sample identity change, authority restoration fails before model training.
+1. **data identity**: processed-data SHA-256 plus exact source/calibration/evaluation indices;
+2. **learned-state identity**: SHA-256 of the complete trained model state, including registered buffers;
+3. **representation identity**: SHA-256 over the exact frozen source/calibration/evaluation embedding tensors used by a downstream method.
 
-## Supported comparison lanes
+Configuration and seed are provenance. They are not substitutes for learned-state identity.
 
-The executable runner currently exposes seven lanes:
+## Comparison lanes
 
-| Method ID | Representation behavior | Target-session behavior |
-| --- | --- | --- |
-| `csp-lda` | CSP fit at each budget | source + declared labeled calibration |
-| `eegnet` | end-to-end EEGNet fit at each budget | source + declared labeled calibration |
-| `eeg-conformer` | end-to-end EEG-Conformer fit at each budget | source + declared labeled calibration |
-| `frozen-eegnet` | EEGNet trained once on prior history, then frozen | logistic readout refit with declared calibration |
-| `frozen-eeg-conformer` | EEG-Conformer trained once on prior history, then frozen | logistic readout refit with declared calibration |
-| `sourceweigher-eegnet` | one frozen source-trained EEGNet representation | source-session weights estimated from target calibration embeddings only |
-| `sourceweigher-eeg-conformer` | one frozen source-trained EEG-Conformer representation | source-session weights estimated from target calibration embeddings only |
+The initial executable ladder supports:
 
-The frozen lanes answer a different scientific question from end-to-end retraining:
+- `csp-lda`
+- `eegnet`
+- `eeg-conformer`
+- `frozen-eegnet`
+- `frozen-eeg-conformer`
+- `sourceweigher-eegnet`
+- `sourceweigher-eeg-conformer`
 
-> **Did the representation itself remain useful after the neural distribution moved?**
+The family intentionally spans a transparent classical baseline, task-specific deep decoders, fixed-representation transfer, and reliability-weighted transfer.
 
-## SourceWeigher target authority
+### CSP + LDA
 
-SourceWeigher operates in one common frozen embedding space.
+The classical floor. This remains important because a sophisticated neural system should not be promoted merely for beating a weak or incorrectly configured baseline.
 
-For target session `S4`:
+### EEGNet and EEG-Conformer
 
-```text
-S1 embeddings ----+
-S2 embeddings ----+----> RepresentationSourceWeigher ----> source weights
-S3 embeddings ----+                         ^
-                                            |
-                           declared S4 calibration embeddings
-```
+Task decoders are refit end to end at each declared target calibration budget. Their parameter count, fit time, training history, learned-state hash, analysis-manifest identity, calibration behavior and inference latency remain visible beside predictive performance.
 
-The final S4 evaluation examples are never passed to SourceWeigher.
+The benchmark does not claim the two architectures are capacity matched.
 
-At labeled calibration budget `0`, target-dependent SourceWeigher is explicitly unavailable:
+### Frozen encoder + matched readout
 
-```text
-status = unavailable_no_target_observations
-```
+A frozen encoder is trained once from declared prior history. Its source, target-calibration and target-evaluation embeddings are then materialized and fingerprinted.
 
-neurOS does **not** reuse final-evaluation EEG as unlabeled target data and call the result zero-shot.
+Only the matched logistic readout is refit across target calibration budgets. This isolates representation transfer from encoder adaptation.
 
-If a future experiment allows unlabeled target observations, that is a separate protocol with its own observation budget.
+### SourceWeigher + frozen encoder
 
-## Method identity is not transfer strategy
+SourceWeigher consumes the **same frozen encoder and exact same embedding tensors** as the corresponding unweighted frozen lane.
 
-The evidence schema keeps these concepts separate.
+This is a critical comparison invariant. The weighted and unweighted lanes must share:
 
-For example:
+- `model_state_sha256`;
+- `representation_sha256`;
+- encoder-state fingerprint;
+- encoder configuration;
+- analysis-manifest identity.
 
-```text
-method_id = sourceweigher-eegnet
-strategy  = sourceweigher-mean
-encoder   = eegnet
-```
+Only the transfer strategy changes.
 
-and:
+Target-dependent source weights may be estimated from declared target calibration embeddings. Final evaluation embeddings are forbidden from target-moment estimation.
 
-```text
-method_id = sourceweigher-eeg-conformer
-strategy  = sourceweigher-mean
-encoder   = eeg-conformer
-```
+## LongitudinalCaseAuthority
 
-This prevents aggregation from collapsing two distinct encoders merely because they use the same transfer algorithm.
+Each subject / target-session case is serialized as a `LongitudinalCaseAuthority` before model fitting.
 
-## Calibration metrics
+The authority binds:
 
-### Primary full frontier
+- subject identity;
+- target session;
+- observed chronology;
+- source-history indices;
+- ordered target calibration indices;
+- immutable final evaluation indices;
+- processed-data SHA-256;
+- partition fingerprint;
+- calibration fingerprint;
+- case fingerprint;
+- dataset-specific metadata such as original protocol/cohort.
 
-For methods genuinely defined at zero target calibration, the preregistered Kumar comparison uses:
+A method restores and validates that authority before fitting. Changed processed EEG bytes, sample order, labels, grouping metadata or case identity fail before a model is trained.
+
+## Prospective history semantics
+
+The default evidence question is prospective next-session transfer.
+
+For held-out target session `S_k`, only sessions observed before `S_k` may enter the source history. Later sessions are future-excluded.
+
+A conventional all-other-session analysis may still be useful as a secondary symmetric benchmark, but it must not be narrated as prospective evidence.
+
+## Fixed target evaluation identity
+
+For each target session, neurOS creates one deterministic balanced calibration pool and one immutable final evaluation set.
+
+Increasing the calibration budget changes only how much of the calibration pool a method may use. The final evaluation indices never move.
+
+This avoids an especially common source of false calibration gains: testing larger-budget models on a smaller or easier remainder of the same held-out session.
+
+## Nested calibration budgets
+
+Calibration examples are deterministic and nested per class.
+
+If the budgets are:
 
 ```text
-0, 1, 2, 5, 10 labeled examples / class
+0, 1, 2, 5, 10
 ```
 
-and computes normalized area under the balanced-accuracy calibration frontier.
+the budget-2 set must contain the budget-1 examples, the budget-5 set must contain budget 2, and so on.
 
-```text
-balanced accuracy
-^
-|                      *
-|                 *----
-|            *----
-|       *----
-|  *----
-+------------------------------> labels / class
-   0   1   2      5        10
-```
+The resulting frontier measures the marginal value of additional labeled target calibration under a fixed final evaluation identity.
 
-This rewards useful zero/few-shot behavior rather than only the largest-budget endpoint.
+## Zero-calibration semantics
 
-### Positive-budget adaptation frontier
+Target-independent methods can report budget 0.
 
-Target-dependent SourceWeigher is not defined at zero calibration. neurOS therefore reports a **separate secondary AUC over strictly positive budgets**.
+A target-dependent SourceWeigher lane is explicitly unavailable at budget 0 because no legal target calibration observations exist. neurOS does not substitute final evaluation examples as unlabeled target observations.
 
-This allows adaptation strategies to be compared without manufacturing a zero-calibration operating point.
+This produces two frontier summaries:
 
-The two metrics are never silently mixed.
+- **full calibration-frontier AUC**, only for methods genuinely defined from zero calibration onward;
+- **positive-budget adaptation AUC**, for methods whose adaptation begins only after target calibration becomes available.
 
-## Model capacity is part of the evidence
+An unavailable zero-calibration point is not a failure.
 
-EEGNet and EEG-Conformer are not capacity-matched architectures.
+## PreparedFrozenEncoderCase
 
-The evidence rows therefore record:
+Frozen representation work is prepared once per case, encoder architecture and seed.
 
-- resolved model configuration;
-- model seed;
-- parameter count;
-- fit wall-clock;
-- inference latency per trial;
-- analysis-manifest fingerprint;
+The prepared state contains:
+
+- the trained encoder;
+- complete model-state SHA-256;
+- exact source embeddings;
+- exact ordered target-calibration embeddings;
+- exact final-evaluation embeddings;
+- representation SHA-256;
+- encoder configuration and parameter count;
 - training history;
-- representation geometry.
+- mechanistic-analysis manifest identity;
+- representation-geometry summaries.
 
-A larger contextual model beating a compact reference model is not automatically evidence that attention is the causal reason for the gain.
+Downstream frozen and SourceWeigher methods reuse that object rather than independently retraining nominally identical encoders.
 
-## Representation measurements
-
-Task decoders expose stable `encode(...)` representations. The ladder records representation-health measurements such as:
-
-- effective rank;
-- feature variance;
-- mean representation norm;
-- mean pairwise cosine / anisotropy proxy.
-
-These measurements are supplementary to task performance. They help identify whether cross-session failure comes with representation collapse, excessive domain-specific structure, or a change in representation geometry.
-
-Later phases can add frozen-authority:
-
-- session leakage probes;
-- cross-session CKA;
-- channel/montage perturbation tests;
-- mechanistic intervention replication.
-
-Those analyses should reuse the same serialized case authority rather than inventing new test examples.
+This is what makes weighted-vs-unweighted transfer a clean intervention on the transfer policy rather than an uncontrolled comparison between two separately trained networks.
 
 ## Failure preservation
 
-A method crash is not deleted from the study.
+Method failures are part of the evidence record.
 
-For a failed method/case/seed, neurOS emits explicit failed rows for every requested calibration budget:
+For every requested method, case and calibration budget, the result surface must contain a row. Rows may be:
 
-```text
-status = failed
-failure_reason = <exception type and message>
-```
+- successful;
+- expected unavailable under declared method semantics;
+- failed with an explicit error.
 
-Structural authority failures abort the study because they invalidate the comparison itself.
+A failed method cannot disappear from an aggregate plot.
 
-Method-level failures remain in the artifact so aggregate plots cannot improve by silently discarding difficult subject/session cases.
+Structural authority failures are more severe: if data identity, chronology, partition identity or processed-data fingerprint no longer match the frozen authority, the study aborts rather than emitting a degraded comparison.
 
 ## Paired-case promotion gate
 
-For every method, neurOS audits whether each supported calibration budget contains the same frozen subject/session cases.
+A descriptive bundle is promotion-ready only if:
 
-SourceWeigher's supported set excludes budget `0` by design. Other methods must retain the same cases across the full requested frontier.
+1. no requested method rows failed;
+2. no unexpected unavailable rows exist;
+3. every method retains the same subject/session case membership across every budget it claims to support.
 
-A descriptive bundle is promotion-ready only when:
+SourceWeigher budget 0 is the only expected unavailable point in the initial ladder.
 
-1. there are no method failure rows;
-2. there are no unexpected unavailable rows;
-3. each method has identical case membership across all budgets it claims to support.
+This prevents an apparently stronger high-budget curve from being produced by silently losing difficult cases.
 
-This is a software/evidence gate, not statistical significance.
+## Metrics
 
-## Kumar2024 cohort awareness
+Per-method evidence should include, where applicable:
 
-Kumar2024 contains two original training/adaptation protocols:
+- balanced accuracy;
+- accuracy;
+- ROC-AUC;
+- expected calibration error;
+- Brier score;
+- negative log-likelihood;
+- fit wall-clock time;
+- trial inference latency;
+- parameter count;
+- resolved model configuration;
+- training history;
+- model seed;
+- learned-state SHA-256;
+- representation SHA-256;
+- analysis-manifest fingerprint;
+- representation geometry;
+- exact authority/partition/calibration fingerprints.
 
-- MOABB subjects 1–9: `GR`;
-- MOABB subjects 10–18: `PAR`.
+No single metric is the product claim.
 
-The model-ladder result bundle therefore carries `original_protocol` in every case and emits three descriptive views:
+For BCI productization, one of the most economically legible summaries is **calibration saved**: how many labeled target trials are required to reach a declared performance/reliability operating point.
 
-```text
-pooled frontier
-GR frontier
-PAR frontier
-```
+## Kumar2024 preregistration
 
-It also emits target-session-index summaries.
+For Kumar2024, the ladder preserves the dataset's original `GR` / `PAR` protocol grouping in every case authority and result row.
 
-This prevents decoder adaptation from being confused with the different original participant training histories.
+Reports should include:
 
-Promoted statistical inference follows Issue #27 and must account for repeated sessions within participant rather than treating every subject-session case as independent.
+- pooled descriptive summaries;
+- cohort-specific summaries;
+- target-session summaries;
+- full-frontier AUC where defined;
+- positive-budget adaptation AUC.
+
+Repeated sessions from one participant are not independent biological replicates. Promoted inferential claims must account for that hierarchy rather than treating every session row as a separate subject.
 
 ## Artifact bundle
 
-A model-ladder study emits:
+A complete ladder execution emits:
 
 ```text
 study_manifest.json
@@ -240,123 +230,56 @@ report.md
 artifact_hashes.json
 ```
 
-### `split_authority.json`
+`artifact_hashes.json` binds the machine-readable result surfaces. The human report is rendered from those same rows rather than maintained as an independent narrative source of truth.
 
-This is the central scientific authority.
+## Public API boundary
 
-It contains each case's:
+Scientific ladder logic is package-owned.
 
-- dataset identity;
-- history policy;
-- observed chronology;
-- source group values;
-- held-out group;
-- source indices;
-- ordered calibration indices by class;
-- immutable evaluation indices;
-- processed-data SHA-256;
-- partition fingerprint;
-- calibration-split fingerprint;
-- authority fingerprint;
-- case metadata such as Kumar GR/PAR identity.
+The CLI should remain primarily responsible for:
 
-### `method_runs.json`
+- collecting a supported dataset through its upstream adapter;
+- creating/restoring frozen authority;
+- selecting declared method configurations;
+- writing evidence artifacts.
 
-Preserves resolved method requests and method-level result manifests, including encoder configuration, parameter counts, training time, and failures.
+Core public contracts include:
 
-### `results.csv`
+- `LongitudinalCaseAuthority`;
+- `PreparedFrozenEncoderCase`;
+- method specifications;
+- `LadderRuntimeConfig`;
+- `run_ladder_method(...)`;
+- paired case-set helpers;
+- calibration-frontier summaries;
+- report/artifact generation.
 
-This is the flat Evidence Console table. Every row is traceable back to one frozen authority.
+This keeps the scientific comparison reusable outside one script.
 
-### `summary.json`
+## Execution
 
-Contains:
-
-- seed-averaged budget summaries;
-- cohort summaries;
-- target-session summaries;
-- full-frontier AUC;
-- positive-budget adaptation AUC;
-- paired case-set audits;
-- failure/unavailable counts;
-- descriptive promotion-gate state.
-
-### `report.md`
-
-A human-readable view rendered from the machine-readable result bundle.
-
-### `artifact_hashes.json`
-
-SHA-256 identities for every preceding artifact.
-
-## Run locally
-
-Install the complete ladder profile:
-
-```bash
-python -m pip install -e packages/neuros-core
-python -m pip install -e "packages/neuros-models[pytorch]"
-python -m pip install -e packages/neuros-sourceweigher
-python -m pip install -e "packages/neuros-foundation[evidence,ladder]"
-```
-
-Then run a small provenance pilot:
+The public study runner is:
 
 ```bash
 python scripts/evidence/run_moabb_model_ladder.py \
   --dataset kumar2024 \
-  --subjects 1,10 \
-  --methods csp-lda,eegnet,eeg-conformer,frozen-eegnet,frozen-eeg-conformer,sourceweigher-eegnet,sourceweigher-eeg-conformer \
-  --model-seeds 101 \
+  --subjects 1,2,3 \
   --budgets 0,1,2,5,10 \
-  --history-policy prior \
-  --split-seed 2026 \
-  --output evidence/kumar2024-pilot
+  --methods csp-lda,eegnet,eeg-conformer,frozen-eegnet,frozen-eeg-conformer,sourceweigher-eegnet,sourceweigher-eeg-conformer \
+  --output evidence/kumar2024-model-ladder
 ```
 
-The first real run should remain a provenance pilot. Do not increase model seeds or scale all participants until the complete artifact has been manually inspected.
+The corresponding GitHub Actions study workflow is manual only. Large public datasets are never downloaded as a normal push/PR side effect.
 
-## Run from GitHub Actions
+## External research extensions
 
-Use the manual workflow:
+External research packages, including the documented QuantumBCI extension, must reuse the same frozen `LongitudinalCaseAuthority` and evidence identities if they join this comparison. An extension may add a method lane, mechanism analysis, or resource accounting, but it may not create a second hidden split/calibration authority and still claim a matched comparison.
 
-```text
-neurOS longitudinal EEG model ladder
-```
+This keeps external experiments interoperable with neurOS Evidence without making those projects dependencies of the core runtime.
 
-It is `workflow_dispatch` only. Normal pushes and pull requests never download large public datasets.
+## Evidence presentation
 
-The workflow records Python, pip, Git and requested-method identity, executes the real MOABB study, verifies the emitted SHA-256 hashes and authority list, and uploads the evidence bundle as a GitHub artifact.
-
-## Evidence Console layout
-
-The recommended public console is five linked views.
-
-### 1. Chronology
-
-```text
-history -------- history -------- TARGET -------- future excluded
-                                  |     |
-                            calibration eval
-```
-
-### 2. Calibration frontier
-
-Show all methods and every operating point, not only the best endpoint.
-
-Methods without a legal zero-calibration point should begin where their declared target-observation requirement begins.
-
-### 3. Historical source trust
-
-For SourceWeigher, render source-session weights, ESS, entropy, residual and sensitivity diagnostics beside the target session.
-
-### 4. Cohort and session drift
-
-Provide pooled, GR, PAR and target-session-index views without changing the underlying result authority.
-
-### 5. Evidence identity
-
-Always keep visible:
+A public result should keep the following identities visually adjacent to the performance curve:
 
 ```text
 dataset/version

--- a/docs/LONGITUDINAL_MODEL_LADDER.md
+++ b/docs/LONGITUDINAL_MODEL_LADDER.md
@@ -1,0 +1,386 @@
+# Longitudinal EEG Model Ladder
+
+The longitudinal model ladder is the first neurOS benchmark where multiple neural decoding strategies are forced to answer the **same deployment question on the same samples**.
+
+The benchmark is not a model zoo. It is a controlled comparison of how much useful decoding performance survives a session shift and how much target-session calibration is required to recover it.
+
+## The authority comes before the model
+
+For each subject and target session, neurOS first creates a `LongitudinalCaseAuthority`.
+
+That object freezes:
+
+```text
+prior source indices
+        |
+        +----------------------+
+                               |
+target session                 |
+  +--> ordered calibration pool|
+  +--> immutable final eval    |
+                               v
+                    LongitudinalCaseAuthority
+                               |
+                 processed-data SHA-256
+                 partition fingerprint
+                 calibration fingerprint
+                 exact integer indices
+                               |
+          +--------------------+--------------------+
+          |                    |                    |
+        CSP+LDA              EEGNet          EEG-Conformer
+          |                    |                    |
+          +--------- frozen representation lanes --+
+                               |
+                         SourceWeigher
+```
+
+Every method restores and validates that authority before fitting.
+
+A method cannot silently regenerate a convenient split. If processed EEG bytes, labels, group order, or sample identity change, authority restoration fails before model training.
+
+## Supported comparison lanes
+
+The executable runner currently exposes seven lanes:
+
+| Method ID | Representation behavior | Target-session behavior |
+| --- | --- | --- |
+| `csp-lda` | CSP fit at each budget | source + declared labeled calibration |
+| `eegnet` | end-to-end EEGNet fit at each budget | source + declared labeled calibration |
+| `eeg-conformer` | end-to-end EEG-Conformer fit at each budget | source + declared labeled calibration |
+| `frozen-eegnet` | EEGNet trained once on prior history, then frozen | logistic readout refit with declared calibration |
+| `frozen-eeg-conformer` | EEG-Conformer trained once on prior history, then frozen | logistic readout refit with declared calibration |
+| `sourceweigher-eegnet` | one frozen source-trained EEGNet representation | source-session weights estimated from target calibration embeddings only |
+| `sourceweigher-eeg-conformer` | one frozen source-trained EEG-Conformer representation | source-session weights estimated from target calibration embeddings only |
+
+The frozen lanes answer a different scientific question from end-to-end retraining:
+
+> **Did the representation itself remain useful after the neural distribution moved?**
+
+## SourceWeigher target authority
+
+SourceWeigher operates in one common frozen embedding space.
+
+For target session `S4`:
+
+```text
+S1 embeddings ----+
+S2 embeddings ----+----> RepresentationSourceWeigher ----> source weights
+S3 embeddings ----+                         ^
+                                            |
+                           declared S4 calibration embeddings
+```
+
+The final S4 evaluation examples are never passed to SourceWeigher.
+
+At labeled calibration budget `0`, target-dependent SourceWeigher is explicitly unavailable:
+
+```text
+status = unavailable_no_target_observations
+```
+
+neurOS does **not** reuse final-evaluation EEG as unlabeled target data and call the result zero-shot.
+
+If a future experiment allows unlabeled target observations, that is a separate protocol with its own observation budget.
+
+## Method identity is not transfer strategy
+
+The evidence schema keeps these concepts separate.
+
+For example:
+
+```text
+method_id = sourceweigher-eegnet
+strategy  = sourceweigher-mean
+encoder   = eegnet
+```
+
+and:
+
+```text
+method_id = sourceweigher-eeg-conformer
+strategy  = sourceweigher-mean
+encoder   = eeg-conformer
+```
+
+This prevents aggregation from collapsing two distinct encoders merely because they use the same transfer algorithm.
+
+## Calibration metrics
+
+### Primary full frontier
+
+For methods genuinely defined at zero target calibration, the preregistered Kumar comparison uses:
+
+```text
+0, 1, 2, 5, 10 labeled examples / class
+```
+
+and computes normalized area under the balanced-accuracy calibration frontier.
+
+```text
+balanced accuracy
+^
+|                      *
+|                 *----
+|            *----
+|       *----
+|  *----
++------------------------------> labels / class
+   0   1   2      5        10
+```
+
+This rewards useful zero/few-shot behavior rather than only the largest-budget endpoint.
+
+### Positive-budget adaptation frontier
+
+Target-dependent SourceWeigher is not defined at zero calibration. neurOS therefore reports a **separate secondary AUC over strictly positive budgets**.
+
+This allows adaptation strategies to be compared without manufacturing a zero-calibration operating point.
+
+The two metrics are never silently mixed.
+
+## Model capacity is part of the evidence
+
+EEGNet and EEG-Conformer are not capacity-matched architectures.
+
+The evidence rows therefore record:
+
+- resolved model configuration;
+- model seed;
+- parameter count;
+- fit wall-clock;
+- inference latency per trial;
+- analysis-manifest fingerprint;
+- training history;
+- representation geometry.
+
+A larger contextual model beating a compact reference model is not automatically evidence that attention is the causal reason for the gain.
+
+## Representation measurements
+
+Task decoders expose stable `encode(...)` representations. The ladder records representation-health measurements such as:
+
+- effective rank;
+- feature variance;
+- mean representation norm;
+- mean pairwise cosine / anisotropy proxy.
+
+These measurements are supplementary to task performance. They help identify whether cross-session failure comes with representation collapse, excessive domain-specific structure, or a change in representation geometry.
+
+Later phases can add frozen-authority:
+
+- session leakage probes;
+- cross-session CKA;
+- channel/montage perturbation tests;
+- mechanistic intervention replication.
+
+Those analyses should reuse the same serialized case authority rather than inventing new test examples.
+
+## Failure preservation
+
+A method crash is not deleted from the study.
+
+For a failed method/case/seed, neurOS emits explicit failed rows for every requested calibration budget:
+
+```text
+status = failed
+failure_reason = <exception type and message>
+```
+
+Structural authority failures abort the study because they invalidate the comparison itself.
+
+Method-level failures remain in the artifact so aggregate plots cannot improve by silently discarding difficult subject/session cases.
+
+## Paired-case promotion gate
+
+For every method, neurOS audits whether each supported calibration budget contains the same frozen subject/session cases.
+
+SourceWeigher's supported set excludes budget `0` by design. Other methods must retain the same cases across the full requested frontier.
+
+A descriptive bundle is promotion-ready only when:
+
+1. there are no method failure rows;
+2. there are no unexpected unavailable rows;
+3. each method has identical case membership across all budgets it claims to support.
+
+This is a software/evidence gate, not statistical significance.
+
+## Kumar2024 cohort awareness
+
+Kumar2024 contains two original training/adaptation protocols:
+
+- MOABB subjects 1–9: `GR`;
+- MOABB subjects 10–18: `PAR`.
+
+The model-ladder result bundle therefore carries `original_protocol` in every case and emits three descriptive views:
+
+```text
+pooled frontier
+GR frontier
+PAR frontier
+```
+
+It also emits target-session-index summaries.
+
+This prevents decoder adaptation from being confused with the different original participant training histories.
+
+Promoted statistical inference follows Issue #27 and must account for repeated sessions within participant rather than treating every subject-session case as independent.
+
+## Artifact bundle
+
+A model-ladder study emits:
+
+```text
+study_manifest.json
+split_authority.json
+method_runs.json
+results.csv
+summary.json
+report.md
+artifact_hashes.json
+```
+
+### `split_authority.json`
+
+This is the central scientific authority.
+
+It contains each case's:
+
+- dataset identity;
+- history policy;
+- observed chronology;
+- source group values;
+- held-out group;
+- source indices;
+- ordered calibration indices by class;
+- immutable evaluation indices;
+- processed-data SHA-256;
+- partition fingerprint;
+- calibration-split fingerprint;
+- authority fingerprint;
+- case metadata such as Kumar GR/PAR identity.
+
+### `method_runs.json`
+
+Preserves resolved method requests and method-level result manifests, including encoder configuration, parameter counts, training time, and failures.
+
+### `results.csv`
+
+This is the flat Evidence Console table. Every row is traceable back to one frozen authority.
+
+### `summary.json`
+
+Contains:
+
+- seed-averaged budget summaries;
+- cohort summaries;
+- target-session summaries;
+- full-frontier AUC;
+- positive-budget adaptation AUC;
+- paired case-set audits;
+- failure/unavailable counts;
+- descriptive promotion-gate state.
+
+### `report.md`
+
+A human-readable view rendered from the machine-readable result bundle.
+
+### `artifact_hashes.json`
+
+SHA-256 identities for every preceding artifact.
+
+## Run locally
+
+Install the complete ladder profile:
+
+```bash
+python -m pip install -e packages/neuros-core
+python -m pip install -e "packages/neuros-models[pytorch]"
+python -m pip install -e packages/neuros-sourceweigher
+python -m pip install -e "packages/neuros-foundation[evidence,ladder]"
+```
+
+Then run a small provenance pilot:
+
+```bash
+python scripts/evidence/run_moabb_model_ladder.py \
+  --dataset kumar2024 \
+  --subjects 1,10 \
+  --methods csp-lda,eegnet,eeg-conformer,frozen-eegnet,frozen-eeg-conformer,sourceweigher-eegnet,sourceweigher-eeg-conformer \
+  --model-seeds 101 \
+  --budgets 0,1,2,5,10 \
+  --history-policy prior \
+  --split-seed 2026 \
+  --output evidence/kumar2024-pilot
+```
+
+The first real run should remain a provenance pilot. Do not increase model seeds or scale all participants until the complete artifact has been manually inspected.
+
+## Run from GitHub Actions
+
+Use the manual workflow:
+
+```text
+neurOS longitudinal EEG model ladder
+```
+
+It is `workflow_dispatch` only. Normal pushes and pull requests never download large public datasets.
+
+The workflow records Python, pip, Git and requested-method identity, executes the real MOABB study, verifies the emitted SHA-256 hashes and authority list, and uploads the evidence bundle as a GitHub artifact.
+
+## Evidence Console layout
+
+The recommended public console is five linked views.
+
+### 1. Chronology
+
+```text
+history -------- history -------- TARGET -------- future excluded
+                                  |     |
+                            calibration eval
+```
+
+### 2. Calibration frontier
+
+Show all methods and every operating point, not only the best endpoint.
+
+Methods without a legal zero-calibration point should begin where their declared target-observation requirement begins.
+
+### 3. Historical source trust
+
+For SourceWeigher, render source-session weights, ESS, entropy, residual and sensitivity diagnostics beside the target session.
+
+### 4. Cohort and session drift
+
+Provide pooled, GR, PAR and target-session-index views without changing the underlying result authority.
+
+### 5. Evidence identity
+
+Always keep visible:
+
+```text
+dataset/version
+Git revision
+method ID
+model seed
+processed-data SHA-256
+authority fingerprint
+partition fingerprint
+calibration fingerprint
+artifact verification
+```
+
+## Claim boundary
+
+This ladder can establish controlled **offline real-dataset evidence** for longitudinal transfer and labeled recalibration burden.
+
+It does not establish:
+
+- live hardware reliability;
+- online closed-loop improvement;
+- clinical benefit;
+- causal biological interpretation;
+- foundation-model superiority without a verified executable foundation encoder;
+- ORION superiority until an actual ORION EEG representation is evaluated under this same authority.
+
+The long-term neurOS/ORION claim should be earned by moving the calibration frontier under increasingly difficult real-world shifts while preserving this evidence discipline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Ranked Source Map: EVIDENCE_SOURCE_MAP.md
       - Longitudinal EEG Showcase: LONGITUDINAL_EEG_SHOWCASE.md
       - Longitudinal Model Ladder: LONGITUDINAL_MODEL_LADDER.md
+  - Research Extensions: RESEARCH_EXTENSIONS.md
   - Installation: getting-started/installation.md
   - Architecture: ARCHITECTURE.md
   - API Surface: API_REFERENCE.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Evidence Program: REAL_WORLD_EVIDENCE.md
       - Ranked Source Map: EVIDENCE_SOURCE_MAP.md
       - Longitudinal EEG Showcase: LONGITUDINAL_EEG_SHOWCASE.md
+      - Longitudinal Model Ladder: LONGITUDINAL_MODEL_LADDER.md
   - Installation: getting-started/installation.md
   - Architecture: ARCHITECTURE.md
   - API Surface: API_REFERENCE.md

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -45,7 +45,10 @@ allen = ["allensdk>=2.15.0"]
 legacy = ["torch>=2.1.0"]
 eeg = ["mne>=1.6.0"]
 evidence = ["moabb>=1.5.0,<2"]
-ladder = ["torch>=2.1.0"]
+ladder = [
+    "torch>=2.1.0",
+    "neuros-sourceweigher>=0.2.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
@@ -53,6 +56,7 @@ dev = [
 ]
 all = [
     "torch>=2.1.0",
+    "neuros-sourceweigher>=0.2.0",
     "cebra>=0.3.0",
     "zuna",
     "mne>=1.6.0",

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -45,6 +45,7 @@ allen = ["allensdk>=2.15.0"]
 legacy = ["torch>=2.1.0"]
 eeg = ["mne>=1.6.0"]
 evidence = ["moabb>=1.5.0,<2"]
+ladder = ["torch>=2.1.0"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -45,10 +45,9 @@ allen = ["allensdk>=2.15.0"]
 legacy = ["torch>=2.1.0"]
 eeg = ["mne>=1.6.0"]
 evidence = ["moabb>=1.5.0,<2"]
-ladder = [
-    "torch>=2.1.0",
-    "neuros-sourceweigher>=0.2.0",
-]
+# SourceWeigher is a sibling workspace package and is intentionally installed
+# explicitly in the full ladder profile until it has a published distribution.
+ladder = ["torch>=2.1.0"]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
@@ -56,7 +55,6 @@ dev = [
 ]
 all = [
     "torch>=2.1.0",
-    "neuros-sourceweigher>=0.2.0",
     "cebra>=0.3.0",
     "zuna",
     "mne>=1.6.0",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -31,6 +31,11 @@ from neuros.foundation_models.longitudinal_methods import (
     TaskDecoderMethodSpec,
     run_task_decoder_case,
 )
+from neuros.foundation_models.longitudinal_transfer import (
+    FrozenTransferCaseResult,
+    FrozenTransferMethodSpec,
+    run_frozen_transfer_case,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -93,8 +98,8 @@ try:
     from neuros.foundation_models.cebra_model import CEBRAModel
     CEBRA_AVAILABLE = True
 except ImportError:
-    CEBRA_AVAILABLE = False
     CEBRAModel = None
+    CEBRA_AVAILABLE = False
 
 try:
     from neuros.foundation_models.neuroformer_model import NeuroformerModel
@@ -158,6 +163,9 @@ __all__ = [
     "TaskDecoderMethodSpec",
     "TaskDecoderCaseResult",
     "run_task_decoder_case",
+    "FrozenTransferMethodSpec",
+    "FrozenTransferCaseResult",
+    "run_frozen_transfer_case",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -27,6 +27,17 @@ from neuros.foundation_models.longitudinal_authority import (
     processed_data_sha256,
 )
 from neuros.foundation_models.longitudinal_baseline import CSPCaseResult, run_csp_case
+from neuros.foundation_models.longitudinal_ladder import (
+    LADDER_METHODS,
+    SOURCEWEIGHER_METHODS,
+    LadderRuntimeConfig,
+    frontier_auc,
+    paired_case_set_audit,
+    render_ladder_report,
+    run_ladder_method,
+    seed_averaged_case_rows,
+    summarize_ladder_rows,
+)
 from neuros.foundation_models.longitudinal_methods import (
     TaskDecoderCaseResult,
     TaskDecoderMethodSpec,
@@ -35,6 +46,8 @@ from neuros.foundation_models.longitudinal_methods import (
 from neuros.foundation_models.longitudinal_transfer import (
     FrozenTransferCaseResult,
     FrozenTransferMethodSpec,
+    PreparedFrozenEncoderCase,
+    prepare_frozen_encoder_case,
     run_frozen_transfer_case,
 )
 from neuros.foundation_models.moabb_longitudinal import (
@@ -175,7 +188,18 @@ __all__ = [
     "run_task_decoder_case",
     "FrozenTransferMethodSpec",
     "FrozenTransferCaseResult",
+    "PreparedFrozenEncoderCase",
+    "prepare_frozen_encoder_case",
     "run_frozen_transfer_case",
+    "LADDER_METHODS",
+    "SOURCEWEIGHER_METHODS",
+    "LadderRuntimeConfig",
+    "run_ladder_method",
+    "seed_averaged_case_rows",
+    "frontier_auc",
+    "paired_case_set_audit",
+    "summarize_ladder_rows",
+    "render_ladder_report",
     "MOABBLongitudinalDatasetSpec",
     "MOABB_LONGITUDINAL_DATASETS",
     "get_moabb_longitudinal_spec",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -26,6 +26,11 @@ from neuros.foundation_models.longitudinal_authority import (
     LongitudinalCaseAuthority,
     processed_data_sha256,
 )
+from neuros.foundation_models.longitudinal_methods import (
+    TaskDecoderCaseResult,
+    TaskDecoderMethodSpec,
+    run_task_decoder_case,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -150,6 +155,9 @@ __all__ = [
     "make_nested_calibration_split",
     "LongitudinalCaseAuthority",
     "processed_data_sha256",
+    "TaskDecoderMethodSpec",
+    "TaskDecoderCaseResult",
+    "run_task_decoder_case",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -22,6 +22,10 @@ from neuros.foundation_models.longitudinal import (
     make_nested_calibration_split,
     ordered_group_values,
 )
+from neuros.foundation_models.longitudinal_authority import (
+    LongitudinalCaseAuthority,
+    processed_data_sha256,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -144,6 +148,8 @@ __all__ = [
     "chronological_partition",
     "NestedCalibrationSplit",
     "make_nested_calibration_split",
+    "LongitudinalCaseAuthority",
+    "processed_data_sha256",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -26,6 +26,7 @@ from neuros.foundation_models.longitudinal_authority import (
     LongitudinalCaseAuthority,
     processed_data_sha256,
 )
+from neuros.foundation_models.longitudinal_baseline import CSPCaseResult, run_csp_case
 from neuros.foundation_models.longitudinal_methods import (
     TaskDecoderCaseResult,
     TaskDecoderMethodSpec,
@@ -35,6 +36,13 @@ from neuros.foundation_models.longitudinal_transfer import (
     FrozenTransferCaseResult,
     FrozenTransferMethodSpec,
     run_frozen_transfer_case,
+)
+from neuros.foundation_models.moabb_longitudinal import (
+    MOABB_LONGITUDINAL_DATASETS,
+    MOABBLongitudinalDatasetSpec,
+    build_moabb_longitudinal_dataset,
+    get_moabb_longitudinal_spec,
+    validate_observed_sessions,
 )
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
@@ -160,12 +168,19 @@ __all__ = [
     "make_nested_calibration_split",
     "LongitudinalCaseAuthority",
     "processed_data_sha256",
+    "CSPCaseResult",
+    "run_csp_case",
     "TaskDecoderMethodSpec",
     "TaskDecoderCaseResult",
     "run_task_decoder_case",
     "FrozenTransferMethodSpec",
     "FrozenTransferCaseResult",
     "run_frozen_transfer_case",
+    "MOABBLongitudinalDatasetSpec",
+    "MOABB_LONGITUDINAL_DATASETS",
+    "get_moabb_longitudinal_spec",
+    "build_moabb_longitudinal_dataset",
+    "validate_observed_sessions",
     "FoundationEmbeddingDecoder",
     "BaseFoundationModel",
     "POYOModel",

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_authority.py
@@ -1,0 +1,327 @@
+"""Replayable authority for longitudinal neural benchmark cases.
+
+A protocol fingerprint is necessary but not sufficient when multiple methods are
+run in separate processes. This module serializes the *actual* source,
+calibration, and final-evaluation indices together with a SHA-256 fingerprint of
+the processed neural array. A competing method must restore and validate this
+authority before it can claim to share the same evidence case.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
+
+import numpy as np
+
+from .benchmark import SplitUnit
+from .longitudinal import NestedCalibrationSplit, ordered_group_values
+from .real_world import EvaluationPartition, GroupedEvaluationData
+
+HistoryPolicy = Literal["prior", "all-other", "custom"]
+
+
+def processed_data_sha256(data: GroupedEvaluationData) -> str:
+    """Hash the exact processed neural array plus target/group sample identity.
+
+    This hash is intentionally downstream of MOABB/MNE preprocessing. It does
+    not replace the upstream raw-file/version checksum, but it guarantees that
+    two method runs consumed byte-identical processed ``X`` values with the same
+    row order, labels, and deployment-unit identities.
+    """
+
+    x = np.asarray(data.X)
+    if x.dtype.hasobject:
+        raise TypeError("processed neural arrays with object dtype cannot be fingerprinted")
+
+    digest = hashlib.sha256()
+    digest.update(b"neuros.processed-neural-data.v1\0")
+    digest.update(str(data.dataset_id).encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(x.dtype.str.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(json.dumps(list(x.shape), separators=(",", ":")).encode("ascii"))
+    digest.update(b"\0")
+
+    # Stream sample-by-sample to avoid materializing a second full dataset copy.
+    for sample in x:
+        contiguous = np.ascontiguousarray(sample)
+        digest.update(memoryview(contiguous).cast("B"))
+
+    identity = {
+        "targets": np.asarray(data.y).astype(str).tolist(),
+        "groups": {
+            key: np.asarray(values).astype(str).tolist()
+            for key, values in sorted(data.groups.items())
+        },
+    }
+    digest.update(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    return digest.hexdigest()
+
+
+def _ordered_values(values: np.ndarray) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(np.asarray(values).astype(str).tolist()))
+
+
+def _indices_tuple(values: Any) -> tuple[int, ...]:
+    array = np.asarray(values, dtype=np.int64).reshape(-1)
+    return tuple(int(value) for value in array.tolist())
+
+
+@dataclass(frozen=True, slots=True)
+class LongitudinalCaseAuthority:
+    """Frozen sample authority for one target deployment unit.
+
+    ``source_train_indices`` contains only historical/source examples.
+    ``calibration_order_by_class`` contains the ordered target-session pool from
+    which every labeled budget is sliced. ``evaluation_indices`` is immutable
+    across budgets.
+    """
+
+    dataset_id: str
+    case_id: str
+    split_unit: SplitUnit
+    held_out_values: tuple[str, ...]
+    history_policy: HistoryPolicy
+    observed_group_order: tuple[str, ...]
+    source_group_values: tuple[str, ...]
+    source_train_indices: tuple[int, ...]
+    evaluation_indices: tuple[int, ...]
+    calibration_order_by_class: Mapping[str, tuple[int, ...]]
+    evaluation_fraction: float
+    seed: int
+    partition_fingerprint: str
+    calibration_split_fingerprint: str
+    processed_data_sha256: str
+    n_samples: int
+    input_shape: tuple[int, ...]
+    case_metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.dataset_id or not self.case_id:
+            raise ValueError("dataset_id and case_id must be non-empty")
+        if self.split_unit == "sample":
+            raise ValueError("longitudinal authority requires a deployment-unit split")
+        if not self.held_out_values:
+            raise ValueError("held_out_values must be non-empty")
+        if self.history_policy not in {"prior", "all-other", "custom"}:
+            raise ValueError(f"unsupported history_policy={self.history_policy!r}")
+        if self.n_samples <= 0:
+            raise ValueError("n_samples must be positive")
+        if not self.input_shape or self.input_shape[0] != self.n_samples:
+            raise ValueError("input_shape must begin with n_samples")
+        if len(self.processed_data_sha256) != 64:
+            raise ValueError("processed_data_sha256 must be a SHA-256 hex digest")
+        if not 0.0 < float(self.evaluation_fraction) < 1.0:
+            raise ValueError("evaluation_fraction must lie strictly between 0 and 1")
+
+        calibration = {
+            str(label): _indices_tuple(values)
+            for label, values in self.calibration_order_by_class.items()
+        }
+        if not calibration:
+            raise ValueError("calibration_order_by_class must be non-empty")
+        object.__setattr__(self, "calibration_order_by_class", MappingProxyType(calibration))
+        object.__setattr__(self, "case_metadata", MappingProxyType(dict(self.case_metadata)))
+
+    @classmethod
+    def from_split(
+        cls,
+        split: NestedCalibrationSplit,
+        *,
+        case_id: str,
+        history_policy: HistoryPolicy,
+        observed_group_order: tuple[str, ...] | None = None,
+        case_metadata: Mapping[str, Any] | None = None,
+    ) -> "LongitudinalCaseAuthority":
+        data = split.partition.data
+        unit = split.partition.split_unit
+        if unit == "sample":
+            raise ValueError("longitudinal authority requires a deployment-unit split")
+        group = np.asarray(data.groups[unit]).astype(str)
+        observed = observed_group_order or ordered_group_values(data, split_unit=unit)
+        source_values = _ordered_values(group[split.source_train_indices])
+        return cls(
+            dataset_id=data.dataset_id,
+            case_id=case_id,
+            split_unit=unit,
+            held_out_values=tuple(str(v) for v in split.partition.held_out_values),
+            history_policy=history_policy,
+            observed_group_order=tuple(str(v) for v in observed),
+            source_group_values=source_values,
+            source_train_indices=_indices_tuple(split.source_train_indices),
+            evaluation_indices=_indices_tuple(split.evaluation_indices),
+            calibration_order_by_class={
+                label: _indices_tuple(values)
+                for label, values in split.calibration_order_by_class.items()
+            },
+            evaluation_fraction=float(split.evaluation_fraction),
+            seed=int(split.seed),
+            partition_fingerprint=split.partition.fingerprint,
+            calibration_split_fingerprint=split.fingerprint,
+            processed_data_sha256=processed_data_sha256(data),
+            n_samples=int(len(data.X)),
+            input_shape=tuple(int(v) for v in np.asarray(data.X).shape),
+            case_metadata={} if case_metadata is None else case_metadata,
+        )
+
+    @property
+    def authority_fingerprint(self) -> str:
+        payload = self.to_dict(include_fingerprint=False)
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "case_id": self.case_id,
+            "split_unit": self.split_unit,
+            "held_out_values": list(self.held_out_values),
+            "history_policy": self.history_policy,
+            "observed_group_order": list(self.observed_group_order),
+            "source_group_values": list(self.source_group_values),
+            "source_train_indices": list(self.source_train_indices),
+            "evaluation_indices": list(self.evaluation_indices),
+            "calibration_order_by_class": {
+                key: list(values)
+                for key, values in sorted(self.calibration_order_by_class.items())
+            },
+            "evaluation_fraction": float(self.evaluation_fraction),
+            "seed": int(self.seed),
+            "partition_fingerprint": self.partition_fingerprint,
+            "calibration_split_fingerprint": self.calibration_split_fingerprint,
+            "processed_data_sha256": self.processed_data_sha256,
+            "n_samples": int(self.n_samples),
+            "input_shape": list(self.input_shape),
+            "case_metadata": dict(self.case_metadata),
+        }
+        if include_fingerprint:
+            payload["authority_fingerprint"] = self.authority_fingerprint
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "LongitudinalCaseAuthority":
+        value = cls(
+            dataset_id=str(payload["dataset_id"]),
+            case_id=str(payload["case_id"]),
+            split_unit=str(payload["split_unit"]),  # type: ignore[arg-type]
+            held_out_values=tuple(str(v) for v in payload["held_out_values"]),
+            history_policy=str(payload["history_policy"]),  # type: ignore[arg-type]
+            observed_group_order=tuple(str(v) for v in payload["observed_group_order"]),
+            source_group_values=tuple(str(v) for v in payload["source_group_values"]),
+            source_train_indices=tuple(int(v) for v in payload["source_train_indices"]),
+            evaluation_indices=tuple(int(v) for v in payload["evaluation_indices"]),
+            calibration_order_by_class={
+                str(key): tuple(int(v) for v in values)
+                for key, values in dict(payload["calibration_order_by_class"]).items()
+            },
+            evaluation_fraction=float(payload["evaluation_fraction"]),
+            seed=int(payload["seed"]),
+            partition_fingerprint=str(payload["partition_fingerprint"]),
+            calibration_split_fingerprint=str(payload["calibration_split_fingerprint"]),
+            processed_data_sha256=str(payload["processed_data_sha256"]),
+            n_samples=int(payload["n_samples"]),
+            input_shape=tuple(int(v) for v in payload["input_shape"]),
+            case_metadata=dict(payload.get("case_metadata", {})),
+            schema_version=int(payload.get("schema_version", 1)),
+        )
+        expected = payload.get("authority_fingerprint")
+        if expected is not None and str(expected) != value.authority_fingerprint:
+            raise ValueError("authority_fingerprint does not match serialized content")
+        return value
+
+    def restore(self, data: GroupedEvaluationData) -> NestedCalibrationSplit:
+        """Validate a newly loaded dataset and reconstruct the frozen split."""
+        if data.dataset_id != self.dataset_id:
+            raise ValueError(
+                f"dataset mismatch: authority={self.dataset_id!r}, loaded={data.dataset_id!r}"
+            )
+        if len(data.X) != self.n_samples or tuple(np.asarray(data.X).shape) != self.input_shape:
+            raise ValueError("processed dataset sample count/shape differs from authority")
+        actual_sha = processed_data_sha256(data)
+        if actual_sha != self.processed_data_sha256:
+            raise ValueError("processed neural data SHA-256 differs from authority")
+        if self.split_unit not in data.groups:
+            raise ValueError(f"loaded dataset has no {self.split_unit!r} group")
+
+        n = len(data.X)
+        source = np.asarray(self.source_train_indices, dtype=np.int64)
+        evaluation = np.asarray(self.evaluation_indices, dtype=np.int64)
+        calibration = {
+            label: np.asarray(values, dtype=np.int64)
+            for label, values in self.calibration_order_by_class.items()
+        }
+        all_indices = [source, evaluation, *calibration.values()]
+        if any(np.any(values < 0) or np.any(values >= n) for values in all_indices):
+            raise ValueError("authority contains out-of-range sample indices")
+
+        calibration_flat = (
+            np.concatenate(list(calibration.values()))
+            if calibration
+            else np.asarray([], dtype=np.int64)
+        )
+        test = np.sort(np.concatenate([evaluation, calibration_flat]))
+        partition = EvaluationPartition(
+            data=data,
+            split_unit=self.split_unit,
+            train_indices=source,
+            test_indices=test,
+            held_out_values=self.held_out_values,
+        )
+        if partition.fingerprint != self.partition_fingerprint:
+            raise ValueError("partition fingerprint differs from authority")
+
+        split = NestedCalibrationSplit(
+            partition=partition,
+            evaluation_indices=evaluation,
+            calibration_order_by_class=calibration,
+            evaluation_fraction=self.evaluation_fraction,
+            seed=self.seed,
+        )
+        if split.fingerprint != self.calibration_split_fingerprint:
+            raise ValueError("calibration split fingerprint differs from authority")
+
+        group = np.asarray(data.groups[self.split_unit]).astype(str)
+        observed = ordered_group_values(data, split_unit=self.split_unit)
+        if observed != self.observed_group_order:
+            raise ValueError(
+                "deployment-unit order differs from authority; "
+                f"authority={self.observed_group_order}, loaded={observed}"
+            )
+        if set(group[test].tolist()) != set(self.held_out_values):
+            raise ValueError("held-out indices do not match authority held_out_values")
+        actual_source_values = _ordered_values(group[source])
+        if actual_source_values != self.source_group_values:
+            raise ValueError("source deployment-unit identities differ from authority")
+
+        source_set = set(source.tolist())
+        expected_source = set(
+            np.flatnonzero(np.isin(group, np.asarray(self.source_group_values, dtype=str))).tolist()
+        )
+        if source_set != expected_source:
+            raise ValueError("authority source indices do not cover source groups exactly")
+
+        if self.history_policy == "prior":
+            if len(self.held_out_values) != 1:
+                raise ValueError("prior authority requires exactly one held-out group")
+            held = self.held_out_values[0]
+            if held not in observed:
+                raise ValueError("held-out group missing from observed chronology")
+            expected_values = observed[: observed.index(held)]
+            if self.source_group_values != expected_values:
+                raise ValueError(
+                    "prior authority source groups are not the complete chronological prefix"
+                )
+        elif self.history_policy == "all-other":
+            expected_values = tuple(v for v in observed if v not in self.held_out_values)
+            if self.source_group_values != expected_values:
+                raise ValueError("all-other authority does not contain every non-held-out group")
+
+        return split

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_baseline.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_baseline.py
@@ -1,0 +1,126 @@
+"""Transparent CSP+LDA baseline under a frozen longitudinal sample authority."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+from sklearn.metrics import accuracy_score, balanced_accuracy_score, roc_auc_score
+
+from .longitudinal_authority import LongitudinalCaseAuthority
+from .real_world import GroupedEvaluationData
+
+
+@dataclass(frozen=True, slots=True)
+class CSPCaseResult:
+    authority_fingerprint: str
+    csp_components: int
+    rows: tuple[Mapping[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "authority_fingerprint": self.authority_fingerprint,
+            "method_id": "csp-lda",
+            "csp_components": int(self.csp_components),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+
+def _build_csp_lda(components: int):
+    try:
+        from mne.decoding import CSP
+        from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+        from sklearn.pipeline import make_pipeline
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("CSP+LDA requires MNE and scikit-learn") from exc
+    return make_pipeline(CSP(n_components=int(components), reg=None), LDA())
+
+
+def _encode_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[np.ndarray, tuple[str, ...]]:
+    values = np.asarray(y).astype(str)
+    labels = tuple(sorted(np.unique(values[source_indices]).tolist()))
+    if len(labels) < 2:
+        raise ValueError("source history must contain at least two task classes")
+    mapping = {label: index for index, label in enumerate(labels)}
+    unknown = sorted(set(values.tolist()) - set(mapping))
+    if unknown:
+        raise ValueError(f"target contains labels absent from source history: {unknown}")
+    return np.asarray([mapping[value] for value in values], dtype=np.int64), labels
+
+
+def run_csp_case(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    *,
+    budgets_per_class: Sequence[int],
+    csp_components: int = 8,
+) -> CSPCaseResult:
+    if csp_components <= 0:
+        raise ValueError("csp_components must be positive")
+    split = authority.restore(data)
+    budgets = tuple(sorted(set(int(value) for value in budgets_per_class)))
+    if not budgets or budgets[0] < 0:
+        raise ValueError("budgets_per_class must contain non-negative values")
+    if budgets[-1] > split.max_budget_per_class:
+        raise ValueError(
+            f"requested budget {budgets[-1]} exceeds authority maximum "
+            f"{split.max_budget_per_class}/class"
+        )
+
+    X = np.asarray(data.X)
+    y, class_labels = _encode_labels(np.asarray(data.y), split.source_train_indices)
+    rows = []
+    for budget in budgets:
+        train = split.train_indices_for_budget(budget)
+        calibration = split.calibration_indices(budget)
+        evaluation = split.evaluation_indices
+        model = _build_csp_lda(csp_components)
+
+        started = time.perf_counter()
+        model.fit(X[train], y[train])
+        fit_s = time.perf_counter() - started
+        started = time.perf_counter()
+        prediction = np.asarray(model.predict(X[evaluation]), dtype=np.int64)
+        probability = np.asarray(model.predict_proba(X[evaluation]), dtype=np.float64)
+        inference_s = time.perf_counter() - started
+        roc_auc = None
+        if probability.shape[1] == 2 and len(np.unique(y[evaluation])) == 2:
+            roc_auc = float(roc_auc_score(y[evaluation], probability[:, 1]))
+
+        rows.append(
+            {
+                "case_id": authority.case_id,
+                "authority_fingerprint": authority.authority_fingerprint,
+                "processed_data_sha256": authority.processed_data_sha256,
+                "partition_fingerprint": authority.partition_fingerprint,
+                "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+                "method_id": "csp-lda",
+                "model_seed": None,
+                "calibration_per_class": int(budget),
+                "status": "ok",
+                "failure_reason": None,
+                "source_train_samples": int(len(split.source_train_indices)),
+                "calibration_samples": int(len(calibration)),
+                "evaluation_samples": int(len(evaluation)),
+                "fit_samples": int(len(train)),
+                "class_labels": list(class_labels),
+                "accuracy": float(accuracy_score(y[evaluation], prediction)),
+                "balanced_accuracy": float(
+                    balanced_accuracy_score(y[evaluation], prediction)
+                ),
+                "roc_auc": roc_auc,
+                "fit_s": float(fit_s),
+                "inference_s": float(inference_s),
+                "inference_ms_per_trial": float(
+                    1000.0 * inference_s / max(len(evaluation), 1)
+                ),
+            }
+        )
+
+    return CSPCaseResult(
+        authority_fingerprint=authority.authority_fingerprint,
+        csp_components=int(csp_components),
+        rows=tuple(rows),
+    )

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_ladder.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_ladder.py
@@ -1,0 +1,516 @@
+"""Reusable orchestration and aggregation for longitudinal EEG model ladders."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence
+
+import numpy as np
+
+from .longitudinal_authority import LongitudinalCaseAuthority
+from .longitudinal_baseline import run_csp_case
+from .longitudinal_methods import TaskDecoderMethodSpec, run_task_decoder_case
+from .longitudinal_transfer import (
+    FrozenTransferMethodSpec,
+    PreparedFrozenEncoderCase,
+    prepare_frozen_encoder_case,
+    run_frozen_transfer_case,
+)
+
+LADDER_METHODS = (
+    "csp-lda",
+    "eegnet",
+    "eeg-conformer",
+    "frozen-eegnet",
+    "frozen-eeg-conformer",
+    "sourceweigher-eegnet",
+    "sourceweigher-eeg-conformer",
+)
+SOURCEWEIGHER_METHODS = frozenset(
+    {"sourceweigher-eegnet", "sourceweigher-eeg-conformer"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LadderRuntimeConfig:
+    epochs: int = 20
+    batch_size: int = 32
+    device: str = "auto"
+    csp_components: int = 8
+    readout_c: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.epochs <= 0 or self.batch_size <= 0:
+            raise ValueError("epochs and batch_size must be positive")
+        if self.csp_components <= 0 or self.readout_c <= 0:
+            raise ValueError("csp_components and readout_c must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "epochs": int(self.epochs),
+            "batch_size": int(self.batch_size),
+            "device": self.device,
+            "csp_components": int(self.csp_components),
+            "readout_c": float(self.readout_c),
+        }
+
+
+def _encoder_for_method(method: str) -> str:
+    if method.endswith("eegnet"):
+        return "eegnet"
+    if method.endswith("eeg-conformer"):
+        return "eeg-conformer"
+    raise ValueError(f"method {method!r} is not a frozen encoder lane")
+
+
+def _prepared_state(
+    data: Any,
+    authority: LongitudinalCaseAuthority,
+    *,
+    encoder_id: str,
+    model_seed: int,
+    config: LadderRuntimeConfig,
+    cache: MutableMapping[tuple[str, int], PreparedFrozenEncoderCase],
+) -> PreparedFrozenEncoderCase:
+    key = (encoder_id, int(model_seed))
+    state = cache.get(key)
+    if state is None:
+        state = prepare_frozen_encoder_case(
+            data,
+            authority,
+            encoder_id=encoder_id,  # type: ignore[arg-type]
+            encoder_seed=int(model_seed),
+            encoder_kwargs={
+                "n_epochs": int(config.epochs),
+                "batch_size": int(config.batch_size),
+                "device": config.device,
+            },
+        )
+        cache[key] = state
+    return state
+
+
+def run_ladder_method(
+    data: Any,
+    authority: LongitudinalCaseAuthority,
+    *,
+    method: str,
+    budgets_per_class: Sequence[int],
+    model_seed: int | None,
+    config: LadderRuntimeConfig,
+    prepared_cache: MutableMapping[
+        tuple[str, int], PreparedFrozenEncoderCase
+    ] | None = None,
+):
+    """Run one ladder lane under one frozen case authority.
+
+    Frozen and SourceWeigher lanes sharing an encoder ID/seed reuse the exact
+    same ``PreparedFrozenEncoderCase`` when the caller supplies one cache.
+    """
+    if method not in LADDER_METHODS:
+        raise ValueError(f"unsupported ladder method {method!r}")
+    budgets = tuple(sorted(set(int(value) for value in budgets_per_class)))
+    if not budgets or budgets[0] < 0:
+        raise ValueError("budgets_per_class must contain non-negative values")
+
+    if method == "csp-lda":
+        if model_seed is not None:
+            raise ValueError("csp-lda does not consume a model seed")
+        return run_csp_case(
+            data,
+            authority,
+            budgets_per_class=budgets,
+            csp_components=config.csp_components,
+        )
+
+    if model_seed is None:
+        raise ValueError(f"method {method} requires model_seed")
+    common_kwargs = {
+        "n_epochs": int(config.epochs),
+        "batch_size": int(config.batch_size),
+        "device": config.device,
+    }
+
+    if method in {"eegnet", "eeg-conformer"}:
+        return run_task_decoder_case(
+            data,
+            authority,
+            spec=TaskDecoderMethodSpec(
+                method_id=method,
+                model_seed=int(model_seed),
+                model_kwargs=common_kwargs,
+            ),
+            budgets_per_class=budgets,
+        )
+
+    encoder = _encoder_for_method(method)
+    cache = prepared_cache if prepared_cache is not None else {}
+    prepared = _prepared_state(
+        data,
+        authority,
+        encoder_id=encoder,
+        model_seed=int(model_seed),
+        config=config,
+        cache=cache,
+    )
+    strategy = (
+        "sourceweigher-mean" if method in SOURCEWEIGHER_METHODS else "frozen-logistic"
+    )
+    return run_frozen_transfer_case(
+        data,
+        authority,
+        spec=FrozenTransferMethodSpec(
+            method_id=method,
+            strategy=strategy,
+            encoder_id=encoder,  # type: ignore[arg-type]
+            encoder_seed=int(model_seed),
+            encoder_kwargs=common_kwargs,
+            readout_c=config.readout_c,
+        ),
+        budgets_per_class=budgets,
+        prepared=prepared,
+    )
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(array.mean())
+
+
+def _std(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    if len(array) == 0:
+        return None
+    return float(array.std(ddof=1)) if len(array) > 1 else 0.0
+
+
+def seed_averaged_case_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Average optimization seeds inside one frozen subject/session case."""
+    ok = [
+        dict(row)
+        for row in rows
+        if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
+    ]
+    groups: dict[tuple[str, int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in ok:
+        groups[
+            (
+                str(row["method_id"]),
+                int(row["calibration_per_class"]),
+                str(row["case_id"]),
+            )
+        ].append(row)
+
+    collapsed: list[dict[str, Any]] = []
+    for (method, budget, case_id), values in groups.items():
+        first = values[0]
+        collapsed.append(
+            {
+                "method_id": method,
+                "calibration_per_class": budget,
+                "case_id": case_id,
+                "subject": first.get("subject"),
+                "original_protocol": first.get("original_protocol"),
+                "held_out_session": first.get("held_out_session"),
+                "balanced_accuracy": _mean(
+                    float(value["balanced_accuracy"]) for value in values
+                ),
+                "roc_auc": _mean(
+                    float(value["roc_auc"])
+                    for value in values
+                    if value.get("roc_auc") is not None
+                ),
+                "n_model_seeds": len(values),
+            }
+        )
+    return collapsed
+
+
+def _case_set_fingerprint(case_ids: Sequence[str]) -> str:
+    raw = json.dumps(sorted(case_ids), separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def group_budget_summary(
+    collapsed: Sequence[Mapping[str, Any]],
+    *,
+    group_field: str | None = None,
+) -> list[dict[str, Any]]:
+    groups: dict[tuple[Any, ...], list[Mapping[str, Any]]] = defaultdict(list)
+    for row in collapsed:
+        key: tuple[Any, ...] = (
+            row["method_id"],
+            row["calibration_per_class"],
+        )
+        if group_field is not None:
+            key = (*key, row.get(group_field))
+        groups[key].append(row)
+
+    result: list[dict[str, Any]] = []
+    for key, values in sorted(groups.items(), key=lambda item: tuple(str(v) for v in item[0])):
+        method, budget, *group_value = key
+        case_ids = [str(row["case_id"]) for row in values]
+        record: dict[str, Any] = {
+            "method_id": method,
+            "calibration_per_class": int(budget),
+            "n_cases": len(values),
+            "case_set_fingerprint": _case_set_fingerprint(case_ids),
+            "mean_balanced_accuracy": _mean(
+                float(row["balanced_accuracy"]) for row in values
+            ),
+            "std_balanced_accuracy": _std(
+                float(row["balanced_accuracy"]) for row in values
+            ),
+            "mean_roc_auc": _mean(
+                float(row["roc_auc"])
+                for row in values
+                if row.get("roc_auc") is not None
+            ),
+        }
+        if group_field is not None:
+            record[group_field] = group_value[0]
+        result.append(record)
+    return result
+
+
+def manual_trapezoid(y: np.ndarray, x: np.ndarray) -> float:
+    """NumPy >=1.24-compatible trapezoidal integration."""
+    if y.ndim != 1 or x.ndim != 1 or len(y) != len(x):
+        raise ValueError("trapezoid inputs must be aligned 1-D vectors")
+    if len(x) < 2:
+        return 0.0
+    return float(np.sum((y[:-1] + y[1:]) * 0.5 * np.diff(x)))
+
+
+def frontier_auc(
+    rows: Sequence[Mapping[str, Any]],
+    requested_budgets: Sequence[int],
+) -> list[dict[str, Any]]:
+    """Compute seed-averaged per-case normalized AUC for one budget set."""
+    budgets = tuple(int(value) for value in requested_budgets)
+    if len(budgets) < 2:
+        return []
+    ok = [
+        row
+        for row in rows
+        if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
+    ]
+    by_method_case_seed: dict[tuple[str, str, str], dict[int, float]] = defaultdict(dict)
+    for row in ok:
+        seed = "none" if row.get("model_seed") is None else str(row["model_seed"])
+        key = (str(row["method_id"]), str(row["case_id"]), seed)
+        by_method_case_seed[key][int(row["calibration_per_class"])] = float(
+            row["balanced_accuracy"]
+        )
+
+    budget_x = np.asarray(budgets, dtype=np.float64)
+    span = float(budget_x[-1] - budget_x[0])
+    if span <= 0:
+        return []
+
+    per_method_case: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for (method, case_id, _seed), curve in by_method_case_seed.items():
+        if any(budget not in curve for budget in budgets):
+            continue
+        y = np.asarray([curve[budget] for budget in budgets], dtype=np.float64)
+        per_method_case[(method, case_id)].append(manual_trapezoid(y, budget_x) / span)
+
+    by_method: dict[str, list[float]] = defaultdict(list)
+    for (method, _case), seed_values in per_method_case.items():
+        by_method[method].append(float(np.mean(seed_values)))
+
+    return [
+        {
+            "method_id": method,
+            "complete_frontier_cases": len(values),
+            "mean_seed_averaged_frontier_auc": _mean(values),
+            "std_seed_averaged_frontier_auc": _std(values),
+            "requested_budgets": list(budgets),
+        }
+        for method, values in sorted(by_method.items())
+    ]
+
+
+def paired_case_set_audit(
+    collapsed: Sequence[Mapping[str, Any]],
+    methods: Sequence[str],
+    budgets: Sequence[int],
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for method in methods:
+        supported = tuple(
+            int(budget)
+            for budget in budgets
+            if not (method in SOURCEWEIGHER_METHODS and int(budget) == 0)
+        )
+        fingerprints: list[str] = []
+        counts: list[int] = []
+        for budget in supported:
+            case_ids = [
+                str(row["case_id"])
+                for row in collapsed
+                if row["method_id"] == method
+                and int(row["calibration_per_class"]) == budget
+            ]
+            fingerprints.append(_case_set_fingerprint(case_ids))
+            counts.append(len(case_ids))
+        identical = bool(fingerprints) and len(set(fingerprints)) == 1
+        result.append(
+            {
+                "method_id": method,
+                "supported_budgets": list(supported),
+                "case_counts": counts,
+                "case_set_fingerprints": fingerprints,
+                "paired_across_supported_budgets": identical,
+            }
+        )
+    return result
+
+
+def summarize_ladder_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    budgets: Sequence[int],
+    methods: Sequence[str],
+) -> dict[str, Any]:
+    failures = [row for row in rows if row.get("status") == "failed"]
+    unavailable = [
+        row for row in rows if str(row.get("status", "")).startswith("unavailable")
+    ]
+    unexpected_unavailable = [
+        row
+        for row in unavailable
+        if not (
+            row.get("method_id") in SOURCEWEIGHER_METHODS
+            and int(row.get("calibration_per_class", -1)) == 0
+        )
+    ]
+    collapsed = seed_averaged_case_rows(rows)
+    paired_audit = paired_case_set_audit(collapsed, methods, budgets)
+    positive_budgets = tuple(int(budget) for budget in budgets if int(budget) > 0)
+    promotion_ready = (
+        len(failures) == 0
+        and len(unexpected_unavailable) == 0
+        and all(item["paired_across_supported_budgets"] for item in paired_audit)
+    )
+    return {
+        "schema_version": 2,
+        "primary_metric": "balanced_accuracy",
+        "budget_summary_seed_averaged_within_case": group_budget_summary(collapsed),
+        "cohort_budget_summary": group_budget_summary(
+            collapsed, group_field="original_protocol"
+        ),
+        "target_session_budget_summary": group_budget_summary(
+            collapsed, group_field="held_out_session"
+        ),
+        "complete_frontier_auc": frontier_auc(rows, budgets),
+        "positive_budget_adaptation_auc": frontier_auc(rows, positive_budgets),
+        "paired_case_set_audit": paired_audit,
+        "failed_rows": len(failures),
+        "unavailable_rows": len(unavailable),
+        "unexpected_unavailable_rows": len(unexpected_unavailable),
+        "failure_reasons": sorted(
+            {str(row.get("failure_reason")) for row in failures if row.get("failure_reason")}
+        ),
+        "promotion_ready_descriptive": promotion_ready,
+        "statistical_boundary": (
+            "Descriptive only. Promoted Kumar2024 inference follows preregistration issue #27: "
+            "subject-clustered/hierarchical inference with GR/PAR cohort reporting."
+        ),
+    }
+
+
+def render_ladder_report(manifest: Mapping[str, Any], summary: Mapping[str, Any]) -> str:
+    def fmt(value: Any) -> str:
+        return "n/a" if value is None else f"{float(value):.4f}"
+
+    lines = [
+        "# neurOS Longitudinal Model Ladder",
+        "",
+        f"- Dataset: **{manifest['dataset_key']}**",
+        f"- History: **{manifest['history_policy']}**",
+        f"- Methods: **{', '.join(manifest['methods'])}**",
+        f"- Budgets / class: **{', '.join(str(v) for v in manifest['budgets_per_class'])}**",
+        f"- Model seeds: **{', '.join(str(v) for v in manifest['model_seeds'])}**",
+        f"- Frozen authority cases: **{len(manifest['authority_fingerprints'])}**",
+        f"- Descriptive promotion gate: **{'PASS' if summary['promotion_ready_descriptive'] else 'FAIL'}**",
+        "",
+        "## Seed-averaged calibration frontier",
+        "",
+        "| method | calibration/class | cases | case-set fp | balanced accuracy | std | ROC-AUC |",
+        "| --- | ---: | ---: | --- | ---: | ---: | ---: |",
+    ]
+    for row in summary["budget_summary_seed_averaged_within_case"]:
+        lines.append(
+            "| {method_id} | {calibration_per_class} | {n_cases} | {case_set_fingerprint} | "
+            "{ba} | {std} | {auc} |".format(
+                **row,
+                ba=fmt(row["mean_balanced_accuracy"]),
+                std=fmt(row["std_balanced_accuracy"]),
+                auc=fmt(row["mean_roc_auc"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Full calibration-frontier AUC",
+            "",
+            "Methods not defined at zero target calibration do not receive a fabricated full-frontier AUC.",
+            "",
+            "| method | complete cases | mean AUC | std |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for row in summary["complete_frontier_auc"]:
+        lines.append(
+            "| {method_id} | {complete_frontier_cases} | {mean} | {std} |".format(
+                **row,
+                mean=fmt(row["mean_seed_averaged_frontier_auc"]),
+                std=fmt(row["std_seed_averaged_frontier_auc"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Positive-budget adaptation AUC",
+            "",
+            "Secondary comparison over strictly positive labeled-calibration budgets.",
+            "",
+            "| method | complete cases | mean AUC | std |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for row in summary["positive_budget_adaptation_auc"]:
+        lines.append(
+            "| {method_id} | {complete_frontier_cases} | {mean} | {std} |".format(
+                **row,
+                mean=fmt(row["mean_seed_averaged_frontier_auc"]),
+                std=fmt(row["std_seed_averaged_frontier_auc"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Evidence boundary",
+            "",
+            "Every method row references serialized sample authority and processed-data identity.",
+            "SourceWeigher at zero target calibration is explicitly unavailable rather than transductive.",
+            "",
+            f"Failed rows: **{summary['failed_rows']}**. Unavailable rows: **{summary['unavailable_rows']}**. "
+            f"Unexpected unavailable rows: **{summary['unexpected_unavailable_rows']}**.",
+            "",
+            "Kumar GR/PAR cohort and target-session summaries are emitted from this same bundle.",
+            "",
+            "This is descriptive offline real-dataset evidence, not hardware, closed-loop, clinical, or ORION superiority evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_methods.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_methods.py
@@ -70,7 +70,7 @@ class TaskDecoderCaseResult:
     resolved_model_config: Mapping[str, Any]
     parameter_count: int
     analysis_manifest_fingerprint: str
-    schema_version: int = 1
+    schema_version: int = 2
 
     def __post_init__(self) -> None:
         if self.parameter_count <= 0:
@@ -163,6 +163,27 @@ def _resolved_config(model: Any) -> dict[str, Any]:
 def _parameter_count(model: Any) -> int:
     module = model.analysis_model()
     return int(sum(parameter.numel() for parameter in module.parameters()))
+
+
+def _model_state_sha256(model: Any) -> str:
+    """Hash the actual learned PyTorch state, including registered buffers.
+
+    Config/seed identity is not sufficient evidence of learned-state identity on
+    every accelerator. The state hash includes every ``state_dict`` tensor name,
+    dtype, shape and raw CPU bytes in sorted-key order, including BatchNorm
+    running statistics and other registered buffers.
+    """
+    module = model.analysis_model()
+    state = module.state_dict()
+    digest = hashlib.sha256()
+    for name in sorted(state):
+        tensor = state[name].detach().cpu().contiguous()
+        array = tensor.numpy()
+        digest.update(name.encode("utf-8"))
+        digest.update(str(array.dtype).encode("ascii"))
+        digest.update(json.dumps(list(array.shape), separators=(",", ":")).encode("ascii"))
+        digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
 
 
 def _encode_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[np.ndarray, tuple[str, ...]]:
@@ -292,6 +313,7 @@ def run_task_decoder_case(
         started = time.perf_counter()
         model.train(X[train_indices], y_encoded[train_indices])
         fit_s = time.perf_counter() - started
+        model_state_sha256 = _model_state_sha256(model)
 
         started = time.perf_counter()
         probability = model.predict_proba(X[evaluation_indices])
@@ -314,6 +336,7 @@ def run_task_decoder_case(
                 "method_id": spec.method_id,
                 "method_spec_fingerprint": spec.fingerprint,
                 "model_seed": int(spec.model_seed),
+                "model_state_sha256": model_state_sha256,
                 "calibration_per_class": int(budget),
                 "source_train_samples": int(len(split.source_train_indices)),
                 "calibration_samples": int(len(calibration_indices)),

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_methods.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_methods.py
@@ -1,0 +1,350 @@
+"""Task-decoder methods for replayable longitudinal evidence cases.
+
+Every method in this module receives a :class:`LongitudinalCaseAuthority` and
+must restore it before fitting. The method therefore has no authority to choose
+source, calibration, or final-evaluation examples.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal, Mapping, Sequence
+
+import numpy as np
+from sklearn.metrics import accuracy_score, balanced_accuracy_score, roc_auc_score
+
+from neuros.models import EEGConformerModel, EEGNetModel
+
+from .longitudinal_authority import LongitudinalCaseAuthority
+from .probes import representation_report
+from .real_world import GroupedEvaluationData
+
+TaskDecoderId = Literal["eegnet", "eeg-conformer"]
+
+
+@dataclass(frozen=True, slots=True)
+class TaskDecoderMethodSpec:
+    """Frozen identity/configuration for one supervised task-decoder method."""
+
+    method_id: TaskDecoderId
+    model_seed: int
+    model_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.method_id not in {"eegnet", "eeg-conformer"}:
+            raise ValueError(f"unsupported task decoder {self.method_id!r}")
+        forbidden = {"n_channels", "n_classes", "random_state"}.intersection(self.model_kwargs)
+        if forbidden:
+            raise ValueError(
+                "n_channels, n_classes and random_state are controlled by the evidence runner; "
+                f"remove overrides {sorted(forbidden)}"
+            )
+        object.__setattr__(self, "model_kwargs", MappingProxyType(dict(self.model_kwargs)))
+
+    @property
+    def fingerprint(self) -> str:
+        raw = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "method_id": self.method_id,
+            "model_seed": int(self.model_seed),
+            "model_kwargs": dict(self.model_kwargs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TaskDecoderCaseResult:
+    """One method/seed evaluated across calibration budgets for one authority."""
+
+    authority_fingerprint: str
+    method_spec: TaskDecoderMethodSpec
+    rows: tuple[Mapping[str, Any], ...]
+    resolved_model_config: Mapping[str, Any]
+    parameter_count: int
+    analysis_manifest_fingerprint: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.parameter_count <= 0:
+            raise ValueError("parameter_count must be positive")
+        object.__setattr__(self, "rows", tuple(MappingProxyType(dict(row)) for row in self.rows))
+        object.__setattr__(
+            self,
+            "resolved_model_config",
+            MappingProxyType(dict(self.resolved_model_config)),
+        )
+
+    @property
+    def method_run_fingerprint(self) -> str:
+        payload = self.to_dict(include_fingerprint=False)
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema_version": self.schema_version,
+            "authority_fingerprint": self.authority_fingerprint,
+            "method_spec": self.method_spec.to_dict(),
+            "method_spec_fingerprint": self.method_spec.fingerprint,
+            "resolved_model_config": dict(self.resolved_model_config),
+            "parameter_count": int(self.parameter_count),
+            "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "rows": [dict(row) for row in self.rows],
+        }
+        if include_fingerprint:
+            payload["method_run_fingerprint"] = self.method_run_fingerprint
+        return payload
+
+
+def _model_for(
+    spec: TaskDecoderMethodSpec,
+    *,
+    n_channels: int,
+    n_classes: int,
+):
+    kwargs = dict(spec.model_kwargs)
+    kwargs.update(
+        {
+            "n_channels": int(n_channels),
+            "n_classes": int(n_classes),
+            "random_state": int(spec.model_seed),
+        }
+    )
+    if spec.method_id == "eegnet":
+        return EEGNetModel(**kwargs)
+    if spec.method_id == "eeg-conformer":
+        return EEGConformerModel(**kwargs)
+    raise ValueError(f"unsupported task decoder {spec.method_id!r}")
+
+
+def _resolved_config(model: Any) -> dict[str, Any]:
+    common = (
+        "n_channels",
+        "n_classes",
+        "learning_rate",
+        "weight_decay",
+        "n_epochs",
+        "batch_size",
+        "device_spec",
+        "random_state",
+    )
+    architecture = (
+        "temporal_filters",
+        "depth_multiplier",
+        "separable_filters",
+        "temporal_kernel",
+        "separable_kernel",
+        "embedding_dim",
+        "pool_length",
+        "pool_stride",
+        "n_heads",
+        "n_layers",
+        "feedforward_multiplier",
+        "dropout",
+    )
+    result: dict[str, Any] = {}
+    for name in common + architecture:
+        if hasattr(model, name):
+            value = getattr(model, name)
+            if isinstance(value, np.generic):
+                value = value.item()
+            result[name] = value
+    return result
+
+
+def _parameter_count(model: Any) -> int:
+    module = model.analysis_model()
+    return int(sum(parameter.numel() for parameter in module.parameters()))
+
+
+def _encode_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[np.ndarray, tuple[str, ...]]:
+    labels = tuple(sorted(np.unique(np.asarray(y)[source_indices].astype(str)).tolist()))
+    if len(labels) < 2:
+        raise ValueError("source history must contain at least two task classes")
+    mapping = {label: index for index, label in enumerate(labels)}
+    all_labels = np.asarray(y).astype(str)
+    unknown = sorted(set(all_labels.tolist()) - set(mapping))
+    if unknown:
+        raise ValueError(
+            "loaded data contains labels absent from source-history class vocabulary: "
+            f"{unknown}"
+        )
+    encoded = np.asarray([mapping[value] for value in all_labels], dtype=np.int64)
+    return encoded, labels
+
+
+def _multiclass_brier(y_true: np.ndarray, probability: np.ndarray, n_classes: int) -> float:
+    one_hot = np.eye(n_classes, dtype=np.float64)[np.asarray(y_true, dtype=np.int64)]
+    return float(np.mean(np.sum((np.asarray(probability) - one_hot) ** 2, axis=1)))
+
+
+def _expected_calibration_error(
+    y_true: np.ndarray,
+    probability: np.ndarray,
+    *,
+    n_bins: int = 10,
+) -> float:
+    probs = np.asarray(probability, dtype=np.float64)
+    prediction = probs.argmax(axis=1)
+    confidence = probs.max(axis=1)
+    correct = (prediction == np.asarray(y_true)).astype(np.float64)
+    edges = np.linspace(0.0, 1.0, n_bins + 1)
+    error = 0.0
+    for index in range(n_bins):
+        if index == n_bins - 1:
+            mask = (confidence >= edges[index]) & (confidence <= edges[index + 1])
+        else:
+            mask = (confidence >= edges[index]) & (confidence < edges[index + 1])
+        if not np.any(mask):
+            continue
+        weight = float(np.mean(mask))
+        error += weight * abs(float(correct[mask].mean()) - float(confidence[mask].mean()))
+    return float(error)
+
+
+def _score(
+    y_true: np.ndarray,
+    probability: np.ndarray,
+) -> dict[str, float | None]:
+    probs = np.asarray(probability, dtype=np.float64)
+    prediction = probs.argmax(axis=1)
+    y = np.asarray(y_true, dtype=np.int64)
+    n_classes = probs.shape[1]
+    roc_auc: float | None = None
+    if n_classes == 2 and len(np.unique(y)) == 2:
+        roc_auc = float(roc_auc_score(y, probs[:, 1]))
+    return {
+        "accuracy": float(accuracy_score(y, prediction)),
+        "balanced_accuracy": float(balanced_accuracy_score(y, prediction)),
+        "roc_auc": roc_auc,
+        "brier_score": _multiclass_brier(y, probs, n_classes),
+        "expected_calibration_error": _expected_calibration_error(y, probs),
+    }
+
+
+def run_task_decoder_case(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    *,
+    spec: TaskDecoderMethodSpec,
+    budgets_per_class: Sequence[int],
+) -> TaskDecoderCaseResult:
+    """Evaluate one task decoder under a previously frozen sample authority.
+
+    A fresh model is trained at every calibration budget. No final evaluation
+    example is used for fitting, preprocessing, adaptation, or model selection.
+    """
+
+    split = authority.restore(data)
+    budgets = tuple(sorted(set(int(value) for value in budgets_per_class)))
+    if not budgets or budgets[0] < 0:
+        raise ValueError("budgets_per_class must contain non-negative values")
+    if budgets[-1] > split.max_budget_per_class:
+        raise ValueError(
+            f"requested budget {budgets[-1]} exceeds authority maximum "
+            f"{split.max_budget_per_class}/class"
+        )
+
+    X = np.asarray(data.X, dtype=np.float32)
+    if X.ndim != 3:
+        raise ValueError("task decoder ladder expects X=(sample, channel, time)")
+    y_encoded, class_labels = _encode_labels(np.asarray(data.y), split.source_train_indices)
+    n_channels = int(X.shape[1])
+    n_classes = len(class_labels)
+
+    rows: list[dict[str, Any]] = []
+    resolved: dict[str, Any] | None = None
+    parameters: int | None = None
+    manifest_fingerprint: str | None = None
+
+    for budget in budgets:
+        train_indices = split.train_indices_for_budget(budget)
+        calibration_indices = split.calibration_indices(budget)
+        evaluation_indices = split.evaluation_indices
+
+        model = _model_for(
+            spec,
+            n_channels=n_channels,
+            n_classes=n_classes,
+        )
+        current_resolved = _resolved_config(model)
+        current_parameters = _parameter_count(model)
+        current_manifest = model.analysis_manifest().fingerprint()
+        if resolved is None:
+            resolved = current_resolved
+            parameters = current_parameters
+            manifest_fingerprint = current_manifest
+        elif (
+            current_resolved != resolved
+            or current_parameters != parameters
+            or current_manifest != manifest_fingerprint
+        ):
+            raise RuntimeError("method identity changed across calibration budgets")
+
+        started = time.perf_counter()
+        model.train(X[train_indices], y_encoded[train_indices])
+        fit_s = time.perf_counter() - started
+
+        started = time.perf_counter()
+        probability = model.predict_proba(X[evaluation_indices])
+        inference_s = time.perf_counter() - started
+        metrics = _score(y_encoded[evaluation_indices], probability)
+
+        eval_embedding = model.encode(X[evaluation_indices])
+        source_embedding = model.encode(X[split.source_train_indices])
+        eval_report = representation_report(eval_embedding)
+        source_report = representation_report(source_embedding)
+        final_training = model.training_history[-1] if model.training_history else {}
+
+        rows.append(
+            {
+                "case_id": authority.case_id,
+                "authority_fingerprint": authority.authority_fingerprint,
+                "processed_data_sha256": authority.processed_data_sha256,
+                "partition_fingerprint": authority.partition_fingerprint,
+                "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+                "method_id": spec.method_id,
+                "method_spec_fingerprint": spec.fingerprint,
+                "model_seed": int(spec.model_seed),
+                "calibration_per_class": int(budget),
+                "source_train_samples": int(len(split.source_train_indices)),
+                "calibration_samples": int(len(calibration_indices)),
+                "evaluation_samples": int(len(evaluation_indices)),
+                "fit_samples": int(len(train_indices)),
+                "class_labels": list(class_labels),
+                **metrics,
+                "fit_s": float(fit_s),
+                "inference_s": float(inference_s),
+                "inference_ms_per_trial": float(
+                    1000.0 * inference_s / max(len(evaluation_indices), 1)
+                ),
+                "training_final_loss": (
+                    None if "loss" not in final_training else float(final_training["loss"])
+                ),
+                "training_final_accuracy": (
+                    None
+                    if "accuracy" not in final_training
+                    else float(final_training["accuracy"])
+                ),
+                "evaluation_representation": eval_report,
+                "source_representation": source_report,
+            }
+        )
+
+    assert resolved is not None and parameters is not None and manifest_fingerprint is not None
+    return TaskDecoderCaseResult(
+        authority_fingerprint=authority.authority_fingerprint,
+        method_spec=spec,
+        rows=tuple(rows),
+        resolved_model_config=resolved,
+        parameter_count=parameters,
+        analysis_manifest_fingerprint=manifest_fingerprint,
+    )

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
@@ -26,26 +26,34 @@ from .longitudinal_methods import (
     _resolved_config,
     _score,
 )
-from .probes import representation_report
 from .real_world import GroupedEvaluationData
 
-FrozenTransferId = Literal["frozen-logistic", "sourceweigher-mean"]
+FrozenTransferStrategy = Literal["frozen-logistic", "sourceweigher-mean"]
 
 
 @dataclass(frozen=True, slots=True)
 class FrozenTransferMethodSpec:
-    """Identity for a source-trained frozen encoder plus matched linear readout."""
+    """Identity for a source-trained frozen encoder plus matched linear readout.
 
-    method_id: FrozenTransferId
+    ``method_id`` identifies the public comparison lane, for example
+    ``frozen-eegnet`` or ``sourceweigher-eeg-conformer``. ``strategy`` names the
+    transfer algorithm independently. Keeping the two fields separate prevents
+    aggregation from collapsing distinct encoders into one curve.
+    """
+
+    method_id: str
+    strategy: FrozenTransferStrategy
     encoder_id: Literal["eegnet", "eeg-conformer"]
     encoder_seed: int
     encoder_kwargs: Mapping[str, Any] = field(default_factory=dict)
     readout_c: float = 1.0
-    schema_version: int = 1
+    schema_version: int = 2
 
     def __post_init__(self) -> None:
-        if self.method_id not in {"frozen-logistic", "sourceweigher-mean"}:
-            raise ValueError(f"unsupported frozen transfer method {self.method_id!r}")
+        if not str(self.method_id).strip():
+            raise ValueError("method_id must be non-empty")
+        if self.strategy not in {"frozen-logistic", "sourceweigher-mean"}:
+            raise ValueError(f"unsupported frozen transfer strategy {self.strategy!r}")
         if self.encoder_id not in {"eegnet", "eeg-conformer"}:
             raise ValueError(f"unsupported encoder {self.encoder_id!r}")
         if self.readout_c <= 0:
@@ -58,12 +66,14 @@ class FrozenTransferMethodSpec:
                 "n_channels, n_classes and random_state are evidence-controlled; "
                 f"remove overrides {sorted(forbidden)}"
             )
+        object.__setattr__(self, "method_id", str(self.method_id).strip())
         object.__setattr__(self, "encoder_kwargs", MappingProxyType(dict(self.encoder_kwargs)))
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema_version": self.schema_version,
             "method_id": self.method_id,
+            "strategy": self.strategy,
             "encoder_id": self.encoder_id,
             "encoder_seed": int(self.encoder_seed),
             "encoder_kwargs": dict(self.encoder_kwargs),
@@ -85,7 +95,7 @@ class FrozenTransferCaseResult:
     analysis_manifest_fingerprint: str
     encoder_fit_s: float
     rows: tuple[Mapping[str, Any], ...]
-    schema_version: int = 1
+    schema_version: int = 2
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "encoder_config", MappingProxyType(dict(self.encoder_config)))
@@ -260,13 +270,16 @@ def run_frozen_transfer_case(
             else np.empty((0, source_embedding.shape[1]), dtype=source_embedding.dtype)
         )
 
-        if spec.method_id == "sourceweigher-mean" and budget == 0:
+        if spec.strategy == "sourceweigher-mean" and budget == 0:
             rows.append(
                 {
                     "case_id": authority.case_id,
                     "authority_fingerprint": authority.authority_fingerprint,
                     "processed_data_sha256": authority.processed_data_sha256,
+                    "partition_fingerprint": authority.partition_fingerprint,
+                    "calibration_split_fingerprint": authority.calibration_split_fingerprint,
                     "method_id": spec.method_id,
+                    "transfer_strategy": spec.strategy,
                     "method_spec_fingerprint": spec.fingerprint,
                     "encoder_id": spec.encoder_id,
                     "encoder_seed": int(spec.encoder_seed),
@@ -285,7 +298,7 @@ def run_frozen_transfer_case(
         sample_weight: np.ndarray | None = None
         weighting_payload: dict[str, Any] | None = None
 
-        if spec.method_id == "sourceweigher-mean":
+        if spec.strategy == "sourceweigher-mean":
             weighting = _sourceweigher_result(
                 source_embeddings=source_embeddings_by_session,
                 target_embeddings=calibration_embedding,
@@ -305,7 +318,7 @@ def run_frozen_transfer_case(
             sample_weight = np.concatenate(
                 [source_weights, np.ones(len(calibration_indices), dtype=np.float64)]
             )
-        elif spec.method_id == "sourceweigher-mean":  # guarded above; defensive
+        elif spec.strategy == "sourceweigher-mean":  # guarded above; defensive
             raise RuntimeError("SourceWeigher reached zero budget unexpectedly")
 
         started = time.perf_counter()
@@ -329,6 +342,7 @@ def run_frozen_transfer_case(
                 "partition_fingerprint": authority.partition_fingerprint,
                 "calibration_split_fingerprint": authority.calibration_split_fingerprint,
                 "method_id": spec.method_id,
+                "transfer_strategy": spec.strategy,
                 "method_spec_fingerprint": spec.fingerprint,
                 "encoder_id": spec.encoder_id,
                 "encoder_seed": int(spec.encoder_seed),

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
@@ -1,9 +1,9 @@
 """Frozen-representation transfer methods for longitudinal BCI evidence.
 
-The encoder is trained once on source history and then frozen. Target-session
-calibration can change only the low-capacity readout and, for SourceWeigher, the
-source-domain weights. This keeps representation adaptation distinct from
-end-to-end target fine-tuning.
+A frozen encoder is trained once on source history and materialized as a
+``PreparedFrozenEncoderCase``. Multiple transfer strategies can then consume the
+exact same representation tensors, making SourceWeigher-vs-unweighted readout a
+clean comparison rather than two nominally identical encoder trainings.
 """
 
 from __future__ import annotations
@@ -31,15 +31,23 @@ from .real_world import GroupedEvaluationData
 FrozenTransferStrategy = Literal["frozen-logistic", "sourceweigher-mean"]
 
 
+def _readonly_array(values: Any, *, dtype: Any | None = None) -> np.ndarray:
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _hash_array(digest: Any, name: str, values: np.ndarray) -> None:
+    array = np.ascontiguousarray(values)
+    digest.update(name.encode("utf-8"))
+    digest.update(str(array.dtype).encode("ascii"))
+    digest.update(json.dumps(list(array.shape), separators=(",", ":")).encode("ascii"))
+    digest.update(array.tobytes(order="C"))
+
+
 @dataclass(frozen=True, slots=True)
 class FrozenTransferMethodSpec:
-    """Identity for a source-trained frozen encoder plus matched linear readout.
-
-    ``method_id`` identifies the public comparison lane, for example
-    ``frozen-eegnet`` or ``sourceweigher-eeg-conformer``. ``strategy`` names the
-    transfer algorithm independently. Keeping the two fields separate prevents
-    aggregation from collapsing distinct encoders into one curve.
-    """
+    """Identity for a frozen representation plus one transfer/readout strategy."""
 
     method_id: str
     strategy: FrozenTransferStrategy
@@ -87,18 +95,102 @@ class FrozenTransferMethodSpec:
 
 
 @dataclass(frozen=True, slots=True)
-class FrozenTransferCaseResult:
+class PreparedFrozenEncoderCase:
+    """One source-trained encoder and immutable representation tensors for a case."""
+
     authority_fingerprint: str
-    method_spec: FrozenTransferMethodSpec
+    encoder_id: str
+    encoder_seed: int
+    encoder_spec_fingerprint: str
     encoder_config: Mapping[str, Any]
     encoder_parameter_count: int
     analysis_manifest_fingerprint: str
     encoder_fit_s: float
-    rows: tuple[Mapping[str, Any], ...]
-    schema_version: int = 2
+    class_labels: tuple[str, ...]
+    y_encoded: np.ndarray
+    source_indices: np.ndarray
+    evaluation_indices: np.ndarray
+    target_pool_indices: np.ndarray
+    source_embedding: np.ndarray
+    evaluation_embedding: np.ndarray
+    target_pool_embedding: np.ndarray
+    source_session: np.ndarray
+    source_embeddings_by_session: Mapping[str, np.ndarray]
+    schema_version: int = 1
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "encoder_config", MappingProxyType(dict(self.encoder_config)))
+        object.__setattr__(self, "y_encoded", _readonly_array(self.y_encoded, dtype=np.int64))
+        object.__setattr__(self, "source_indices", _readonly_array(self.source_indices, dtype=np.int64))
+        object.__setattr__(self, "evaluation_indices", _readonly_array(self.evaluation_indices, dtype=np.int64))
+        object.__setattr__(self, "target_pool_indices", _readonly_array(self.target_pool_indices, dtype=np.int64))
+        object.__setattr__(self, "source_embedding", _readonly_array(self.source_embedding))
+        object.__setattr__(self, "evaluation_embedding", _readonly_array(self.evaluation_embedding))
+        object.__setattr__(self, "target_pool_embedding", _readonly_array(self.target_pool_embedding))
+        object.__setattr__(self, "source_session", _readonly_array(self.source_session))
+        frozen_sources = {
+            str(key): _readonly_array(value)
+            for key, value in self.source_embeddings_by_session.items()
+        }
+        object.__setattr__(self, "source_embeddings_by_session", MappingProxyType(frozen_sources))
+
+    @property
+    def representation_sha256(self) -> str:
+        digest = hashlib.sha256()
+        _hash_array(digest, "source_indices", self.source_indices)
+        _hash_array(digest, "evaluation_indices", self.evaluation_indices)
+        _hash_array(digest, "target_pool_indices", self.target_pool_indices)
+        _hash_array(digest, "source_embedding", self.source_embedding)
+        _hash_array(digest, "evaluation_embedding", self.evaluation_embedding)
+        _hash_array(digest, "target_pool_embedding", self.target_pool_embedding)
+        return digest.hexdigest()
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "schema_version": self.schema_version,
+            "authority_fingerprint": self.authority_fingerprint,
+            "encoder_id": self.encoder_id,
+            "encoder_seed": int(self.encoder_seed),
+            "encoder_spec_fingerprint": self.encoder_spec_fingerprint,
+            "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "representation_sha256": self.representation_sha256,
+        }
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def manifest(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "authority_fingerprint": self.authority_fingerprint,
+            "encoder_id": self.encoder_id,
+            "encoder_seed": int(self.encoder_seed),
+            "encoder_spec_fingerprint": self.encoder_spec_fingerprint,
+            "encoder_config": dict(self.encoder_config),
+            "encoder_parameter_count": int(self.encoder_parameter_count),
+            "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "encoder_fit_s": float(self.encoder_fit_s),
+            "class_labels": list(self.class_labels),
+            "source_samples": int(len(self.source_indices)),
+            "target_pool_samples": int(len(self.target_pool_indices)),
+            "evaluation_samples": int(len(self.evaluation_indices)),
+            "representation_sha256": self.representation_sha256,
+            "encoder_state_fingerprint": self.fingerprint,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenTransferCaseResult:
+    authority_fingerprint: str
+    method_spec: FrozenTransferMethodSpec
+    encoder_state_manifest: Mapping[str, Any]
+    rows: tuple[Mapping[str, Any], ...]
+    schema_version: int = 3
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "encoder_state_manifest", MappingProxyType(dict(self.encoder_state_manifest))
+        )
         object.__setattr__(self, "rows", tuple(MappingProxyType(dict(row)) for row in self.rows))
 
     def to_dict(self) -> dict[str, Any]:
@@ -107,10 +199,7 @@ class FrozenTransferCaseResult:
             "authority_fingerprint": self.authority_fingerprint,
             "method_spec": self.method_spec.to_dict(),
             "method_spec_fingerprint": self.method_spec.fingerprint,
-            "encoder_config": dict(self.encoder_config),
-            "encoder_parameter_count": int(self.encoder_parameter_count),
-            "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
-            "encoder_fit_s": float(self.encoder_fit_s),
+            "encoder_state": dict(self.encoder_state_manifest),
             "rows": [dict(row) for row in self.rows],
         }
 
@@ -125,6 +214,93 @@ def _encode_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[np.ndarra
     if unknown:
         raise ValueError(f"target contains class labels absent from source history: {unknown}")
     return np.asarray([mapping[value] for value in values], dtype=np.int64), labels
+
+
+def prepare_frozen_encoder_case(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    *,
+    encoder_id: Literal["eegnet", "eeg-conformer"],
+    encoder_seed: int,
+    encoder_kwargs: Mapping[str, Any] | None = None,
+) -> PreparedFrozenEncoderCase:
+    """Train one encoder on source history and materialize immutable embeddings."""
+    split = authority.restore(data)
+    if authority.split_unit != "session":
+        raise ValueError("frozen longitudinal transfer currently requires session authority")
+    X = np.asarray(data.X, dtype=np.float32)
+    if X.ndim != 3:
+        raise ValueError("frozen EEG transfer expects X=(sample, channel, time)")
+    y_encoded, class_labels = _encode_labels(np.asarray(data.y), split.source_train_indices)
+
+    encoder_spec = TaskDecoderMethodSpec(
+        method_id=encoder_id,
+        model_seed=int(encoder_seed),
+        model_kwargs=dict(encoder_kwargs or {}),
+    )
+    encoder = _model_for(
+        encoder_spec,
+        n_channels=int(X.shape[1]),
+        n_classes=len(class_labels),
+    )
+    encoder_config = _resolved_config(encoder)
+    parameter_count = _parameter_count(encoder)
+    manifest_fingerprint = encoder.analysis_manifest().fingerprint()
+
+    started = time.perf_counter()
+    encoder.train(X[split.source_train_indices], y_encoded[split.source_train_indices])
+    encoder_fit_s = time.perf_counter() - started
+
+    source_embedding = encoder.encode(X[split.source_train_indices])
+    evaluation_embedding = encoder.encode(X[split.evaluation_indices])
+    target_pool_indices = np.sort(
+        np.concatenate(
+            [np.asarray(values, dtype=np.int64) for values in split.calibration_order_by_class.values()]
+        )
+    )
+    target_pool_embedding = encoder.encode(X[target_pool_indices])
+    source_session = np.asarray(data.groups["session"])[split.source_train_indices].astype(str)
+    source_embeddings_by_session = {
+        session: source_embedding[source_session == session]
+        for session in authority.source_group_values
+    }
+
+    return PreparedFrozenEncoderCase(
+        authority_fingerprint=authority.authority_fingerprint,
+        encoder_id=encoder_id,
+        encoder_seed=int(encoder_seed),
+        encoder_spec_fingerprint=encoder_spec.fingerprint,
+        encoder_config=encoder_config,
+        encoder_parameter_count=parameter_count,
+        analysis_manifest_fingerprint=manifest_fingerprint,
+        encoder_fit_s=float(encoder_fit_s),
+        class_labels=class_labels,
+        y_encoded=y_encoded,
+        source_indices=split.source_train_indices,
+        evaluation_indices=split.evaluation_indices,
+        target_pool_indices=target_pool_indices,
+        source_embedding=source_embedding,
+        evaluation_embedding=evaluation_embedding,
+        target_pool_embedding=target_pool_embedding,
+        source_session=source_session,
+        source_embeddings_by_session=source_embeddings_by_session,
+    )
+
+
+def _validate_prepared(
+    prepared: PreparedFrozenEncoderCase,
+    authority: LongitudinalCaseAuthority,
+    spec: FrozenTransferMethodSpec,
+) -> None:
+    if prepared.authority_fingerprint != authority.authority_fingerprint:
+        raise ValueError("prepared encoder authority does not match requested case authority")
+    encoder_spec = TaskDecoderMethodSpec(
+        method_id=spec.encoder_id,
+        model_seed=spec.encoder_seed,
+        model_kwargs=spec.encoder_kwargs,
+    )
+    if prepared.encoder_spec_fingerprint != encoder_spec.fingerprint:
+        raise ValueError("prepared encoder spec does not match transfer method encoder spec")
 
 
 def _fit_logistic(
@@ -152,27 +328,22 @@ def _sourceweigher_result(
 ):
     try:
         from neuros_sourceweigher import RepresentationSourceWeigher
-    except ImportError as exc:  # pragma: no cover - optional package boundary
+    except ImportError as exc:  # pragma: no cover
         raise ImportError(
             "sourceweigher-mean requires neuros-sourceweigher. Install the local "
             "package or the matching published distribution."
         ) from exc
-
-    estimator = RepresentationSourceWeigher(statistics=("mean",))
-    return estimator.estimate(source_embeddings, target_embeddings)
+    return RepresentationSourceWeigher(statistics=("mean",)).estimate(
+        source_embeddings,
+        target_embeddings,
+    )
 
 
 def _source_sample_weights(
     source_sessions: np.ndarray,
     by_source: Mapping[str, float],
 ) -> np.ndarray:
-    """Redistribute fixed total source sample mass across source sessions.
-
-    Unweighted fitting gives every source example weight 1, for total source mass
-    ``N``. This helper preserves total mass ``N`` while making each source
-    session's aggregate mass equal ``N * source_weight``. No free target/source
-    mass hyperparameter is introduced.
-    """
+    """Redistribute fixed total source mass across source sessions."""
     sessions = np.asarray(source_sessions).astype(str)
     total = len(sessions)
     result = np.zeros(total, dtype=np.float64)
@@ -195,21 +366,10 @@ def run_frozen_transfer_case(
     *,
     spec: FrozenTransferMethodSpec,
     budgets_per_class: Sequence[int],
+    prepared: PreparedFrozenEncoderCase | None = None,
 ) -> FrozenTransferCaseResult:
-    """Run one frozen encoder across all calibration budgets.
-
-    ``frozen-logistic`` uses labels from source history plus the declared target
-    calibration examples.
-
-    ``sourceweigher-mean`` additionally estimates source-session weights from
-    source embeddings and the declared target calibration embeddings. Final
-    evaluation embeddings are never passed to SourceWeigher. At budget 0 this
-    target-dependent method emits an explicit unavailable row rather than using
-    the evaluation set as unlabeled target data.
-    """
+    """Run one transfer strategy on an exact frozen encoder representation."""
     split = authority.restore(data)
-    if authority.split_unit != "session":
-        raise ValueError("frozen longitudinal transfer currently requires session authority")
     budgets = tuple(sorted(set(int(value) for value in budgets_per_class)))
     if not budgets or budgets[0] < 0:
         raise ValueError("budgets_per_class must contain non-negative values")
@@ -219,70 +379,47 @@ def run_frozen_transfer_case(
             f"{split.max_budget_per_class}/class"
         )
 
-    X = np.asarray(data.X, dtype=np.float32)
-    if X.ndim != 3:
-        raise ValueError("frozen EEG transfer expects X=(sample, channel, time)")
-    y_encoded, class_labels = _encode_labels(np.asarray(data.y), split.source_train_indices)
-
-    encoder_spec = TaskDecoderMethodSpec(
-        method_id=spec.encoder_id,
-        model_seed=spec.encoder_seed,
-        model_kwargs=spec.encoder_kwargs,
+    state = prepared or prepare_frozen_encoder_case(
+        data,
+        authority,
+        encoder_id=spec.encoder_id,
+        encoder_seed=spec.encoder_seed,
+        encoder_kwargs=spec.encoder_kwargs,
     )
-    encoder = _model_for(
-        encoder_spec,
-        n_channels=int(X.shape[1]),
-        n_classes=len(class_labels),
-    )
-    encoder_config = _resolved_config(encoder)
-    parameter_count = _parameter_count(encoder)
-    manifest_fingerprint = encoder.analysis_manifest().fingerprint()
+    _validate_prepared(state, authority, spec)
 
-    started = time.perf_counter()
-    encoder.train(X[split.source_train_indices], y_encoded[split.source_train_indices])
-    encoder_fit_s = time.perf_counter() - started
-
-    source_embedding = encoder.encode(X[split.source_train_indices])
-    evaluation_embedding = encoder.encode(X[split.evaluation_indices])
-    target_pool_indices = np.sort(
-        np.concatenate(
-            [np.asarray(values, dtype=np.int64) for values in split.calibration_order_by_class.values()]
-        )
-    )
-    target_pool_embedding = encoder.encode(X[target_pool_indices])
     target_embedding_by_index = {
-        int(index): target_pool_embedding[position]
-        for position, index in enumerate(target_pool_indices.tolist())
+        int(index): state.target_pool_embedding[position]
+        for position, index in enumerate(state.target_pool_indices.tolist())
     }
-
-    source_session = np.asarray(data.groups["session"])[split.source_train_indices].astype(str)
-    source_embeddings_by_session = {
-        session: source_embedding[source_session == session]
-        for session in authority.source_group_values
-    }
-
     rows: list[dict[str, Any]] = []
     for budget in budgets:
         calibration_indices = split.calibration_indices(budget)
         calibration_embedding = (
             np.stack([target_embedding_by_index[int(index)] for index in calibration_indices])
             if len(calibration_indices)
-            else np.empty((0, source_embedding.shape[1]), dtype=source_embedding.dtype)
+            else np.empty((0, state.source_embedding.shape[1]), dtype=state.source_embedding.dtype)
         )
+
+        common_identity = {
+            "case_id": authority.case_id,
+            "authority_fingerprint": authority.authority_fingerprint,
+            "processed_data_sha256": authority.processed_data_sha256,
+            "partition_fingerprint": authority.partition_fingerprint,
+            "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+            "method_id": spec.method_id,
+            "transfer_strategy": spec.strategy,
+            "method_spec_fingerprint": spec.fingerprint,
+            "encoder_id": spec.encoder_id,
+            "encoder_seed": int(spec.encoder_seed),
+            "encoder_state_fingerprint": state.fingerprint,
+            "representation_sha256": state.representation_sha256,
+        }
 
         if spec.strategy == "sourceweigher-mean" and budget == 0:
             rows.append(
                 {
-                    "case_id": authority.case_id,
-                    "authority_fingerprint": authority.authority_fingerprint,
-                    "processed_data_sha256": authority.processed_data_sha256,
-                    "partition_fingerprint": authority.partition_fingerprint,
-                    "calibration_split_fingerprint": authority.calibration_split_fingerprint,
-                    "method_id": spec.method_id,
-                    "transfer_strategy": spec.strategy,
-                    "method_spec_fingerprint": spec.fingerprint,
-                    "encoder_id": spec.encoder_id,
-                    "encoder_seed": int(spec.encoder_seed),
+                    **common_identity,
                     "calibration_per_class": 0,
                     "status": "unavailable_no_target_observations",
                     "failure_reason": (
@@ -293,32 +430,32 @@ def run_frozen_transfer_case(
             )
             continue
 
-        train_embedding = source_embedding
-        train_labels = y_encoded[split.source_train_indices]
+        train_embedding = state.source_embedding
+        train_labels = state.y_encoded[state.source_indices]
         sample_weight: np.ndarray | None = None
         weighting_payload: dict[str, Any] | None = None
 
         if spec.strategy == "sourceweigher-mean":
             weighting = _sourceweigher_result(
-                source_embeddings=source_embeddings_by_session,
+                source_embeddings=state.source_embeddings_by_session,
                 target_embeddings=calibration_embedding,
             )
-            source_weights = _source_sample_weights(source_session, weighting.by_source())
+            source_weights = _source_sample_weights(state.source_session, weighting.by_source())
             weighting_payload = weighting.to_dict()
         else:
-            source_weights = np.ones(len(source_embedding), dtype=np.float64)
+            source_weights = np.ones(len(state.source_embedding), dtype=np.float64)
 
         if len(calibration_indices):
-            train_embedding = np.concatenate([source_embedding, calibration_embedding], axis=0)
-            train_labels = np.concatenate(
-                [train_labels, y_encoded[calibration_indices]], axis=0
+            train_embedding = np.concatenate(
+                [state.source_embedding, calibration_embedding], axis=0
             )
-            # Calibration labels retain ordinary per-example mass. SourceWeigher
-            # only redistributes the source-history mass across source sessions.
+            train_labels = np.concatenate(
+                [train_labels, state.y_encoded[calibration_indices]], axis=0
+            )
             sample_weight = np.concatenate(
                 [source_weights, np.ones(len(calibration_indices), dtype=np.float64)]
             )
-        elif spec.strategy == "sourceweigher-mean":  # guarded above; defensive
+        elif spec.strategy == "sourceweigher-mean":
             raise RuntimeError("SourceWeigher reached zero budget unexpectedly")
 
         started = time.perf_counter()
@@ -330,34 +467,25 @@ def run_frozen_transfer_case(
         )
         readout_fit_s = time.perf_counter() - started
         started = time.perf_counter()
-        probability = readout.predict_proba(evaluation_embedding)
+        probability = readout.predict_proba(state.evaluation_embedding)
         inference_s = time.perf_counter() - started
-        metrics = _score(y_encoded[split.evaluation_indices], probability)
+        metrics = _score(state.y_encoded[state.evaluation_indices], probability)
 
         rows.append(
             {
-                "case_id": authority.case_id,
-                "authority_fingerprint": authority.authority_fingerprint,
-                "processed_data_sha256": authority.processed_data_sha256,
-                "partition_fingerprint": authority.partition_fingerprint,
-                "calibration_split_fingerprint": authority.calibration_split_fingerprint,
-                "method_id": spec.method_id,
-                "transfer_strategy": spec.strategy,
-                "method_spec_fingerprint": spec.fingerprint,
-                "encoder_id": spec.encoder_id,
-                "encoder_seed": int(spec.encoder_seed),
+                **common_identity,
                 "calibration_per_class": int(budget),
                 "status": "ok",
                 "failure_reason": None,
-                "source_train_samples": int(len(split.source_train_indices)),
+                "source_train_samples": int(len(state.source_indices)),
                 "calibration_samples": int(len(calibration_indices)),
-                "evaluation_samples": int(len(split.evaluation_indices)),
-                "class_labels": list(class_labels),
+                "evaluation_samples": int(len(state.evaluation_indices)),
+                "class_labels": list(state.class_labels),
                 **metrics,
                 "readout_fit_s": float(readout_fit_s),
                 "inference_s": float(inference_s),
                 "inference_ms_per_trial": float(
-                    1000.0 * inference_s / max(len(split.evaluation_indices), 1)
+                    1000.0 * inference_s / max(len(state.evaluation_indices), 1)
                 ),
                 "sourceweigher": weighting_payload,
             }
@@ -366,9 +494,6 @@ def run_frozen_transfer_case(
     return FrozenTransferCaseResult(
         authority_fingerprint=authority.authority_fingerprint,
         method_spec=spec,
-        encoder_config=encoder_config,
-        encoder_parameter_count=parameter_count,
-        analysis_manifest_fingerprint=manifest_fingerprint,
-        encoder_fit_s=float(encoder_fit_s),
+        encoder_state_manifest=state.manifest(),
         rows=tuple(rows),
     )

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
@@ -2,8 +2,8 @@
 
 A frozen encoder is trained once on source history and materialized as a
 ``PreparedFrozenEncoderCase``. Multiple transfer strategies can then consume the
-exact same representation tensors, making SourceWeigher-vs-unweighted readout a
-clean comparison rather than two nominally identical encoder trainings.
+exact same learned state and representation tensors, making SourceWeigher-vs-
+unweighted readout a clean comparison.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from .longitudinal_authority import LongitudinalCaseAuthority
 from .longitudinal_methods import (
     TaskDecoderMethodSpec,
     _model_for,
+    _model_state_sha256,
     _parameter_count,
     _resolved_config,
     _score,
@@ -105,6 +106,7 @@ class PreparedFrozenEncoderCase:
     encoder_config: Mapping[str, Any]
     encoder_parameter_count: int
     analysis_manifest_fingerprint: str
+    model_state_sha256: str
     encoder_fit_s: float
     class_labels: tuple[str, ...]
     y_encoded: np.ndarray
@@ -116,9 +118,11 @@ class PreparedFrozenEncoderCase:
     target_pool_embedding: np.ndarray
     source_session: np.ndarray
     source_embeddings_by_session: Mapping[str, np.ndarray]
-    schema_version: int = 1
+    schema_version: int = 2
 
     def __post_init__(self) -> None:
+        if len(self.model_state_sha256) != 64:
+            raise ValueError("model_state_sha256 must be a SHA-256 hex digest")
         object.__setattr__(self, "encoder_config", MappingProxyType(dict(self.encoder_config)))
         object.__setattr__(self, "y_encoded", _readonly_array(self.y_encoded, dtype=np.int64))
         object.__setattr__(self, "source_indices", _readonly_array(self.source_indices, dtype=np.int64))
@@ -154,6 +158,7 @@ class PreparedFrozenEncoderCase:
             "encoder_seed": int(self.encoder_seed),
             "encoder_spec_fingerprint": self.encoder_spec_fingerprint,
             "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "model_state_sha256": self.model_state_sha256,
             "representation_sha256": self.representation_sha256,
         }
         raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
@@ -169,6 +174,7 @@ class PreparedFrozenEncoderCase:
             "encoder_config": dict(self.encoder_config),
             "encoder_parameter_count": int(self.encoder_parameter_count),
             "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "model_state_sha256": self.model_state_sha256,
             "encoder_fit_s": float(self.encoder_fit_s),
             "class_labels": list(self.class_labels),
             "source_samples": int(len(self.source_indices)),
@@ -185,7 +191,7 @@ class FrozenTransferCaseResult:
     method_spec: FrozenTransferMethodSpec
     encoder_state_manifest: Mapping[str, Any]
     rows: tuple[Mapping[str, Any], ...]
-    schema_version: int = 3
+    schema_version: int = 4
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -250,6 +256,7 @@ def prepare_frozen_encoder_case(
     started = time.perf_counter()
     encoder.train(X[split.source_train_indices], y_encoded[split.source_train_indices])
     encoder_fit_s = time.perf_counter() - started
+    model_state_sha256 = _model_state_sha256(encoder)
 
     source_embedding = encoder.encode(X[split.source_train_indices])
     evaluation_embedding = encoder.encode(X[split.evaluation_indices])
@@ -279,6 +286,7 @@ def prepare_frozen_encoder_case(
         encoder_config=encoder_config,
         encoder_parameter_count=parameter_count,
         analysis_manifest_fingerprint=manifest_fingerprint,
+        model_state_sha256=model_state_sha256,
         encoder_fit_s=float(encoder_fit_s),
         class_labels=class_labels,
         y_encoded=y_encoded,
@@ -418,6 +426,7 @@ def run_frozen_transfer_case(
             "method_spec_fingerprint": spec.fingerprint,
             "encoder_id": spec.encoder_id,
             "encoder_seed": int(spec.encoder_seed),
+            "model_state_sha256": state.model_state_sha256,
             "encoder_state_fingerprint": state.fingerprint,
             "representation_sha256": state.representation_sha256,
         }

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
@@ -258,7 +258,13 @@ def prepare_frozen_encoder_case(
             [np.asarray(values, dtype=np.int64) for values in split.calibration_order_by_class.values()]
         )
     )
-    target_pool_embedding = encoder.encode(X[target_pool_indices])
+    if len(target_pool_indices):
+        target_pool_embedding = encoder.encode(X[target_pool_indices])
+    else:
+        target_pool_embedding = np.empty(
+            (0, source_embedding.shape[1]),
+            dtype=source_embedding.dtype,
+        )
     source_session = np.asarray(data.groups["session"])[split.source_train_indices].astype(str)
     source_embeddings_by_session = {
         session: source_embedding[source_session == session]

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_transfer.py
@@ -1,0 +1,360 @@
+"""Frozen-representation transfer methods for longitudinal BCI evidence.
+
+The encoder is trained once on source history and then frozen. Target-session
+calibration can change only the low-capacity readout and, for SourceWeigher, the
+source-domain weights. This keeps representation adaptation distinct from
+end-to-end target fine-tuning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal, Mapping, Sequence
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+from .longitudinal_authority import LongitudinalCaseAuthority
+from .longitudinal_methods import (
+    TaskDecoderMethodSpec,
+    _model_for,
+    _parameter_count,
+    _resolved_config,
+    _score,
+)
+from .probes import representation_report
+from .real_world import GroupedEvaluationData
+
+FrozenTransferId = Literal["frozen-logistic", "sourceweigher-mean"]
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenTransferMethodSpec:
+    """Identity for a source-trained frozen encoder plus matched linear readout."""
+
+    method_id: FrozenTransferId
+    encoder_id: Literal["eegnet", "eeg-conformer"]
+    encoder_seed: int
+    encoder_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    readout_c: float = 1.0
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.method_id not in {"frozen-logistic", "sourceweigher-mean"}:
+            raise ValueError(f"unsupported frozen transfer method {self.method_id!r}")
+        if self.encoder_id not in {"eegnet", "eeg-conformer"}:
+            raise ValueError(f"unsupported encoder {self.encoder_id!r}")
+        if self.readout_c <= 0:
+            raise ValueError("readout_c must be positive")
+        forbidden = {"n_channels", "n_classes", "random_state"}.intersection(
+            self.encoder_kwargs
+        )
+        if forbidden:
+            raise ValueError(
+                "n_channels, n_classes and random_state are evidence-controlled; "
+                f"remove overrides {sorted(forbidden)}"
+            )
+        object.__setattr__(self, "encoder_kwargs", MappingProxyType(dict(self.encoder_kwargs)))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "method_id": self.method_id,
+            "encoder_id": self.encoder_id,
+            "encoder_seed": int(self.encoder_seed),
+            "encoder_kwargs": dict(self.encoder_kwargs),
+            "readout_c": float(self.readout_c),
+        }
+
+    @property
+    def fingerprint(self) -> str:
+        raw = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"), default=str)
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenTransferCaseResult:
+    authority_fingerprint: str
+    method_spec: FrozenTransferMethodSpec
+    encoder_config: Mapping[str, Any]
+    encoder_parameter_count: int
+    analysis_manifest_fingerprint: str
+    encoder_fit_s: float
+    rows: tuple[Mapping[str, Any], ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "encoder_config", MappingProxyType(dict(self.encoder_config)))
+        object.__setattr__(self, "rows", tuple(MappingProxyType(dict(row)) for row in self.rows))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "authority_fingerprint": self.authority_fingerprint,
+            "method_spec": self.method_spec.to_dict(),
+            "method_spec_fingerprint": self.method_spec.fingerprint,
+            "encoder_config": dict(self.encoder_config),
+            "encoder_parameter_count": int(self.encoder_parameter_count),
+            "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "encoder_fit_s": float(self.encoder_fit_s),
+            "rows": [dict(row) for row in self.rows],
+        }
+
+
+def _encode_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[np.ndarray, tuple[str, ...]]:
+    labels = tuple(sorted(np.unique(np.asarray(y)[source_indices].astype(str)).tolist()))
+    if len(labels) < 2:
+        raise ValueError("source history must contain at least two task classes")
+    mapping = {label: index for index, label in enumerate(labels)}
+    values = np.asarray(y).astype(str)
+    unknown = sorted(set(values.tolist()) - set(mapping))
+    if unknown:
+        raise ValueError(f"target contains class labels absent from source history: {unknown}")
+    return np.asarray([mapping[value] for value in values], dtype=np.int64), labels
+
+
+def _fit_logistic(
+    train_embeddings: np.ndarray,
+    train_labels: np.ndarray,
+    *,
+    c: float,
+    sample_weight: np.ndarray | None = None,
+) -> LogisticRegression:
+    model = LogisticRegression(
+        C=float(c),
+        penalty="l2",
+        solver="lbfgs",
+        max_iter=1000,
+        random_state=0,
+    )
+    model.fit(train_embeddings, train_labels, sample_weight=sample_weight)
+    return model
+
+
+def _sourceweigher_result(
+    *,
+    source_embeddings: Mapping[str, np.ndarray],
+    target_embeddings: np.ndarray,
+):
+    try:
+        from neuros_sourceweigher import RepresentationSourceWeigher
+    except ImportError as exc:  # pragma: no cover - optional package boundary
+        raise ImportError(
+            "sourceweigher-mean requires neuros-sourceweigher. Install the local "
+            "package or the matching published distribution."
+        ) from exc
+
+    estimator = RepresentationSourceWeigher(statistics=("mean",))
+    return estimator.estimate(source_embeddings, target_embeddings)
+
+
+def _source_sample_weights(
+    source_sessions: np.ndarray,
+    by_source: Mapping[str, float],
+) -> np.ndarray:
+    """Redistribute fixed total source sample mass across source sessions.
+
+    Unweighted fitting gives every source example weight 1, for total source mass
+    ``N``. This helper preserves total mass ``N`` while making each source
+    session's aggregate mass equal ``N * source_weight``. No free target/source
+    mass hyperparameter is introduced.
+    """
+    sessions = np.asarray(source_sessions).astype(str)
+    total = len(sessions)
+    result = np.zeros(total, dtype=np.float64)
+    for source_id, weight in by_source.items():
+        mask = sessions == str(source_id)
+        count = int(mask.sum())
+        if count <= 0:
+            raise ValueError(f"SourceWeigher returned unknown/empty source {source_id!r}")
+        result[mask] = float(weight) * total / count
+    if not np.isfinite(result).all() or np.any(result < 0):
+        raise ValueError("computed source sample weights are invalid")
+    if not np.isclose(result.sum(), float(total), rtol=1e-6, atol=1e-6):
+        raise ValueError("source sample weighting failed to preserve total source mass")
+    return result
+
+
+def run_frozen_transfer_case(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    *,
+    spec: FrozenTransferMethodSpec,
+    budgets_per_class: Sequence[int],
+) -> FrozenTransferCaseResult:
+    """Run one frozen encoder across all calibration budgets.
+
+    ``frozen-logistic`` uses labels from source history plus the declared target
+    calibration examples.
+
+    ``sourceweigher-mean`` additionally estimates source-session weights from
+    source embeddings and the declared target calibration embeddings. Final
+    evaluation embeddings are never passed to SourceWeigher. At budget 0 this
+    target-dependent method emits an explicit unavailable row rather than using
+    the evaluation set as unlabeled target data.
+    """
+    split = authority.restore(data)
+    if authority.split_unit != "session":
+        raise ValueError("frozen longitudinal transfer currently requires session authority")
+    budgets = tuple(sorted(set(int(value) for value in budgets_per_class)))
+    if not budgets or budgets[0] < 0:
+        raise ValueError("budgets_per_class must contain non-negative values")
+    if budgets[-1] > split.max_budget_per_class:
+        raise ValueError(
+            f"requested budget {budgets[-1]} exceeds authority maximum "
+            f"{split.max_budget_per_class}/class"
+        )
+
+    X = np.asarray(data.X, dtype=np.float32)
+    if X.ndim != 3:
+        raise ValueError("frozen EEG transfer expects X=(sample, channel, time)")
+    y_encoded, class_labels = _encode_labels(np.asarray(data.y), split.source_train_indices)
+
+    encoder_spec = TaskDecoderMethodSpec(
+        method_id=spec.encoder_id,
+        model_seed=spec.encoder_seed,
+        model_kwargs=spec.encoder_kwargs,
+    )
+    encoder = _model_for(
+        encoder_spec,
+        n_channels=int(X.shape[1]),
+        n_classes=len(class_labels),
+    )
+    encoder_config = _resolved_config(encoder)
+    parameter_count = _parameter_count(encoder)
+    manifest_fingerprint = encoder.analysis_manifest().fingerprint()
+
+    started = time.perf_counter()
+    encoder.train(X[split.source_train_indices], y_encoded[split.source_train_indices])
+    encoder_fit_s = time.perf_counter() - started
+
+    source_embedding = encoder.encode(X[split.source_train_indices])
+    evaluation_embedding = encoder.encode(X[split.evaluation_indices])
+    target_pool_indices = np.sort(
+        np.concatenate(
+            [np.asarray(values, dtype=np.int64) for values in split.calibration_order_by_class.values()]
+        )
+    )
+    target_pool_embedding = encoder.encode(X[target_pool_indices])
+    target_embedding_by_index = {
+        int(index): target_pool_embedding[position]
+        for position, index in enumerate(target_pool_indices.tolist())
+    }
+
+    source_session = np.asarray(data.groups["session"])[split.source_train_indices].astype(str)
+    source_embeddings_by_session = {
+        session: source_embedding[source_session == session]
+        for session in authority.source_group_values
+    }
+
+    rows: list[dict[str, Any]] = []
+    for budget in budgets:
+        calibration_indices = split.calibration_indices(budget)
+        calibration_embedding = (
+            np.stack([target_embedding_by_index[int(index)] for index in calibration_indices])
+            if len(calibration_indices)
+            else np.empty((0, source_embedding.shape[1]), dtype=source_embedding.dtype)
+        )
+
+        if spec.method_id == "sourceweigher-mean" and budget == 0:
+            rows.append(
+                {
+                    "case_id": authority.case_id,
+                    "authority_fingerprint": authority.authority_fingerprint,
+                    "processed_data_sha256": authority.processed_data_sha256,
+                    "method_id": spec.method_id,
+                    "method_spec_fingerprint": spec.fingerprint,
+                    "encoder_id": spec.encoder_id,
+                    "encoder_seed": int(spec.encoder_seed),
+                    "calibration_per_class": 0,
+                    "status": "unavailable_no_target_observations",
+                    "failure_reason": (
+                        "target-dependent SourceWeigher requires declared target calibration "
+                        "embeddings; final evaluation examples are forbidden"
+                    ),
+                }
+            )
+            continue
+
+        train_embedding = source_embedding
+        train_labels = y_encoded[split.source_train_indices]
+        sample_weight: np.ndarray | None = None
+        weighting_payload: dict[str, Any] | None = None
+
+        if spec.method_id == "sourceweigher-mean":
+            weighting = _sourceweigher_result(
+                source_embeddings=source_embeddings_by_session,
+                target_embeddings=calibration_embedding,
+            )
+            source_weights = _source_sample_weights(source_session, weighting.by_source())
+            weighting_payload = weighting.to_dict()
+        else:
+            source_weights = np.ones(len(source_embedding), dtype=np.float64)
+
+        if len(calibration_indices):
+            train_embedding = np.concatenate([source_embedding, calibration_embedding], axis=0)
+            train_labels = np.concatenate(
+                [train_labels, y_encoded[calibration_indices]], axis=0
+            )
+            # Calibration labels retain ordinary per-example mass. SourceWeigher
+            # only redistributes the source-history mass across source sessions.
+            sample_weight = np.concatenate(
+                [source_weights, np.ones(len(calibration_indices), dtype=np.float64)]
+            )
+        elif spec.method_id == "sourceweigher-mean":  # guarded above; defensive
+            raise RuntimeError("SourceWeigher reached zero budget unexpectedly")
+
+        started = time.perf_counter()
+        readout = _fit_logistic(
+            train_embedding,
+            train_labels,
+            c=spec.readout_c,
+            sample_weight=sample_weight,
+        )
+        readout_fit_s = time.perf_counter() - started
+        started = time.perf_counter()
+        probability = readout.predict_proba(evaluation_embedding)
+        inference_s = time.perf_counter() - started
+        metrics = _score(y_encoded[split.evaluation_indices], probability)
+
+        rows.append(
+            {
+                "case_id": authority.case_id,
+                "authority_fingerprint": authority.authority_fingerprint,
+                "processed_data_sha256": authority.processed_data_sha256,
+                "partition_fingerprint": authority.partition_fingerprint,
+                "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+                "method_id": spec.method_id,
+                "method_spec_fingerprint": spec.fingerprint,
+                "encoder_id": spec.encoder_id,
+                "encoder_seed": int(spec.encoder_seed),
+                "calibration_per_class": int(budget),
+                "status": "ok",
+                "failure_reason": None,
+                "source_train_samples": int(len(split.source_train_indices)),
+                "calibration_samples": int(len(calibration_indices)),
+                "evaluation_samples": int(len(split.evaluation_indices)),
+                "class_labels": list(class_labels),
+                **metrics,
+                "readout_fit_s": float(readout_fit_s),
+                "inference_s": float(inference_s),
+                "inference_ms_per_trial": float(
+                    1000.0 * inference_s / max(len(split.evaluation_indices), 1)
+                ),
+                "sourceweigher": weighting_payload,
+            }
+        )
+
+    return FrozenTransferCaseResult(
+        authority_fingerprint=authority.authority_fingerprint,
+        method_spec=spec,
+        encoder_config=encoder_config,
+        encoder_parameter_count=parameter_count,
+        analysis_manifest_fingerprint=manifest_fingerprint,
+        encoder_fit_s=float(encoder_fit_s),
+        rows=tuple(rows),
+    )

--- a/packages/neuros-foundation/src/neuros/foundation_models/moabb_longitudinal.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/moabb_longitudinal.py
@@ -1,0 +1,133 @@
+"""Dataset-specific MOABB semantics for longitudinal neurOS evidence studies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass(frozen=True, slots=True)
+class MOABBLongitudinalDatasetSpec:
+    key: str
+    class_name: str
+    source_id: str
+    description: str
+    paradigm: Literal["left_right", "motor_imagery"]
+    events: tuple[str, ...] | None = None
+    expected_session_order: tuple[str, ...] | None = None
+
+    def case_metadata(self, subject: int) -> dict[str, Any]:
+        metadata: dict[str, Any] = {"subject": int(subject)}
+        if self.key == "kumar2024":
+            if not 1 <= int(subject) <= 18:
+                raise ValueError("Kumar2024 subject must lie in 1..18")
+            metadata["original_protocol"] = "GR" if int(subject) <= 9 else "PAR"
+        return metadata
+
+
+MOABB_LONGITUDINAL_DATASETS: dict[str, MOABBLongitudinalDatasetSpec] = {
+    "kumar2024": MOABBLongitudinalDatasetSpec(
+        key="kumar2024",
+        class_name="Kumar2024",
+        source_id="moabb-kumar2024",
+        description="18 participants x 6 separate-day MI sessions",
+        paradigm="left_right",
+        expected_session_order=("0", "1", "2", "3", "4", "5"),
+    ),
+    "ma2020": MOABBLongitudinalDatasetSpec(
+        key="ma2020",
+        class_name="Ma2020",
+        source_id="moabb-ma2020",
+        description="25 participants x 15 right-hand/right-elbow MI sessions",
+        paradigm="motor_imagery",
+        events=("right_hand", "right_elbow"),
+    ),
+    "lee2019-mi": MOABBLongitudinalDatasetSpec(
+        key="lee2019-mi",
+        class_name="Lee2019_MI",
+        source_id="moabb-lee2019-family",
+        description="OpenBMI MI member of the shared 54-person cohort",
+        paradigm="left_right",
+    ),
+    "wang2026": MOABBLongitudinalDatasetSpec(
+        key="wang2026",
+        class_name="Wang2026",
+        source_id="moabb-wang2026",
+        description="39 participants x 5 sessions with online cursor-control study",
+        paradigm="left_right",
+    ),
+}
+
+
+def get_moabb_longitudinal_spec(key: str) -> MOABBLongitudinalDatasetSpec:
+    try:
+        return MOABB_LONGITUDINAL_DATASETS[key]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown longitudinal MOABB dataset {key!r}; "
+            f"available={sorted(MOABB_LONGITUDINAL_DATASETS)}"
+        ) from exc
+
+
+def build_moabb_longitudinal_dataset(
+    key: str,
+    *,
+    fmin: float = 8.0,
+    fmax: float = 30.0,
+    resample: float | None = None,
+):
+    """Instantiate the declared upstream dataset and paradigm.
+
+    The function fails closed when the installed MOABB version does not expose a
+    declared dataset or considers the dataset/paradigm combination invalid.
+    """
+    try:
+        import moabb.datasets as datasets
+        from moabb.paradigms import LeftRightImagery, MotorImagery
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "MOABB longitudinal data requires `neuros-foundation[evidence]`."
+        ) from exc
+
+    spec = get_moabb_longitudinal_spec(key)
+    dataset_cls = getattr(datasets, spec.class_name, None)
+    if dataset_cls is None:
+        raise RuntimeError(
+            f"installed MOABB does not expose {spec.class_name}; choose another "
+            "dataset or pin an upstream version that contains it"
+        )
+    dataset = dataset_cls()
+    if spec.paradigm == "left_right":
+        paradigm = LeftRightImagery(
+            fmin=float(fmin),
+            fmax=float(fmax),
+            resample=resample,
+        )
+    else:
+        assert spec.events is not None
+        paradigm = MotorImagery(
+            n_classes=len(spec.events),
+            events=list(spec.events),
+            fmin=float(fmin),
+            fmax=float(fmax),
+            resample=resample,
+        )
+    if not paradigm.is_valid(dataset):
+        raise RuntimeError(
+            f"MOABB rejected {spec.class_name} for declared paradigm {spec.paradigm}"
+        )
+    return spec, dataset, paradigm
+
+
+def validate_observed_sessions(
+    spec: MOABBLongitudinalDatasetSpec,
+    observed: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Apply dataset-specific chronology checks when upstream semantics are pinned."""
+    observed = tuple(str(value) for value in observed)
+    if spec.expected_session_order is not None and observed != spec.expected_session_order:
+        raise ValueError(
+            f"{spec.key} session order differs from pinned upstream chronology; "
+            f"expected={spec.expected_session_order}, observed={observed}"
+        )
+    return observed

--- a/packages/neuros-foundation/tests/test_longitudinal_authority.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_authority.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.longitudinal import (
+    chronological_partition,
+    make_nested_calibration_split,
+)
+from neuros.foundation_models.longitudinal_authority import (
+    LongitudinalCaseAuthority,
+    processed_data_sha256,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(123)
+    X = []
+    y = []
+    metadata = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left", "right")):
+            for trial in range(8):
+                signal = rng.normal(size=(4, 32))
+                signal[label_index, 8:24] += 0.1 * session_index + (1 if label_index else -1)
+                X.append(signal)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"r-{trial // 4}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X, dtype=np.float32), np.asarray(y), metadata),
+        dataset_id="fixture",
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+        order=("0", "1", "2"),
+    )
+    split = make_nested_calibration_split(
+        partition,
+        evaluation_fraction=0.5,
+        seed=2026,
+    )
+    return LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="subject-1/session-2",
+        history_policy="prior",
+        observed_group_order=("0", "1", "2"),
+        case_metadata={"subject": 1, "original_protocol": "GR"},
+    )
+
+
+def test_processed_fingerprint_is_stable_and_value_sensitive():
+    data = _fixture()
+    first = processed_data_sha256(data)
+    second = processed_data_sha256(data)
+    assert first == second
+    assert len(first) == 64
+
+    changed_x = data.X.copy()
+    changed_x[0, 0, 0] += 1e-3
+    changed = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=changed_x,
+        y=data.y,
+        groups=data.groups,
+        metadata=data.metadata,
+    )
+    assert processed_data_sha256(changed) != first
+
+
+def test_authority_roundtrip_restores_exact_split():
+    data = _fixture()
+    authority = _authority(data)
+    serialized = authority.to_dict()
+    json.dumps(serialized, sort_keys=True)
+
+    restored_authority = LongitudinalCaseAuthority.from_dict(serialized)
+    split = restored_authority.restore(data)
+
+    assert restored_authority.authority_fingerprint == authority.authority_fingerprint
+    assert split.partition.fingerprint == authority.partition_fingerprint
+    assert split.fingerprint == authority.calibration_split_fingerprint
+    assert tuple(split.source_train_indices) == authority.source_train_indices
+    assert tuple(split.evaluation_indices) == authority.evaluation_indices
+    assert restored_authority.case_metadata["original_protocol"] == "GR"
+
+
+def test_authority_rejects_changed_processed_neural_values():
+    data = _fixture()
+    authority = _authority(data)
+    changed_x = data.X.copy()
+    changed_x[-1, -1, -1] += 0.25
+    changed = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=changed_x,
+        y=data.y,
+        groups=data.groups,
+        metadata=data.metadata,
+    )
+    with pytest.raises(ValueError, match="SHA-256"):
+        authority.restore(changed)
+
+
+def test_authority_rejects_sample_order_change_even_when_shape_matches():
+    data = _fixture()
+    authority = _authority(data)
+    order = np.arange(len(data.X))
+    order[[0, 1]] = order[[1, 0]]
+    reordered = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=data.X[order],
+        y=data.y[order],
+        groups={key: np.asarray(values)[order] for key, values in data.groups.items()},
+        metadata=tuple(data.metadata[index] for index in order),
+    )
+    with pytest.raises(ValueError, match="SHA-256"):
+        authority.restore(reordered)
+
+
+def test_serialized_authority_fingerprint_detects_index_tampering():
+    authority = _authority(_fixture())
+    payload = copy.deepcopy(authority.to_dict())
+    payload["evaluation_indices"][0] += 1
+    with pytest.raises(ValueError, match="authority_fingerprint"):
+        LongitudinalCaseAuthority.from_dict(payload)
+
+
+def test_prior_authority_rejects_future_session_in_source_history():
+    data = _fixture()
+    authority = _authority(data)
+    payload = authority.to_dict(include_fingerprint=False)
+
+    # Make a structurally self-consistent but scientifically invalid authority:
+    # target session 1 with source sessions 0 and 2 (future leakage). Recompute
+    # the serial authority fingerprint by constructing it normally, then restore
+    # must reject the non-prefix source-group semantics.
+    group = np.asarray(data.groups["session"])
+    payload["held_out_values"] = ["1"]
+    payload["source_group_values"] = ["0", "2"]
+    payload["source_train_indices"] = np.flatnonzero(np.isin(group, ["0", "2"])).tolist()
+    target = np.flatnonzero(group == "1")
+    payload["evaluation_indices"] = target[:8].tolist()
+    payload["calibration_order_by_class"] = {
+        "left": target[8:12].tolist(),
+        "right": target[12:16].tolist(),
+    }
+
+    # Partition/split fingerprints intentionally no longer match; restore should
+    # fail closed before such an authority can be used by a method runner.
+    invalid = LongitudinalCaseAuthority.from_dict(payload)
+    with pytest.raises(ValueError):
+        invalid.restore(data)

--- a/packages/neuros-foundation/tests/test_longitudinal_methods.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_methods.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    LongitudinalCaseAuthority,
+    TaskDecoderMethodSpec,
+    chronological_partition,
+    make_nested_calibration_split,
+    run_task_decoder_case,
+)
+
+pytest.importorskip("torch")
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(321)
+    X = []
+    y = []
+    metadata = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left", "right")):
+            for trial in range(8):
+                x = rng.normal(scale=0.5, size=(4, 128)).astype(np.float32)
+                # Deliberately simple discriminative temporal pattern.
+                sign = -1.0 if label_index == 0 else 1.0
+                x[label_index, 24:88] += sign * (1.2 + 0.05 * session_index)
+                X.append(x)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"r-{trial // 4}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="fixture",
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+        order=("0", "1", "2"),
+    )
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=2026)
+    return LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="subject-1/session-2",
+        history_policy="prior",
+        observed_group_order=("0", "1", "2"),
+        case_metadata={"subject": 1, "original_protocol": "GR"},
+    )
+
+
+def test_eegnet_runs_two_budgets_against_same_authority():
+    data = _fixture()
+    authority = _authority(data)
+    spec = TaskDecoderMethodSpec(
+        method_id="eegnet",
+        model_seed=101,
+        model_kwargs={
+            "n_epochs": 1,
+            "batch_size": 16,
+            "device": "cpu",
+            "temporal_filters": 4,
+            "depth_multiplier": 1,
+            "separable_filters": 8,
+            "temporal_kernel": 15,
+            "separable_kernel": 7,
+        },
+    )
+    result = run_task_decoder_case(
+        data,
+        authority,
+        spec=spec,
+        budgets_per_class=(0, 1),
+    )
+
+    assert result.authority_fingerprint == authority.authority_fingerprint
+    assert result.parameter_count > 0
+    assert result.resolved_model_config["n_epochs"] == 1
+    assert result.resolved_model_config["device_spec"] == "cpu"
+    assert len(result.rows) == 2
+    assert {row["calibration_per_class"] for row in result.rows} == {0, 1}
+    assert {row["authority_fingerprint"] for row in result.rows} == {
+        authority.authority_fingerprint
+    }
+    assert {row["calibration_split_fingerprint"] for row in result.rows} == {
+        authority.calibration_split_fingerprint
+    }
+    for row in result.rows:
+        assert 0.0 <= row["accuracy"] <= 1.0
+        assert 0.0 <= row["balanced_accuracy"] <= 1.0
+        assert row["roc_auc"] is None or 0.0 <= row["roc_auc"] <= 1.0
+        assert 0.0 <= row["brier_score"] <= 2.0
+        assert 0.0 <= row["expected_calibration_error"] <= 1.0
+        assert row["evaluation_representation"]["finite"] is True
+        assert row["source_representation"]["finite"] is True
+
+    json.dumps(result.to_dict(), sort_keys=True)
+
+
+def test_compact_conformer_runs_under_same_contract():
+    data = _fixture()
+    authority = _authority(data)
+    spec = TaskDecoderMethodSpec(
+        method_id="eeg-conformer",
+        model_seed=503,
+        model_kwargs={
+            "n_epochs": 1,
+            "batch_size": 16,
+            "device": "cpu",
+            "embedding_dim": 8,
+            "temporal_kernel": 9,
+            "pool_length": 8,
+            "pool_stride": 4,
+            "n_heads": 2,
+            "n_layers": 1,
+            "feedforward_multiplier": 2,
+            "dropout": 0.1,
+        },
+    )
+    result = run_task_decoder_case(
+        data,
+        authority,
+        spec=spec,
+        budgets_per_class=(0,),
+    )
+
+    assert result.parameter_count > 0
+    assert result.resolved_model_config["embedding_dim"] == 8
+    assert result.resolved_model_config["n_layers"] == 1
+    assert result.rows[0]["evaluation_representation"]["n_features"] == 8
+
+
+def test_method_spec_forbids_overriding_evidence_controlled_fields():
+    for key in ("n_channels", "n_classes", "random_state"):
+        with pytest.raises(ValueError, match="controlled"):
+            TaskDecoderMethodSpec(
+                method_id="eegnet",
+                model_seed=1,
+                model_kwargs={key: 123},
+            )
+
+
+def test_method_runner_rejects_budget_beyond_authority():
+    data = _fixture()
+    authority = _authority(data)
+    split = authority.restore(data)
+    spec = TaskDecoderMethodSpec(
+        method_id="eegnet",
+        model_seed=1,
+        model_kwargs={"n_epochs": 1, "device": "cpu"},
+    )
+    with pytest.raises(ValueError, match="exceeds authority maximum"):
+        run_task_decoder_case(
+            data,
+            authority,
+            spec=spec,
+            budgets_per_class=(split.max_budget_per_class + 1,),
+        )
+
+
+def test_method_runner_validates_processed_data_before_training():
+    data = _fixture()
+    authority = _authority(data)
+    changed_x = data.X.copy()
+    changed_x[0, 0, 0] += 0.5
+    changed = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=changed_x,
+        y=data.y,
+        groups=data.groups,
+        metadata=data.metadata,
+    )
+    spec = TaskDecoderMethodSpec(
+        method_id="eegnet",
+        model_seed=1,
+        model_kwargs={"n_epochs": 1, "device": "cpu"},
+    )
+    with pytest.raises(ValueError, match="SHA-256"):
+        run_task_decoder_case(
+            changed,
+            authority,
+            spec=spec,
+            budgets_per_class=(0,),
+        )

--- a/packages/neuros-foundation/tests/test_longitudinal_model_identity.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_model_identity.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    LadderRuntimeConfig,
+    LongitudinalCaseAuthority,
+    chronological_partition,
+    make_nested_calibration_split,
+    run_ladder_method,
+)
+
+pytest.importorskip("torch")
+pytest.importorskip("neuros_sourceweigher")
+
+
+def _case():
+    rng = np.random.default_rng(808)
+    X = []
+    y = []
+    metadata = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left", "right")):
+            for trial in range(6):
+                signal = rng.normal(scale=0.4, size=(4, 96)).astype(np.float32)
+                signal[label_index, 18:72] += (-1.0 if label_index == 0 else 1.0) * (
+                    1.0 + 0.05 * session_index
+                )
+                X.append(signal)
+                y.append(label)
+                metadata.append(
+                    {"subject": "1", "session": session, "run": f"r-{trial // 3}"}
+                )
+    data = GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata), dataset_id="identity-fixture"
+    )
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+        order=("0", "1", "2"),
+    )
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=22)
+    authority = LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="identity/subject-1/session-2",
+        history_policy="prior",
+        observed_group_order=("0", "1", "2"),
+    )
+    return data, authority
+
+
+def test_task_decoder_rows_hash_actual_learned_state():
+    data, authority = _case()
+    result = run_ladder_method(
+        data,
+        authority,
+        method="eegnet",
+        budgets_per_class=(0, 1),
+        model_seed=17,
+        config=LadderRuntimeConfig(epochs=1, batch_size=8, device="cpu"),
+    )
+    hashes = [row["model_state_sha256"] for row in result.rows]
+    assert len(hashes) == 2
+    assert all(len(value) == 64 for value in hashes)
+    assert all(set(value) <= set("0123456789abcdef") for value in hashes)
+
+
+def test_weighted_and_unweighted_frozen_lanes_share_learned_state_and_embeddings():
+    data, authority = _case()
+    cache = {}
+    config = LadderRuntimeConfig(epochs=1, batch_size=8, device="cpu")
+    frozen = run_ladder_method(
+        data,
+        authority,
+        method="frozen-eegnet",
+        budgets_per_class=(0, 1),
+        model_seed=17,
+        config=config,
+        prepared_cache=cache,
+    )
+    weighted = run_ladder_method(
+        data,
+        authority,
+        method="sourceweigher-eegnet",
+        budgets_per_class=(0, 1),
+        model_seed=17,
+        config=config,
+        prepared_cache=cache,
+    )
+
+    frozen_state = frozen.encoder_state_manifest
+    weighted_state = weighted.encoder_state_manifest
+    assert len(frozen_state["model_state_sha256"]) == 64
+    assert frozen_state["model_state_sha256"] == weighted_state["model_state_sha256"]
+    assert frozen_state["representation_sha256"] == weighted_state["representation_sha256"]
+    assert frozen_state["encoder_state_fingerprint"] == weighted_state["encoder_state_fingerprint"]
+    assert {row["model_state_sha256"] for row in frozen.rows} == {
+        frozen_state["model_state_sha256"]
+    }
+    assert {row["model_state_sha256"] for row in weighted.rows} == {
+        frozen_state["model_state_sha256"]
+    }

--- a/packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import GroupedEvaluationData
+
+pytest.importorskip("torch")
+pytest.importorskip("neuros_sourceweigher")
+pytest.importorskip("mne")
+
+
+def _load_runner():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts" / "evidence" / "run_moabb_model_ladder.py"
+    spec = importlib.util.spec_from_file_location("neuros_model_ladder_runner", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(1717)
+    X = []
+    y = []
+    metadata = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left_hand", "right_hand")):
+            for trial in range(8):
+                signal = rng.normal(scale=0.35, size=(4, 128)).astype(np.float32)
+                direction = -1.0 if label_index == 0 else 1.0
+                signal[label_index, 18:94] += direction * (1.2 + 0.05 * session_index)
+                signal[3] += 0.04 * session_index
+                X.append(signal)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"r-{trial // 4}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="moabb-kumar2024",
+    )
+
+
+def test_complete_model_ladder_writes_one_authoritative_bundle(tmp_path, monkeypatch):
+    runner = _load_runner()
+    data = _fixture()
+
+    fake_spec = SimpleNamespace(
+        key="kumar2024",
+        class_name="Kumar2024",
+        source_id="moabb-kumar2024",
+        case_metadata=lambda subject: {
+            "subject": int(subject),
+            "original_protocol": "GR" if int(subject) <= 9 else "PAR",
+        },
+    )
+    monkeypatch.setattr(
+        runner,
+        "build_moabb_longitudinal_dataset",
+        lambda *args, **kwargs: (fake_spec, object(), object()),
+    )
+    monkeypatch.setattr(runner, "collect_moabb", lambda *args, **kwargs: data)
+    monkeypatch.setattr(
+        runner,
+        "validate_observed_sessions",
+        lambda _spec, observed: tuple(observed),
+    )
+
+    output = tmp_path / "ladder"
+    methods = (
+        "csp-lda,eegnet,eeg-conformer,frozen-eegnet,frozen-eeg-conformer,"
+        "sourceweigher-eegnet,sourceweigher-eeg-conformer"
+    )
+    code = runner.main(
+        [
+            "--dataset",
+            "kumar2024",
+            "--subjects",
+            "1",
+            "--held-out-sessions",
+            "2",
+            "--methods",
+            methods,
+            "--model-seeds",
+            "101",
+            "--budgets",
+            "0,1,2",
+            "--history-policy",
+            "prior",
+            "--epochs",
+            "1",
+            "--batch-size",
+            "16",
+            "--device",
+            "cpu",
+            "--csp-components",
+            "2",
+            "--output",
+            str(output),
+        ]
+    )
+    assert code == 0
+
+    manifest = json.loads((output / "study_manifest.json").read_text())
+    authority = json.loads((output / "split_authority.json").read_text())
+    method_runs = json.loads((output / "method_runs.json").read_text())
+    summary = json.loads((output / "summary.json").read_text())
+    hashes = json.loads((output / "artifact_hashes.json").read_text())
+    report = (output / "report.md").read_text()
+    with (output / "results.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    expected_methods = {
+        "csp-lda",
+        "eegnet",
+        "eeg-conformer",
+        "frozen-eegnet",
+        "frozen-eeg-conformer",
+        "sourceweigher-eegnet",
+        "sourceweigher-eeg-conformer",
+    }
+    assert set(manifest["methods"]) == expected_methods
+    assert manifest["history_policy"] == "prior"
+    assert manifest["subjects"] == [1]
+    assert len(authority["cases"]) == 1
+    case = authority["cases"][0]
+    assert case["source_group_values"] == ["0", "1"]
+    assert case["held_out_values"] == ["2"]
+    assert len(case["processed_data_sha256"]) == 64
+
+    assert len(method_runs["runs"]) == 7
+    assert {item["requested_method_id"] for item in method_runs["runs"]} == expected_methods
+    assert all(item["status"] == "ok" for item in method_runs["runs"])
+
+    assert {row["method_id"] for row in rows} == expected_methods
+    assert {row["original_protocol"] for row in rows} == {"GR"}
+    assert {row["held_out_session"] for row in rows} == {"2"}
+    assert {row["authority_fingerprint"] for row in rows} == {
+        case["authority_fingerprint"]
+    }
+    assert {row["partition_fingerprint"] for row in rows} == {
+        case["partition_fingerprint"]
+    }
+    assert {row["calibration_split_fingerprint"] for row in rows} == {
+        case["calibration_split_fingerprint"]
+    }
+
+    unavailable = [
+        row for row in rows if row["status"] == "unavailable_no_target_observations"
+    ]
+    assert {row["method_id"] for row in unavailable} == {
+        "sourceweigher-eegnet",
+        "sourceweigher-eeg-conformer",
+    }
+    assert {row["calibration_per_class"] for row in unavailable} == {"0"}
+
+    ok_rows = [row for row in rows if row["status"] == "ok"]
+    assert all(0.0 <= float(row["balanced_accuracy"]) <= 1.0 for row in ok_rows)
+    assert summary["failed_rows"] == 0
+    assert summary["unexpected_unavailable_rows"] == 0
+    assert summary["promotion_ready_descriptive"] is True
+    assert {row["original_protocol"] for row in summary["cohort_budget_summary"]} == {"GR"}
+    assert {row["held_out_session"] for row in summary["target_session_budget_summary"]} == {"2"}
+
+    full_auc_methods = {row["method_id"] for row in summary["complete_frontier_auc"]}
+    assert "sourceweigher-eegnet" not in full_auc_methods
+    assert "sourceweigher-eeg-conformer" not in full_auc_methods
+    positive_auc_methods = {
+        row["method_id"] for row in summary["positive_budget_adaptation_auc"]
+    }
+    assert expected_methods <= positive_auc_methods
+
+    paired = {row["method_id"]: row for row in summary["paired_case_set_audit"]}
+    assert set(paired) == expected_methods
+    assert all(row["paired_across_supported_budgets"] for row in paired.values())
+    assert paired["sourceweigher-eegnet"]["supported_budgets"] == [1, 2]
+
+    assert "Descriptive promotion gate: **PASS**" in report
+    assert "Positive-budget adaptation AUC" in report
+    assert "do not receive a fabricated full-frontier AUC" in report
+
+    assert set(hashes["sha256"]) == {
+        "study_manifest.json",
+        "split_authority.json",
+        "method_runs.json",
+        "results.csv",
+        "summary.json",
+        "report.md",
+    }
+    for digest in hashes["sha256"].values():
+        assert len(digest) == 64

--- a/packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_model_ladder.py
@@ -143,6 +143,19 @@ def test_complete_model_ladder_writes_one_authoritative_bundle(tmp_path, monkeyp
     assert len(method_runs["runs"]) == 7
     assert {item["requested_method_id"] for item in method_runs["runs"]} == expected_methods
     assert all(item["status"] == "ok" for item in method_runs["runs"])
+    run_by_method = {
+        item["requested_method_id"]: item["result"]
+        for item in method_runs["runs"]
+    }
+    for frozen_id, weighted_id in (
+        ("frozen-eegnet", "sourceweigher-eegnet"),
+        ("frozen-eeg-conformer", "sourceweigher-eeg-conformer"),
+    ):
+        frozen_state = run_by_method[frozen_id]["encoder_state"]
+        weighted_state = run_by_method[weighted_id]["encoder_state"]
+        assert frozen_state["encoder_state_fingerprint"] == weighted_state["encoder_state_fingerprint"]
+        assert frozen_state["representation_sha256"] == weighted_state["representation_sha256"]
+        assert len(frozen_state["representation_sha256"]) == 64
 
     assert {row["method_id"] for row in rows} == expected_methods
     assert {row["original_protocol"] for row in rows} == {"GR"}

--- a/packages/neuros-foundation/tests/test_longitudinal_transfer.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_transfer.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    LongitudinalCaseAuthority,
+    chronological_partition,
+    make_nested_calibration_split,
+)
+from neuros.foundation_models.longitudinal_transfer import (
+    FrozenTransferMethodSpec,
+    run_frozen_transfer_case,
+)
+
+pytest.importorskip("torch")
+pytest.importorskip("neuros_sourceweigher")
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(909)
+    X = []
+    y = []
+    metadata = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left", "right")):
+            for trial in range(8):
+                x = rng.normal(scale=0.45, size=(4, 128)).astype(np.float32)
+                sign = -1.0 if label_index == 0 else 1.0
+                x[label_index, 20:92] += sign * (1.0 + 0.07 * session_index)
+                # Session-specific nuisance shift gives SourceWeigher something
+                # nontrivial to summarize in representation space.
+                x[3] += 0.03 * session_index
+                X.append(x)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"r-{trial // 4}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="fixture",
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+        order=("0", "1", "2"),
+    )
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=2026)
+    return LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="subject-1/session-2",
+        history_policy="prior",
+        observed_group_order=("0", "1", "2"),
+    )
+
+
+def _encoder_kwargs():
+    return {
+        "n_epochs": 1,
+        "batch_size": 16,
+        "device": "cpu",
+        "temporal_filters": 4,
+        "depth_multiplier": 1,
+        "separable_filters": 8,
+        "temporal_kernel": 15,
+        "separable_kernel": 7,
+    }
+
+
+def test_frozen_logistic_reuses_one_source_trained_encoder_across_budgets():
+    data = _fixture()
+    authority = _authority(data)
+    spec = FrozenTransferMethodSpec(
+        method_id="frozen-logistic",
+        encoder_id="eegnet",
+        encoder_seed=101,
+        encoder_kwargs=_encoder_kwargs(),
+        readout_c=1.0,
+    )
+    result = run_frozen_transfer_case(
+        data,
+        authority,
+        spec=spec,
+        budgets_per_class=(0, 1, 2),
+    )
+
+    assert result.authority_fingerprint == authority.authority_fingerprint
+    assert result.encoder_parameter_count > 0
+    assert result.encoder_fit_s >= 0.0
+    assert len(result.rows) == 3
+    assert {row["status"] for row in result.rows} == {"ok"}
+    assert [row["calibration_per_class"] for row in result.rows] == [0, 1, 2]
+    assert all(row["sourceweigher"] is None for row in result.rows)
+    for row in result.rows:
+        assert row["authority_fingerprint"] == authority.authority_fingerprint
+        assert 0.0 <= row["balanced_accuracy"] <= 1.0
+        assert 0.0 <= row["brier_score"] <= 2.0
+    json.dumps(result.to_dict(), sort_keys=True)
+
+
+def test_sourceweigher_uses_only_declared_target_calibration_embeddings(monkeypatch):
+    import neuros.foundation_models.longitudinal_transfer as transfer
+
+    data = _fixture()
+    authority = _authority(data)
+    observed_target_sizes = []
+    real = transfer._sourceweigher_result
+
+    def wrapped(*, source_embeddings, target_embeddings):
+        observed_target_sizes.append(len(target_embeddings))
+        return real(
+            source_embeddings=source_embeddings,
+            target_embeddings=target_embeddings,
+        )
+
+    monkeypatch.setattr(transfer, "_sourceweigher_result", wrapped)
+    spec = FrozenTransferMethodSpec(
+        method_id="sourceweigher-mean",
+        encoder_id="eegnet",
+        encoder_seed=101,
+        encoder_kwargs=_encoder_kwargs(),
+    )
+    result = run_frozen_transfer_case(
+        data,
+        authority,
+        spec=spec,
+        budgets_per_class=(0, 1, 2),
+    )
+
+    assert observed_target_sizes == [2, 4]  # 1/class then 2/class; never evaluation set
+    zero, one, two = result.rows
+    assert zero["status"] == "unavailable_no_target_observations"
+    assert "evaluation examples are forbidden" in zero["failure_reason"]
+
+    for row in (one, two):
+        assert row["status"] == "ok"
+        payload = row["sourceweigher"]
+        assert payload is not None
+        assert payload["source_ids"] == ["0", "1"]
+        assert np.isclose(sum(payload["weights"]), 1.0)
+        diagnostics = payload["diagnostics"]
+        assert diagnostics["effective_sample_size"] >= 1.0
+        assert diagnostics["entropy"] >= 0.0
+        assert diagnostics["max_weight"] <= 1.0 + 1e-9
+        assert diagnostics["iterations"] >= 1
+
+
+def test_sourceweigher_rejects_zero_only_run_without_using_eval_data():
+    data = _fixture()
+    authority = _authority(data)
+    spec = FrozenTransferMethodSpec(
+        method_id="sourceweigher-mean",
+        encoder_id="eegnet",
+        encoder_seed=101,
+        encoder_kwargs=_encoder_kwargs(),
+    )
+    result = run_frozen_transfer_case(
+        data,
+        authority,
+        spec=spec,
+        budgets_per_class=(0,),
+    )
+    assert result.rows[0]["status"] == "unavailable_no_target_observations"
+
+
+def test_frozen_transfer_validates_authority_before_encoder_training():
+    data = _fixture()
+    authority = _authority(data)
+    changed_x = data.X.copy()
+    changed_x[0, 0, 0] += 0.2
+    changed = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=changed_x,
+        y=data.y,
+        groups=data.groups,
+        metadata=data.metadata,
+    )
+    spec = FrozenTransferMethodSpec(
+        method_id="frozen-logistic",
+        encoder_id="eegnet",
+        encoder_seed=101,
+        encoder_kwargs=_encoder_kwargs(),
+    )
+    with pytest.raises(ValueError, match="SHA-256"):
+        run_frozen_transfer_case(
+            changed,
+            authority,
+            spec=spec,
+            budgets_per_class=(0,),
+        )

--- a/packages/neuros-foundation/tests/test_longitudinal_transfer.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_transfer.py
@@ -13,6 +13,7 @@ from neuros.foundation_models import (
 )
 from neuros.foundation_models.longitudinal_transfer import (
     FrozenTransferMethodSpec,
+    prepare_frozen_encoder_case,
     run_frozen_transfer_case,
 )
 
@@ -76,9 +77,20 @@ def _encoder_kwargs():
     }
 
 
+def _prepared(data, authority):
+    return prepare_frozen_encoder_case(
+        data,
+        authority,
+        encoder_id="eegnet",
+        encoder_seed=101,
+        encoder_kwargs=_encoder_kwargs(),
+    )
+
+
 def test_frozen_logistic_reuses_one_source_trained_encoder_across_budgets():
     data = _fixture()
     authority = _authority(data)
+    prepared = _prepared(data, authority)
     spec = FrozenTransferMethodSpec(
         method_id="frozen-eegnet",
         strategy="frozen-logistic",
@@ -92,22 +104,100 @@ def test_frozen_logistic_reuses_one_source_trained_encoder_across_budgets():
         authority,
         spec=spec,
         budgets_per_class=(0, 1, 2),
+        prepared=prepared,
     )
 
     assert result.authority_fingerprint == authority.authority_fingerprint
-    assert result.encoder_parameter_count > 0
-    assert result.encoder_fit_s >= 0.0
+    assert result.encoder_state_manifest["encoder_parameter_count"] > 0
+    assert result.encoder_state_manifest["encoder_fit_s"] >= 0.0
+    assert result.encoder_state_manifest["encoder_state_fingerprint"] == prepared.fingerprint
+    assert result.encoder_state_manifest["representation_sha256"] == prepared.representation_sha256
     assert len(result.rows) == 3
     assert {row["status"] for row in result.rows} == {"ok"}
     assert {row["method_id"] for row in result.rows} == {"frozen-eegnet"}
     assert {row["transfer_strategy"] for row in result.rows} == {"frozen-logistic"}
     assert [row["calibration_per_class"] for row in result.rows] == [0, 1, 2]
     assert all(row["sourceweigher"] is None for row in result.rows)
+    assert {row["encoder_state_fingerprint"] for row in result.rows} == {prepared.fingerprint}
+    assert {row["representation_sha256"] for row in result.rows} == {prepared.representation_sha256}
     for row in result.rows:
         assert row["authority_fingerprint"] == authority.authority_fingerprint
         assert 0.0 <= row["balanced_accuracy"] <= 1.0
         assert 0.0 <= row["brier_score"] <= 2.0
     json.dumps(result.to_dict(), sort_keys=True)
+
+
+def test_sourceweigher_and_unweighted_transfer_share_exact_prepared_encoder(monkeypatch):
+    import neuros.foundation_models.longitudinal_transfer as transfer
+
+    data = _fixture()
+    authority = _authority(data)
+    prepared = _prepared(data, authority)
+    observed_target_sizes = []
+    real = transfer._sourceweigher_result
+
+    def wrapped(*, source_embeddings, target_embeddings):
+        observed_target_sizes.append(len(target_embeddings))
+        return real(
+            source_embeddings=source_embeddings,
+            target_embeddings=target_embeddings,
+        )
+
+    monkeypatch.setattr(transfer, "_sourceweigher_result", wrapped)
+    frozen = run_frozen_transfer_case(
+        data,
+        authority,
+        spec=FrozenTransferMethodSpec(
+            method_id="frozen-eegnet",
+            strategy="frozen-logistic",
+            encoder_id="eegnet",
+            encoder_seed=101,
+            encoder_kwargs=_encoder_kwargs(),
+        ),
+        budgets_per_class=(0, 1, 2),
+        prepared=prepared,
+    )
+    weighted = run_frozen_transfer_case(
+        data,
+        authority,
+        spec=FrozenTransferMethodSpec(
+            method_id="sourceweigher-eegnet",
+            strategy="sourceweigher-mean",
+            encoder_id="eegnet",
+            encoder_seed=101,
+            encoder_kwargs=_encoder_kwargs(),
+        ),
+        budgets_per_class=(0, 1, 2),
+        prepared=prepared,
+    )
+
+    assert observed_target_sizes == [2, 4]
+    assert frozen.encoder_state_manifest["encoder_state_fingerprint"] == weighted.encoder_state_manifest["encoder_state_fingerprint"]
+    assert frozen.encoder_state_manifest["representation_sha256"] == weighted.encoder_state_manifest["representation_sha256"]
+    assert frozen.encoder_state_manifest["representation_sha256"] == prepared.representation_sha256
+
+    zero, one, two = weighted.rows
+    assert zero["status"] == "unavailable_no_target_observations"
+    assert zero["method_id"] == "sourceweigher-eegnet"
+    assert zero["transfer_strategy"] == "sourceweigher-mean"
+    assert zero["partition_fingerprint"] == authority.partition_fingerprint
+    assert zero["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
+    assert zero["encoder_state_fingerprint"] == prepared.fingerprint
+    assert "evaluation examples are forbidden" in zero["failure_reason"]
+
+    for row in (one, two):
+        assert row["status"] == "ok"
+        assert row["method_id"] == "sourceweigher-eegnet"
+        assert row["representation_sha256"] == prepared.representation_sha256
+        payload = row["sourceweigher"]
+        assert payload is not None
+        assert payload["source_ids"] == ["0", "1"]
+        assert np.isclose(sum(payload["weights"]), 1.0)
+        diagnostics = payload["diagnostics"]
+        assert diagnostics["effective_sample_size"] >= 1.0
+        assert diagnostics["entropy"] >= 0.0
+        assert diagnostics["max_weight"] <= 1.0 + 1e-9
+        assert diagnostics["iterations"] >= 1
 
 
 def test_distinct_encoders_can_have_distinct_ladder_method_ids():
@@ -128,62 +218,10 @@ def test_distinct_encoders_can_have_distinct_ladder_method_ids():
     assert first.fingerprint != second.fingerprint
 
 
-def test_sourceweigher_uses_only_declared_target_calibration_embeddings(monkeypatch):
-    import neuros.foundation_models.longitudinal_transfer as transfer
-
-    data = _fixture()
-    authority = _authority(data)
-    observed_target_sizes = []
-    real = transfer._sourceweigher_result
-
-    def wrapped(*, source_embeddings, target_embeddings):
-        observed_target_sizes.append(len(target_embeddings))
-        return real(
-            source_embeddings=source_embeddings,
-            target_embeddings=target_embeddings,
-        )
-
-    monkeypatch.setattr(transfer, "_sourceweigher_result", wrapped)
-    spec = FrozenTransferMethodSpec(
-        method_id="sourceweigher-eegnet",
-        strategy="sourceweigher-mean",
-        encoder_id="eegnet",
-        encoder_seed=101,
-        encoder_kwargs=_encoder_kwargs(),
-    )
-    result = run_frozen_transfer_case(
-        data,
-        authority,
-        spec=spec,
-        budgets_per_class=(0, 1, 2),
-    )
-
-    assert observed_target_sizes == [2, 4]
-    zero, one, two = result.rows
-    assert zero["status"] == "unavailable_no_target_observations"
-    assert zero["method_id"] == "sourceweigher-eegnet"
-    assert zero["transfer_strategy"] == "sourceweigher-mean"
-    assert zero["partition_fingerprint"] == authority.partition_fingerprint
-    assert zero["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
-    assert "evaluation examples are forbidden" in zero["failure_reason"]
-
-    for row in (one, two):
-        assert row["status"] == "ok"
-        assert row["method_id"] == "sourceweigher-eegnet"
-        payload = row["sourceweigher"]
-        assert payload is not None
-        assert payload["source_ids"] == ["0", "1"]
-        assert np.isclose(sum(payload["weights"]), 1.0)
-        diagnostics = payload["diagnostics"]
-        assert diagnostics["effective_sample_size"] >= 1.0
-        assert diagnostics["entropy"] >= 0.0
-        assert diagnostics["max_weight"] <= 1.0 + 1e-9
-        assert diagnostics["iterations"] >= 1
-
-
 def test_sourceweigher_zero_only_run_is_explicitly_unavailable():
     data = _fixture()
     authority = _authority(data)
+    prepared = _prepared(data, authority)
     spec = FrozenTransferMethodSpec(
         method_id="sourceweigher-eegnet",
         strategy="sourceweigher-mean",
@@ -196,6 +234,7 @@ def test_sourceweigher_zero_only_run_is_explicitly_unavailable():
         authority,
         spec=spec,
         budgets_per_class=(0,),
+        prepared=prepared,
     )
     row = result.rows[0]
     assert row["status"] == "unavailable_no_target_observations"
@@ -204,9 +243,10 @@ def test_sourceweigher_zero_only_run_is_explicitly_unavailable():
     assert row["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
 
 
-def test_frozen_transfer_validates_authority_before_encoder_training():
+def test_prepared_encoder_validates_authority_before_transfer():
     data = _fixture()
     authority = _authority(data)
+    prepared = _prepared(data, authority)
     changed_x = data.X.copy()
     changed_x[0, 0, 0] += 0.2
     changed = GroupedEvaluationData(
@@ -229,4 +269,5 @@ def test_frozen_transfer_validates_authority_before_encoder_training():
             authority,
             spec=spec,
             budgets_per_class=(0,),
+            prepared=prepared,
         )

--- a/packages/neuros-foundation/tests/test_longitudinal_transfer.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_transfer.py
@@ -31,8 +31,6 @@ def _fixture() -> GroupedEvaluationData:
                 x = rng.normal(scale=0.45, size=(4, 128)).astype(np.float32)
                 sign = -1.0 if label_index == 0 else 1.0
                 x[label_index, 20:92] += sign * (1.0 + 0.07 * session_index)
-                # Session-specific nuisance shift gives SourceWeigher something
-                # nontrivial to summarize in representation space.
                 x[3] += 0.03 * session_index
                 X.append(x)
                 y.append(label)
@@ -82,7 +80,8 @@ def test_frozen_logistic_reuses_one_source_trained_encoder_across_budgets():
     data = _fixture()
     authority = _authority(data)
     spec = FrozenTransferMethodSpec(
-        method_id="frozen-logistic",
+        method_id="frozen-eegnet",
+        strategy="frozen-logistic",
         encoder_id="eegnet",
         encoder_seed=101,
         encoder_kwargs=_encoder_kwargs(),
@@ -100,6 +99,8 @@ def test_frozen_logistic_reuses_one_source_trained_encoder_across_budgets():
     assert result.encoder_fit_s >= 0.0
     assert len(result.rows) == 3
     assert {row["status"] for row in result.rows} == {"ok"}
+    assert {row["method_id"] for row in result.rows} == {"frozen-eegnet"}
+    assert {row["transfer_strategy"] for row in result.rows} == {"frozen-logistic"}
     assert [row["calibration_per_class"] for row in result.rows] == [0, 1, 2]
     assert all(row["sourceweigher"] is None for row in result.rows)
     for row in result.rows:
@@ -107,6 +108,24 @@ def test_frozen_logistic_reuses_one_source_trained_encoder_across_budgets():
         assert 0.0 <= row["balanced_accuracy"] <= 1.0
         assert 0.0 <= row["brier_score"] <= 2.0
     json.dumps(result.to_dict(), sort_keys=True)
+
+
+def test_distinct_encoders_can_have_distinct_ladder_method_ids():
+    first = FrozenTransferMethodSpec(
+        method_id="frozen-eegnet",
+        strategy="frozen-logistic",
+        encoder_id="eegnet",
+        encoder_seed=101,
+    )
+    second = FrozenTransferMethodSpec(
+        method_id="frozen-eeg-conformer",
+        strategy="frozen-logistic",
+        encoder_id="eeg-conformer",
+        encoder_seed=101,
+    )
+    assert first.method_id != second.method_id
+    assert first.strategy == second.strategy
+    assert first.fingerprint != second.fingerprint
 
 
 def test_sourceweigher_uses_only_declared_target_calibration_embeddings(monkeypatch):
@@ -126,7 +145,8 @@ def test_sourceweigher_uses_only_declared_target_calibration_embeddings(monkeypa
 
     monkeypatch.setattr(transfer, "_sourceweigher_result", wrapped)
     spec = FrozenTransferMethodSpec(
-        method_id="sourceweigher-mean",
+        method_id="sourceweigher-eegnet",
+        strategy="sourceweigher-mean",
         encoder_id="eegnet",
         encoder_seed=101,
         encoder_kwargs=_encoder_kwargs(),
@@ -138,13 +158,18 @@ def test_sourceweigher_uses_only_declared_target_calibration_embeddings(monkeypa
         budgets_per_class=(0, 1, 2),
     )
 
-    assert observed_target_sizes == [2, 4]  # 1/class then 2/class; never evaluation set
+    assert observed_target_sizes == [2, 4]
     zero, one, two = result.rows
     assert zero["status"] == "unavailable_no_target_observations"
+    assert zero["method_id"] == "sourceweigher-eegnet"
+    assert zero["transfer_strategy"] == "sourceweigher-mean"
+    assert zero["partition_fingerprint"] == authority.partition_fingerprint
+    assert zero["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
     assert "evaluation examples are forbidden" in zero["failure_reason"]
 
     for row in (one, two):
         assert row["status"] == "ok"
+        assert row["method_id"] == "sourceweigher-eegnet"
         payload = row["sourceweigher"]
         assert payload is not None
         assert payload["source_ids"] == ["0", "1"]
@@ -156,11 +181,12 @@ def test_sourceweigher_uses_only_declared_target_calibration_embeddings(monkeypa
         assert diagnostics["iterations"] >= 1
 
 
-def test_sourceweigher_rejects_zero_only_run_without_using_eval_data():
+def test_sourceweigher_zero_only_run_is_explicitly_unavailable():
     data = _fixture()
     authority = _authority(data)
     spec = FrozenTransferMethodSpec(
-        method_id="sourceweigher-mean",
+        method_id="sourceweigher-eegnet",
+        strategy="sourceweigher-mean",
         encoder_id="eegnet",
         encoder_seed=101,
         encoder_kwargs=_encoder_kwargs(),
@@ -171,7 +197,11 @@ def test_sourceweigher_rejects_zero_only_run_without_using_eval_data():
         spec=spec,
         budgets_per_class=(0,),
     )
-    assert result.rows[0]["status"] == "unavailable_no_target_observations"
+    row = result.rows[0]
+    assert row["status"] == "unavailable_no_target_observations"
+    assert row["authority_fingerprint"] == authority.authority_fingerprint
+    assert row["partition_fingerprint"] == authority.partition_fingerprint
+    assert row["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
 
 
 def test_frozen_transfer_validates_authority_before_encoder_training():
@@ -187,7 +217,8 @@ def test_frozen_transfer_validates_authority_before_encoder_training():
         metadata=data.metadata,
     )
     spec = FrozenTransferMethodSpec(
-        method_id="frozen-logistic",
+        method_id="frozen-eegnet",
+        strategy="frozen-logistic",
         encoder_id="eegnet",
         encoder_seed=101,
         encoder_kwargs=_encoder_kwargs(),

--- a/packages/neuros-foundation/tests/test_longitudinal_zero_calibration.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_zero_calibration.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import (
+    GroupedEvaluationData,
+    LongitudinalCaseAuthority,
+    chronological_partition,
+    make_nested_calibration_split,
+)
+from neuros.foundation_models.longitudinal_transfer import (
+    FrozenTransferMethodSpec,
+    prepare_frozen_encoder_case,
+    run_frozen_transfer_case,
+)
+
+pytest.importorskip("torch")
+
+
+def test_frozen_encoder_supports_empty_target_calibration_pool():
+    rng = np.random.default_rng(44)
+    X = []
+    y = []
+    metadata = []
+
+    # Source history has enough trials to train; the target has exactly one
+    # example per class, so the evidence contract reserves both for final eval
+    # and exposes a legal maximum calibration budget of zero.
+    for label_index, label in enumerate(("left", "right")):
+        for trial in range(6):
+            signal = rng.normal(size=(4, 64)).astype(np.float32)
+            signal[label_index, 16:48] += -1.0 if label_index == 0 else 1.0
+            X.append(signal)
+            y.append(label)
+            metadata.append({"subject": "1", "session": "0", "run": f"s-{trial}"})
+
+    for label_index, label in enumerate(("left", "right")):
+        signal = rng.normal(size=(4, 64)).astype(np.float32)
+        signal[label_index, 16:48] += -1.0 if label_index == 0 else 1.0
+        X.append(signal)
+        y.append(label)
+        metadata.append({"subject": "1", "session": "1", "run": "target"})
+
+    data = GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="tiny-zero-calibration",
+    )
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="1",
+        order=("0", "1"),
+    )
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=3)
+    assert split.max_budget_per_class == 0
+
+    authority = LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="tiny/subject-1/session-1",
+        history_policy="prior",
+        observed_group_order=("0", "1"),
+    )
+    kwargs = {
+        "n_epochs": 1,
+        "batch_size": 8,
+        "device": "cpu",
+        "temporal_filters": 4,
+        "depth_multiplier": 1,
+        "separable_filters": 8,
+        "temporal_kernel": 15,
+        "separable_kernel": 7,
+    }
+    prepared = prepare_frozen_encoder_case(
+        data,
+        authority,
+        encoder_id="eegnet",
+        encoder_seed=9,
+        encoder_kwargs=kwargs,
+    )
+    assert prepared.target_pool_indices.size == 0
+    assert prepared.target_pool_embedding.shape == (0, prepared.source_embedding.shape[1])
+    assert len(prepared.representation_sha256) == 64
+
+    result = run_frozen_transfer_case(
+        data,
+        authority,
+        spec=FrozenTransferMethodSpec(
+            method_id="frozen-eegnet",
+            strategy="frozen-logistic",
+            encoder_id="eegnet",
+            encoder_seed=9,
+            encoder_kwargs=kwargs,
+        ),
+        budgets_per_class=(0,),
+        prepared=prepared,
+    )
+    assert len(result.rows) == 1
+    assert result.rows[0]["status"] == "ok"
+    assert result.rows[0]["calibration_per_class"] == 0

--- a/scripts/evidence/run_moabb_model_ladder.py
+++ b/scripts/evidence/run_moabb_model_ladder.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""Run multiple longitudinal EEG methods under one frozen evidence authority.
-
-For every subject/target-session case the runner freezes source, calibration,
-and final-evaluation identities once, serializes the actual indices plus a
-processed-data SHA-256, and gives every method exactly that authority.
-
-The script deliberately preserves failures and method-unavailable operating
-points. A missing or failed case is evidence, not a row to silently drop.
-"""
+"""Run a longitudinal EEG model ladder under serialized sample authority."""
 
 from __future__ import annotations
 
@@ -19,11 +11,8 @@ import json
 import platform
 import subprocess
 import time
-from collections import defaultdict
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
-
-import numpy as np
+from typing import Any, Mapping
 
 from neuros.foundation_models.longitudinal import (
     chronological_partition,
@@ -31,35 +20,20 @@ from neuros.foundation_models.longitudinal import (
     ordered_group_values,
 )
 from neuros.foundation_models.longitudinal_authority import LongitudinalCaseAuthority
-from neuros.foundation_models.longitudinal_baseline import run_csp_case
-from neuros.foundation_models.longitudinal_methods import (
-    TaskDecoderMethodSpec,
-    run_task_decoder_case,
+from neuros.foundation_models.longitudinal_ladder import (
+    LADDER_METHODS,
+    LadderRuntimeConfig,
+    render_ladder_report,
+    run_ladder_method,
+    summarize_ladder_rows,
 )
-from neuros.foundation_models.longitudinal_transfer import (
-    FrozenTransferMethodSpec,
-    run_frozen_transfer_case,
-)
+from neuros.foundation_models.longitudinal_transfer import PreparedFrozenEncoderCase
 from neuros.foundation_models.moabb_longitudinal import (
     MOABB_LONGITUDINAL_DATASETS,
     build_moabb_longitudinal_dataset,
     validate_observed_sessions,
 )
 from neuros.foundation_models.real_world import collect_moabb, hold_out_groups
-
-_METHODS = (
-    "csp-lda",
-    "eegnet",
-    "eeg-conformer",
-    "frozen-eegnet",
-    "frozen-eeg-conformer",
-    "sourceweigher-eegnet",
-    "sourceweigher-eeg-conformer",
-)
-_SOURCEWEIGHER_METHODS = {
-    "sourceweigher-eegnet",
-    "sourceweigher-eeg-conformer",
-}
 
 
 def _parse_int_list(value: str) -> list[int]:
@@ -81,10 +55,10 @@ def _parse_text_list(value: str) -> list[str]:
 
 def _parse_methods(value: str) -> list[str]:
     values = _parse_text_list(value)
-    unknown = sorted(set(values) - set(_METHODS))
+    unknown = sorted(set(values) - set(LADDER_METHODS))
     if unknown:
         raise argparse.ArgumentTypeError(
-            f"unknown methods {unknown}; available={list(_METHODS)}"
+            f"unknown methods {unknown}; available={list(LADDER_METHODS)}"
         )
     return values
 
@@ -107,7 +81,8 @@ def _git_revision() -> str | None:
 
 
 def _versions() -> dict[str, str | None]:
-    names = (
+    result: dict[str, str | None] = {}
+    for name in (
         "neuros-foundation",
         "neuros-core",
         "neuros-models",
@@ -117,9 +92,7 @@ def _versions() -> dict[str, str | None]:
         "scikit-learn",
         "torch",
         "numpy",
-    )
-    result: dict[str, str | None] = {}
-    for name in names:
+    ):
         try:
             result[name] = importlib.metadata.version(name)
         except importlib.metadata.PackageNotFoundError:
@@ -142,42 +115,21 @@ def _json_dump(path: Path, value: Any) -> None:
     )
 
 
-def _method_spec_payload(
-    method: str,
-    seed: int | None,
-    args: argparse.Namespace,
-) -> dict[str, Any]:
-    return {
-        "method_id": method,
-        "model_seed": seed,
-        "epochs": int(args.epochs),
-        "batch_size": int(args.batch_size),
-        "device": args.device,
-        "csp_components": int(args.csp_components),
-        "readout_c": float(args.readout_c),
-    }
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return value
 
 
-def _failure_row(
-    *,
-    authority: LongitudinalCaseAuthority,
-    method: str,
-    seed: int | None,
-    budget: int,
-    exc: Exception,
-) -> dict[str, Any]:
-    return {
-        "case_id": authority.case_id,
-        "authority_fingerprint": authority.authority_fingerprint,
-        "processed_data_sha256": authority.processed_data_sha256,
-        "partition_fingerprint": authority.partition_fingerprint,
-        "calibration_split_fingerprint": authority.calibration_split_fingerprint,
-        "method_id": method,
-        "model_seed": seed,
-        "calibration_per_class": int(budget),
-        "status": "failed",
-        "failure_reason": f"{type(exc).__name__}: {exc}",
-    }
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("cannot write an empty model-ladder result table")
+    fields = sorted({key for row in rows for key in row})
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: _csv_value(row.get(field)) for field in fields})
 
 
 def _enrich_row(
@@ -203,442 +155,26 @@ def _enrich_row(
     return value
 
 
-def _run_one_method(
+def _failure_row(
+    authority: LongitudinalCaseAuthority,
     *,
     method: str,
-    data: Any,
-    authority: LongitudinalCaseAuthority,
-    budgets: tuple[int, ...],
-    model_seed: int | None,
-    args: argparse.Namespace,
-):
-    if method == "csp-lda":
-        return run_csp_case(
-            data,
-            authority,
-            budgets_per_class=budgets,
-            csp_components=args.csp_components,
-        )
-
-    if model_seed is None:
-        raise ValueError(f"method {method} requires a model seed")
-
-    common_kwargs = {
-        "n_epochs": int(args.epochs),
-        "batch_size": int(args.batch_size),
-        "device": args.device,
-    }
-    if method in {"eegnet", "eeg-conformer"}:
-        return run_task_decoder_case(
-            data,
-            authority,
-            spec=TaskDecoderMethodSpec(
-                method_id=method,
-                model_seed=model_seed,
-                model_kwargs=common_kwargs,
-            ),
-            budgets_per_class=budgets,
-        )
-
-    if method.startswith("frozen-"):
-        encoder = "eegnet" if method == "frozen-eegnet" else "eeg-conformer"
-        return run_frozen_transfer_case(
-            data,
-            authority,
-            spec=FrozenTransferMethodSpec(
-                method_id=method,
-                strategy="frozen-logistic",
-                encoder_id=encoder,
-                encoder_seed=model_seed,
-                encoder_kwargs=common_kwargs,
-                readout_c=args.readout_c,
-            ),
-            budgets_per_class=budgets,
-        )
-
-    if method in _SOURCEWEIGHER_METHODS:
-        encoder = "eegnet" if method.endswith("eegnet") else "eeg-conformer"
-        return run_frozen_transfer_case(
-            data,
-            authority,
-            spec=FrozenTransferMethodSpec(
-                method_id=method,
-                strategy="sourceweigher-mean",
-                encoder_id=encoder,
-                encoder_seed=model_seed,
-                encoder_kwargs=common_kwargs,
-                readout_c=args.readout_c,
-            ),
-            budgets_per_class=budgets,
-        )
-
-    raise ValueError(f"unsupported method {method!r}")
-
-
-def _csv_value(value: Any) -> Any:
-    if isinstance(value, (dict, list, tuple)):
-        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
-    return value
-
-
-def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
-    if not rows:
-        raise ValueError("cannot write an empty model-ladder result table")
-    fields = sorted({key for row in rows for key in row})
-    with path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=fields)
-        writer.writeheader()
-        for row in rows:
-            writer.writerow({field: _csv_value(row.get(field)) for field in fields})
-
-
-def _mean(values: Iterable[float]) -> float | None:
-    array = np.asarray(list(values), dtype=np.float64)
-    array = array[np.isfinite(array)]
-    return None if len(array) == 0 else float(array.mean())
-
-
-def _std(values: Iterable[float]) -> float | None:
-    array = np.asarray(list(values), dtype=np.float64)
-    array = array[np.isfinite(array)]
-    if len(array) == 0:
-        return None
-    return float(array.std(ddof=1)) if len(array) > 1 else 0.0
-
-
-def _seed_averaged_case_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Average optimization seeds inside one frozen subject/session case."""
-    ok = [
-        row
-        for row in rows
-        if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
-    ]
-    groups: dict[tuple[str, int, str], list[dict[str, Any]]] = defaultdict(list)
-    for row in ok:
-        key = (
-            str(row["method_id"]),
-            int(row["calibration_per_class"]),
-            str(row["case_id"]),
-        )
-        groups[key].append(row)
-
-    collapsed: list[dict[str, Any]] = []
-    for (method, budget, case_id), values in groups.items():
-        first = values[0]
-        collapsed.append(
-            {
-                "method_id": method,
-                "calibration_per_class": budget,
-                "case_id": case_id,
-                "subject": first.get("subject"),
-                "original_protocol": first.get("original_protocol"),
-                "held_out_session": first.get("held_out_session"),
-                "balanced_accuracy": _mean(
-                    float(value["balanced_accuracy"]) for value in values
-                ),
-                "roc_auc": _mean(
-                    float(value["roc_auc"])
-                    for value in values
-                    if value.get("roc_auc") is not None
-                ),
-                "n_model_seeds": len(values),
-            }
-        )
-    return collapsed
-
-
-def _case_set_fingerprint(case_ids: Sequence[str]) -> str:
-    raw = json.dumps(sorted(case_ids), separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(raw).hexdigest()[:16]
-
-
-def _group_budget_summary(
-    collapsed: list[dict[str, Any]],
-    *,
-    group_field: str | None = None,
-) -> list[dict[str, Any]]:
-    groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
-    for row in collapsed:
-        key: tuple[Any, ...] = (
-            row["method_id"],
-            row["calibration_per_class"],
-        )
-        if group_field is not None:
-            key = (*key, row.get(group_field))
-        groups[key].append(row)
-
-    result: list[dict[str, Any]] = []
-    for key, values in sorted(groups.items(), key=lambda item: tuple(str(v) for v in item[0])):
-        method, budget, *group_value = key
-        case_ids = [str(row["case_id"]) for row in values]
-        record: dict[str, Any] = {
-            "method_id": method,
-            "calibration_per_class": int(budget),
-            "n_cases": len(values),
-            "case_set_fingerprint": _case_set_fingerprint(case_ids),
-            "mean_balanced_accuracy": _mean(
-                float(row["balanced_accuracy"]) for row in values
-            ),
-            "std_balanced_accuracy": _std(
-                float(row["balanced_accuracy"]) for row in values
-            ),
-            "mean_roc_auc": _mean(
-                float(row["roc_auc"])
-                for row in values
-                if row["roc_auc"] is not None
-            ),
-        }
-        if group_field is not None:
-            record[group_field] = group_value[0]
-        result.append(record)
-    return result
-
-
-def _manual_trapezoid(y: np.ndarray, x: np.ndarray) -> float:
-    """NumPy >=1.24 compatible trapezoidal integration without deprecated aliases."""
-    if y.ndim != 1 or x.ndim != 1 or len(y) != len(x):
-        raise ValueError("trapezoid inputs must be aligned 1-D vectors")
-    if len(x) < 2:
-        return 0.0
-    return float(np.sum((y[:-1] + y[1:]) * 0.5 * np.diff(x)))
-
-
-def _frontier_auc(
-    rows: list[dict[str, Any]],
-    requested_budgets: tuple[int, ...],
-) -> list[dict[str, Any]]:
-    """Compute seed-averaged per-case normalized AUC for one declared budget set."""
-    if len(requested_budgets) < 2:
-        return []
-    ok = [
-        row
-        for row in rows
-        if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
-    ]
-    by_method_case_seed: dict[tuple[str, str, str], dict[int, float]] = defaultdict(dict)
-    for row in ok:
-        seed = "none" if row.get("model_seed") is None else str(row["model_seed"])
-        key = (str(row["method_id"]), str(row["case_id"]), seed)
-        by_method_case_seed[key][int(row["calibration_per_class"])] = float(
-            row["balanced_accuracy"]
-        )
-
-    budget_x = np.asarray(requested_budgets, dtype=np.float64)
-    span = float(budget_x[-1] - budget_x[0])
-    if span <= 0:
-        return []
-
-    per_method_case: dict[tuple[str, str], list[float]] = defaultdict(list)
-    for (method, case_id, _seed), curve in by_method_case_seed.items():
-        if any(budget not in curve for budget in requested_budgets):
-            continue
-        y = np.asarray([curve[budget] for budget in requested_budgets], dtype=np.float64)
-        auc = _manual_trapezoid(y, budget_x) / span
-        per_method_case[(method, case_id)].append(float(auc))
-
-    by_method: dict[str, list[float]] = defaultdict(list)
-    for (method, _case), seed_values in per_method_case.items():
-        by_method[method].append(float(np.mean(seed_values)))
-
-    return [
-        {
-            "method_id": method,
-            "complete_frontier_cases": len(values),
-            "mean_seed_averaged_frontier_auc": _mean(values),
-            "std_seed_averaged_frontier_auc": _std(values),
-            "requested_budgets": list(requested_budgets),
-        }
-        for method, values in sorted(by_method.items())
-    ]
-
-
-def _paired_case_set_audit(
-    collapsed: list[dict[str, Any]],
-    methods: Sequence[str],
-    budgets: tuple[int, ...],
-) -> list[dict[str, Any]]:
-    result: list[dict[str, Any]] = []
-    for method in methods:
-        supported = tuple(
-            budget
-            for budget in budgets
-            if not (method in _SOURCEWEIGHER_METHODS and budget == 0)
-        )
-        fingerprints: list[str] = []
-        counts: list[int] = []
-        for budget in supported:
-            case_ids = [
-                str(row["case_id"])
-                for row in collapsed
-                if row["method_id"] == method
-                and row["calibration_per_class"] == budget
-            ]
-            fingerprints.append(_case_set_fingerprint(case_ids))
-            counts.append(len(case_ids))
-        identical = bool(fingerprints) and len(set(fingerprints)) == 1
-        result.append(
-            {
-                "method_id": method,
-                "supported_budgets": list(supported),
-                "case_counts": counts,
-                "case_set_fingerprints": fingerprints,
-                "paired_across_supported_budgets": identical,
-            }
-        )
-    return result
-
-
-def _summarize(
-    rows: list[dict[str, Any]],
-    budgets: tuple[int, ...],
-    methods: Sequence[str],
+    seed: int | None,
+    budget: int,
+    exc: Exception,
 ) -> dict[str, Any]:
-    failures = [row for row in rows if row.get("status") == "failed"]
-    unavailable = [
-        row for row in rows if str(row.get("status", "")).startswith("unavailable")
-    ]
-    unexpected_unavailable = [
-        row
-        for row in unavailable
-        if not (
-            row.get("method_id") in _SOURCEWEIGHER_METHODS
-            and int(row.get("calibration_per_class", -1)) == 0
-        )
-    ]
-    collapsed = _seed_averaged_case_rows(rows)
-    paired_audit = _paired_case_set_audit(collapsed, methods, budgets)
-    positive_budgets = tuple(budget for budget in budgets if budget > 0)
-    promotion_ready = (
-        len(failures) == 0
-        and len(unexpected_unavailable) == 0
-        and all(item["paired_across_supported_budgets"] for item in paired_audit)
-    )
     return {
-        "schema_version": 2,
-        "primary_metric": "balanced_accuracy",
-        "budget_summary_seed_averaged_within_case": _group_budget_summary(collapsed),
-        "cohort_budget_summary": _group_budget_summary(
-            collapsed, group_field="original_protocol"
-        ),
-        "target_session_budget_summary": _group_budget_summary(
-            collapsed, group_field="held_out_session"
-        ),
-        "complete_frontier_auc": _frontier_auc(rows, budgets),
-        "positive_budget_adaptation_auc": _frontier_auc(rows, positive_budgets),
-        "paired_case_set_audit": paired_audit,
-        "failed_rows": len(failures),
-        "unavailable_rows": len(unavailable),
-        "unexpected_unavailable_rows": len(unexpected_unavailable),
-        "failure_reasons": sorted(
-            {str(row.get("failure_reason")) for row in failures if row.get("failure_reason")}
-        ),
-        "promotion_ready_descriptive": promotion_ready,
-        "statistical_boundary": (
-            "Descriptive only. Promoted Kumar2024 inference follows preregistration issue #27: "
-            "subject-clustered/hierarchical inference with GR/PAR cohort reporting."
-        ),
+        "case_id": authority.case_id,
+        "authority_fingerprint": authority.authority_fingerprint,
+        "processed_data_sha256": authority.processed_data_sha256,
+        "partition_fingerprint": authority.partition_fingerprint,
+        "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+        "method_id": method,
+        "model_seed": seed,
+        "calibration_per_class": int(budget),
+        "status": "failed",
+        "failure_reason": f"{type(exc).__name__}: {exc}",
     }
-
-
-def _render_report(manifest: dict[str, Any], summary: dict[str, Any]) -> str:
-    lines = [
-        "# neurOS Longitudinal Model Ladder",
-        "",
-        f"- Dataset: **{manifest['dataset_key']}**",
-        f"- History: **{manifest['history_policy']}**",
-        f"- Methods: **{', '.join(manifest['methods'])}**",
-        f"- Budgets / class: **{', '.join(str(v) for v in manifest['budgets_per_class'])}**",
-        f"- Model seeds: **{', '.join(str(v) for v in manifest['model_seeds'])}**",
-        f"- Frozen authority cases: **{len(manifest['authority_fingerprints'])}**",
-        f"- Descriptive promotion gate: **{'PASS' if summary['promotion_ready_descriptive'] else 'FAIL'}**",
-        "",
-        "## Seed-averaged calibration frontier",
-        "",
-        "| method | calibration/class | cases | case-set fp | balanced accuracy | std | ROC-AUC |",
-        "| --- | ---: | ---: | --- | ---: | ---: | ---: |",
-    ]
-
-    def fmt(value: Any) -> str:
-        return "n/a" if value is None else f"{float(value):.4f}"
-
-    for row in summary["budget_summary_seed_averaged_within_case"]:
-        lines.append(
-            "| {method_id} | {calibration_per_class} | {n_cases} | {case_set_fingerprint} | "
-            "{ba} | {std} | {auc} |".format(
-                **row,
-                ba=fmt(row["mean_balanced_accuracy"]),
-                std=fmt(row["std_balanced_accuracy"]),
-                auc=fmt(row["mean_roc_auc"]),
-            )
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Full calibration-frontier AUC",
-            "",
-            "This is the preregistered 0-to-max calibration frontier. Methods that are not "
-            "defined at zero target calibration, including target-dependent SourceWeigher, "
-            "do not receive a fabricated full-frontier AUC.",
-            "",
-            "| method | complete cases | mean AUC | std |",
-            "| --- | ---: | ---: | ---: |",
-        ]
-    )
-    for row in summary["complete_frontier_auc"]:
-        lines.append(
-            "| {method_id} | {complete_frontier_cases} | {mean} | {std} |".format(
-                **row,
-                mean=fmt(row["mean_seed_averaged_frontier_auc"]),
-                std=fmt(row["std_seed_averaged_frontier_auc"]),
-            )
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Positive-budget adaptation AUC",
-            "",
-            "Secondary comparison across strictly positive labeled-calibration budgets. This "
-            "allows target-dependent adaptation methods to be compared without pretending they "
-            "are zero-shot methods.",
-            "",
-            "| method | complete cases | mean AUC | std |",
-            "| --- | ---: | ---: | ---: |",
-        ]
-    )
-    for row in summary["positive_budget_adaptation_auc"]:
-        lines.append(
-            "| {method_id} | {complete_frontier_cases} | {mean} | {std} |".format(
-                **row,
-                mean=fmt(row["mean_seed_averaged_frontier_auc"]),
-                std=fmt(row["std_seed_averaged_frontier_auc"]),
-            )
-        )
-
-    lines.extend(
-        [
-            "",
-            "## Evidence boundary",
-            "",
-            "Every method row references a serialized `LongitudinalCaseAuthority` containing "
-            "the actual source/calibration/evaluation indices and processed-data SHA-256.",
-            "",
-            "SourceWeigher rows at zero target calibration are explicitly unavailable. Final "
-            "evaluation examples are never repurposed as unlabeled target observations.",
-            "",
-            f"Failed rows: **{summary['failed_rows']}**. Unavailable rows: **{summary['unavailable_rows']}**. "
-            f"Unexpected unavailable rows: **{summary['unexpected_unavailable_rows']}**.",
-            "",
-            "Kumar2024 cohort and target-session summaries are emitted from the same result "
-            "bundle so GR/PAR and session-index effects remain visible.",
-            "",
-            "This report is descriptive offline real-dataset evidence, not hardware, closed-loop, "
-            "clinical, or ORION superiority evidence.",
-            "",
-        ]
-    )
-    return "\n".join(lines)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -656,7 +192,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--methods",
         type=_parse_methods,
         default=["csp-lda"],
-        help=f"Comma-separated subset of: {','.join(_METHODS)}",
+        help=f"Comma-separated subset of: {','.join(LADDER_METHODS)}",
     )
     parser.add_argument("--model-seeds", type=_parse_int_list, default=[101, 503, 1601])
     parser.add_argument("--budgets", type=_parse_int_list, default=[0, 1, 2, 5, 10])
@@ -682,11 +218,14 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("--evaluation-fraction must lie strictly between 0 and 1")
     if args.fmin <= 0 or args.fmax <= args.fmin:
         raise SystemExit("require 0 < --fmin < --fmax")
-    if args.epochs <= 0 or args.batch_size <= 0:
-        raise SystemExit("--epochs and --batch-size must be positive")
-    if args.csp_components <= 0 or args.readout_c <= 0:
-        raise SystemExit("--csp-components and --readout-c must be positive")
 
+    runtime = LadderRuntimeConfig(
+        epochs=int(args.epochs),
+        batch_size=int(args.batch_size),
+        device=str(args.device),
+        csp_components=int(args.csp_components),
+        readout_c=float(args.readout_c),
+    )
     budgets = tuple(sorted(set(int(value) for value in args.budgets)))
     if not budgets or budgets[0] < 0:
         raise SystemExit("--budgets must contain non-negative values")
@@ -721,7 +260,6 @@ def main(argv: list[str] | None = None) -> int:
         fmax=args.fmax,
         resample=args.resample,
     )
-
     authorities: list[LongitudinalCaseAuthority] = []
     result_rows: list[dict[str, Any]] = []
     method_runs: list[dict[str, Any]] = []
@@ -806,19 +344,21 @@ def main(argv: list[str] | None = None) -> int:
             authority.restore(data)
             authorities.append(authority)
 
+            prepared_cache: dict[tuple[str, int], PreparedFrozenEncoderCase] = {}
             for method in methods:
                 seeds: tuple[int | None, ...] = (
                     (None,) if method == "csp-lda" else tuple(model_seeds)
                 )
                 for model_seed in seeds:
                     try:
-                        run = _run_one_method(
+                        run = run_ladder_method(
+                            data,
+                            authority,
                             method=method,
-                            data=data,
-                            authority=authority,
-                            budgets=budgets,
+                            budgets_per_class=budgets,
                             model_seed=model_seed,
-                            args=args,
+                            config=runtime,
+                            prepared_cache=prepared_cache,
                         )
                         payload = run.to_dict()
                         method_runs.append(
@@ -852,16 +392,14 @@ def main(argv: list[str] | None = None) -> int:
                                 "requested_model_seed": model_seed,
                                 "status": "failed",
                                 "failure_reason": f"{type(exc).__name__}: {exc}",
-                                "method_request": _method_spec_payload(
-                                    method, model_seed, args
-                                ),
+                                "runtime": runtime.to_dict(),
                             }
                         )
                         for budget in budgets:
                             result_rows.append(
                                 _enrich_row(
                                     _failure_row(
-                                        authority=authority,
+                                        authority,
                                         method=method,
                                         seed=model_seed,
                                         budget=budget,
@@ -872,9 +410,13 @@ def main(argv: list[str] | None = None) -> int:
                                 )
                             )
 
-    summary = _summarize(result_rows, budgets, methods)
+    summary = summarize_ladder_rows(
+        result_rows,
+        budgets=budgets,
+        methods=methods,
+    )
     manifest = {
-        "schema_version": 2,
+        "schema_version": 3,
         "evidence_tier": "real_dataset",
         "study": "longitudinal_eeg_model_ladder",
         "dataset_key": dataset_spec.key,
@@ -890,11 +432,7 @@ def main(argv: list[str] | None = None) -> int:
         "model_seeds": list(model_seeds),
         "band_hz": [float(args.fmin), float(args.fmax)],
         "resample_hz": args.resample,
-        "csp_components": int(args.csp_components),
-        "epochs": int(args.epochs),
-        "batch_size": int(args.batch_size),
-        "device": args.device,
-        "readout_c": float(args.readout_c),
+        "runtime_config": runtime.to_dict(),
         "authority_fingerprints": [item.authority_fingerprint for item in authorities],
         "git_revision": _git_revision(),
         "python": platform.python_version(),
@@ -906,6 +444,7 @@ def main(argv: list[str] | None = None) -> int:
             "all methods consume serialized frozen sample authority",
             "prior policy excludes future sessions",
             "final evaluation examples never enter fitting or SourceWeigher target estimation",
+            "frozen-logistic and SourceWeigher sharing encoder/seed reuse exact representation tensors",
             "SourceWeigher zero-target-calibration is explicitly unavailable",
             "full frontier AUC is not fabricated for methods undefined at zero calibration",
             "GR/PAR cohort and target-session effects remain visible for Kumar2024",
@@ -921,17 +460,23 @@ def main(argv: list[str] | None = None) -> int:
             "cases": [authority.to_dict() for authority in authorities],
         },
     )
-    _json_dump(paths["methods"], {"schema_version": 2, "runs": method_runs})
+    _json_dump(paths["methods"], {"schema_version": 3, "runs": method_runs})
     _write_csv(paths["results"], result_rows)
     _json_dump(paths["summary"], summary)
-    paths["report"].write_text(_render_report(manifest, summary), encoding="utf-8")
-
-    hashed = {
-        path.name: _sha256(path)
-        for key, path in paths.items()
-        if key != "hashes"
-    }
-    _json_dump(paths["hashes"], {"sha256": hashed})
+    paths["report"].write_text(
+        render_ladder_report(manifest, summary),
+        encoding="utf-8",
+    )
+    _json_dump(
+        paths["hashes"],
+        {
+            "sha256": {
+                path.name: _sha256(path)
+                for key, path in paths.items()
+                if key != "hashes"
+            }
+        },
+    )
 
     print(
         json.dumps(

--- a/scripts/evidence/run_moabb_model_ladder.py
+++ b/scripts/evidence/run_moabb_model_ladder.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Run multiple longitudinal EEG methods under one frozen evidence authority.
 
-This runner is the comparison counterpart to ``run_moabb_longitudinal.py``.
-For every subject/target-session case it freezes the source/calibration/final
-sample authority once, serializes the actual indices and processed-data SHA-256,
-and then gives each method exactly that authority.
+For every subject/target-session case the runner freezes source, calibration,
+and final-evaluation identities once, serializes the actual indices plus a
+processed-data SHA-256, and gives every method exactly that authority.
+
+The script deliberately preserves failures and method-unavailable operating
+points. A missing or failed case is evidence, not a row to silently drop.
 """
 
 from __future__ import annotations
@@ -19,7 +21,7 @@ import subprocess
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 import numpy as np
 
@@ -54,6 +56,10 @@ _METHODS = (
     "sourceweigher-eegnet",
     "sourceweigher-eeg-conformer",
 )
+_SOURCEWEIGHER_METHODS = {
+    "sourceweigher-eegnet",
+    "sourceweigher-eeg-conformer",
+}
 
 
 def _parse_int_list(value: str) -> list[int]:
@@ -112,7 +118,7 @@ def _versions() -> dict[str, str | None]:
         "torch",
         "numpy",
     )
-    result = {}
+    result: dict[str, str | None] = {}
     for name in names:
         try:
             result[name] = importlib.metadata.version(name)
@@ -136,7 +142,11 @@ def _json_dump(path: Path, value: Any) -> None:
     )
 
 
-def _method_spec_payload(method: str, seed: int | None, args: argparse.Namespace) -> dict[str, Any]:
+def _method_spec_payload(
+    method: str,
+    seed: int | None,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
     return {
         "method_id": method,
         "model_seed": seed,
@@ -153,7 +163,7 @@ def _failure_row(
     authority: LongitudinalCaseAuthority,
     method: str,
     seed: int | None,
-    budget: int | None,
+    budget: int,
     exc: Exception,
 ) -> dict[str, Any]:
     return {
@@ -164,7 +174,7 @@ def _failure_row(
         "calibration_split_fingerprint": authority.calibration_split_fingerprint,
         "method_id": method,
         "model_seed": seed,
-        "calibration_per_class": budget,
+        "calibration_per_class": int(budget),
         "status": "failed",
         "failure_reason": f"{type(exc).__name__}: {exc}",
     }
@@ -179,6 +189,12 @@ def _enrich_row(
     value = dict(row)
     value.setdefault("status", "ok")
     value.setdefault("failure_reason", None)
+    value.setdefault("authority_fingerprint", authority.authority_fingerprint)
+    value.setdefault("processed_data_sha256", authority.processed_data_sha256)
+    value.setdefault("partition_fingerprint", authority.partition_fingerprint)
+    value.setdefault(
+        "calibration_split_fingerprint", authority.calibration_split_fingerprint
+    )
     value["dataset_id"] = authority.dataset_id
     value["history_policy"] = authority.history_policy
     value["split_seed"] = int(split_seed)
@@ -206,56 +222,53 @@ def _run_one_method(
 
     if model_seed is None:
         raise ValueError(f"method {method} requires a model seed")
+
     common_kwargs = {
         "n_epochs": int(args.epochs),
         "batch_size": int(args.batch_size),
         "device": args.device,
     }
-
     if method in {"eegnet", "eeg-conformer"}:
-        spec = TaskDecoderMethodSpec(
-            method_id=method,
-            model_seed=model_seed,
-            model_kwargs=common_kwargs,
-        )
         return run_task_decoder_case(
             data,
             authority,
-            spec=spec,
+            spec=TaskDecoderMethodSpec(
+                method_id=method,
+                model_seed=model_seed,
+                model_kwargs=common_kwargs,
+            ),
             budgets_per_class=budgets,
         )
 
     if method.startswith("frozen-"):
         encoder = "eegnet" if method == "frozen-eegnet" else "eeg-conformer"
-        spec = FrozenTransferMethodSpec(
-            method_id="frozen-logistic",
-            encoder_id=encoder,
-            encoder_seed=model_seed,
-            encoder_kwargs=common_kwargs,
-            readout_c=args.readout_c,
-        )
         return run_frozen_transfer_case(
             data,
             authority,
-            spec=spec,
+            spec=FrozenTransferMethodSpec(
+                method_id=method,
+                strategy="frozen-logistic",
+                encoder_id=encoder,
+                encoder_seed=model_seed,
+                encoder_kwargs=common_kwargs,
+                readout_c=args.readout_c,
+            ),
             budgets_per_class=budgets,
         )
 
-    if method.startswith("sourceweigher-"):
-        encoder = (
-            "eegnet" if method == "sourceweigher-eegnet" else "eeg-conformer"
-        )
-        spec = FrozenTransferMethodSpec(
-            method_id="sourceweigher-mean",
-            encoder_id=encoder,
-            encoder_seed=model_seed,
-            encoder_kwargs=common_kwargs,
-            readout_c=args.readout_c,
-        )
+    if method in _SOURCEWEIGHER_METHODS:
+        encoder = "eegnet" if method.endswith("eegnet") else "eeg-conformer"
         return run_frozen_transfer_case(
             data,
             authority,
-            spec=spec,
+            spec=FrozenTransferMethodSpec(
+                method_id=method,
+                strategy="sourceweigher-mean",
+                encoder_id=encoder,
+                encoder_seed=model_seed,
+                encoder_kwargs=common_kwargs,
+                readout_c=args.readout_c,
+            ),
             budgets_per_class=budgets,
         )
 
@@ -293,66 +306,110 @@ def _std(values: Iterable[float]) -> float | None:
     return float(array.std(ddof=1)) if len(array) > 1 else 0.0
 
 
-def _seed_averaged_budget_summary(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Average optimization seeds within each case before averaging participants/cases."""
+def _seed_averaged_case_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Average optimization seeds inside one frozen subject/session case."""
     ok = [
         row
         for row in rows
         if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
     ]
-    per_case: dict[tuple[str, int, str], list[dict[str, Any]]] = defaultdict(list)
+    groups: dict[tuple[str, int, str], list[dict[str, Any]]] = defaultdict(list)
     for row in ok:
-        per_case[(str(row["method_id"]), int(row["calibration_per_class"]), str(row["case_id"]))].append(row)
+        key = (
+            str(row["method_id"]),
+            int(row["calibration_per_class"]),
+            str(row["case_id"]),
+        )
+        groups[key].append(row)
 
-    collapsed = []
-    for (method, budget, case_id), values in per_case.items():
+    collapsed: list[dict[str, Any]] = []
+    for (method, budget, case_id), values in groups.items():
+        first = values[0]
         collapsed.append(
             {
                 "method_id": method,
                 "calibration_per_class": budget,
                 "case_id": case_id,
-                "balanced_accuracy": _mean(float(v["balanced_accuracy"]) for v in values),
+                "subject": first.get("subject"),
+                "original_protocol": first.get("original_protocol"),
+                "held_out_session": first.get("held_out_session"),
+                "balanced_accuracy": _mean(
+                    float(value["balanced_accuracy"]) for value in values
+                ),
                 "roc_auc": _mean(
-                    float(v["roc_auc"])
-                    for v in values
-                    if v.get("roc_auc") is not None
+                    float(value["roc_auc"])
+                    for value in values
+                    if value.get("roc_auc") is not None
                 ),
                 "n_model_seeds": len(values),
             }
         )
+    return collapsed
 
-    groups: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+
+def _case_set_fingerprint(case_ids: Sequence[str]) -> str:
+    raw = json.dumps(sorted(case_ids), separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _group_budget_summary(
+    collapsed: list[dict[str, Any]],
+    *,
+    group_field: str | None = None,
+) -> list[dict[str, Any]]:
+    groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
     for row in collapsed:
-        groups[(row["method_id"], row["calibration_per_class"])].append(row)
-
-    result = []
-    for (method, budget), values in sorted(groups.items()):
-        case_ids = sorted(row["case_id"] for row in values)
-        case_raw = json.dumps(case_ids, separators=(",", ":")).encode("utf-8")
-        result.append(
-            {
-                "method_id": method,
-                "calibration_per_class": int(budget),
-                "n_cases": len(values),
-                "case_set_fingerprint": hashlib.sha256(case_raw).hexdigest()[:16],
-                "mean_balanced_accuracy": _mean(
-                    float(row["balanced_accuracy"]) for row in values
-                ),
-                "std_balanced_accuracy": _std(
-                    float(row["balanced_accuracy"]) for row in values
-                ),
-                "mean_roc_auc": _mean(
-                    float(row["roc_auc"])
-                    for row in values
-                    if row["roc_auc"] is not None
-                ),
-            }
+        key: tuple[Any, ...] = (
+            row["method_id"],
+            row["calibration_per_class"],
         )
+        if group_field is not None:
+            key = (*key, row.get(group_field))
+        groups[key].append(row)
+
+    result: list[dict[str, Any]] = []
+    for key, values in sorted(groups.items(), key=lambda item: tuple(str(v) for v in item[0])):
+        method, budget, *group_value = key
+        case_ids = [str(row["case_id"]) for row in values]
+        record: dict[str, Any] = {
+            "method_id": method,
+            "calibration_per_class": int(budget),
+            "n_cases": len(values),
+            "case_set_fingerprint": _case_set_fingerprint(case_ids),
+            "mean_balanced_accuracy": _mean(
+                float(row["balanced_accuracy"]) for row in values
+            ),
+            "std_balanced_accuracy": _std(
+                float(row["balanced_accuracy"]) for row in values
+            ),
+            "mean_roc_auc": _mean(
+                float(row["roc_auc"])
+                for row in values
+                if row["roc_auc"] is not None
+            ),
+        }
+        if group_field is not None:
+            record[group_field] = group_value[0]
+        result.append(record)
     return result
 
 
-def _frontier_auc(rows: list[dict[str, Any]], requested_budgets: tuple[int, ...]) -> list[dict[str, Any]]:
-    """Compute seed-averaged per-case normalized calibration-frontier AUC."""
+def _manual_trapezoid(y: np.ndarray, x: np.ndarray) -> float:
+    """NumPy >=1.24 compatible trapezoidal integration without deprecated aliases."""
+    if y.ndim != 1 or x.ndim != 1 or len(y) != len(x):
+        raise ValueError("trapezoid inputs must be aligned 1-D vectors")
+    if len(x) < 2:
+        return 0.0
+    return float(np.sum((y[:-1] + y[1:]) * 0.5 * np.diff(x)))
+
+
+def _frontier_auc(
+    rows: list[dict[str, Any]],
+    requested_budgets: tuple[int, ...],
+) -> list[dict[str, Any]]:
+    """Compute seed-averaged per-case normalized AUC for one declared budget set."""
+    if len(requested_budgets) < 2:
+        return []
     ok = [
         row
         for row in rows
@@ -367,48 +424,115 @@ def _frontier_auc(rows: list[dict[str, Any]], requested_budgets: tuple[int, ...]
         )
 
     budget_x = np.asarray(requested_budgets, dtype=np.float64)
-    span = float(budget_x[-1] - budget_x[0]) if len(budget_x) > 1 else 0.0
+    span = float(budget_x[-1] - budget_x[0])
+    if span <= 0:
+        return []
+
     per_method_case: dict[tuple[str, str], list[float]] = defaultdict(list)
     for (method, case_id, _seed), curve in by_method_case_seed.items():
-        if tuple(sorted(curve)) != requested_budgets or span <= 0:
+        if any(budget not in curve for budget in requested_budgets):
             continue
         y = np.asarray([curve[budget] for budget in requested_budgets], dtype=np.float64)
-        auc = float(np.trapezoid(y, budget_x) / span)
-        per_method_case[(method, case_id)].append(auc)
+        auc = _manual_trapezoid(y, budget_x) / span
+        per_method_case[(method, case_id)].append(float(auc))
 
     by_method: dict[str, list[float]] = defaultdict(list)
     for (method, _case), seed_values in per_method_case.items():
         by_method[method].append(float(np.mean(seed_values)))
 
-    result = []
-    for method, values in sorted(by_method.items()):
+    return [
+        {
+            "method_id": method,
+            "complete_frontier_cases": len(values),
+            "mean_seed_averaged_frontier_auc": _mean(values),
+            "std_seed_averaged_frontier_auc": _std(values),
+            "requested_budgets": list(requested_budgets),
+        }
+        for method, values in sorted(by_method.items())
+    ]
+
+
+def _paired_case_set_audit(
+    collapsed: list[dict[str, Any]],
+    methods: Sequence[str],
+    budgets: tuple[int, ...],
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for method in methods:
+        supported = tuple(
+            budget
+            for budget in budgets
+            if not (method in _SOURCEWEIGHER_METHODS and budget == 0)
+        )
+        fingerprints: list[str] = []
+        counts: list[int] = []
+        for budget in supported:
+            case_ids = [
+                str(row["case_id"])
+                for row in collapsed
+                if row["method_id"] == method
+                and row["calibration_per_class"] == budget
+            ]
+            fingerprints.append(_case_set_fingerprint(case_ids))
+            counts.append(len(case_ids))
+        identical = bool(fingerprints) and len(set(fingerprints)) == 1
         result.append(
             {
                 "method_id": method,
-                "complete_frontier_cases": len(values),
-                "mean_seed_averaged_frontier_auc": _mean(values),
-                "std_seed_averaged_frontier_auc": _std(values),
-                "requested_budgets": list(requested_budgets),
+                "supported_budgets": list(supported),
+                "case_counts": counts,
+                "case_set_fingerprints": fingerprints,
+                "paired_across_supported_budgets": identical,
             }
         )
     return result
 
 
-def _summarize(rows: list[dict[str, Any]], budgets: tuple[int, ...]) -> dict[str, Any]:
+def _summarize(
+    rows: list[dict[str, Any]],
+    budgets: tuple[int, ...],
+    methods: Sequence[str],
+) -> dict[str, Any]:
     failures = [row for row in rows if row.get("status") == "failed"]
     unavailable = [
         row for row in rows if str(row.get("status", "")).startswith("unavailable")
     ]
+    unexpected_unavailable = [
+        row
+        for row in unavailable
+        if not (
+            row.get("method_id") in _SOURCEWEIGHER_METHODS
+            and int(row.get("calibration_per_class", -1)) == 0
+        )
+    ]
+    collapsed = _seed_averaged_case_rows(rows)
+    paired_audit = _paired_case_set_audit(collapsed, methods, budgets)
+    positive_budgets = tuple(budget for budget in budgets if budget > 0)
+    promotion_ready = (
+        len(failures) == 0
+        and len(unexpected_unavailable) == 0
+        and all(item["paired_across_supported_budgets"] for item in paired_audit)
+    )
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "primary_metric": "balanced_accuracy",
-        "budget_summary_seed_averaged_within_case": _seed_averaged_budget_summary(rows),
+        "budget_summary_seed_averaged_within_case": _group_budget_summary(collapsed),
+        "cohort_budget_summary": _group_budget_summary(
+            collapsed, group_field="original_protocol"
+        ),
+        "target_session_budget_summary": _group_budget_summary(
+            collapsed, group_field="held_out_session"
+        ),
         "complete_frontier_auc": _frontier_auc(rows, budgets),
+        "positive_budget_adaptation_auc": _frontier_auc(rows, positive_budgets),
+        "paired_case_set_audit": paired_audit,
         "failed_rows": len(failures),
         "unavailable_rows": len(unavailable),
+        "unexpected_unavailable_rows": len(unexpected_unavailable),
         "failure_reasons": sorted(
             {str(row.get("failure_reason")) for row in failures if row.get("failure_reason")}
         ),
+        "promotion_ready_descriptive": promotion_ready,
         "statistical_boundary": (
             "Descriptive only. Promoted Kumar2024 inference follows preregistration issue #27: "
             "subject-clustered/hierarchical inference with GR/PAR cohort reporting."
@@ -426,6 +550,7 @@ def _render_report(manifest: dict[str, Any], summary: dict[str, Any]) -> str:
         f"- Budgets / class: **{', '.join(str(v) for v in manifest['budgets_per_class'])}**",
         f"- Model seeds: **{', '.join(str(v) for v in manifest['model_seeds'])}**",
         f"- Frozen authority cases: **{len(manifest['authority_fingerprints'])}**",
+        f"- Descriptive promotion gate: **{'PASS' if summary['promotion_ready_descriptive'] else 'FAIL'}**",
         "",
         "## Seed-averaged calibration frontier",
         "",
@@ -450,10 +575,11 @@ def _render_report(manifest: dict[str, Any], summary: dict[str, Any]) -> str:
     lines.extend(
         [
             "",
-            "## Complete calibration-frontier AUC",
+            "## Full calibration-frontier AUC",
             "",
-            "AUC is normalized by the labeled-calibration budget span. Model seeds are "
-            "averaged within each frozen case before cases are summarized.",
+            "This is the preregistered 0-to-max calibration frontier. Methods that are not "
+            "defined at zero target calibration, including target-dependent SourceWeigher, "
+            "do not receive a fabricated full-frontier AUC.",
             "",
             "| method | complete cases | mean AUC | std |",
             "| --- | ---: | ---: | ---: |",
@@ -471,15 +597,41 @@ def _render_report(manifest: dict[str, Any], summary: dict[str, Any]) -> str:
     lines.extend(
         [
             "",
+            "## Positive-budget adaptation AUC",
+            "",
+            "Secondary comparison across strictly positive labeled-calibration budgets. This "
+            "allows target-dependent adaptation methods to be compared without pretending they "
+            "are zero-shot methods.",
+            "",
+            "| method | complete cases | mean AUC | std |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for row in summary["positive_budget_adaptation_auc"]:
+        lines.append(
+            "| {method_id} | {complete_frontier_cases} | {mean} | {std} |".format(
+                **row,
+                mean=fmt(row["mean_seed_averaged_frontier_auc"]),
+                std=fmt(row["std_seed_averaged_frontier_auc"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
             "## Evidence boundary",
             "",
             "Every method row references a serialized `LongitudinalCaseAuthority` containing "
             "the actual source/calibration/evaluation indices and processed-data SHA-256.",
             "",
-            "SourceWeigher rows at zero target calibration are explicitly unavailable. The "
-            "final evaluation examples are never repurposed as unlabeled target observations.",
+            "SourceWeigher rows at zero target calibration are explicitly unavailable. Final "
+            "evaluation examples are never repurposed as unlabeled target observations.",
             "",
-            f"Failed rows: **{summary['failed_rows']}**. Unavailable rows: **{summary['unavailable_rows']}**.",
+            f"Failed rows: **{summary['failed_rows']}**. Unavailable rows: **{summary['unavailable_rows']}**. "
+            f"Unexpected unavailable rows: **{summary['unexpected_unavailable_rows']}**.",
+            "",
+            "Kumar2024 cohort and target-session summaries are emitted from the same result "
+            "bundle so GR/PAR and session-index effects remain visible.",
             "",
             "This report is descriptive offline real-dataset evidence, not hardware, closed-loop, "
             "clinical, or ORION superiority evidence.",
@@ -535,13 +687,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.csp_components <= 0 or args.readout_c <= 0:
         raise SystemExit("--csp-components and --readout-c must be positive")
 
-    budgets = tuple(sorted(set(int(v) for v in args.budgets)))
+    budgets = tuple(sorted(set(int(value) for value in args.budgets)))
     if not budgets or budgets[0] < 0:
         raise SystemExit("--budgets must contain non-negative values")
     if 0 not in budgets:
         budgets = (0, *budgets)
     methods = tuple(dict.fromkeys(args.methods))
-    model_seeds = tuple(dict.fromkeys(int(v) for v in args.model_seeds))
+    model_seeds = tuple(dict.fromkeys(int(value) for value in args.model_seeds))
     if any(method != "csp-lda" for method in methods) and not model_seeds:
         raise SystemExit("neural/transfer methods require at least one --model-seeds value")
 
@@ -651,7 +803,6 @@ def main(argv: list[str] | None = None) -> int:
                 observed_group_order=observed,
                 case_metadata=metadata,
             )
-            # Restore immediately so serialized authority is verified before any method runs.
             authority.restore(data)
             authorities.append(authority)
 
@@ -680,18 +831,20 @@ def main(argv: list[str] | None = None) -> int:
                             }
                         )
                         for row in payload["rows"]:
-                            # Frozen transfer internal method IDs are deliberately more
-                            # specific; preserve requested ladder identity separately.
                             enriched = _enrich_row(
                                 row,
                                 authority,
                                 split_seed=case_split_seed,
                             )
-                            enriched["method_id"] = method
+                            if enriched.get("method_id") != method:
+                                raise RuntimeError(
+                                    "method result identity mismatch: "
+                                    f"requested={method}, returned={enriched.get('method_id')}"
+                                )
                             if model_seed is not None:
                                 enriched["model_seed"] = int(model_seed)
                             result_rows.append(enriched)
-                    except Exception as exc:  # preserve method failure; authority already validated
+                    except Exception as exc:
                         method_runs.append(
                             {
                                 "case_id": authority.case_id,
@@ -699,7 +852,9 @@ def main(argv: list[str] | None = None) -> int:
                                 "requested_model_seed": model_seed,
                                 "status": "failed",
                                 "failure_reason": f"{type(exc).__name__}: {exc}",
-                                "method_request": _method_spec_payload(method, model_seed, args),
+                                "method_request": _method_spec_payload(
+                                    method, model_seed, args
+                                ),
                             }
                         )
                         for budget in budgets:
@@ -717,9 +872,9 @@ def main(argv: list[str] | None = None) -> int:
                                 )
                             )
 
-    summary = _summarize(result_rows, budgets)
+    summary = _summarize(result_rows, budgets, methods)
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "evidence_tier": "real_dataset",
         "study": "longitudinal_eeg_model_ladder",
         "dataset_key": dataset_spec.key,
@@ -746,11 +901,14 @@ def main(argv: list[str] | None = None) -> int:
         "platform": platform.platform(),
         "package_versions": _versions(),
         "wall_time_s": float(time.perf_counter() - started_study),
+        "promotion_ready_descriptive": summary["promotion_ready_descriptive"],
         "claim_boundary": [
             "all methods consume serialized frozen sample authority",
             "prior policy excludes future sessions",
             "final evaluation examples never enter fitting or SourceWeigher target estimation",
             "SourceWeigher zero-target-calibration is explicitly unavailable",
+            "full frontier AUC is not fabricated for methods undefined at zero calibration",
+            "GR/PAR cohort and target-session effects remain visible for Kumar2024",
             "descriptive offline real-dataset evidence is not hardware/closed-loop/clinical evidence",
         ],
     }
@@ -759,11 +917,11 @@ def main(argv: list[str] | None = None) -> int:
     _json_dump(
         paths["authority"],
         {
-            "schema_version": 1,
+            "schema_version": 2,
             "cases": [authority.to_dict() for authority in authorities],
         },
     )
-    _json_dump(paths["methods"], {"schema_version": 1, "runs": method_runs})
+    _json_dump(paths["methods"], {"schema_version": 2, "runs": method_runs})
     _write_csv(paths["results"], result_rows)
     _json_dump(paths["summary"], summary)
     paths["report"].write_text(_render_report(manifest, summary), encoding="utf-8")
@@ -782,6 +940,8 @@ def main(argv: list[str] | None = None) -> int:
                 "authority_cases": len(authorities),
                 "result_rows": len(result_rows),
                 "failed_rows": summary["failed_rows"],
+                "unavailable_rows": summary["unavailable_rows"],
+                "promotion_ready_descriptive": summary["promotion_ready_descriptive"],
                 "artifacts": [path.name for path in paths.values()],
             },
             indent=2,

--- a/scripts/evidence/run_moabb_model_ladder.py
+++ b/scripts/evidence/run_moabb_model_ladder.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""Run multiple longitudinal EEG methods under one frozen evidence authority.
+
+This runner is the comparison counterpart to ``run_moabb_longitudinal.py``.
+For every subject/target-session case it freezes the source/calibration/final
+sample authority once, serializes the actual indices and processed-data SHA-256,
+and then gives each method exactly that authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.metadata
+import json
+import platform
+import subprocess
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import numpy as np
+
+from neuros.foundation_models.longitudinal import (
+    chronological_partition,
+    make_nested_calibration_split,
+    ordered_group_values,
+)
+from neuros.foundation_models.longitudinal_authority import LongitudinalCaseAuthority
+from neuros.foundation_models.longitudinal_baseline import run_csp_case
+from neuros.foundation_models.longitudinal_methods import (
+    TaskDecoderMethodSpec,
+    run_task_decoder_case,
+)
+from neuros.foundation_models.longitudinal_transfer import (
+    FrozenTransferMethodSpec,
+    run_frozen_transfer_case,
+)
+from neuros.foundation_models.moabb_longitudinal import (
+    MOABB_LONGITUDINAL_DATASETS,
+    build_moabb_longitudinal_dataset,
+    validate_observed_sessions,
+)
+from neuros.foundation_models.real_world import collect_moabb, hold_out_groups
+
+_METHODS = (
+    "csp-lda",
+    "eegnet",
+    "eeg-conformer",
+    "frozen-eegnet",
+    "frozen-eeg-conformer",
+    "sourceweigher-eegnet",
+    "sourceweigher-eeg-conformer",
+)
+
+
+def _parse_int_list(value: str) -> list[int]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated integer")
+    try:
+        return [int(item) for item in values]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("values must be integers") from exc
+
+
+def _parse_text_list(value: str) -> list[str]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated value")
+    return values
+
+
+def _parse_methods(value: str) -> list[str]:
+    values = _parse_text_list(value)
+    unknown = sorted(set(values) - set(_METHODS))
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"unknown methods {unknown}; available={list(_METHODS)}"
+        )
+    return values
+
+
+def _stable_seed(base: int, *parts: Any) -> int:
+    raw = "|".join([str(base), *(str(part) for part in parts)])
+    return int.from_bytes(hashlib.sha256(raw.encode("utf-8")).digest()[:4], "big")
+
+
+def _git_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _versions() -> dict[str, str | None]:
+    names = (
+        "neuros-foundation",
+        "neuros-core",
+        "neuros-models",
+        "neuros-sourceweigher",
+        "moabb",
+        "mne",
+        "scikit-learn",
+        "torch",
+        "numpy",
+    )
+    result = {}
+    for name in names:
+        try:
+            result[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            result[name] = None
+    return result
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_dump(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _method_spec_payload(method: str, seed: int | None, args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "method_id": method,
+        "model_seed": seed,
+        "epochs": int(args.epochs),
+        "batch_size": int(args.batch_size),
+        "device": args.device,
+        "csp_components": int(args.csp_components),
+        "readout_c": float(args.readout_c),
+    }
+
+
+def _failure_row(
+    *,
+    authority: LongitudinalCaseAuthority,
+    method: str,
+    seed: int | None,
+    budget: int | None,
+    exc: Exception,
+) -> dict[str, Any]:
+    return {
+        "case_id": authority.case_id,
+        "authority_fingerprint": authority.authority_fingerprint,
+        "processed_data_sha256": authority.processed_data_sha256,
+        "partition_fingerprint": authority.partition_fingerprint,
+        "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+        "method_id": method,
+        "model_seed": seed,
+        "calibration_per_class": budget,
+        "status": "failed",
+        "failure_reason": f"{type(exc).__name__}: {exc}",
+    }
+
+
+def _enrich_row(
+    row: Mapping[str, Any],
+    authority: LongitudinalCaseAuthority,
+    *,
+    split_seed: int,
+) -> dict[str, Any]:
+    value = dict(row)
+    value.setdefault("status", "ok")
+    value.setdefault("failure_reason", None)
+    value["dataset_id"] = authority.dataset_id
+    value["history_policy"] = authority.history_policy
+    value["split_seed"] = int(split_seed)
+    value.update(dict(authority.case_metadata))
+    value["held_out_session"] = authority.held_out_values[0]
+    return value
+
+
+def _run_one_method(
+    *,
+    method: str,
+    data: Any,
+    authority: LongitudinalCaseAuthority,
+    budgets: tuple[int, ...],
+    model_seed: int | None,
+    args: argparse.Namespace,
+):
+    if method == "csp-lda":
+        return run_csp_case(
+            data,
+            authority,
+            budgets_per_class=budgets,
+            csp_components=args.csp_components,
+        )
+
+    if model_seed is None:
+        raise ValueError(f"method {method} requires a model seed")
+    common_kwargs = {
+        "n_epochs": int(args.epochs),
+        "batch_size": int(args.batch_size),
+        "device": args.device,
+    }
+
+    if method in {"eegnet", "eeg-conformer"}:
+        spec = TaskDecoderMethodSpec(
+            method_id=method,
+            model_seed=model_seed,
+            model_kwargs=common_kwargs,
+        )
+        return run_task_decoder_case(
+            data,
+            authority,
+            spec=spec,
+            budgets_per_class=budgets,
+        )
+
+    if method.startswith("frozen-"):
+        encoder = "eegnet" if method == "frozen-eegnet" else "eeg-conformer"
+        spec = FrozenTransferMethodSpec(
+            method_id="frozen-logistic",
+            encoder_id=encoder,
+            encoder_seed=model_seed,
+            encoder_kwargs=common_kwargs,
+            readout_c=args.readout_c,
+        )
+        return run_frozen_transfer_case(
+            data,
+            authority,
+            spec=spec,
+            budgets_per_class=budgets,
+        )
+
+    if method.startswith("sourceweigher-"):
+        encoder = (
+            "eegnet" if method == "sourceweigher-eegnet" else "eeg-conformer"
+        )
+        spec = FrozenTransferMethodSpec(
+            method_id="sourceweigher-mean",
+            encoder_id=encoder,
+            encoder_seed=model_seed,
+            encoder_kwargs=common_kwargs,
+            readout_c=args.readout_c,
+        )
+        return run_frozen_transfer_case(
+            data,
+            authority,
+            spec=spec,
+            budgets_per_class=budgets,
+        )
+
+    raise ValueError(f"unsupported method {method!r}")
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return value
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError("cannot write an empty model-ladder result table")
+    fields = sorted({key for row in rows for key in row})
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: _csv_value(row.get(field)) for field in fields})
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(array.mean())
+
+
+def _std(values: Iterable[float]) -> float | None:
+    array = np.asarray(list(values), dtype=np.float64)
+    array = array[np.isfinite(array)]
+    if len(array) == 0:
+        return None
+    return float(array.std(ddof=1)) if len(array) > 1 else 0.0
+
+
+def _seed_averaged_budget_summary(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Average optimization seeds within each case before averaging participants/cases."""
+    ok = [
+        row
+        for row in rows
+        if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
+    ]
+    per_case: dict[tuple[str, int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in ok:
+        per_case[(str(row["method_id"]), int(row["calibration_per_class"]), str(row["case_id"]))].append(row)
+
+    collapsed = []
+    for (method, budget, case_id), values in per_case.items():
+        collapsed.append(
+            {
+                "method_id": method,
+                "calibration_per_class": budget,
+                "case_id": case_id,
+                "balanced_accuracy": _mean(float(v["balanced_accuracy"]) for v in values),
+                "roc_auc": _mean(
+                    float(v["roc_auc"])
+                    for v in values
+                    if v.get("roc_auc") is not None
+                ),
+                "n_model_seeds": len(values),
+            }
+        )
+
+    groups: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in collapsed:
+        groups[(row["method_id"], row["calibration_per_class"])].append(row)
+
+    result = []
+    for (method, budget), values in sorted(groups.items()):
+        case_ids = sorted(row["case_id"] for row in values)
+        case_raw = json.dumps(case_ids, separators=(",", ":")).encode("utf-8")
+        result.append(
+            {
+                "method_id": method,
+                "calibration_per_class": int(budget),
+                "n_cases": len(values),
+                "case_set_fingerprint": hashlib.sha256(case_raw).hexdigest()[:16],
+                "mean_balanced_accuracy": _mean(
+                    float(row["balanced_accuracy"]) for row in values
+                ),
+                "std_balanced_accuracy": _std(
+                    float(row["balanced_accuracy"]) for row in values
+                ),
+                "mean_roc_auc": _mean(
+                    float(row["roc_auc"])
+                    for row in values
+                    if row["roc_auc"] is not None
+                ),
+            }
+        )
+    return result
+
+
+def _frontier_auc(rows: list[dict[str, Any]], requested_budgets: tuple[int, ...]) -> list[dict[str, Any]]:
+    """Compute seed-averaged per-case normalized calibration-frontier AUC."""
+    ok = [
+        row
+        for row in rows
+        if row.get("status") == "ok" and row.get("balanced_accuracy") is not None
+    ]
+    by_method_case_seed: dict[tuple[str, str, str], dict[int, float]] = defaultdict(dict)
+    for row in ok:
+        seed = "none" if row.get("model_seed") is None else str(row["model_seed"])
+        key = (str(row["method_id"]), str(row["case_id"]), seed)
+        by_method_case_seed[key][int(row["calibration_per_class"])] = float(
+            row["balanced_accuracy"]
+        )
+
+    budget_x = np.asarray(requested_budgets, dtype=np.float64)
+    span = float(budget_x[-1] - budget_x[0]) if len(budget_x) > 1 else 0.0
+    per_method_case: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for (method, case_id, _seed), curve in by_method_case_seed.items():
+        if tuple(sorted(curve)) != requested_budgets or span <= 0:
+            continue
+        y = np.asarray([curve[budget] for budget in requested_budgets], dtype=np.float64)
+        auc = float(np.trapezoid(y, budget_x) / span)
+        per_method_case[(method, case_id)].append(auc)
+
+    by_method: dict[str, list[float]] = defaultdict(list)
+    for (method, _case), seed_values in per_method_case.items():
+        by_method[method].append(float(np.mean(seed_values)))
+
+    result = []
+    for method, values in sorted(by_method.items()):
+        result.append(
+            {
+                "method_id": method,
+                "complete_frontier_cases": len(values),
+                "mean_seed_averaged_frontier_auc": _mean(values),
+                "std_seed_averaged_frontier_auc": _std(values),
+                "requested_budgets": list(requested_budgets),
+            }
+        )
+    return result
+
+
+def _summarize(rows: list[dict[str, Any]], budgets: tuple[int, ...]) -> dict[str, Any]:
+    failures = [row for row in rows if row.get("status") == "failed"]
+    unavailable = [
+        row for row in rows if str(row.get("status", "")).startswith("unavailable")
+    ]
+    return {
+        "schema_version": 1,
+        "primary_metric": "balanced_accuracy",
+        "budget_summary_seed_averaged_within_case": _seed_averaged_budget_summary(rows),
+        "complete_frontier_auc": _frontier_auc(rows, budgets),
+        "failed_rows": len(failures),
+        "unavailable_rows": len(unavailable),
+        "failure_reasons": sorted(
+            {str(row.get("failure_reason")) for row in failures if row.get("failure_reason")}
+        ),
+        "statistical_boundary": (
+            "Descriptive only. Promoted Kumar2024 inference follows preregistration issue #27: "
+            "subject-clustered/hierarchical inference with GR/PAR cohort reporting."
+        ),
+    }
+
+
+def _render_report(manifest: dict[str, Any], summary: dict[str, Any]) -> str:
+    lines = [
+        "# neurOS Longitudinal Model Ladder",
+        "",
+        f"- Dataset: **{manifest['dataset_key']}**",
+        f"- History: **{manifest['history_policy']}**",
+        f"- Methods: **{', '.join(manifest['methods'])}**",
+        f"- Budgets / class: **{', '.join(str(v) for v in manifest['budgets_per_class'])}**",
+        f"- Model seeds: **{', '.join(str(v) for v in manifest['model_seeds'])}**",
+        f"- Frozen authority cases: **{len(manifest['authority_fingerprints'])}**",
+        "",
+        "## Seed-averaged calibration frontier",
+        "",
+        "| method | calibration/class | cases | case-set fp | balanced accuracy | std | ROC-AUC |",
+        "| --- | ---: | ---: | --- | ---: | ---: | ---: |",
+    ]
+
+    def fmt(value: Any) -> str:
+        return "n/a" if value is None else f"{float(value):.4f}"
+
+    for row in summary["budget_summary_seed_averaged_within_case"]:
+        lines.append(
+            "| {method_id} | {calibration_per_class} | {n_cases} | {case_set_fingerprint} | "
+            "{ba} | {std} | {auc} |".format(
+                **row,
+                ba=fmt(row["mean_balanced_accuracy"]),
+                std=fmt(row["std_balanced_accuracy"]),
+                auc=fmt(row["mean_roc_auc"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Complete calibration-frontier AUC",
+            "",
+            "AUC is normalized by the labeled-calibration budget span. Model seeds are "
+            "averaged within each frozen case before cases are summarized.",
+            "",
+            "| method | complete cases | mean AUC | std |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for row in summary["complete_frontier_auc"]:
+        lines.append(
+            "| {method_id} | {complete_frontier_cases} | {mean} | {std} |".format(
+                **row,
+                mean=fmt(row["mean_seed_averaged_frontier_auc"]),
+                std=fmt(row["std_seed_averaged_frontier_auc"]),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Evidence boundary",
+            "",
+            "Every method row references a serialized `LongitudinalCaseAuthority` containing "
+            "the actual source/calibration/evaluation indices and processed-data SHA-256.",
+            "",
+            "SourceWeigher rows at zero target calibration are explicitly unavailable. The "
+            "final evaluation examples are never repurposed as unlabeled target observations.",
+            "",
+            f"Failed rows: **{summary['failed_rows']}**. Unavailable rows: **{summary['unavailable_rows']}**.",
+            "",
+            "This report is descriptive offline real-dataset evidence, not hardware, closed-loop, "
+            "clinical, or ORION superiority evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a multi-method longitudinal EEG ladder under frozen sample authority."
+    )
+    parser.add_argument(
+        "--dataset",
+        choices=sorted(MOABB_LONGITUDINAL_DATASETS),
+        default="kumar2024",
+    )
+    parser.add_argument("--subjects", type=_parse_int_list, default=[1, 10])
+    parser.add_argument("--held-out-sessions", type=_parse_text_list, default=None)
+    parser.add_argument(
+        "--methods",
+        type=_parse_methods,
+        default=["csp-lda"],
+        help=f"Comma-separated subset of: {','.join(_METHODS)}",
+    )
+    parser.add_argument("--model-seeds", type=_parse_int_list, default=[101, 503, 1601])
+    parser.add_argument("--budgets", type=_parse_int_list, default=[0, 1, 2, 5, 10])
+    parser.add_argument("--history-policy", choices=("prior", "all-other"), default="prior")
+    parser.add_argument("--split-seed", type=int, default=2026)
+    parser.add_argument("--evaluation-fraction", type=float, default=0.5)
+    parser.add_argument("--fmin", type=float, default=8.0)
+    parser.add_argument("--fmax", type=float, default=30.0)
+    parser.add_argument("--resample", type=float, default=None)
+    parser.add_argument("--csp-components", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--device", default="auto")
+    parser.add_argument("--readout-c", type=float, default=1.0)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not 0.0 < args.evaluation_fraction < 1.0:
+        raise SystemExit("--evaluation-fraction must lie strictly between 0 and 1")
+    if args.fmin <= 0 or args.fmax <= args.fmin:
+        raise SystemExit("require 0 < --fmin < --fmax")
+    if args.epochs <= 0 or args.batch_size <= 0:
+        raise SystemExit("--epochs and --batch-size must be positive")
+    if args.csp_components <= 0 or args.readout_c <= 0:
+        raise SystemExit("--csp-components and --readout-c must be positive")
+
+    budgets = tuple(sorted(set(int(v) for v in args.budgets)))
+    if not budgets or budgets[0] < 0:
+        raise SystemExit("--budgets must contain non-negative values")
+    if 0 not in budgets:
+        budgets = (0, *budgets)
+    methods = tuple(dict.fromkeys(args.methods))
+    model_seeds = tuple(dict.fromkeys(int(v) for v in args.model_seeds))
+    if any(method != "csp-lda" for method in methods) and not model_seeds:
+        raise SystemExit("neural/transfer methods require at least one --model-seeds value")
+
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "manifest": output / "study_manifest.json",
+        "authority": output / "split_authority.json",
+        "methods": output / "method_runs.json",
+        "results": output / "results.csv",
+        "summary": output / "summary.json",
+        "report": output / "report.md",
+        "hashes": output / "artifact_hashes.json",
+    }
+    existing = [path for path in paths.values() if path.exists()]
+    if existing and not args.overwrite:
+        raise SystemExit(
+            "refusing to overwrite existing artifacts: "
+            + ", ".join(path.name for path in existing)
+        )
+
+    dataset_spec, dataset, paradigm = build_moabb_longitudinal_dataset(
+        args.dataset,
+        fmin=args.fmin,
+        fmax=args.fmax,
+        resample=args.resample,
+    )
+
+    authorities: list[LongitudinalCaseAuthority] = []
+    result_rows: list[dict[str, Any]] = []
+    method_runs: list[dict[str, Any]] = []
+    started_study = time.perf_counter()
+
+    for subject in args.subjects:
+        data = collect_moabb(
+            dataset,
+            paradigm,
+            subjects=[int(subject)],
+            dataset_id=dataset_spec.source_id,
+        )
+        observed = validate_observed_sessions(
+            dataset_spec,
+            ordered_group_values(data, split_unit="session"),
+        )
+        if len(observed) < 2:
+            raise RuntimeError(f"subject {subject} has fewer than two usable sessions")
+
+        if args.held_out_sessions is not None:
+            missing = [value for value in args.held_out_sessions if value not in observed]
+            if missing:
+                raise RuntimeError(
+                    f"subject {subject} missing requested session(s) {missing}; "
+                    f"observed={list(observed)}"
+                )
+            targets = tuple(args.held_out_sessions)
+        elif args.history_policy == "prior":
+            targets = observed[1:]
+        else:
+            targets = observed
+
+        for target in targets:
+            if args.history_policy == "prior":
+                partition = chronological_partition(
+                    data,
+                    split_unit="session",
+                    held_out_value=target,
+                    order=observed,
+                )
+            else:
+                partition = hold_out_groups(
+                    data,
+                    split_unit="session",
+                    held_out_values=[target],
+                )
+            case_split_seed = _stable_seed(
+                args.split_seed,
+                dataset_spec.source_id,
+                subject,
+                target,
+            )
+            split = make_nested_calibration_split(
+                partition,
+                evaluation_fraction=args.evaluation_fraction,
+                seed=case_split_seed,
+            )
+            if budgets[-1] > split.max_budget_per_class:
+                raise RuntimeError(
+                    f"strict paired frontier requires {budgets[-1]}/class, but "
+                    f"subject={subject}, session={target} supports only "
+                    f"{split.max_budget_per_class}/class"
+                )
+
+            metadata = dataset_spec.case_metadata(int(subject))
+            metadata.update(
+                {
+                    "held_out_session": str(target),
+                    "split_seed": int(case_split_seed),
+                }
+            )
+            authority = LongitudinalCaseAuthority.from_split(
+                split,
+                case_id=(
+                    f"{dataset_spec.source_id}/subject-{subject}/session-{target}/"
+                    f"split-{case_split_seed}"
+                ),
+                history_policy=args.history_policy,
+                observed_group_order=observed,
+                case_metadata=metadata,
+            )
+            # Restore immediately so serialized authority is verified before any method runs.
+            authority.restore(data)
+            authorities.append(authority)
+
+            for method in methods:
+                seeds: tuple[int | None, ...] = (
+                    (None,) if method == "csp-lda" else tuple(model_seeds)
+                )
+                for model_seed in seeds:
+                    try:
+                        run = _run_one_method(
+                            method=method,
+                            data=data,
+                            authority=authority,
+                            budgets=budgets,
+                            model_seed=model_seed,
+                            args=args,
+                        )
+                        payload = run.to_dict()
+                        method_runs.append(
+                            {
+                                "case_id": authority.case_id,
+                                "requested_method_id": method,
+                                "requested_model_seed": model_seed,
+                                "status": "ok",
+                                "result": payload,
+                            }
+                        )
+                        for row in payload["rows"]:
+                            # Frozen transfer internal method IDs are deliberately more
+                            # specific; preserve requested ladder identity separately.
+                            enriched = _enrich_row(
+                                row,
+                                authority,
+                                split_seed=case_split_seed,
+                            )
+                            enriched["method_id"] = method
+                            if model_seed is not None:
+                                enriched["model_seed"] = int(model_seed)
+                            result_rows.append(enriched)
+                    except Exception as exc:  # preserve method failure; authority already validated
+                        method_runs.append(
+                            {
+                                "case_id": authority.case_id,
+                                "requested_method_id": method,
+                                "requested_model_seed": model_seed,
+                                "status": "failed",
+                                "failure_reason": f"{type(exc).__name__}: {exc}",
+                                "method_request": _method_spec_payload(method, model_seed, args),
+                            }
+                        )
+                        for budget in budgets:
+                            result_rows.append(
+                                _enrich_row(
+                                    _failure_row(
+                                        authority=authority,
+                                        method=method,
+                                        seed=model_seed,
+                                        budget=budget,
+                                        exc=exc,
+                                    ),
+                                    authority,
+                                    split_seed=case_split_seed,
+                                )
+                            )
+
+    summary = _summarize(result_rows, budgets)
+    manifest = {
+        "schema_version": 1,
+        "evidence_tier": "real_dataset",
+        "study": "longitudinal_eeg_model_ladder",
+        "dataset_key": dataset_spec.key,
+        "dataset_class": dataset_spec.class_name,
+        "dataset_id": dataset_spec.source_id,
+        "subjects": [int(value) for value in args.subjects],
+        "history_policy": args.history_policy,
+        "held_out_sessions_requested": args.held_out_sessions,
+        "split_seed_base": int(args.split_seed),
+        "evaluation_fraction": float(args.evaluation_fraction),
+        "budgets_per_class": list(budgets),
+        "methods": list(methods),
+        "model_seeds": list(model_seeds),
+        "band_hz": [float(args.fmin), float(args.fmax)],
+        "resample_hz": args.resample,
+        "csp_components": int(args.csp_components),
+        "epochs": int(args.epochs),
+        "batch_size": int(args.batch_size),
+        "device": args.device,
+        "readout_c": float(args.readout_c),
+        "authority_fingerprints": [item.authority_fingerprint for item in authorities],
+        "git_revision": _git_revision(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "package_versions": _versions(),
+        "wall_time_s": float(time.perf_counter() - started_study),
+        "claim_boundary": [
+            "all methods consume serialized frozen sample authority",
+            "prior policy excludes future sessions",
+            "final evaluation examples never enter fitting or SourceWeigher target estimation",
+            "SourceWeigher zero-target-calibration is explicitly unavailable",
+            "descriptive offline real-dataset evidence is not hardware/closed-loop/clinical evidence",
+        ],
+    }
+
+    _json_dump(paths["manifest"], manifest)
+    _json_dump(
+        paths["authority"],
+        {
+            "schema_version": 1,
+            "cases": [authority.to_dict() for authority in authorities],
+        },
+    )
+    _json_dump(paths["methods"], {"schema_version": 1, "runs": method_runs})
+    _write_csv(paths["results"], result_rows)
+    _json_dump(paths["summary"], summary)
+    paths["report"].write_text(_render_report(manifest, summary), encoding="utf-8")
+
+    hashed = {
+        path.name: _sha256(path)
+        for key, path in paths.items()
+        if key != "hashes"
+    }
+    _json_dump(paths["hashes"], {"sha256": hashed})
+
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "authority_cases": len(authorities),
+                "result_rows": len(result_rows),
+                "failed_rows": summary["failed_rows"],
+                "artifacts": [path.name for path in paths.values()],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Build the first multi-method longitudinal EEG comparison layer on top of the prospective calibration authority merged in #25, without relaxing the evidence rules established there.

## Central invariant: one frozen authority, many methods

Each subject / target-session case is serialized as a `LongitudinalCaseAuthority` containing exact prior-source indices, ordered target calibration indices, immutable final-evaluation indices, processed-data SHA-256, chronology, partition/calibration fingerprints and dataset-specific metadata such as Kumar GR/PAR cohort.

Every method restores and validates this authority before fitting. Changed processed EEG bytes, sample order, labels or group identity fail before model training.

## Comparison lanes

The executable ladder supports:

- `csp-lda`
- `eegnet`
- `eeg-conformer`
- `frozen-eegnet`
- `frozen-eeg-conformer`
- `sourceweigher-eegnet`
- `sourceweigher-eeg-conformer`

Task decoders refit end-to-end at each declared calibration budget. Frozen lanes train one encoder on prior history and refit only a matched logistic readout. SourceWeigher lanes estimate source-session reliability from declared target calibration embeddings only. Final evaluation embeddings never enter target-moment estimation.

## Three-level evidence identity

Neural evidence distinguishes:

1. **data identity** — processed-data SHA-256 plus serialized source/calibration/evaluation indices;
2. **learned-state identity** — SHA-256 of the complete trained PyTorch `state_dict`, including registered buffers;
3. **representation identity** — SHA-256 over the exact frozen source/calibration/evaluation embedding tensors.

Frozen and SourceWeigher variants of the same encoder consume the same learned state and exact same representation tensors, making weighted-vs-unweighted transfer a real controlled comparison.

## Zero-calibration and failure semantics

Target-dependent SourceWeigher is explicitly unavailable at budget 0 rather than observing final-evaluation examples. Full-frontier AUC is reported only for methods genuinely defined at zero calibration; positive-budget adaptation AUC is separate.

Method failures emit explicit rows. Structural authority failures abort the study. Descriptive promotion requires no failed rows, no unexpected unavailable rows, and identical supported case membership.

## Kumar2024 integration

The bundle preserves `original_protocol = GR | PAR`, pooled/cohort/target-session summaries, full-frontier and positive-budget AUCs. Promoted inference must account for repeated sessions within participant.

## Artifact bundle

```text
study_manifest.json
split_authority.json
method_runs.json
results.csv
summary.json
report.md
artifact_hashes.json
```

Public package APIs include `LongitudinalCaseAuthority`, `PreparedFrozenEncoderCase`, method specs, `LadderRuntimeConfig`, `run_ladder_method(...)`, paired case/frontier helpers and summary/report generation.

## Current-main reconciliation

This branch now includes current neurOS `main` at `ecabc539a17ab063117d586b8bbd44faa6a8ed0d`, preserving the merged QuantumBCI research-extension documentation while retaining the model-ladder navigation and implementation.

## Exact-head qualification

Exact head: `7a4dc37a610049b1c5f78c27c69b43d5e89e10f0`

Both complete workflows passed on this exact combined head:

### neurOS real-world evidence — run `32783479688`

- MOABB evidence profile — success
- Evidence contracts / Python 3.10 — success
- Evidence contracts / Python 3.11 — success
- Evidence contracts / Python 3.12 — success
- Longitudinal model ladder / Python 3.11 — success
  - complete local PyTorch/MNE/MOABB/SourceWeigher stack installed;
  - authority, task decoders, frozen transfer, full seven-lane bundle and ladder CLI all passed.

### neurOS CI — run `32783479689`

All repository lanes passed, including:

- BCI end-to-end smoke
- kernel contracts on Python 3.10/3.11/3.12
- repository hygiene
- model / mech-int contracts
- recording interoperability
- scientific and latency gates
- ORION contracts/tokenization
- workspace wheel builds
- SourceWeigher on Python 3.10/3.11/3.12
- foundation interoperability

This exact head is fully qualified and ready to merge.