### PR TITLE
drivers: add deterministic synchronized LSL source

### DIFF
--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -6,6 +6,7 @@ on:
       - "packages/neuros-core/**"
       - "packages/neuros-drivers/**"
       - "tests/test_brainflow_driver.py"
+      - "tests/test_lsl_driver.py"
       - ".github/workflows/drivers-ci.yml"
   push:
     branches:
@@ -15,6 +16,7 @@ on:
       - "packages/neuros-core/**"
       - "packages/neuros-drivers/**"
       - "tests/test_brainflow_driver.py"
+      - "tests/test_lsl_driver.py"
       - ".github/workflows/drivers-ci.yml"
 
 permissions:
@@ -37,3 +39,20 @@ jobs:
           python -m pip install -e "packages/neuros-drivers[test]"
       - name: Verify hardware-boundary semantics without physical hardware
         run: pytest -q tests/test_brainflow_driver.py
+
+  lsl-contracts:
+    name: LSL synchronized source contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install driver test profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-drivers[test]"
+      - name: Verify LSL discovery and timing semantics with deterministic fakes
+        run: pytest -q tests/test_lsl_driver.py

--- a/packages/neuros-drivers/README.md
+++ b/packages/neuros-drivers/README.md
@@ -1,8 +1,8 @@
 # neurOS Drivers
 
-Hardware, simulated, and dataset sources for neurOS.
+Hardware, simulated, network-stream, and dataset sources for neurOS.
 
-The driver layer adapts acquisition systems to the neurOS streaming contracts. Hardware support is deliberately separated from hardware **qualification**: a driver can satisfy its software contract without implying that every device, firmware, transport, operating system, or montage has been validated.
+The driver layer adapts acquisition systems to the neurOS streaming contracts. Hardware support is deliberately separated from hardware **qualification**: a driver can satisfy its software contract without implying that every device, firmware, transport, operating system, montage, or network topology has been validated.
 
 ## Installation
 
@@ -13,6 +13,9 @@ pip install neuros-drivers
 # EEG acquisition through BrainFlow + LSL dependencies
 pip install "neuros-drivers[eeg]"
 
+# LSL-only network acquisition
+pip install "neuros-drivers[lsl]"
+
 # Other optional integrations
 pip install "neuros-drivers[video]"
 pip install "neuros-drivers[nwb]"
@@ -21,7 +24,7 @@ pip install "neuros-drivers[all]"
 
 ## Mock data
 
