### PR TITLE
Make neural windows a first-class neurOS runtime contract

### DIFF
--- a/.github/workflows/neural-window-ci.yml
+++ b/.github/workflows/neural-window-ci.yml
@@ -1,0 +1,77 @@
+name: Neural Window Contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-core/**"
+      - "packages/neuros-models/**"
+      - "tests/test_neural_windows.py"
+      - "tests/test_neural_window_model_integration.py"
+      - ".github/workflows/neural-window-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/neuros-core/**"
+      - "packages/neuros-models/**"
+      - "tests/test_neural_windows.py"
+      - "tests/test_neural_window_model_integration.py"
+      - ".github/workflows/neural-window-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  window-contracts:
+    name: Neural window contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install kernel test profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[test]"
+      - name: Verify window, runtime, config, and plugin contracts
+        run: |
+          pytest -q \
+            tests/test_neural_windows.py \
+            tests/test_runtime_executor.py \
+            tests/test_plugin_registry.py \
+            tests/test_config_schema.py
+
+  installed-window-model:
+    name: Installed EEGNet neural-window integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install kernel and raw-window model stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[test]"
+          python -m pip install -e "packages/neuros-models[pytorch]"
+      - name: Verify installed window transform entry point
+        run: |
+          python - <<'PY'
+          from importlib.metadata import entry_points
+
+          transforms = {entry.name: entry for entry in entry_points(group="neuros.transforms")}
+          assert "window" in transforms, sorted(transforms)
+          transform_type = transforms["window"].load()
+          transform = transform_type(window_samples=64, stride_samples=32)
+          assert transform.spec.window_samples == 64
+          assert transform.spec.stride_samples == 32
+          PY
+      - name: Run a maintained raw-window decoder through RuntimeGraph
+        run: pytest -q tests/test_neural_window_model_integration.py

--- a/docs/NEURAL_WINDOWS.md
+++ b/docs/NEURAL_WINDOWS.md
@@ -1,0 +1,144 @@
+# Neural windows
+
+`SignalFrame` and `NeuralWindow` represent different stages of the neurOS data plane.
+
+- **`SignalFrame`** is a timestamped streaming chunk. Its native multi-sample convention is `sample x channel` and must be declared through `metadata["axis_order"]` when two-dimensional.
+- **`NeuralWindow`** is exactly one decoder-ready temporal window. Its geometry is always `channel x time`.
+- **The runtime**, not the model adapter, adds the batch dimension. A `NeuralWindow(C, T)` therefore reaches a decoder as `(1, C, T)`.
+
+This boundary exists so raw-window neural models do not depend on hidden NumPy conventions.
+
+## Canonical path
+
+```text
+hardware / MNE / LSL / replay
+              |
+              v
+         SignalFrame
+       sample x channel
+              |
+              v
+   SlidingWindowTransform
+              |
+              v
+         NeuralWindow
+        channel x time
+              |
+              v
+        RuntimeExecutor
+        adds batch axis
+              |
+              v
+          Decoder
+      1 x channel x time
+              |
+              v
+       DecoderOutput
+  + window provenance
+```
+
+## Window specification
+
+Window geometry is sample-domain and deterministic:
+
+```python
+from neuros.contracts import WindowSpec
+
+spec = WindowSpec(window_samples=500, stride_samples=125)
+```
+
+A seconds-based constructor is available when the sampling rate is known:
+
+```python
+spec = WindowSpec.from_seconds(
+    sample_rate_hz=250.0,
+    window_seconds=2.0,
+    stride_seconds=0.5,
+)
+```
+
+`stride_samples` may equal `window_samples` for non-overlapping windows. A stride larger than the window is rejected because neurOS does not silently create temporal holes.
+
+## Windowing inside RuntimeGraph
+
+```python
+from neuros.contracts import WindowSpec
+from neuros.processing import SlidingWindowTransform
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
+
+windowing = SlidingWindowTransform(
+    WindowSpec(window_samples=500, stride_samples=125),
+    descriptor=source.descriptor,
+)
+
+graph = RuntimeGraph()
+graph.add_node(RuntimeNode("source", NodeKind.SOURCE, source))
+graph.add_node(RuntimeNode("window", NodeKind.TRANSFORM, windowing))
+graph.add_node(RuntimeNode("decoder", NodeKind.DECODER, decoder))
+graph.connect(RuntimeEdge("source", "window"))
+graph.connect(RuntimeEdge("window", "decoder"))
+```
+
+Chunked inputs may contain enough samples to create more than one window. The transform returns an explicit `TransformEmission`, and the native executor fans every emitted window downstream in deterministic order. Plain Python lists and tuples are **not** treated as fan-out because they may be legitimate data values.
+
+## Configuration-first path
+
+The same transform is registered as the `window` plugin:
+
+```yaml
+schema_version: 1
+streams:
+  - id: eeg
+    source:
+      plugin: lsl
+      options: {}
+    transforms:
+      - plugin: window
+        options:
+          window_samples: 500
+          stride_samples: 125
+          discontinuity: error
+
+decoder:
+  plugin: your_raw_window_decoder
+  options: {}
+```
+
+This is the intended path for EEGNet, CNN, Transformer, EEG-Conformer, and external raw-window decoder adapters. The legacy `Pipeline` remains a feature-vector compatibility facade and should not be used to route raw windows.
+
+## Provenance carried into inference
+
+Each `NeuralWindow` binds:
+
+- stream ID;
+- monotonic window ID;
+- sample rate;
+- channel names;
+- half-open start/end timestamps;
+- clock domain;
+- aggregated signal-quality flags;
+- the exact `SignalFrame.sequence_id` values used to construct it.
+
+When a decoder returns a `DecoderOutput`, the runtime adds this information to `DecoderOutput.metadata`. Predictions can therefore be traced back to the exact live or replayed source chunks that produced them.
+
+## Discontinuity semantics
+
+The default behavior is fail-closed:
+
+```python
+SlidingWindowTransform(spec, discontinuity="error")
+```
+
+A sequence gap, dropped-sample flag, incompatible clock transition, channel geometry change, or inconsistent sample rate cannot be silently bridged.
+
+For workloads where a discontinuity should begin a new independent segment, use:
+
+```python
+SlidingWindowTransform(spec, discontinuity="reset")
+```
+
+`reset` discards pending overlap and starts a new contiguous segment. It does **not** pad, interpolate, resample, or fabricate the missing samples. The transform records the discontinuity count in window metadata.
+
+## Scientific boundary
+
+Window creation is a representation boundary, not evidence of model validity. A decoder becomes trustworthy only when the resulting pipeline is exercised under the appropriate neurOS Evidence protocol, including subject/session separation, calibration accounting, artifact stress, device/montage transfer, and latency/closed-loop qualification where applicable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Implementation Sprints: neurotokenization/03_IMPLEMENTATION_SPRINTS.md
   - SDK:
       - Installation: getting-started/installation.md
+      - Neural Windows: NEURAL_WINDOWS.md
       - API Surface: API_REFERENCE.md
   - Research Extensions: RESEARCH_EXTENSIONS.md
   - Historical Archive: archive/README.md

--- a/packages/neuros-core/pyproject.toml
+++ b/packages/neuros-core/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 bandpass = "neuros.processing.plugin_transforms:BandpassTransform"
 smoothing = "neuros.processing.plugin_transforms:SmoothingTransform"
 bandpower = "neuros.processing.plugin_transforms:BandPowerTransform"
+window = "neuros.processing.plugin_transforms:NeuralWindowTransform"
 
 [project.urls]
 Homepage = "https://github.com/sidhulyalkar/neurOS-v1"

--- a/packages/neuros-core/src/neuros/contracts/__init__.py
+++ b/packages/neuros-core/src/neuros/contracts/__init__.py
@@ -2,8 +2,9 @@
 
 from .artifacts import ModelArtifactManifest
 from .models import Decoder, DecoderCapabilities, DecoderOutput, TrainableDecoder
-from .operators import Monitor, OutputSubscriber, Sink, Source, Transform
+from .operators import Monitor, OutputSubscriber, Sink, Source, Transform, TransformEmission
 from .signal import ClockDomain, QualityFlag, SignalFrame, StreamDescriptor
+from .window import NeuralWindow, WindowSpec
 
 __all__ = [
     "ClockDomain",
@@ -12,6 +13,7 @@ __all__ = [
     "DecoderOutput",
     "ModelArtifactManifest",
     "Monitor",
+    "NeuralWindow",
     "OutputSubscriber",
     "QualityFlag",
     "SignalFrame",
@@ -20,4 +22,6 @@ __all__ = [
     "StreamDescriptor",
     "TrainableDecoder",
     "Transform",
+    "TransformEmission",
+    "WindowSpec",
 ]

--- a/packages/neuros-core/src/neuros/contracts/operators.py
+++ b/packages/neuros-core/src/neuros/contracts/operators.py
@@ -1,11 +1,33 @@
-"""Protocols for runtime operators."""
+"""Protocols and explicit emission contracts for runtime operators."""
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Iterable, Protocol, runtime_checkable
 
 from .models import DecoderOutput
 from .signal import SignalFrame, StreamDescriptor
+
+
+@dataclass(frozen=True, slots=True)
+class TransformEmission:
+    """Explicit fan-out from one transform invocation.
+
+    Returning a plain list/tuple from a transform is ambiguous because arrays,
+    feature collections, and structured model inputs may themselves be
+    sequences. ``TransformEmission`` is therefore the only kernel-level signal
+    that one transform input should produce multiple downstream items.
+    """
+
+    items: tuple[Any, ...]
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise ValueError("TransformEmission must contain at least one item")
+
+    @classmethod
+    def from_iterable(cls, items: Iterable[Any]) -> "TransformEmission":
+        return cls(tuple(items))
 
 
 @runtime_checkable

--- a/packages/neuros-core/src/neuros/contracts/window.py
+++ b/packages/neuros-core/src/neuros/contracts/window.py
@@ -1,0 +1,130 @@
+"""Decoder-ready neural window contracts.
+
+A :class:`SignalFrame` represents one timestamped streaming chunk. A
+:class:`NeuralWindow` represents exactly one decoder-ready temporal window with
+canonical ``(channels, time)`` geometry. Keeping these concepts distinct removes
+array-shape guessing from model/runtime boundaries and makes window provenance
+replayable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .signal import ClockDomain, QualityFlag
+
+
+@dataclass(frozen=True, slots=True)
+class WindowSpec:
+    """Deterministic sample-domain windowing specification."""
+
+    window_samples: int
+    stride_samples: int
+
+    def __post_init__(self) -> None:
+        if self.window_samples <= 0:
+            raise ValueError("window_samples must be positive")
+        if self.stride_samples <= 0:
+            raise ValueError("stride_samples must be positive")
+        if self.stride_samples > self.window_samples:
+            raise ValueError("stride_samples cannot exceed window_samples")
+
+    @property
+    def overlap_samples(self) -> int:
+        return self.window_samples - self.stride_samples
+
+    @classmethod
+    def from_seconds(
+        cls,
+        *,
+        sample_rate_hz: float,
+        window_seconds: float,
+        stride_seconds: float,
+    ) -> "WindowSpec":
+        if sample_rate_hz <= 0:
+            raise ValueError("sample_rate_hz must be positive")
+        if window_seconds <= 0 or stride_seconds <= 0:
+            raise ValueError("window_seconds and stride_seconds must be positive")
+        return cls(
+            window_samples=int(round(window_seconds * sample_rate_hz)),
+            stride_samples=int(round(stride_seconds * sample_rate_hz)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NeuralWindow:
+    """One decoder-ready neural window with explicit geometry and provenance.
+
+    ``data`` is always two-dimensional and channel-major: ``(channels, time)``.
+    The runtime adds the batch axis at decoder invocation, yielding
+    ``(batch=1, channels, time)`` for raw-window neural decoders.
+    """
+
+    stream_id: str
+    window_id: int
+    data: NDArray[np.generic]
+    sample_rate_hz: float
+    start_time_ns: int
+    end_time_ns: int
+    channel_names: tuple[str, ...] = ()
+    source_sequence_ids: tuple[int, ...] = ()
+    clock_domain: ClockDomain = ClockDomain.UNKNOWN
+    quality: QualityFlag = QualityFlag.GOOD
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.stream_id:
+            raise ValueError("stream_id must be non-empty")
+        if self.window_id < 0:
+            raise ValueError("window_id must be >= 0")
+        if self.sample_rate_hz <= 0:
+            raise ValueError("sample_rate_hz must be positive")
+        if self.start_time_ns < 0 or self.end_time_ns <= self.start_time_ns:
+            raise ValueError("NeuralWindow requires a positive half-open time interval")
+
+        arr = np.asarray(self.data)
+        if arr.ndim != 2:
+            raise ValueError(
+                "NeuralWindow.data must have shape (channels, time); "
+                f"received {tuple(arr.shape)}"
+            )
+        if arr.shape[0] <= 0 or arr.shape[1] <= 0:
+            raise ValueError("NeuralWindow.data cannot contain empty axes")
+        if not np.isfinite(arr).all():
+            raise ValueError("NeuralWindow.data contains NaN or infinite values")
+        if self.channel_names and len(self.channel_names) != arr.shape[0]:
+            raise ValueError("channel_names must match the channel axis")
+        if any(sequence_id < 0 for sequence_id in self.source_sequence_ids):
+            raise ValueError("source_sequence_ids must be non-negative")
+        if any(
+            current <= previous
+            for previous, current in zip(
+                self.source_sequence_ids, self.source_sequence_ids[1:]
+            )
+        ):
+            raise ValueError("source_sequence_ids must be strictly increasing")
+
+        object.__setattr__(self, "data", arr)
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+    @property
+    def n_channels(self) -> int:
+        return int(self.data.shape[0])
+
+    @property
+    def n_samples(self) -> int:
+        return int(self.data.shape[1])
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.n_samples / self.sample_rate_hz
+
+    def as_batch(self) -> NDArray[np.generic]:
+        """Return one explicit decoder batch with shape ``(1, channels, time)``."""
+
+        return self.data[np.newaxis, ...]

--- a/packages/neuros-core/src/neuros/processing/__init__.py
+++ b/packages/neuros-core/src/neuros/processing/__init__.py
@@ -11,16 +11,22 @@ from neuros.processing.feature_extraction import (  # noqa: F401
 )
 from neuros.processing.filters import BandpassFilter, SmoothingFilter  # noqa: F401
 from neuros.processing.operators import FeatureTransform  # noqa: F401
+from neuros.processing.windowing import (  # noqa: F401
+    DiscontinuityPolicy,
+    SlidingWindowTransform,
+)
 
 __all__ = [
     "AdaptiveThreshold",
     "AudioFeatureExtractor",
     "BandPowerExtractor",
     "BandpassFilter",
+    "DiscontinuityPolicy",
     "FeatureTransform",
     "HeartRateExtractor",
     "HormoneExtractor",
     "RespirationExtractor",
     "SkinConductanceExtractor",
+    "SlidingWindowTransform",
     "SmoothingFilter",
 ]

--- a/packages/neuros-core/src/neuros/processing/plugin_transforms.py
+++ b/packages/neuros-core/src/neuros/processing/plugin_transforms.py
@@ -7,9 +7,10 @@ from typing import Any
 
 import numpy as np
 
-from neuros.contracts import SignalFrame
+from neuros.contracts import SignalFrame, WindowSpec
 from neuros.processing.feature_extraction import BandPowerExtractor
 from neuros.processing.filters import BandpassFilter, SmoothingFilter
+from neuros.processing.windowing import SlidingWindowTransform
 
 
 def _map(item: Any, data: np.ndarray, *, representation: str) -> Any:
@@ -47,3 +48,18 @@ class BandPowerTransform:
     def transform(self, item: Any) -> Any:
         data = np.asarray(item.data if isinstance(item, SignalFrame) else item)
         return _map(item, self.extractor.extract(data), representation="bandpower")
+
+
+class NeuralWindowTransform(SlidingWindowTransform):
+    """Configuration-friendly adapter for canonical decoder windows."""
+
+    def __init__(
+        self,
+        window_samples: int,
+        stride_samples: int,
+        discontinuity: str = "error",
+    ) -> None:
+        super().__init__(
+            WindowSpec(window_samples=window_samples, stride_samples=stride_samples),
+            discontinuity=discontinuity,
+        )

--- a/packages/neuros-core/src/neuros/processing/windowing.py
+++ b/packages/neuros-core/src/neuros/processing/windowing.py
@@ -1,0 +1,306 @@
+"""Deterministic SignalFrame -> NeuralWindow transforms."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import numpy as np
+
+from neuros.contracts import (
+    ClockDomain,
+    NeuralWindow,
+    QualityFlag,
+    SignalFrame,
+    StreamDescriptor,
+    TransformEmission,
+    WindowSpec,
+)
+
+
+class DiscontinuityPolicy(str, Enum):
+    """Behavior when frame continuity is broken."""
+
+    ERROR = "error"
+    RESET = "reset"
+
+
+class SlidingWindowTransform:
+    """Build decoder-ready windows from contiguous ``SignalFrame`` chunks.
+
+    Input frames use neurOS' streaming convention: one-dimensional frames are a
+    single multi-channel sample, while two-dimensional frames must declare
+    ``axis_order=('sample', 'channel')``. Output windows are always
+    ``(channels, time)``.
+
+    The transform never pads, interpolates, resamples, or stitches sequence
+    gaps. With ``discontinuity='error'`` (the default), gaps fail closed. The
+    opt-in ``'reset'`` policy discards pending overlap and begins a new
+    contiguous window segment.
+    """
+
+    def __init__(
+        self,
+        spec: WindowSpec,
+        *,
+        descriptor: StreamDescriptor | None = None,
+        discontinuity: DiscontinuityPolicy | str = DiscontinuityPolicy.ERROR,
+    ) -> None:
+        self.spec = spec
+        self.descriptor = descriptor
+        self.discontinuity = DiscontinuityPolicy(discontinuity)
+
+        self._stream_id: str | None = descriptor.stream_id if descriptor else None
+        self._sample_rate_hz: float | None = (
+            float(descriptor.sample_rate_hz) if descriptor else None
+        )
+        self._channel_names: tuple[str, ...] = (
+            tuple(descriptor.channel_names) if descriptor else ()
+        )
+        self._channel_count: int | None = (
+            len(self._channel_names) if self._channel_names else None
+        )
+        self._clock_domain: ClockDomain | None = (
+            descriptor.clock_domain
+            if descriptor and descriptor.clock_domain is not ClockDomain.UNKNOWN
+            else None
+        )
+
+        self._data = np.empty((0, self._channel_count or 0), dtype=np.float64)
+        self._times_ns = np.empty((0,), dtype=np.int64)
+        self._sequence_per_sample = np.empty((0,), dtype=np.int64)
+        self._quality_per_sample = np.empty((0,), dtype=np.int64)
+
+        self._last_sequence_id: int | None = None
+        self._next_window_id = 0
+        self._discontinuity_count = 0
+
+    @property
+    def pending_samples(self) -> int:
+        return int(self._data.shape[0])
+
+    @property
+    def discontinuity_count(self) -> int:
+        return self._discontinuity_count
+
+    def reset(self) -> None:
+        """Discard pending overlap without changing stream geometry."""
+
+        channel_count = self._channel_count or 0
+        self._data = np.empty((0, channel_count), dtype=np.float64)
+        self._times_ns = np.empty((0,), dtype=np.int64)
+        self._sequence_per_sample = np.empty((0,), dtype=np.int64)
+        self._quality_per_sample = np.empty((0,), dtype=np.int64)
+        self._last_sequence_id = None
+        self._clock_domain = (
+            self.descriptor.clock_domain
+            if self.descriptor
+            and self.descriptor.clock_domain is not ClockDomain.UNKNOWN
+            else None
+        )
+
+    @staticmethod
+    def _matrix(frame: SignalFrame) -> np.ndarray:
+        arr = np.asarray(frame.data)
+        if arr.ndim == 1:
+            matrix = arr.reshape(1, -1)
+        elif arr.ndim == 2:
+            axis_order = tuple(frame.metadata.get("axis_order", ()))
+            if axis_order != ("sample", "channel"):
+                raise ValueError(
+                    "Two-dimensional SignalFrames require "
+                    "metadata axis_order=('sample', 'channel') before windowing"
+                )
+            matrix = arr
+        else:
+            raise ValueError(
+                "SlidingWindowTransform accepts one- or two-dimensional SignalFrames"
+            )
+        if matrix.shape[0] == 0 or matrix.shape[1] == 0:
+            raise ValueError("SignalFrame cannot contain an empty sample/channel axis")
+        if not np.isfinite(matrix).all():
+            raise ValueError("SignalFrame contains NaN or infinite samples")
+        return np.asarray(matrix)
+
+    def _bind_geometry(self, frame: SignalFrame, matrix: np.ndarray) -> None:
+        if self._stream_id is None:
+            self._stream_id = frame.stream_id
+        elif frame.stream_id != self._stream_id:
+            raise ValueError(
+                f"Window transform is bound to stream {self._stream_id!r}, "
+                f"received {frame.stream_id!r}"
+            )
+
+        if self._sample_rate_hz is None:
+            self._sample_rate_hz = float(frame.sample_rate_hz)
+        elif not np.isclose(frame.sample_rate_hz, self._sample_rate_hz, rtol=0.0, atol=1e-12):
+            raise ValueError("SignalFrame sample rate changed within a window stream")
+
+        if self.descriptor is not None:
+            if frame.stream_id != self.descriptor.stream_id:
+                raise ValueError("SignalFrame stream_id does not match descriptor")
+            if not np.isclose(
+                frame.sample_rate_hz,
+                self.descriptor.sample_rate_hz,
+                rtol=0.0,
+                atol=1e-12,
+            ):
+                raise ValueError("SignalFrame sample rate does not match descriptor")
+
+        metadata_names = tuple(frame.metadata.get("channel_names", ()))
+        if metadata_names:
+            if len(metadata_names) != matrix.shape[1]:
+                raise ValueError("SignalFrame channel_names do not match channel axis")
+            if self._channel_names and metadata_names != self._channel_names:
+                raise ValueError("SignalFrame channel identity changed within stream")
+            self._channel_names = metadata_names
+
+        if self._channel_count is None:
+            self._channel_count = int(matrix.shape[1])
+            if not self._channel_names:
+                self._channel_names = tuple(
+                    f"ch{index}" for index in range(self._channel_count)
+                )
+            self._data = np.empty((0, self._channel_count), dtype=matrix.dtype)
+        elif matrix.shape[1] != self._channel_count:
+            raise ValueError("SignalFrame channel count changed within stream")
+
+        if self._channel_names and len(self._channel_names) != self._channel_count:
+            raise ValueError("Configured channel names do not match observed geometry")
+
+    def _handle_continuity(self, frame: SignalFrame) -> None:
+        if self._last_sequence_id is None:
+            return
+
+        expected = self._last_sequence_id + 1
+        broken = frame.sequence_id != expected or bool(
+            frame.quality & QualityFlag.DROPPED_SAMPLES
+        )
+        if not broken:
+            return
+
+        if self.discontinuity is DiscontinuityPolicy.ERROR:
+            reason = (
+                "dropped-sample quality flag"
+                if frame.quality & QualityFlag.DROPPED_SAMPLES
+                else f"sequence gap: expected {expected}, received {frame.sequence_id}"
+            )
+            raise ValueError(f"Cannot build a neural window across {reason}")
+
+        self._discontinuity_count += 1
+        channel_count = self._channel_count or 0
+        self._data = np.empty((0, channel_count), dtype=self._data.dtype)
+        self._times_ns = np.empty((0,), dtype=np.int64)
+        self._sequence_per_sample = np.empty((0,), dtype=np.int64)
+        self._quality_per_sample = np.empty((0,), dtype=np.int64)
+        self._clock_domain = None
+
+    def _bind_clock(self, frame: SignalFrame) -> None:
+        domain = frame.clock_domain
+        if self._clock_domain is None:
+            self._clock_domain = domain
+            return
+        if domain != self._clock_domain:
+            if self.pending_samples and self.discontinuity is DiscontinuityPolicy.ERROR:
+                raise ValueError("Clock domain changed inside a pending neural window")
+            if self.pending_samples:
+                self._discontinuity_count += 1
+                channel_count = self._channel_count or 0
+                self._data = np.empty((0, channel_count), dtype=self._data.dtype)
+                self._times_ns = np.empty((0,), dtype=np.int64)
+                self._sequence_per_sample = np.empty((0,), dtype=np.int64)
+                self._quality_per_sample = np.empty((0,), dtype=np.int64)
+            self._clock_domain = domain
+
+    def transform(self, frame: SignalFrame) -> TransformEmission | None:
+        if not isinstance(frame, SignalFrame):
+            raise TypeError("SlidingWindowTransform requires SignalFrame input")
+
+        matrix = self._matrix(frame)
+        self._bind_geometry(frame, matrix)
+        self._handle_continuity(frame)
+        self._bind_clock(frame)
+
+        assert self._sample_rate_hz is not None
+        assert self._stream_id is not None
+        assert self._channel_count is not None
+
+        period_ns = 1_000_000_000.0 / self._sample_rate_hz
+        sample_times = np.asarray(
+            [
+                int(round(frame.timestamp_ns + offset * period_ns))
+                for offset in range(matrix.shape[0])
+            ],
+            dtype=np.int64,
+        )
+        if self.pending_samples and sample_times[0] <= self._times_ns[-1]:
+            if self.discontinuity is DiscontinuityPolicy.ERROR:
+                raise ValueError("SignalFrame timestamps are not strictly increasing")
+            self._discontinuity_count += 1
+            self.reset()
+            self._clock_domain = frame.clock_domain
+
+        matrix = np.asarray(matrix)
+        if self._data.dtype != matrix.dtype and self.pending_samples == 0:
+            self._data = np.empty((0, self._channel_count), dtype=matrix.dtype)
+        self._data = np.concatenate([self._data, matrix], axis=0)
+        self._times_ns = np.concatenate([self._times_ns, sample_times])
+        self._sequence_per_sample = np.concatenate(
+            [
+                self._sequence_per_sample,
+                np.full(matrix.shape[0], frame.sequence_id, dtype=np.int64),
+            ]
+        )
+        self._quality_per_sample = np.concatenate(
+            [
+                self._quality_per_sample,
+                np.full(matrix.shape[0], int(frame.quality), dtype=np.int64),
+            ]
+        )
+        self._last_sequence_id = frame.sequence_id
+
+        windows: list[NeuralWindow] = []
+        while self.pending_samples >= self.spec.window_samples:
+            stop = self.spec.window_samples
+            sample_major = self._data[:stop]
+            source_sequences = tuple(
+                dict.fromkeys(
+                    int(value) for value in self._sequence_per_sample[:stop].tolist()
+                )
+            )
+            quality_value = 0
+            for value in self._quality_per_sample[:stop]:
+                quality_value |= int(value)
+
+            start_time_ns = int(self._times_ns[0])
+            end_time_ns = int(round(self._times_ns[stop - 1] + period_ns))
+            windows.append(
+                NeuralWindow(
+                    stream_id=self._stream_id,
+                    window_id=self._next_window_id,
+                    data=sample_major.T.copy(),
+                    sample_rate_hz=self._sample_rate_hz,
+                    start_time_ns=start_time_ns,
+                    end_time_ns=end_time_ns,
+                    channel_names=self._channel_names,
+                    source_sequence_ids=source_sequences,
+                    clock_domain=self._clock_domain or ClockDomain.UNKNOWN,
+                    quality=QualityFlag(quality_value),
+                    metadata={
+                        "representation": "neural_window",
+                        "axis_order": ("channel", "time"),
+                        "window_samples": self.spec.window_samples,
+                        "stride_samples": self.spec.stride_samples,
+                        "overlap_samples": self.spec.overlap_samples,
+                        "discontinuity_count": self._discontinuity_count,
+                    },
+                )
+            )
+            self._next_window_id += 1
+
+            stride = self.spec.stride_samples
+            self._data = self._data[stride:]
+            self._times_ns = self._times_ns[stride:]
+            self._sequence_per_sample = self._sequence_per_sample[stride:]
+            self._quality_per_sample = self._quality_per_sample[stride:]
+
+        return TransformEmission(tuple(windows)) if windows else None

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncIterator, Callable
 
 import numpy as np
 
-from neuros.contracts import DecoderOutput, SignalFrame
+from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
 from neuros.errors import ProcessingError
 from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from neuros.runtime.lifecycle import RuntimeEvent, RuntimeState
@@ -276,7 +276,12 @@ class RuntimeExecutor:
             started = time.perf_counter_ns()
             result = await self._invoke(node, item)
             self._node_stats[node.node_id].observe(time.perf_counter_ns() - started)
-            if result is not None and node.kind is not NodeKind.SINK:
+            if result is None or node.kind is NodeKind.SINK:
+                continue
+            if isinstance(result, TransformEmission):
+                for emitted in result.items:
+                    await self._emit(node, emitted)
+            else:
                 await self._emit(node, result)
 
     async def _run_fusion(self, node: RuntimeNode) -> None:
@@ -355,10 +360,29 @@ class RuntimeExecutor:
         if node.kind is NodeKind.DECODER:
             if not hasattr(operator, "infer"):
                 raise TypeError(f"Decoder node {node.node_id} lacks infer()")
-            value = np.asarray(item.data if isinstance(item, SignalFrame) else item)
-            if value.ndim == 1:
-                value = value.reshape(1, -1)
-            return await self._invoke_callable(node, operator.infer, value)
+            if isinstance(item, NeuralWindow):
+                value = item.as_batch()
+            else:
+                value = np.asarray(item.data if isinstance(item, SignalFrame) else item)
+                if value.ndim == 1:
+                    value = value.reshape(1, -1)
+            result = await self._invoke_callable(node, operator.infer, value)
+            if isinstance(item, NeuralWindow) and isinstance(result, DecoderOutput):
+                result = replace(
+                    result,
+                    metadata={
+                        **dict(result.metadata),
+                        "neuros_stream_id": item.stream_id,
+                        "neuros_window_id": item.window_id,
+                        "window_start_time_ns": item.start_time_ns,
+                        "window_end_time_ns": item.end_time_ns,
+                        "window_sample_rate_hz": item.sample_rate_hz,
+                        "window_channel_names": item.channel_names,
+                        "source_sequence_ids": item.source_sequence_ids,
+                        "window_quality": int(item.quality),
+                    },
+                )
+            return result
         if node.kind is NodeKind.SINK:
             if not hasattr(operator, "write"):
                 raise TypeError(f"Sink node {node.node_id} lacks write()")

--- a/tests/test_neural_window_model_integration.py
+++ b/tests/test_neural_window_model_integration.py
@@ -1,0 +1,96 @@
+import asyncio
+
+import numpy as np
+import pytest
+
+from neuros.contracts import SignalFrame, StreamDescriptor, WindowSpec
+from neuros.models import EEGNetModel
+from neuros.processing import SlidingWindowTransform
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+
+
+class _OneWindowSource:
+    def __init__(self, data: np.ndarray, sample_rate_hz: float = 64.0) -> None:
+        self.data = np.asarray(data, dtype=np.float32)
+        self._descriptor = StreamDescriptor(
+            stream_id="eeg",
+            modality="eeg",
+            sample_rate_hz=sample_rate_hz,
+            channel_names=("C3", "C4"),
+        )
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return self._descriptor
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def frames(self):
+        yield SignalFrame(
+            stream_id="eeg",
+            sequence_id=0,
+            data=self.data,
+            sample_rate_hz=self._descriptor.sample_rate_hz,
+            host_receive_time_ns=1_000_000_000,
+            metadata={
+                "axis_order": ("sample", "channel"),
+                "channel_names": self._descriptor.channel_names,
+            },
+        )
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_eegnet_runs_through_canonical_neural_window_runtime_path():
+    rng = np.random.default_rng(7)
+    train_x = rng.normal(size=(6, 2, 64)).astype(np.float32)
+    train_y = np.array([0, 1, 0, 1, 0, 1], dtype=np.int64)
+
+    model = EEGNetModel(
+        n_channels=2,
+        n_classes=2,
+        temporal_filters=2,
+        depth_multiplier=1,
+        separable_filters=4,
+        temporal_kernel=15,
+        separable_kernel=7,
+        n_epochs=1,
+        batch_size=2,
+        random_state=7,
+        device="cpu",
+    )
+    model.train(train_x, train_y)
+
+    sample_major = rng.normal(size=(64, 2)).astype(np.float32)
+    source = _OneWindowSource(sample_major)
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, source))
+    graph.add_node(
+        RuntimeNode(
+            "window",
+            NodeKind.TRANSFORM,
+            SlidingWindowTransform(WindowSpec(64, 64), descriptor=source.descriptor),
+        )
+    )
+    graph.add_node(RuntimeNode("decoder", NodeKind.DECODER, model))
+    graph.connect(RuntimeEdge("source", "window", overflow="block"))
+    graph.connect(RuntimeEdge("window", "decoder", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    await executor.start()
+    outputs = [output async for output in executor.outputs()]
+    await executor.wait()
+
+    assert len(outputs) == 1
+    output = outputs[0]
+    assert output.model_id == "EEGNetModel"
+    assert output.probabilities is not None
+    assert np.asarray(output.probabilities).shape == (2,)
+    assert output.metadata["neuros_stream_id"] == "eeg"
+    assert output.metadata["neuros_window_id"] == 0
+    assert output.metadata["window_channel_names"] == ("C3", "C4")
+    assert output.metadata["source_sequence_ids"] == (0,)

--- a/tests/test_neural_windows.py
+++ b/tests/test_neural_windows.py
@@ -1,0 +1,253 @@
+import asyncio
+
+import numpy as np
+import pytest
+
+from neuros.contracts import (
+    DecoderCapabilities,
+    DecoderOutput,
+    NeuralWindow,
+    QualityFlag,
+    SignalFrame,
+    StreamDescriptor,
+    TransformEmission,
+    WindowSpec,
+)
+from neuros.processing import DiscontinuityPolicy, SlidingWindowTransform
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+
+
+def _frame(
+    sequence_id: int,
+    data: np.ndarray,
+    *,
+    start_time_ns: int,
+    sample_rate_hz: float = 10.0,
+    quality: QualityFlag = QualityFlag.GOOD,
+    axis_order: bool = True,
+) -> SignalFrame:
+    metadata = {"channel_names": ("C3", "C4")}
+    if axis_order and np.asarray(data).ndim == 2:
+        metadata["axis_order"] = ("sample", "channel")
+    return SignalFrame(
+        stream_id="eeg",
+        sequence_id=sequence_id,
+        data=np.asarray(data, dtype=np.float32),
+        sample_rate_hz=sample_rate_hz,
+        host_receive_time_ns=start_time_ns,
+        quality=quality,
+        metadata=metadata,
+    )
+
+
+def test_neural_window_contract_is_channel_major_and_decoder_batchable():
+    window = NeuralWindow(
+        stream_id="eeg",
+        window_id=3,
+        data=np.arange(8, dtype=np.float32).reshape(2, 4),
+        sample_rate_hz=100.0,
+        start_time_ns=1_000,
+        end_time_ns=40_001_000,
+        channel_names=("C3", "C4"),
+        source_sequence_ids=(4, 5),
+    )
+
+    assert window.n_channels == 2
+    assert window.n_samples == 4
+    assert window.as_batch().shape == (1, 2, 4)
+    assert window.metadata == {}
+
+    with pytest.raises(ValueError, match="channels, time"):
+        NeuralWindow(
+            stream_id="eeg",
+            window_id=0,
+            data=np.ones(4),
+            sample_rate_hz=100.0,
+            start_time_ns=1,
+            end_time_ns=2,
+        )
+
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        NeuralWindow(
+            stream_id="eeg",
+            window_id=0,
+            data=np.array([[1.0, np.nan]]),
+            sample_rate_hz=100.0,
+            start_time_ns=1,
+            end_time_ns=2,
+        )
+
+
+def test_sliding_window_transform_emits_all_windows_from_chunked_frames():
+    descriptor = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=10.0,
+        channel_names=("C3", "C4"),
+    )
+    transform = SlidingWindowTransform(
+        WindowSpec(window_samples=4, stride_samples=2),
+        descriptor=descriptor,
+    )
+
+    first = transform.transform(
+        _frame(
+            0,
+            np.array([[0, 10], [1, 11], [2, 12], [3, 13]]),
+            start_time_ns=1_000_000_000,
+        )
+    )
+    assert isinstance(first, TransformEmission)
+    assert len(first.items) == 1
+    assert first.items[0].data.tolist() == [[0, 1, 2, 3], [10, 11, 12, 13]]
+    assert first.items[0].source_sequence_ids == (0,)
+
+    second = transform.transform(
+        _frame(
+            1,
+            np.array([[4, 14], [5, 15], [6, 16], [7, 17]]),
+            start_time_ns=1_400_000_000,
+        )
+    )
+    assert isinstance(second, TransformEmission)
+    assert len(second.items) == 2
+    assert [window.window_id for window in second.items] == [1, 2]
+    assert second.items[0].source_sequence_ids == (0, 1)
+    assert second.items[1].source_sequence_ids == (1,)
+    assert second.items[0].data.tolist() == [[2, 3, 4, 5], [12, 13, 14, 15]]
+    assert second.items[1].data.tolist() == [[4, 5, 6, 7], [14, 15, 16, 17]]
+    assert transform.pending_samples == 2
+
+
+def test_window_transform_fails_closed_on_ambiguous_geometry_and_gaps():
+    transform = SlidingWindowTransform(WindowSpec(4, 2))
+    with pytest.raises(ValueError, match="axis_order"):
+        transform.transform(
+            _frame(
+                0,
+                np.ones((2, 2)),
+                start_time_ns=1_000_000_000,
+                axis_order=False,
+            )
+        )
+
+    transform = SlidingWindowTransform(WindowSpec(4, 2))
+    assert transform.transform(
+        _frame(0, np.array([[0, 10], [1, 11]]), start_time_ns=1_000_000_000)
+    ) is None
+    with pytest.raises(ValueError, match="sequence gap"):
+        transform.transform(
+            _frame(2, np.array([[2, 12], [3, 13]]), start_time_ns=1_400_000_000)
+        )
+
+
+def test_window_transform_can_reset_explicitly_at_discontinuity():
+    transform = SlidingWindowTransform(
+        WindowSpec(4, 2), discontinuity=DiscontinuityPolicy.RESET
+    )
+    assert transform.transform(
+        _frame(0, np.array([[0, 10], [1, 11]]), start_time_ns=1_000_000_000)
+    ) is None
+    assert transform.transform(
+        _frame(2, np.array([[2, 12], [3, 13]]), start_time_ns=1_400_000_000)
+    ) is None
+    emitted = transform.transform(
+        _frame(3, np.array([[4, 14], [5, 15]]), start_time_ns=1_600_000_000)
+    )
+    assert isinstance(emitted, TransformEmission)
+    window = emitted.items[0]
+    assert window.source_sequence_ids == (2, 3)
+    assert window.metadata["discontinuity_count"] == 1
+    assert transform.discontinuity_count == 1
+
+    transform = SlidingWindowTransform(
+        WindowSpec(2, 2), discontinuity=DiscontinuityPolicy.RESET
+    )
+    flagged = transform.transform(
+        _frame(
+            0,
+            np.array([[0, 10], [1, 11]]),
+            start_time_ns=1_000_000_000,
+            quality=QualityFlag.DROPPED_SAMPLES,
+        )
+    )
+    assert isinstance(flagged, TransformEmission)
+    assert flagged.items[0].quality & QualityFlag.DROPPED_SAMPLES
+
+
+class _ChunkSource:
+    def __init__(self) -> None:
+        self._descriptor = StreamDescriptor(
+            stream_id="eeg",
+            modality="eeg",
+            sample_rate_hz=10.0,
+            channel_names=("C3", "C4"),
+        )
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return self._descriptor
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def frames(self):
+        yield _frame(
+            0,
+            np.array([[0, 10], [1, 11], [2, 12], [3, 13]]),
+            start_time_ns=1_000_000_000,
+        )
+        await asyncio.sleep(0)
+        yield _frame(
+            1,
+            np.array([[4, 14], [5, 15], [6, 16], [7, 17]]),
+            start_time_ns=1_400_000_000,
+        )
+
+
+class _WindowDecoder:
+    def __init__(self) -> None:
+        self.shapes: list[tuple[int, ...]] = []
+
+    @property
+    def capabilities(self) -> DecoderCapabilities:
+        return DecoderCapabilities(probabilities=False)
+
+    def infer(self, X: np.ndarray) -> DecoderOutput:
+        self.shapes.append(tuple(np.asarray(X).shape))
+        return DecoderOutput(prediction=len(self.shapes) - 1, model_id="window-test")
+
+
+@pytest.mark.asyncio
+async def test_runtime_fans_out_windows_batches_decoder_input_and_binds_provenance():
+    source = _ChunkSource()
+    decoder = _WindowDecoder()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, source))
+    graph.add_node(
+        RuntimeNode(
+            "window",
+            NodeKind.TRANSFORM,
+            SlidingWindowTransform(WindowSpec(4, 2), descriptor=source.descriptor),
+        )
+    )
+    graph.add_node(RuntimeNode("decoder", NodeKind.DECODER, decoder))
+    graph.connect(RuntimeEdge("source", "window", overflow="block"))
+    graph.connect(RuntimeEdge("window", "decoder", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    await executor.start()
+    outputs = [output async for output in executor.outputs()]
+    await executor.wait()
+
+    assert decoder.shapes == [(1, 2, 4), (1, 2, 4), (1, 2, 4)]
+    assert [output.prediction for output in outputs] == [0, 1, 2]
+    assert [output.metadata["neuros_window_id"] for output in outputs] == [0, 1, 2]
+    assert outputs[1].metadata["source_sequence_ids"] == (0, 1)
+    assert outputs[0].metadata["window_channel_names"] == ("C3", "C4")
+    snapshot = executor.snapshot()
+    assert snapshot["nodes"]["window"]["processed"] == 2
+    assert snapshot["nodes"]["decoder"]["processed"] == 3


### PR DESCRIPTION
## Why

PR #31 establishes the converged neurOS / ORION / Evidence / Studio platform boundary and, in doing so, exposed a missing runtime seam: maintained EEGNet/CNN/Transformer decoders consume raw neural windows while the legacy compatibility pipeline emits feature vectors. Raw-window models need a canonical representation between `SignalFrame` and `DecoderOutput` rather than relying on array-shape convention.

This stacked PR introduces that representation and keeps it inside the existing native RuntimeGraph instead of creating a parallel model runtime.

## What changes

### `NeuralWindow` + `WindowSpec`
- one window is canonically `channels x time`;
- the runtime owns the batch insertion, producing `1 x channels x time` at decoder invocation;
- window timing is an explicit half-open interval;
- channel identity, sample rate, clock domain, quality flags, and source `SignalFrame.sequence_id` provenance travel with the window;
- non-finite data, invalid geometry, and inconsistent provenance fail closed.

### Deterministic sliding window transform
- converts single-sample or explicit `sample x channel` SignalFrames into decoder windows;
- supports overlap via sample-domain `window_samples` / `stride_samples` specifications;
- never pads, interpolates, resamples, or silently joins gaps;
- sequence gaps and clock-domain changes fail closed by default;
- an explicit `reset` discontinuity policy may discard pending overlap and begin a new contiguous segment.

### Explicit transform fan-out
Chunked sources such as MNE/LSL can generate multiple windows from one frame. `TransformEmission` is a dedicated kernel contract for one transform invocation producing multiple downstream items, avoiding ambiguity with ordinary list/tuple-valued data.

### Native decoder routing
- RuntimeExecutor fans out `TransformEmission` deterministically;
- `NeuralWindow` enters decoders as `(1, channels, time)`;
- `DecoderOutput.metadata` is enriched with window ID, time bounds, channel identity, source sequence IDs, quality, and sampling rate.

### Config-first composition
- registers a `window` transform entry point;
- exposes sample-domain window/stride/discontinuity options through the normal plugin/config graph path;
- documents the canonical SignalFrame → NeuralWindow → decoder boundary.

## Qualification
Exact head: `2fbfb859a3307e363d1d8bfbc236baa046eb95f5`

Green on the combined stack against `main` before restoring this review base:
- **Neural Window Contracts**: Python 3.10, 3.11, 3.12;
- installed `window` transform entry-point smoke;
- real trained neurOS `EEGNetModel` through SignalFrame → NeuralWindow → RuntimeGraph → DecoderOutput;
- **neurOS CI** full repository matrix;
- **neurOS driver contracts**;
- **Ecosystem Compatibility**.

`tests/test_neural_windows.py` specifically covers canonical geometry, overlapping multi-window emission, ambiguous 2-D rejection, gap semantics, reset semantics, fan-out, decoder batch shape, and prediction-to-window provenance.

## Stack
Base: `agent/platform-convergence-v1` / PR #31.

The next stacked slice is PR #33, which delegates selected published raw-window architectures to upstream Braindecode rather than copying its model zoo.