-Synthetic data is always explicit. neurOS does not silently replace a requested hardware source with a mock source.
+Synthetic data is always explicit. neurOS does not silently replace a requested hardware or network source with a mock source.
 
 ```python
 import asyncio
@@ -89,26 +92,94 @@ BrainFlow matrices are board-specific. The driver therefore:
 
 These are software safety properties, not evidence that a physical device is qualified. Device qualification still requires measured packet loss, synchronization uncertainty, drift, reconnect behavior, sustained recording reliability, and end-to-end latency for the exact hardware/firmware/software combination.
 
+## Lab Streaming Layer
+
+`LSLDriver` is the first-class neurOS source for continuous regular-rate Lab Streaming Layer streams. It is designed for synchronized multimodal lab acquisition, not for silently choosing whichever outlet happens to be visible first.
+
+```python
+import asyncio
+
+from neuros.drivers import LSLDriver
+
+
+async def main() -> None:
+    driver = LSLDriver(
+        source_id="my-eeg-headset",
+        stream_type="EEG",
+        sampling_rate=250,  # expected rate assertion
+        channels=8,         # expected geometry assertion
+    )
+    await driver.start()
+    try:
+        print(driver.descriptor)
+        async for frame in driver.frames():
+            print(frame.sequence_id, frame.data, frame.timestamp_seconds)
+            break
+    finally:
+        await driver.stop()
+
+
+asyncio.run(main())
+```
+
+At least one exact selector is required: `source_id`, `name`, or `stream_type`. `source_id` is preferred whenever the producer exposes a stable identity. If the supplied selectors still match multiple streams, neurOS fails startup and asks for a more specific selector instead of binding nondeterministically.
+
+### LSL timing semantics
+
+The v1 source keeps liblsl post-processing flags disabled and records its timing transformation explicitly:
+
+```text
+raw LSL sample timestamp
+        +
+LSL inlet time_correction estimate
+        =
+SignalFrame.synchronized_time_ns
+```
+
+Each canonical frame is published with `ClockDomain.SYNCHRONIZED` and retains both `lsl_raw_timestamp_seconds` and `lsl_time_correction_seconds` in metadata. The correction estimate can be refreshed periodically without hiding the exact correction used for any emitted frame.
+
+This is intentional. neurOS does not silently enable LSL dejittering, monotonization, or other timestamp post-processing at the acquisition boundary. Those operations can materially change timing evidence and should be explicit transforms in a qualified pipeline.
+
+The initial first-class source supports **continuous streams with a positive nominal sampling rate**. Irregular event/marker streams should use a dedicated event contract rather than pretending that a zero-rate marker channel is sampled neural data.
+
+When `recover=True`, liblsl recovery is enabled only when the discovered stream exposes a non-empty `source_id`. Expected `sampling_rate=` and `channels=` values are startup assertions, not resampling or channel-selection instructions.
+
+## LSL software qualification boundary
+
+The deterministic LSL contract tests verify, without requiring a physical network stream:
+
+- fail-closed optional dependency behavior;
+- deterministic and unambiguous stream selection;
+- continuous-rate and channel-geometry validation;
+- explicit raw-timestamp plus time-correction semantics;
+- synchronized `SignalFrame` publication;
+- disabled hidden timestamp post-processing;
+- recovery gating on `source_id`;
+- malformed-chunk failure propagation and inlet cleanup.
+
+They do **not** establish a hardware/network qualification result. A named LSL deployment still needs measured clock offset/uncertainty, packet loss, reconnect behavior, topology and firewall behavior, long-run buffer integrity, and end-to-end latency on the actual hosts and network.
+
 ## Supported acquisition families
 
 Current package surfaces include:
 
 - BrainFlow-compatible EEG/biosignal devices;
+- first-class continuous Lab Streaming Layer sources;
 - simulated/mock sources;
 - dataset playback;
 - ECG, ECoG, EMG, EOG, fNIRS, GSR, respiration, and other research-oriented source modules;
 - optional video/audio dependencies;
 - NWB-related integration dependencies.
 
-Lab Streaming Layer support is part of the broader neurOS interoperability stack. New hardware integrations should prefer the neurOS source/plugin contract rather than adding device-specific behavior to `neuros-core`.
+New hardware integrations should prefer the neurOS source/plugin contract rather than adding device-specific behavior to `neuros-core`.
 
 ## Contributor rule
 
-A hardware PR should distinguish three different claims:
+A hardware or live-stream PR should distinguish three different claims:
 
 1. **software contract:** the driver behaves correctly against deterministic fakes/fixtures;
-2. **integration:** the real SDK/device can stream through neurOS;
-3. **hardware qualification:** a named hardware/firmware/transport/software combination passes a recorded qualification protocol.
+2. **integration:** the real SDK/device/network stream can run through neurOS;
+3. **hardware qualification:** a named hardware/firmware/transport/software/network combination passes a recorded qualification protocol.
 
 Only claim the strongest tier actually tested.
 

--- a/packages/neuros-drivers/pyproject.toml
+++ b/packages/neuros-drivers/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neuros-drivers"
-version = "2.0.0"
+version = "2.1.0"
 description = "Hardware and dataset sources for neurOS"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,6 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 eeg = ["brainflow>=5.10.0", "pylsl>=1.16.1"]
+lsl = ["pylsl>=1.16.1"]
 video = ["opencv-python>=4.8.0"]
 audio = ["pyaudio>=0.2.13"]
 nwb = ["pynwb>=2.2.0", "hdmf>=3.10.0"]
@@ -43,6 +44,7 @@ test = ["pytest>=7.4", "pytest-asyncio>=0.21"]
 [project.entry-points."neuros.sources"]
 mock = "neuros.drivers.mock_driver:MockDriver"
 brainflow = "neuros.drivers.brainflow_driver:BrainFlowDriver"
+lsl = "neuros.drivers.lsl_driver:LSLDriver"
 dataset = "neuros.drivers.dataset_driver:DatasetDriver"
 ecg = "neuros.drivers.ecg_driver:ECGDriver"
 ecog = "neuros.drivers.ecog_driver:ECoGDriver"

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -1,31 +1,31 @@
 """
-Drivers provide a common interface for acquiring neural signals.  A driver
-abstracts away hardware details and exposes an asynchronous iterator
-yielding samples as NumPy arrays.
+Drivers provide a common interface for acquiring neural signals. A driver
+abstracts away hardware details and exposes asynchronous neural streams.
 """
 
 from neuros.drivers.base_driver import BaseDriver  # noqa: F401
-from neuros.drivers.mock_driver import MockDriver  # noqa: F401
 from neuros.drivers.brainflow_driver import BrainFlowDriver  # noqa: F401
+from neuros.drivers.lsl_driver import LSLDriver  # noqa: F401
+from neuros.drivers.mock_driver import MockDriver  # noqa: F401
 
 # additional drivers
-from neuros.drivers.video_driver import VideoDriver  # noqa: F401
 from neuros.drivers.dataset_driver import DatasetDriver  # noqa: F401
 from neuros.drivers.motion_sensor_driver import MotionSensorDriver  # noqa: F401
+from neuros.drivers.video_driver import VideoDriver  # noqa: F401
 
 # biosignal drivers
+from neuros.drivers.calcium_imaging_driver import CalciumImagingDriver  # noqa: F401
 from neuros.drivers.ecog_driver import ECoGDriver  # noqa: F401
 from neuros.drivers.emg_driver import EMGDriver  # noqa: F401
 from neuros.drivers.eog_driver import EOGDriver  # noqa: F401
-from neuros.drivers.calcium_imaging_driver import CalciumImagingDriver  # noqa: F401
 
 # newly added biosignal and audio drivers
+from neuros.drivers.audio_driver import AudioDriver  # noqa: F401
 from neuros.drivers.ecg_driver import ECGDriver  # noqa: F401
 from neuros.drivers.gsr_driver import GSRDriver  # noqa: F401
-from neuros.drivers.respiration_driver import RespirationDriver  # noqa: F401
 from neuros.drivers.hormone_driver import HormoneDriver  # noqa: F401
-from neuros.drivers.audio_driver import AudioDriver  # noqa: F401
+from neuros.drivers.respiration_driver import RespirationDriver  # noqa: F401
 
 # behavioural and optical drivers
-from neuros.drivers.phone_driver import PhoneDriver  # noqa: F401
 from neuros.drivers.fnirs_driver import FnirsDriver  # noqa: F401
+from neuros.drivers.phone_driver import PhoneDriver  # noqa: F401

--- a/packages/neuros-drivers/src/neuros/drivers/lsl_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/lsl_driver.py
@@ -47,7 +47,9 @@ class LSLDriver(BaseDriver):
     channels:
         Optional expected channel count. It is an assertion, not a selector.
     resolve_timeout:
-        Maximum seconds spent resolving the primary selector at startup.
+        Maximum seconds spent resolving the primary selector at startup. The
+        complete window is deliberately used to detect a second matching
+        outlet before a stream is accepted.
     open_timeout:
         Maximum seconds spent opening the selected inlet.
     time_correction_timeout:
@@ -192,11 +194,15 @@ class LSLDriver(BaseDriver):
         else:
             prop, value = "type", self._stream_type
 
+        # pylsl's resolver may return as soon as ``minimum`` candidates are
+        # found. Request two so the full timeout is spent checking for a second
+        # matching outlet when only one is initially visible. This makes the
+        # fail-on-ambiguity contract deterministic within the discovery window.
         candidates = list(
             self._resolve_byprop(
                 prop,
                 value,
-                minimum=1,
+                minimum=2,
                 timeout=self._resolve_timeout,
             )
         )
@@ -316,8 +322,8 @@ class LSLDriver(BaseDriver):
                 channel_types=tuple(self.modality for _ in range(channel_count)),
                 clock_domain=ClockDomain.SYNCHRONIZED,
                 device=name,
-                manufacturer="Lab Streaming Layer",
                 metadata={
+                    "transport": "lsl",
                     "lsl_name": name,
                     "lsl_type": stream_type,
                     "lsl_source_id": source_id,

--- a/packages/neuros-drivers/src/neuros/drivers/lsl_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/lsl_driver.py
@@ -1,0 +1,506 @@
+"""Fail-closed Lab Streaming Layer source for neurOS.
+
+The driver resolves one unambiguous continuous LSL stream, keeps liblsl
+post-processing disabled, applies the explicit LSL time-correction estimate,
+and publishes canonical :class:`~neuros.contracts.SignalFrame` objects in the
+synchronized clock domain.
+
+This module deliberately does not enable LSL dejitter/monotonization flags.
+Those operations alter timing semantics and should be explicit transforms in a
+qualified pipeline rather than hidden acquisition behavior.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from contextlib import suppress
+from typing import Any, AsyncIterator
+
+import numpy as np
+
+from neuros.contracts import ClockDomain, QualityFlag, SignalFrame, StreamDescriptor
+from neuros.drivers.base_driver import BaseDriver
+from neuros.runtime import OverflowPolicy, put_with_policy
+
+
+class LSLDriver(BaseDriver):
+    """Receive one continuous numeric stream through Lab Streaming Layer.
+
+    At least one deterministic selector must be supplied. If a selector still
+    matches multiple streams, startup fails instead of attaching to whichever
+    outlet happened to be discovered first.
+
+    Parameters
+    ----------
+    source_id:
+        Preferred LSL source identity. Use this whenever the producer exposes
+        a stable source ID.
+    name:
+        Optional exact LSL stream name constraint.
+    stream_type:
+        Optional exact LSL content type constraint, for example ``"EEG"``.
+    sampling_rate:
+        Optional expected nominal sampling rate. It is an assertion, not a
+        resampler.
+    channels:
+        Optional expected channel count. It is an assertion, not a selector.
+    resolve_timeout:
+        Maximum seconds spent resolving the primary selector at startup.
+    open_timeout:
+        Maximum seconds spent opening the selected inlet.
+    time_correction_timeout:
+        Maximum seconds for the initial LSL clock-correction estimate.
+    correction_refresh_seconds:
+        Refresh cadence for LSL's clock-correction estimate. Set to ``0`` to
+        retain the startup estimate for the session.
+    poll_interval_seconds:
+        Cooperative sleep used when no chunk is immediately available. LSL
+        pulls themselves are non-blocking so the neurOS event loop is not held
+        by a long acquisition call.
+    max_samples:
+        Maximum samples requested from one LSL chunk pull.
+    max_buflen:
+        liblsl inlet buffer length in seconds for regular-rate streams.
+    recover:
+        Request liblsl recovery. Recovery is only effective for streams that
+        expose a non-empty ``source_id``.
+    """
+
+    def __init__(
+        self,
+        *,
+        source_id: str | None = None,
+        name: str | None = None,
+        stream_type: str | None = None,
+        sampling_rate: float | None = None,
+        channels: int | None = None,
+        resolve_timeout: float = 2.0,
+        open_timeout: float = 2.0,
+        time_correction_timeout: float = 1.0,
+        correction_refresh_seconds: float = 5.0,
+        poll_interval_seconds: float = 0.002,
+        max_samples: int = 256,
+        max_buflen: int = 5,
+        recover: bool = True,
+        stream_id: str | None = None,
+        modality: str | None = None,
+        overflow_policy: OverflowPolicy = OverflowPolicy.DROP_OLDEST,
+    ) -> None:
+        try:
+            from pylsl import StreamInlet, resolve_byprop  # type: ignore
+        except (ImportError, OSError, RuntimeError) as exc:
+            raise ImportError(
+                "LSLDriver requires pylsl and a loadable liblsl runtime. "
+                "Install `neuros-drivers[eeg]` and follow pylsl's liblsl "
+                "installation guidance for the host platform."
+            ) from exc
+
+        self._source_id = self._clean_selector(source_id)
+        self._name = self._clean_selector(name)
+        self._stream_type = self._clean_selector(stream_type)
+        if not any((self._source_id, self._name, self._stream_type)):
+            raise ValueError(
+                "LSLDriver requires source_id, name, or stream_type; neurOS will "
+                "not attach to an arbitrary discovered LSL stream"
+            )
+
+        if sampling_rate is not None and sampling_rate <= 0:
+            raise ValueError("sampling_rate must be positive when provided")
+        if channels is not None and channels <= 0:
+            raise ValueError("channels must be positive when provided")
+        if resolve_timeout <= 0 or open_timeout <= 0 or time_correction_timeout <= 0:
+            raise ValueError("LSL startup timeouts must be positive")
+        if correction_refresh_seconds < 0:
+            raise ValueError("correction_refresh_seconds must be >= 0")
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive")
+        if max_samples <= 0 or max_buflen <= 0:
+            raise ValueError("max_samples and max_buflen must be positive")
+
+        self._StreamInlet = StreamInlet
+        self._resolve_byprop = resolve_byprop
+        self._expected_sampling_rate = float(sampling_rate) if sampling_rate is not None else None
+        self._expected_channels = int(channels) if channels is not None else None
+        self._resolve_timeout = float(resolve_timeout)
+        self._open_timeout = float(open_timeout)
+        self._time_correction_timeout = float(time_correction_timeout)
+        self._correction_refresh_seconds = float(correction_refresh_seconds)
+        self._poll_interval_seconds = float(poll_interval_seconds)
+        self._max_samples = int(max_samples)
+        self._max_buflen = int(max_buflen)
+        self._recover_requested = bool(recover)
+        self._explicit_stream_id = stream_id
+        self._explicit_modality = modality
+
+        self._inlet: Any | None = None
+        self._resolved_info: Any | None = None
+        self._descriptor: StreamDescriptor | None = None
+        self._time_correction_seconds: float | None = None
+        self._last_correction_refresh_monotonic = 0.0
+        self._sequence_id = 0
+
+        super().__init__(
+            sampling_rate=self._expected_sampling_rate or 1.0,
+            channels=self._expected_channels or 1,
+            stream_id=stream_id or "lsl-unresolved",
+            modality=modality or (self._stream_type or "unknown").lower(),
+            overflow_policy=overflow_policy,
+        )
+
+    @staticmethod
+    def _clean_selector(value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("LSL selectors must not be empty strings")
+        return cleaned
+
+    @staticmethod
+    def _info_value(info: Any, field: str) -> Any:
+        value = getattr(info, field, None)
+        return value() if callable(value) else value
+
+    def _matches_constraints(self, info: Any) -> bool:
+        constraints = {
+            "source_id": self._source_id,
+            "name": self._name,
+            "type": self._stream_type,
+        }
+        for field, expected in constraints.items():
+            if expected is None:
+                continue
+            if str(self._info_value(info, field) or "") != expected:
+                return False
+        return True
+
+    def _stream_identity(self, info: Any) -> str:
+        return (
+            f"name={self._info_value(info, 'name')!r}, "
+            f"type={self._info_value(info, 'type')!r}, "
+            f"source_id={self._info_value(info, 'source_id')!r}, "
+            f"uid={self._info_value(info, 'uid')!r}"
+        )
+
+    def _resolve_one(self) -> Any:
+        if self._source_id is not None:
+            prop, value = "source_id", self._source_id
+        elif self._name is not None:
+            prop, value = "name", self._name
+        else:
+            prop, value = "type", self._stream_type
+
+        candidates = list(
+            self._resolve_byprop(
+                prop,
+                value,
+                minimum=1,
+                timeout=self._resolve_timeout,
+            )
+        )
+        candidates = [item for item in candidates if self._matches_constraints(item)]
+        if not candidates:
+            raise RuntimeError(
+                "No LSL stream matched the requested selectors within "
+                f"{self._resolve_timeout:g}s"
+            )
+        if len(candidates) > 1:
+            identities = "; ".join(self._stream_identity(item) for item in candidates[:5])
+            raise RuntimeError(
+                "LSL stream selection is ambiguous; refine source_id/name/type. "
+                f"Matches: {identities}"
+            )
+        return candidates[0]
+
+    def _extract_channel_names(self, info: Any, channel_count: int) -> tuple[str, ...]:
+        fallback = tuple(f"lsl_ch{index}" for index in range(channel_count))
+        try:
+            node = info.desc().child("channels").child("channel")
+            names: list[str] = []
+            for index in range(channel_count):
+                if node is None or (hasattr(node, "empty") and node.empty()):
+                    return fallback
+                label = str(node.child_value("label") or "").strip()
+                names.append(label or fallback[index])
+                node = node.next_sibling()
+            return tuple(names)
+        except Exception:
+            return fallback
+
+    def _validate_info(self, info: Any) -> tuple[float, int]:
+        sample_rate = float(self._info_value(info, "nominal_srate") or 0.0)
+        channel_count = int(self._info_value(info, "channel_count") or 0)
+        if not math.isfinite(sample_rate) or sample_rate <= 0:
+            raise ValueError(
+                "LSLDriver v1 supports continuous regular-rate streams only; "
+                f"the selected stream reports nominal_srate={sample_rate!r}"
+            )
+        if channel_count <= 0:
+            raise ValueError("The selected LSL stream reports no channels")
+        if self._expected_sampling_rate is not None and not math.isclose(
+            sample_rate,
+            self._expected_sampling_rate,
+            rel_tol=0.0,
+            abs_tol=1e-9,
+        ):
+            raise ValueError(
+                "LSL stream sampling rate mismatch: expected "
+                f"{self._expected_sampling_rate:g} Hz, discovered {sample_rate:g} Hz"
+            )
+        if self._expected_channels is not None and channel_count != self._expected_channels:
+            raise ValueError(
+                "LSL stream channel-count mismatch: expected "
+                f"{self._expected_channels}, discovered {channel_count}"
+            )
+        return sample_rate, channel_count
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        if self._descriptor is None:
+            raise RuntimeError("LSL stream is unresolved; call `await driver.start()` first")
+        return self._descriptor
+
+    async def start(self) -> None:
+        if self._running:
+            return
+
+        try:
+            resolved = self._resolve_one()
+            sample_rate, channel_count = self._validate_info(resolved)
+            discovered_source_id = str(self._info_value(resolved, "source_id") or "")
+            effective_recover = self._recover_requested and bool(discovered_source_id)
+
+            # Keep liblsl timing post-processing disabled. neurOS records the
+            # explicit raw timestamp + time_correction mapping instead.
+            inlet = self._StreamInlet(
+                resolved,
+                max_buflen=self._max_buflen,
+                max_chunklen=0,
+                recover=effective_recover,
+                processing_flags=0,
+            )
+            self._inlet = inlet
+            open_stream = getattr(inlet, "open_stream", None)
+            if callable(open_stream):
+                open_stream(timeout=self._open_timeout)
+
+            full_info = resolved
+            info_getter = getattr(inlet, "info", None)
+            if callable(info_getter):
+                full_info = info_getter(timeout=self._open_timeout)
+                sample_rate, channel_count = self._validate_info(full_info)
+
+            correction = float(inlet.time_correction(timeout=self._time_correction_timeout))
+            if not math.isfinite(correction):
+                raise RuntimeError("LSL returned a non-finite clock-correction estimate")
+
+            self._resolved_info = full_info
+            self._time_correction_seconds = correction
+            self._last_correction_refresh_monotonic = time.monotonic()
+            self.sampling_rate = sample_rate
+            self.channels = channel_count
+            source_id = str(self._info_value(full_info, "source_id") or discovered_source_id)
+            name = str(self._info_value(full_info, "name") or "unnamed")
+            stream_type = str(self._info_value(full_info, "type") or "unknown")
+            uid = str(self._info_value(full_info, "uid") or "")
+            self.stream_id = self._explicit_stream_id or f"lsl:{source_id or uid or name}"
+            self.modality = self._explicit_modality or stream_type.lower()
+
+            self._descriptor = StreamDescriptor(
+                stream_id=self.stream_id,
+                modality=self.modality,
+                sample_rate_hz=sample_rate,
+                channel_names=self._extract_channel_names(full_info, channel_count),
+                channel_types=tuple(self.modality for _ in range(channel_count)),
+                clock_domain=ClockDomain.SYNCHRONIZED,
+                device=name,
+                manufacturer="Lab Streaming Layer",
+                metadata={
+                    "lsl_name": name,
+                    "lsl_type": stream_type,
+                    "lsl_source_id": source_id,
+                    "lsl_uid": uid,
+                    "lsl_hostname": str(self._info_value(full_info, "hostname") or ""),
+                    "lsl_session_id": str(self._info_value(full_info, "session_id") or ""),
+                    "lsl_channel_format": str(
+                        self._info_value(full_info, "channel_format") or ""
+                    ),
+                    "lsl_recover_requested": self._recover_requested,
+                    "lsl_recover_effective": effective_recover,
+                    "lsl_postprocessing_flags": 0,
+                    "timing_semantics": "raw_lsl_timestamp_plus_time_correction",
+                },
+            )
+            self._sequence_id = 0
+            await super().start()
+        except Exception:
+            self._close_inlet()
+            self._reset_resolved_state()
+            raise
+
+    async def stop(self) -> None:
+        runtime_error: BaseException | None = None
+        cleanup_error: BaseException | None = None
+        try:
+            await super().stop()
+        except BaseException as exc:
+            runtime_error = exc
+        try:
+            self._close_inlet()
+        except BaseException as exc:
+            cleanup_error = exc
+        finally:
+            self._reset_resolved_state(keep_descriptor=True)
+
+        if runtime_error is not None and cleanup_error is not None:
+            raise RuntimeError(
+                "LSL acquisition failed and inlet cleanup also failed: "
+                f"{cleanup_error!r}"
+            ) from runtime_error
+        if runtime_error is not None:
+            raise runtime_error
+        if cleanup_error is not None:
+            raise cleanup_error
+
+    def _close_inlet(self) -> None:
+        if self._inlet is None:
+            return
+        inlet, self._inlet = self._inlet, None
+        close_stream = getattr(inlet, "close_stream", None)
+        if callable(close_stream):
+            close_stream()
+
+    def _reset_resolved_state(self, *, keep_descriptor: bool = False) -> None:
+        self._resolved_info = None
+        self._time_correction_seconds = None
+        self._last_correction_refresh_monotonic = 0.0
+        if not keep_descriptor:
+            self._descriptor = None
+
+    def _refresh_time_correction_if_due(self) -> float:
+        if self._inlet is None or self._time_correction_seconds is None:
+            raise RuntimeError("LSL inlet is not initialized")
+        if self._correction_refresh_seconds > 0:
+            now = time.monotonic()
+            if now - self._last_correction_refresh_monotonic >= self._correction_refresh_seconds:
+                correction = float(
+                    self._inlet.time_correction(timeout=self._time_correction_timeout)
+                )
+                if not math.isfinite(correction):
+                    raise RuntimeError("LSL returned a non-finite clock-correction estimate")
+                self._time_correction_seconds = correction
+                self._last_correction_refresh_monotonic = now
+        return self._time_correction_seconds
+
+    async def _frame_stream(self) -> AsyncIterator[SignalFrame]:
+        if self._inlet is None:
+            raise RuntimeError("LSL inlet is not initialized")
+
+        while self._running:
+            correction = self._refresh_time_correction_if_due()
+            samples, timestamps = self._inlet.pull_chunk(
+                timeout=0.0,
+                max_samples=self._max_samples,
+            )
+            if not samples and not timestamps:
+                await asyncio.sleep(self._poll_interval_seconds)
+                continue
+            if len(samples) != len(timestamps):
+                raise RuntimeError(
+                    "LSL returned mismatched sample/timestamp chunk lengths: "
+                    f"{len(samples)} samples vs {len(timestamps)} timestamps"
+                )
+
+            host_receive_time_ns = time.monotonic_ns()
+            for sample, raw_timestamp in zip(samples, timestamps):
+                timestamp = float(raw_timestamp)
+                if not math.isfinite(timestamp) or timestamp <= 0:
+                    raise RuntimeError(f"LSL emitted invalid timestamp {timestamp!r}")
+                data = np.asarray(sample, dtype=np.float64)
+                if data.ndim != 1 or data.shape[0] != self.channels:
+                    raise RuntimeError(
+                        "LSL sample geometry does not match stream metadata: "
+                        f"expected ({self.channels},), received {data.shape}"
+                    )
+                if not np.isfinite(data).all():
+                    raise RuntimeError("LSL emitted NaN or infinite signal values")
+
+                synchronized_timestamp = timestamp + correction
+                yield SignalFrame(
+                    stream_id=self.stream_id,
+                    sequence_id=self._sequence_id,
+                    data=data,
+                    sample_rate_hz=self.sampling_rate,
+                    host_receive_time_ns=host_receive_time_ns,
+                    synchronized_time_ns=int(round(synchronized_timestamp * 1_000_000_000)),
+                    clock_domain=ClockDomain.SYNCHRONIZED,
+                    quality=QualityFlag.GOOD,
+                    metadata={
+                        "driver": self.__class__.__name__,
+                        "lsl_raw_timestamp_seconds": timestamp,
+                        "lsl_time_correction_seconds": correction,
+                    },
+                )
+                self._sequence_id += 1
+            await asyncio.sleep(0)
+
+    async def _run(self) -> None:
+        async for frame in self._frame_stream():
+            try:
+                await put_with_policy(
+                    self._queue,
+                    frame,
+                    policy=self.overflow_policy,
+                    stats=self._queue_stats,
+                )
+            except asyncio.CancelledError:
+                break
+            if not self._running:
+                break
+
+    async def _next_frame(self) -> SignalFrame:
+        if not self._queue.empty():
+            frame = self._queue.get_nowait()
+            self._queue.task_done()
+            return frame
+        if self._task is None:
+            raise RuntimeError("LSLDriver is not running")
+        if self._task.done():
+            await self._task
+            raise StopAsyncIteration
+
+        queue_get = asyncio.create_task(self._queue.get())
+        done, _ = await asyncio.wait(
+            {queue_get, self._task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if queue_get in done:
+            frame = queue_get.result()
+            self._queue.task_done()
+            return frame
+
+        queue_get.cancel()
+        with suppress(asyncio.CancelledError):
+            await queue_get
+        await self._task
+        raise StopAsyncIteration
+
+    async def frames(self) -> AsyncIterator[SignalFrame]:
+        """Yield synchronized canonical frames and surface acquisition failures."""
+        while self._running or not self._queue.empty():
+            try:
+                yield await self._next_frame()
+            except StopAsyncIteration:
+                break
+
+    async def __aiter__(self) -> AsyncIterator[tuple[float, np.ndarray]]:
+        """Yield legacy tuples using the corrected LSL timestamp."""
+        async for frame in self.frames():
+            yield frame.timestamp_seconds, frame.data
+
+    async def _stream(self) -> AsyncIterator[tuple[float, np.ndarray]]:
+        """Compatibility implementation for the BaseDriver private contract."""
+        async for frame in self._frame_stream():
+            yield frame.timestamp_seconds, frame.data

--- a/tests/test_lsl_driver.py
+++ b/tests/test_lsl_driver.py
@@ -1,0 +1,328 @@
+import builtins
+import sys
+import types
+
+import pytest
+
+from neuros.contracts import ClockDomain
+from neuros.drivers.lsl_driver import LSLDriver
+
+
+class FakeXMLNode:
+    def __init__(self, labels=None, index=0, empty=False):
+        self.labels = list(labels or [])
+        self.index = index
+        self._empty = empty
+
+    def child(self, name):
+        if name == "channels":
+            return self
+        if name == "channel":
+            if not self.labels:
+                return FakeXMLNode(empty=True)
+            return FakeXMLNode(self.labels, 0)
+        return FakeXMLNode(empty=True)
+
+    def child_value(self, name):
+        if name == "label" and self.index < len(self.labels):
+            return self.labels[self.index]
+        return ""
+
+    def next_sibling(self):
+        next_index = self.index + 1
+        if next_index >= len(self.labels):
+            return FakeXMLNode(empty=True)
+        return FakeXMLNode(self.labels, next_index)
+
+    def empty(self):
+        return self._empty
+
+
+class FakeInfo:
+    def __init__(
+        self,
+        *,
+        name="Fake EEG",
+        stream_type="EEG",
+        source_id="fake-source",
+        uid="fake-uid",
+        hostname="fake-host",
+        session_id="fake-session",
+        channel_format="float32",
+        channel_count=2,
+        nominal_srate=250.0,
+        channel_labels=("C3", "C4"),
+    ) -> None:
+        self._name = name
+        self._type = stream_type
+        self._source_id = source_id
+        self._uid = uid
+        self._hostname = hostname
+        self._session_id = session_id
+        self._channel_format = channel_format
+        self._channel_count = channel_count
+        self._nominal_srate = nominal_srate
+        self._channel_labels = tuple(channel_labels)
+
+    def name(self):
+        return self._name
+
+    def type(self):
+        return self._type
+
+    def source_id(self):
+        return self._source_id
+
+    def uid(self):
+        return self._uid
+
+    def hostname(self):
+        return self._hostname
+
+    def session_id(self):
+        return self._session_id
+
+    def channel_format(self):
+        return self._channel_format
+
+    def channel_count(self):
+        return self._channel_count
+
+    def nominal_srate(self):
+        return self._nominal_srate
+
+    def desc(self):
+        return FakeXMLNode(self._channel_labels)
+
+
+class FakeLSLRuntime:
+    streams = []
+    chunks = []
+    correction = 0.125
+    resolve_calls = []
+    inlet_instances = []
+
+    @classmethod
+    def reset(cls, *, streams=None, chunks=None, correction=0.125):
+        cls.streams = list(streams or [])
+        cls.chunks = list(chunks or [])
+        cls.correction = correction
+        cls.resolve_calls = []
+        cls.inlet_instances = []
+
+
+class FakeStreamInlet:
+    def __init__(
+        self,
+        info,
+        *,
+        max_buflen,
+        max_chunklen,
+        recover,
+        processing_flags,
+    ) -> None:
+        self._info = info
+        self.max_buflen = max_buflen
+        self.max_chunklen = max_chunklen
+        self.recover = recover
+        self.processing_flags = processing_flags
+        self.opened = False
+        self.closed = False
+        self.time_correction_calls = 0
+        self.chunks = list(FakeLSLRuntime.chunks)
+        FakeLSLRuntime.inlet_instances.append(self)
+
+    def open_stream(self, timeout):
+        assert timeout > 0
+        self.opened = True
+
+    def info(self, timeout):
+        assert timeout > 0
+        return self._info
+
+    def time_correction(self, timeout):
+        assert timeout > 0
+        self.time_correction_calls += 1
+        return FakeLSLRuntime.correction
+
+    def pull_chunk(self, *, timeout, max_samples):
+        assert timeout == 0.0
+        assert max_samples > 0
+        if self.chunks:
+            return self.chunks.pop(0)
+        return [], []
+
+    def close_stream(self):
+        self.closed = True
+
+
+def install_fake_pylsl(monkeypatch, *, streams=None, chunks=None, correction=0.125):
+    FakeLSLRuntime.reset(streams=streams, chunks=chunks, correction=correction)
+    module = types.ModuleType("pylsl")
+
+    def resolve_byprop(prop, value, minimum=1, timeout=1.0):
+        FakeLSLRuntime.resolve_calls.append((prop, value, minimum, timeout))
+        return list(FakeLSLRuntime.streams)
+
+    module.resolve_byprop = resolve_byprop
+    module.StreamInlet = FakeStreamInlet
+    monkeypatch.setitem(sys.modules, "pylsl", module)
+
+
+def test_lsl_missing_dependency_fails_closed(monkeypatch):
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "pylsl" or name.startswith("pylsl."):
+            raise ImportError("pylsl intentionally unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    with pytest.raises(ImportError, match=r"neuros-drivers\[eeg\].*liblsl"):
+        LSLDriver(source_id="missing")
+
+
+def test_lsl_requires_deterministic_selector(monkeypatch):
+    install_fake_pylsl(monkeypatch)
+
+    with pytest.raises(ValueError, match="requires source_id, name, or stream_type"):
+        LSLDriver()
+
+
+@pytest.mark.asyncio
+async def test_lsl_rejects_ambiguous_streams(monkeypatch):
+    install_fake_pylsl(
+        monkeypatch,
+        streams=[
+            FakeInfo(name="EEG A", source_id="a"),
+            FakeInfo(name="EEG B", source_id="b"),
+        ],
+    )
+    driver = LSLDriver(stream_type="EEG")
+
+    with pytest.raises(RuntimeError, match="selection is ambiguous"):
+        await driver.start()
+
+    assert FakeLSLRuntime.inlet_instances == []
+    assert driver._running is False
+
+
+@pytest.mark.asyncio
+async def test_lsl_emits_explicitly_synchronized_canonical_frames(monkeypatch):
+    info = FakeInfo(source_id="headset-1", channel_labels=("C3", "C4"))
+    install_fake_pylsl(
+        monkeypatch,
+        streams=[info],
+        chunks=[([[1.0, 2.0], [3.0, 4.0]], [100.0, 100.004])],
+        correction=0.125,
+    )
+    driver = LSLDriver(
+        source_id="headset-1",
+        stream_type="EEG",
+        sampling_rate=250,
+        channels=2,
+        correction_refresh_seconds=0,
+    )
+
+    await driver.start()
+    descriptor = driver.descriptor
+    assert descriptor.clock_domain is ClockDomain.SYNCHRONIZED
+    assert descriptor.channel_names == ("C3", "C4")
+    assert descriptor.metadata["lsl_source_id"] == "headset-1"
+    assert descriptor.metadata["lsl_postprocessing_flags"] == 0
+    assert descriptor.metadata["timing_semantics"] == (
+        "raw_lsl_timestamp_plus_time_correction"
+    )
+
+    frames = []
+    async for frame in driver.frames():
+        frames.append(frame)
+        if len(frames) == 2:
+            break
+
+    await driver.stop()
+
+    assert [frame.sequence_id for frame in frames] == [0, 1]
+    assert [frame.data.tolist() for frame in frames] == [[1.0, 2.0], [3.0, 4.0]]
+    assert frames[0].clock_domain is ClockDomain.SYNCHRONIZED
+    assert frames[0].synchronized_time_ns == 100_125_000_000
+    assert frames[1].synchronized_time_ns == 100_129_000_000
+    assert frames[0].metadata["lsl_raw_timestamp_seconds"] == 100.0
+    assert frames[0].metadata["lsl_time_correction_seconds"] == 0.125
+
+    inlet = FakeLSLRuntime.inlet_instances[-1]
+    assert inlet.opened is True
+    assert inlet.closed is True
+    assert inlet.recover is True
+    assert inlet.processing_flags == 0
+    assert inlet.time_correction_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("driver_kwargs", "message"),
+    [
+        ({"sampling_rate": 200}, "sampling rate mismatch"),
+        ({"channels": 8}, "channel-count mismatch"),
+    ],
+)
+async def test_lsl_expected_geometry_is_asserted(monkeypatch, driver_kwargs, message):
+    install_fake_pylsl(monkeypatch, streams=[FakeInfo(source_id="headset-1")])
+    driver = LSLDriver(source_id="headset-1", **driver_kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        await driver.start()
+
+    assert FakeLSLRuntime.inlet_instances == []
+    assert driver._running is False
+
+
+@pytest.mark.asyncio
+async def test_lsl_recovery_is_disabled_without_source_id(monkeypatch):
+    install_fake_pylsl(
+        monkeypatch,
+        streams=[FakeInfo(name="NoSourceId", source_id="")],
+        chunks=[([[1.0, 2.0]], [10.0])],
+    )
+    driver = LSLDriver(name="NoSourceId", recover=True, correction_refresh_seconds=0)
+
+    await driver.start()
+    inlet = FakeLSLRuntime.inlet_instances[-1]
+    assert inlet.recover is False
+    assert driver.descriptor.metadata["lsl_recover_requested"] is True
+    assert driver.descriptor.metadata["lsl_recover_effective"] is False
+    await driver.stop()
+
+
+@pytest.mark.asyncio
+async def test_lsl_rejects_irregular_streams(monkeypatch):
+    install_fake_pylsl(
+        monkeypatch,
+        streams=[FakeInfo(source_id="markers", stream_type="Markers", nominal_srate=0.0)],
+    )
+    driver = LSLDriver(source_id="markers")
+
+    with pytest.raises(ValueError, match="continuous regular-rate streams only"):
+        await driver.start()
+
+    assert FakeLSLRuntime.inlet_instances == []
+
+
+@pytest.mark.asyncio
+async def test_lsl_acquisition_failure_surfaces_to_frame_consumer_and_closes(monkeypatch):
+    install_fake_pylsl(
+        monkeypatch,
+        streams=[FakeInfo(source_id="headset-1")],
+        chunks=[([[1.0, 2.0]], [10.0, 10.004])],
+    )
+    driver = LSLDriver(source_id="headset-1", correction_refresh_seconds=0)
+    await driver.start()
+
+    with pytest.raises(RuntimeError, match="mismatched sample/timestamp"):
+        await anext(driver.frames())
+
+    with pytest.raises(RuntimeError, match="mismatched sample/timestamp"):
+        await driver.stop()
+
+    assert FakeLSLRuntime.inlet_instances[-1].closed is True

--- a/tests/test_lsl_driver.py
+++ b/tests/test_lsl_driver.py
@@ -204,6 +204,7 @@ async def test_lsl_rejects_ambiguous_streams(monkeypatch):
     with pytest.raises(RuntimeError, match="selection is ambiguous"):
         await driver.start()
 
+    assert FakeLSLRuntime.resolve_calls == [("type", "EEG", 2, 2.0)]
     assert FakeLSLRuntime.inlet_instances == []
     assert driver._running is False
 
@@ -229,11 +230,14 @@ async def test_lsl_emits_explicitly_synchronized_canonical_frames(monkeypatch):
     descriptor = driver.descriptor
     assert descriptor.clock_domain is ClockDomain.SYNCHRONIZED
     assert descriptor.channel_names == ("C3", "C4")
+    assert descriptor.manufacturer is None
+    assert descriptor.metadata["transport"] == "lsl"
     assert descriptor.metadata["lsl_source_id"] == "headset-1"
     assert descriptor.metadata["lsl_postprocessing_flags"] == 0
     assert descriptor.metadata["timing_semantics"] == (
         "raw_lsl_timestamp_plus_time_correction"
     )
+    assert FakeLSLRuntime.resolve_calls == [("source_id", "headset-1", 2, 2.0)]
 
     frames = []
     async for frame in driver.frames():


### PR DESCRIPTION
## Summary

Promotes Lab Streaming Layer from an optional dependency / secondary sync utility into a first-class `neuros.sources` acquisition plugin.

### Acquisition contract
- adds `LSLDriver` for continuous regular-rate numeric streams
- requires deterministic `source_id`, name, or type selection
- fails on ambiguous or missing streams instead of attaching to the first discovery result
- treats expected sample rate and channel count as assertions, never fake resampling
- keeps liblsl post-processing flags disabled at acquisition
- records the exact raw LSL timestamp and explicit `time_correction()` value used for every canonical frame
- emits `SignalFrame` with `ClockDomain.SYNCHRONIZED`
- enables liblsl recovery only when a non-empty `source_id` makes recovery meaningful
- surfaces malformed chunk / acquisition failures to frame consumers and closes the inlet

### Packaging
- exposes `lsl = neuros.drivers.lsl_driver:LSLDriver` in `neuros.sources`
- adds `neuros-drivers[lsl]`
- bumps `neuros-drivers` to 2.1.0

### Evidence
- deterministic fake-pylsl contract suite covers dependency failure, selector requirements, ambiguity, sample-rate/channel assertions, synchronized timestamp semantics, recovery gating, irregular-stream rejection, malformed chunk propagation, and cleanup
- adds a dedicated path-scoped `LSL synchronized source contracts` CI job

## Claim boundary

This is a software-contract qualification for the LSL source boundary. It does not claim physical device, network topology, clock uncertainty, reconnect, packet-loss, or end-to-end hardware qualification. Those belong in a named `HardwareQualificationManifest` / evidence bundle in a later layer.

## Strategic role

This establishes the live non-invasive interoperability spine intended for neurOS: device SDKs can terminate in BrainFlow, native producers can publish LSL, and neurOS receives both through explicit source contracts rather than reimplementing transport protocols.