### PR TITLE
Evidence: pair native and Braindecode EEGNet under one longitudinal authority

### DIFF
--- a/.github/workflows/braindecode-evidence-ci.yml
+++ b/.github/workflows/braindecode-evidence-ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "packages/neuros-foundation/**"
       - "packages/neuros-models/**"
+      - "scripts/evidence/run_moabb_braindecode_pair.py"
       - ".github/workflows/braindecode-evidence-ci.yml"
   push:
     branches:
@@ -12,6 +13,7 @@ on:
     paths:
       - "packages/neuros-foundation/**"
       - "packages/neuros-models/**"
+      - "scripts/evidence/run_moabb_braindecode_pair.py"
       - ".github/workflows/braindecode-evidence-ci.yml"
 
 permissions:
@@ -45,9 +47,11 @@ jobs:
           assert version.startswith("1.7."), version
           print(version)
           PY
-      - name: Run paired authority evidence contracts
+      - name: Run paired authority and artifact-pipeline contracts
         run: |
-          pytest -q packages/neuros-foundation/tests/test_braindecode_longitudinal.py
+          pytest -q \
+            packages/neuros-foundation/tests/test_braindecode_longitudinal.py \
+            packages/neuros-foundation/tests/test_braindecode_pair_runner.py
 
   python310-firewall:
     name: Python 3.10 remains external-evidence dependency free

--- a/.github/workflows/braindecode-evidence-ci.yml
+++ b/.github/workflows/braindecode-evidence-ci.yml
@@ -1,0 +1,80 @@
+name: Braindecode Longitudinal Evidence
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-foundation/**"
+      - "packages/neuros-models/**"
+      - ".github/workflows/braindecode-evidence-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/neuros-foundation/**"
+      - "packages/neuros-models/**"
+      - ".github/workflows/braindecode-evidence-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  paired-evidence:
+    name: Paired Braindecode evidence / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install paired evidence stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-models[braindecode]"
+          python -m pip install -e "packages/neuros-foundation[braindecode-evidence,dev]"
+      - name: Verify qualified upstream line
+        run: |
+          python - <<'PY'
+          import importlib.metadata
+          version = importlib.metadata.version("braindecode")
+          assert version.startswith("1.7."), version
+          print(version)
+          PY
+      - name: Run paired authority evidence contracts
+        run: |
+          pytest -q packages/neuros-foundation/tests/test_braindecode_longitudinal.py
+
+  python310-firewall:
+    name: Python 3.10 remains external-evidence dependency free
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install dependency-light evidence stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e packages/neuros-foundation
+      - name: Prove optional ecosystem does not leak into the base package
+        run: |
+          python - <<'PY'
+          import importlib.util
+          from neuros.foundation_models.longitudinal_external import (
+              ExternalTaskDecoderMethodSpec,
+              PairedTaskPerformanceResult,
+          )
+
+          assert importlib.util.find_spec("braindecode") is None
+          spec = ExternalTaskDecoderMethodSpec("braindecode-eegnet", model_seed=7)
+          assert spec.method_id == "braindecode-eegnet"
+          assert PairedTaskPerformanceResult.__name__ == "PairedTaskPerformanceResult"
+          PY

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -46,6 +46,7 @@ legacy = ["torch>=2.1.0"]
 eeg = ["mne>=1.6.0"]
 evidence = ["moabb>=1.5.0,<2"]
 moabb = ["moabb>=1.5.0,<2"]
+braindecode-evidence = ["braindecode>=1.7,<1.8; python_version >= '3.11'"]
 # SourceWeigher is a sibling workspace package and is intentionally installed
 # explicitly in the full ladder profile until it has a published distribution.
 ladder = ["torch>=2.1.0"]

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -27,6 +27,13 @@ from neuros.foundation_models.longitudinal_authority import (
     processed_data_sha256,
 )
 from neuros.foundation_models.longitudinal_baseline import CSPCaseResult, run_csp_case
+from neuros.foundation_models.longitudinal_external import (
+    ExternalTaskDecoderCaseResult,
+    ExternalTaskDecoderMethodSpec,
+    PairedTaskPerformanceResult,
+    pair_task_performance,
+    run_external_task_decoder_case,
+)
 from neuros.foundation_models.longitudinal_ladder import (
     LADDER_METHODS,
     SOURCEWEIGHER_METHODS,
@@ -186,6 +193,11 @@ __all__ = [
     "TaskDecoderMethodSpec",
     "TaskDecoderCaseResult",
     "run_task_decoder_case",
+    "ExternalTaskDecoderMethodSpec",
+    "ExternalTaskDecoderCaseResult",
+    "PairedTaskPerformanceResult",
+    "run_external_task_decoder_case",
+    "pair_task_performance",
     "FrozenTransferMethodSpec",
     "FrozenTransferCaseResult",
     "PreparedFrozenEncoderCase",

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_external.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_external.py
@@ -35,16 +35,27 @@ ExternalTaskDecoderId = Literal["braindecode-eegnet"]
 
 @dataclass(frozen=True, slots=True)
 class ExternalTaskDecoderMethodSpec:
-    """Frozen identity/configuration for one optional external task decoder."""
+    """Frozen identity/configuration for one optional external task decoder.
+
+    ``sample_rate_hz`` is explicit evidence metadata rather than something
+    inferred from ``n_times``. Two windows with equal sample counts but different
+    physical durations are not the same decoder input contract.
+    """
 
     method_id: ExternalTaskDecoderId
     model_seed: int
+    sample_rate_hz: float | None = None
     model_kwargs: Mapping[str, Any] = field(default_factory=dict)
     schema_version: int = 1
 
     def __post_init__(self) -> None:
         if self.method_id != "braindecode-eegnet":
             raise ValueError(f"unsupported external task decoder {self.method_id!r}")
+        if self.sample_rate_hz is not None:
+            rate = float(self.sample_rate_hz)
+            if not np.isfinite(rate) or rate <= 0:
+                raise ValueError("sample_rate_hz must be finite and positive when provided")
+            object.__setattr__(self, "sample_rate_hz", rate)
         forbidden = {
             "model_name",
             "n_channels",
@@ -80,6 +91,7 @@ class ExternalTaskDecoderMethodSpec:
             "schema_version": self.schema_version,
             "method_id": self.method_id,
             "model_seed": int(self.model_seed),
+            "sample_rate_hz": self.sample_rate_hz,
             "model_kwargs": dict(self.model_kwargs),
         }
 
@@ -186,6 +198,7 @@ def _external_model_for(
         n_channels=int(n_channels),
         n_times=int(n_times),
         n_classes=int(n_classes),
+        sample_rate_hz=spec.sample_rate_hz,
         random_state=int(spec.model_seed),
         **dict(spec.model_kwargs),
     )
@@ -291,6 +304,7 @@ def run_external_task_decoder_case(
                 "model_seed": int(spec.model_seed),
                 "model_state_sha256": state_sha256,
                 "upstream_model_version": model.model_version,
+                "sample_rate_hz": spec.sample_rate_hz,
                 "calibration_per_class": int(budget),
                 "source_train_samples": int(len(split.source_train_indices)),
                 "calibration_samples": int(len(calibration_indices)),
@@ -367,9 +381,7 @@ def pair_task_performance(
                     f"paired evidence identity mismatch at budget={budget}: {key}"
                 )
 
-        row: dict[str, Any] = {
-            key: native_row.get(key) for key in identity_keys
-        }
+        row: dict[str, Any] = {key: native_row.get(key) for key in identity_keys}
         row.update(
             {
                 "calibration_per_class": budget,
@@ -380,6 +392,7 @@ def pair_task_performance(
                 "native_model_state_sha256": native_row["model_state_sha256"],
                 "external_model_state_sha256": external_row["model_state_sha256"],
                 "external_upstream_model_version": external_row["upstream_model_version"],
+                "sample_rate_hz": external_row["sample_rate_hz"],
                 "external_representation_evidence_available": bool(
                     external_row["representation_evidence_available"]
                 ),

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_external.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_external.py
@@ -1,0 +1,428 @@
+"""Paired longitudinal evidence for optional external decoder ecosystems.
+
+External model ecosystems may participate in neurOS evidence only after a
+:class:`LongitudinalCaseAuthority` has frozen the source history, target
+calibration pool, and final evaluation examples. This module deliberately
+reports task performance, calibration, runtime, and learned-state identity only.
+It does not invent representation or mechanistic surfaces for an upstream model
+that has not qualified those capabilities.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal, Mapping, Sequence
+
+import numpy as np
+
+from neuros.models import BraindecodeDecoder
+
+from .longitudinal_authority import LongitudinalCaseAuthority
+from .longitudinal_methods import (
+    TaskDecoderCaseResult,
+    _encode_labels,
+    _model_state_sha256,
+    _score,
+)
+from .real_world import GroupedEvaluationData
+
+ExternalTaskDecoderId = Literal["braindecode-eegnet"]
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalTaskDecoderMethodSpec:
+    """Frozen identity/configuration for one optional external task decoder."""
+
+    method_id: ExternalTaskDecoderId
+    model_seed: int
+    model_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.method_id != "braindecode-eegnet":
+            raise ValueError(f"unsupported external task decoder {self.method_id!r}")
+        forbidden = {
+            "model_name",
+            "n_channels",
+            "n_times",
+            "n_classes",
+            "sample_rate_hz",
+            "random_state",
+        }.intersection(self.model_kwargs)
+        if forbidden:
+            raise ValueError(
+                "model identity, geometry, sample-rate provenance and random_state are "
+                f"controlled by the evidence runner; remove overrides {sorted(forbidden)}"
+            )
+        options = dict(self.model_kwargs)
+        try:
+            json.dumps(options, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("model_kwargs must be finite JSON-serializable evidence metadata") from exc
+        object.__setattr__(self, "model_kwargs", MappingProxyType(options))
+
+    @property
+    def fingerprint(self) -> str:
+        raw = json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "method_id": self.method_id,
+            "model_seed": int(self.model_seed),
+            "model_kwargs": dict(self.model_kwargs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalTaskDecoderCaseResult:
+    """One external method/seed evaluated across one frozen authority frontier."""
+
+    authority_fingerprint: str
+    method_spec: ExternalTaskDecoderMethodSpec
+    rows: tuple[Mapping[str, Any], ...]
+    resolved_model_config: Mapping[str, Any]
+    parameter_count: int
+    analysis_manifest_fingerprint: str
+    upstream_version: str | None
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.parameter_count <= 0:
+            raise ValueError("parameter_count must be positive")
+        object.__setattr__(self, "rows", tuple(MappingProxyType(dict(row)) for row in self.rows))
+        object.__setattr__(
+            self,
+            "resolved_model_config",
+            MappingProxyType(dict(self.resolved_model_config)),
+        )
+
+    @property
+    def method_run_fingerprint(self) -> str:
+        raw = json.dumps(
+            self.to_dict(include_fingerprint=False),
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "authority_fingerprint": self.authority_fingerprint,
+            "method_spec": self.method_spec.to_dict(),
+            "method_spec_fingerprint": self.method_spec.fingerprint,
+            "resolved_model_config": dict(self.resolved_model_config),
+            "parameter_count": int(self.parameter_count),
+            "analysis_manifest_fingerprint": self.analysis_manifest_fingerprint,
+            "upstream_version": self.upstream_version,
+            "rows": [dict(row) for row in self.rows],
+        }
+        if include_fingerprint:
+            payload["method_run_fingerprint"] = self.method_run_fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class PairedTaskPerformanceResult:
+    """Paired native/external task evidence under one immutable authority."""
+
+    authority_fingerprint: str
+    native_method_run_fingerprint: str
+    external_method_run_fingerprint: str
+    rows: tuple[Mapping[str, Any], ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.rows:
+            raise ValueError("paired task evidence must contain at least one budget row")
+        object.__setattr__(self, "rows", tuple(MappingProxyType(dict(row)) for row in self.rows))
+
+    @property
+    def pair_fingerprint(self) -> str:
+        raw = json.dumps(
+            self.to_dict(include_fingerprint=False),
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "authority_fingerprint": self.authority_fingerprint,
+            "native_method_run_fingerprint": self.native_method_run_fingerprint,
+            "external_method_run_fingerprint": self.external_method_run_fingerprint,
+            "rows": [dict(row) for row in self.rows],
+        }
+        if include_fingerprint:
+            payload["pair_fingerprint"] = self.pair_fingerprint
+        return payload
+
+
+def _external_model_for(
+    spec: ExternalTaskDecoderMethodSpec,
+    *,
+    n_channels: int,
+    n_times: int,
+    n_classes: int,
+) -> BraindecodeDecoder:
+    if spec.method_id != "braindecode-eegnet":
+        raise ValueError(f"unsupported external task decoder {spec.method_id!r}")
+    return BraindecodeDecoder(
+        "EEGNet",
+        n_channels=int(n_channels),
+        n_times=int(n_times),
+        n_classes=int(n_classes),
+        random_state=int(spec.model_seed),
+        **dict(spec.model_kwargs),
+    )
+
+
+def run_external_task_decoder_case(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    *,
+    spec: ExternalTaskDecoderMethodSpec,
+    budgets_per_class: Sequence[int],
+) -> ExternalTaskDecoderCaseResult:
+    """Evaluate one external decoder under a previously frozen sample authority.
+
+    A fresh upstream model is trained at every declared calibration budget. The
+    adapter receives exactly the processed ``X=(sample, channel, time)`` array
+    governed by ``authority``. It cannot choose samples, preprocess the final
+    evaluation set, or silently change window geometry.
+    """
+
+    split = authority.restore(data)
+    budgets = tuple(sorted(set(int(value) for value in budgets_per_class)))
+    if not budgets or budgets[0] < 0:
+        raise ValueError("budgets_per_class must contain non-negative values")
+    if budgets[-1] > split.max_budget_per_class:
+        raise ValueError(
+            f"requested budget {budgets[-1]} exceeds authority maximum "
+            f"{split.max_budget_per_class}/class"
+        )
+
+    X = np.asarray(data.X, dtype=np.float32)
+    if X.ndim != 3:
+        raise ValueError("external task decoder evidence expects X=(sample, channel, time)")
+    if not np.isfinite(X).all():
+        raise ValueError("external task decoder evidence refuses non-finite processed inputs")
+
+    y_encoded, class_labels = _encode_labels(np.asarray(data.y), split.source_train_indices)
+    n_channels = int(X.shape[1])
+    n_times = int(X.shape[2])
+    n_classes = len(class_labels)
+
+    rows: list[dict[str, Any]] = []
+    resolved: dict[str, Any] | None = None
+    config_fingerprint: str | None = None
+    parameters: int | None = None
+    manifest_fingerprint: str | None = None
+    upstream_version: str | None = None
+
+    for budget in budgets:
+        train_indices = split.train_indices_for_budget(budget)
+        calibration_indices = split.calibration_indices(budget)
+        evaluation_indices = split.evaluation_indices
+
+        model = _external_model_for(
+            spec,
+            n_channels=n_channels,
+            n_times=n_times,
+            n_classes=n_classes,
+        )
+        current_resolved = model.configuration()
+        current_config_fingerprint = model.configuration_fingerprint
+        current_manifest = model.analysis_manifest().fingerprint()
+        if resolved is None:
+            resolved = current_resolved
+            config_fingerprint = current_config_fingerprint
+            manifest_fingerprint = current_manifest
+        elif (
+            current_resolved != resolved
+            or current_config_fingerprint != config_fingerprint
+            or current_manifest != manifest_fingerprint
+        ):
+            raise RuntimeError("external method identity changed across calibration budgets")
+
+        started = time.perf_counter()
+        model.train(X[train_indices], y_encoded[train_indices])
+        fit_s = time.perf_counter() - started
+
+        current_parameters = int(
+            sum(parameter.numel() for parameter in model.analysis_model().parameters())
+        )
+        if parameters is None:
+            parameters = current_parameters
+            upstream_version = model.model_version
+        elif current_parameters != parameters or model.model_version != upstream_version:
+            raise RuntimeError("external learned architecture/version changed across budgets")
+
+        state_sha256 = _model_state_sha256(model)
+        started = time.perf_counter()
+        probability = model.predict_proba(X[evaluation_indices])
+        inference_s = time.perf_counter() - started
+        metrics = _score(y_encoded[evaluation_indices], probability)
+
+        rows.append(
+            {
+                "case_id": authority.case_id,
+                "authority_fingerprint": authority.authority_fingerprint,
+                "processed_data_sha256": authority.processed_data_sha256,
+                "partition_fingerprint": authority.partition_fingerprint,
+                "calibration_split_fingerprint": authority.calibration_split_fingerprint,
+                "method_id": spec.method_id,
+                "method_spec_fingerprint": spec.fingerprint,
+                "adapter_config_fingerprint": current_config_fingerprint,
+                "model_seed": int(spec.model_seed),
+                "model_state_sha256": state_sha256,
+                "upstream_model_version": model.model_version,
+                "calibration_per_class": int(budget),
+                "source_train_samples": int(len(split.source_train_indices)),
+                "calibration_samples": int(len(calibration_indices)),
+                "evaluation_samples": int(len(evaluation_indices)),
+                "fit_samples": int(len(train_indices)),
+                "class_labels": list(class_labels),
+                **metrics,
+                "fit_s": float(fit_s),
+                "inference_s": float(inference_s),
+                "inference_ms_per_trial": float(
+                    1000.0 * inference_s / max(len(evaluation_indices), 1)
+                ),
+                "representation_evidence_available": False,
+                "mechanistic_evidence_available": False,
+            }
+        )
+
+    assert resolved is not None
+    assert config_fingerprint is not None
+    assert parameters is not None
+    assert manifest_fingerprint is not None
+    return ExternalTaskDecoderCaseResult(
+        authority_fingerprint=authority.authority_fingerprint,
+        method_spec=spec,
+        rows=tuple(rows),
+        resolved_model_config=resolved,
+        parameter_count=parameters,
+        analysis_manifest_fingerprint=manifest_fingerprint,
+        upstream_version=upstream_version,
+    )
+
+
+def pair_task_performance(
+    native: TaskDecoderCaseResult,
+    external: ExternalTaskDecoderCaseResult,
+) -> PairedTaskPerformanceResult:
+    """Pair native and external rows only when their evidence identity is exact."""
+
+    if native.authority_fingerprint != external.authority_fingerprint:
+        raise ValueError("native and external results do not share one authority fingerprint")
+
+    native_by_budget = {int(row["calibration_per_class"]): row for row in native.rows}
+    external_by_budget = {int(row["calibration_per_class"]): row for row in external.rows}
+    if set(native_by_budget) != set(external_by_budget):
+        raise ValueError("native and external results must cover identical calibration budgets")
+
+    identity_keys = (
+        "case_id",
+        "authority_fingerprint",
+        "processed_data_sha256",
+        "partition_fingerprint",
+        "calibration_split_fingerprint",
+        "source_train_samples",
+        "calibration_samples",
+        "evaluation_samples",
+        "fit_samples",
+        "class_labels",
+    )
+    score_metrics = (
+        "accuracy",
+        "balanced_accuracy",
+        "roc_auc",
+        "brier_score",
+        "expected_calibration_error",
+    )
+
+    rows: list[dict[str, Any]] = []
+    for budget in sorted(native_by_budget):
+        native_row = native_by_budget[budget]
+        external_row = external_by_budget[budget]
+        for key in identity_keys:
+            if native_row.get(key) != external_row.get(key):
+                raise ValueError(
+                    f"paired evidence identity mismatch at budget={budget}: {key}"
+                )
+
+        row: dict[str, Any] = {
+            key: native_row.get(key) for key in identity_keys
+        }
+        row.update(
+            {
+                "calibration_per_class": budget,
+                "native_method_id": native_row["method_id"],
+                "external_method_id": external_row["method_id"],
+                "native_method_spec_fingerprint": native_row["method_spec_fingerprint"],
+                "external_method_spec_fingerprint": external_row["method_spec_fingerprint"],
+                "native_model_state_sha256": native_row["model_state_sha256"],
+                "external_model_state_sha256": external_row["model_state_sha256"],
+                "external_upstream_model_version": external_row["upstream_model_version"],
+                "external_representation_evidence_available": bool(
+                    external_row["representation_evidence_available"]
+                ),
+                "external_mechanistic_evidence_available": bool(
+                    external_row["mechanistic_evidence_available"]
+                ),
+            }
+        )
+        for metric in score_metrics:
+            native_value = native_row.get(metric)
+            external_value = external_row.get(metric)
+            row[f"native_{metric}"] = native_value
+            row[f"external_{metric}"] = external_value
+            if native_value is None or external_value is None:
+                row[f"delta_external_minus_native_{metric}"] = None
+            else:
+                row[f"delta_external_minus_native_{metric}"] = float(external_value) - float(
+                    native_value
+                )
+
+        native_fit = float(native_row["fit_s"])
+        external_fit = float(external_row["fit_s"])
+        native_inference = float(native_row["inference_ms_per_trial"])
+        external_inference = float(external_row["inference_ms_per_trial"])
+        row.update(
+            {
+                "native_fit_s": native_fit,
+                "external_fit_s": external_fit,
+                "fit_ratio_external_over_native": (
+                    None if native_fit <= 0 else external_fit / native_fit
+                ),
+                "native_inference_ms_per_trial": native_inference,
+                "external_inference_ms_per_trial": external_inference,
+                "inference_ratio_external_over_native": (
+                    None if native_inference <= 0 else external_inference / native_inference
+                ),
+            }
+        )
+        rows.append(row)
+
+    return PairedTaskPerformanceResult(
+        authority_fingerprint=native.authority_fingerprint,
+        native_method_run_fingerprint=native.method_run_fingerprint,
+        external_method_run_fingerprint=external.method_run_fingerprint,
+        rows=tuple(rows),
+    )

--- a/packages/neuros-foundation/tests/test_braindecode_longitudinal.py
+++ b/packages/neuros-foundation/tests/test_braindecode_longitudinal.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.longitudinal import (
+    chronological_partition,
+    make_nested_calibration_split,
+)
+from neuros.foundation_models.longitudinal_authority import LongitudinalCaseAuthority
+from neuros.foundation_models.longitudinal_external import (
+    ExternalTaskDecoderMethodSpec,
+    pair_task_performance,
+    run_external_task_decoder_case,
+)
+from neuros.foundation_models.longitudinal_methods import (
+    TaskDecoderMethodSpec,
+    run_task_decoder_case,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+pytest.importorskip("torch")
+pytest.importorskip("braindecode")
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(4242)
+    X: list[np.ndarray] = []
+    y: list[str] = []
+    metadata: list[dict[str, str]] = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left_hand", "right_hand")):
+            for trial in range(8):
+                signal = rng.normal(scale=0.25, size=(4, 128)).astype(np.float32)
+                direction = -1.0 if label_index == 0 else 1.0
+                signal[label_index, 20:100] += direction * (1.0 + 0.04 * session_index)
+                signal[3] += 0.03 * session_index
+                X.append(signal)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"r-{trial // 4}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="synthetic-longitudinal-eeg",
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+        order=("0", "1", "2"),
+    )
+    split = make_nested_calibration_split(
+        partition,
+        evaluation_fraction=0.5,
+        seed=91,
+    )
+    return LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="subject-1/session-2",
+        history_policy="prior",
+        observed_group_order=("0", "1", "2"),
+        case_metadata={"subject": 1},
+    )
+
+
+def test_external_spec_refuses_evidence_authority_overrides():
+    with pytest.raises(ValueError, match="controlled by the evidence runner"):
+        ExternalTaskDecoderMethodSpec(
+            "braindecode-eegnet",
+            model_seed=7,
+            model_kwargs={"n_times": 999},
+        )
+
+    with pytest.raises(ValueError, match="finite JSON-serializable"):
+        ExternalTaskDecoderMethodSpec(
+            "braindecode-eegnet",
+            model_seed=7,
+            model_kwargs={"learning_rate": float("nan")},
+        )
+
+
+def test_braindecode_eegnet_is_paired_with_native_eegnet_under_one_authority():
+    data = _fixture()
+    authority = _authority(data)
+    common = {
+        "learning_rate": 1e-3,
+        "weight_decay": 0.0,
+        "n_epochs": 1,
+        "batch_size": 8,
+        "device": "cpu",
+    }
+    native = run_task_decoder_case(
+        data,
+        authority,
+        spec=TaskDecoderMethodSpec(
+            "eegnet",
+            model_seed=101,
+            model_kwargs=common,
+        ),
+        budgets_per_class=(0, 1),
+    )
+    external = run_external_task_decoder_case(
+        data,
+        authority,
+        spec=ExternalTaskDecoderMethodSpec(
+            "braindecode-eegnet",
+            model_seed=101,
+            model_kwargs=common,
+        ),
+        budgets_per_class=(0, 1),
+    )
+
+    assert native.authority_fingerprint == external.authority_fingerprint
+    assert external.upstream_version is not None
+    assert external.upstream_version.startswith("1.7.")
+    assert external.parameter_count > 0
+    assert len(external.method_run_fingerprint) == 16
+    assert len(external.analysis_manifest_fingerprint) == 16
+
+    for row in external.rows:
+        assert len(str(row["model_state_sha256"])) == 64
+        assert row["authority_fingerprint"] == authority.authority_fingerprint
+        assert row["processed_data_sha256"] == authority.processed_data_sha256
+        assert row["partition_fingerprint"] == authority.partition_fingerprint
+        assert row["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
+        assert row["representation_evidence_available"] is False
+        assert row["mechanistic_evidence_available"] is False
+        assert 0.0 <= float(row["balanced_accuracy"]) <= 1.0
+        assert 0.0 <= float(row["accuracy"]) <= 1.0
+
+    paired = pair_task_performance(native, external)
+    assert paired.authority_fingerprint == authority.authority_fingerprint
+    assert len(paired.rows) == 2
+    assert len(paired.pair_fingerprint) == 16
+
+    for row in paired.rows:
+        assert row["native_method_id"] == "eegnet"
+        assert row["external_method_id"] == "braindecode-eegnet"
+        assert row["external_representation_evidence_available"] is False
+        assert row["external_mechanistic_evidence_available"] is False
+        expected = float(row["external_balanced_accuracy"]) - float(
+            row["native_balanced_accuracy"]
+        )
+        assert np.isclose(row["delta_external_minus_native_balanced_accuracy"], expected)
+        assert row["native_model_state_sha256"] != row["external_model_state_sha256"]
+
+
+def test_pairing_refuses_results_from_different_authorities():
+    data = _fixture()
+    authority = _authority(data)
+    common = {"n_epochs": 1, "batch_size": 8, "device": "cpu"}
+    native = run_task_decoder_case(
+        data,
+        authority,
+        spec=TaskDecoderMethodSpec("eegnet", model_seed=5, model_kwargs=common),
+        budgets_per_class=(0,),
+    )
+    external = run_external_task_decoder_case(
+        data,
+        authority,
+        spec=ExternalTaskDecoderMethodSpec(
+            "braindecode-eegnet",
+            model_seed=5,
+            model_kwargs=common,
+        ),
+        budgets_per_class=(0,),
+    )
+
+    corrupted = replace(external, authority_fingerprint="not-the-same-authority")
+    with pytest.raises(ValueError, match="one authority fingerprint"):
+        pair_task_performance(native, corrupted)

--- a/packages/neuros-foundation/tests/test_braindecode_longitudinal.py
+++ b/packages/neuros-foundation/tests/test_braindecode_longitudinal.py
@@ -88,6 +88,13 @@ def test_external_spec_refuses_evidence_authority_overrides():
             model_kwargs={"learning_rate": float("nan")},
         )
 
+    with pytest.raises(ValueError, match="finite and positive"):
+        ExternalTaskDecoderMethodSpec(
+            "braindecode-eegnet",
+            model_seed=7,
+            sample_rate_hz=float("nan"),
+        )
+
 
 def test_braindecode_eegnet_is_paired_with_native_eegnet_under_one_authority():
     data = _fixture()
@@ -115,6 +122,7 @@ def test_braindecode_eegnet_is_paired_with_native_eegnet_under_one_authority():
         spec=ExternalTaskDecoderMethodSpec(
             "braindecode-eegnet",
             model_seed=101,
+            sample_rate_hz=128.0,
             model_kwargs=common,
         ),
         budgets_per_class=(0, 1),
@@ -124,6 +132,8 @@ def test_braindecode_eegnet_is_paired_with_native_eegnet_under_one_authority():
     assert external.upstream_version is not None
     assert external.upstream_version.startswith("1.7.")
     assert external.parameter_count > 0
+    assert external.resolved_model_config["sample_rate_hz"] == 128.0
+    assert external.method_spec.sample_rate_hz == 128.0
     assert len(external.method_run_fingerprint) == 16
     assert len(external.analysis_manifest_fingerprint) == 16
 
@@ -133,6 +143,7 @@ def test_braindecode_eegnet_is_paired_with_native_eegnet_under_one_authority():
         assert row["processed_data_sha256"] == authority.processed_data_sha256
         assert row["partition_fingerprint"] == authority.partition_fingerprint
         assert row["calibration_split_fingerprint"] == authority.calibration_split_fingerprint
+        assert row["sample_rate_hz"] == 128.0
         assert row["representation_evidence_available"] is False
         assert row["mechanistic_evidence_available"] is False
         assert 0.0 <= float(row["balanced_accuracy"]) <= 1.0
@@ -146,6 +157,7 @@ def test_braindecode_eegnet_is_paired_with_native_eegnet_under_one_authority():
     for row in paired.rows:
         assert row["native_method_id"] == "eegnet"
         assert row["external_method_id"] == "braindecode-eegnet"
+        assert row["sample_rate_hz"] == 128.0
         assert row["external_representation_evidence_available"] is False
         assert row["external_mechanistic_evidence_available"] is False
         expected = float(row["external_balanced_accuracy"]) - float(
@@ -171,6 +183,7 @@ def test_pairing_refuses_results_from_different_authorities():
         spec=ExternalTaskDecoderMethodSpec(
             "braindecode-eegnet",
             model_seed=5,
+            sample_rate_hz=128.0,
             model_kwargs=common,
         ),
         budgets_per_class=(0,),

--- a/packages/neuros-foundation/tests/test_braindecode_pair_runner.py
+++ b/packages/neuros-foundation/tests/test_braindecode_pair_runner.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models import GroupedEvaluationData
+
+pytest.importorskip("torch")
+pytest.importorskip("braindecode")
+
+
+def _load_runner():
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts" / "evidence" / "run_moabb_braindecode_pair.py"
+    spec = importlib.util.spec_from_file_location("neuros_braindecode_pair_runner", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(9090)
+    X: list[np.ndarray] = []
+    y: list[str] = []
+    metadata: list[dict[str, str]] = []
+    for session_index, session in enumerate(("0", "1", "2")):
+        for label_index, label in enumerate(("left_hand", "right_hand")):
+            for trial in range(8):
+                signal = rng.normal(scale=0.3, size=(4, 128)).astype(np.float32)
+                signal[label_index, 16:104] += (-1.0 if label_index == 0 else 1.0) * (
+                    1.1 + 0.03 * session_index
+                )
+                X.append(signal)
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"run-{trial // 4}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="moabb-kumar2024",
+    )
+
+
+def test_paired_runner_writes_self_consistent_artifact_bundle(tmp_path, monkeypatch):
+    runner = _load_runner()
+    data = _fixture()
+    fake_spec = SimpleNamespace(
+        key="kumar2024",
+        class_name="Kumar2024",
+        source_id="moabb-kumar2024",
+        case_metadata=lambda subject: {
+            "subject": int(subject),
+            "original_protocol": "GR",
+        },
+    )
+    monkeypatch.setattr(
+        runner,
+        "build_moabb_longitudinal_dataset",
+        lambda *args, **kwargs: (fake_spec, object(), object()),
+    )
+    monkeypatch.setattr(runner, "collect_moabb", lambda *args, **kwargs: data)
+    monkeypatch.setattr(
+        runner,
+        "validate_observed_sessions",
+        lambda _spec, observed: tuple(observed),
+    )
+
+    output = tmp_path / "paired"
+    code = runner.main(
+        [
+            "--dataset",
+            "kumar2024",
+            "--subjects",
+            "1",
+            "--held-out-sessions",
+            "2",
+            "--model-seeds",
+            "101",
+            "--budgets",
+            "0,1",
+            "--history-policy",
+            "prior",
+            "--resample",
+            "128",
+            "--epochs",
+            "1",
+            "--batch-size",
+            "8",
+            "--device",
+            "cpu",
+            "--output",
+            str(output),
+        ]
+    )
+    assert code == 0
+
+    manifest = json.loads((output / "study_manifest.json").read_text())
+    authority = json.loads((output / "split_authority.json").read_text())
+    native = json.loads((output / "native_runs.json").read_text())
+    external = json.loads((output / "external_runs.json").read_text())
+    paired = json.loads((output / "paired_runs.json").read_text())
+    summary = json.loads((output / "summary.json").read_text())
+    hashes = json.loads((output / "artifact_hashes.json").read_text())
+    report = (output / "report.md").read_text()
+    with (output / "paired_results.csv").open(newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert manifest["study"] == "native_vs_braindecode_eegnet_longitudinal_pair"
+    assert manifest["dataset_id"] == "moabb-kumar2024"
+    assert manifest["history_policy"] == "prior"
+    assert manifest["resample_hz"] == 128.0
+    assert manifest["budgets_per_class"] == [0, 1]
+    assert manifest["model_seeds"] == [101]
+    assert manifest["native_method_id"] == "eegnet"
+    assert manifest["external_method_id"] == "braindecode-eegnet"
+
+    assert len(authority["cases"]) == 1
+    frozen = authority["cases"][0]
+    assert frozen["source_group_values"] == ["0", "1"]
+    assert frozen["held_out_values"] == ["2"]
+    assert len(frozen["processed_data_sha256"]) == 64
+
+    assert len(native["runs"]) == 1
+    assert len(external["runs"]) == 1
+    assert len(paired["runs"]) == 1
+    assert external["runs"][0]["method_spec"]["sample_rate_hz"] == 128.0
+    assert external["runs"][0]["upstream_version"].startswith("1.7.")
+
+    assert len(rows) == 2
+    assert {row["calibration_per_class"] for row in rows} == {"0", "1"}
+    assert {row["subject"] for row in rows} == {"1"}
+    assert {row["original_protocol"] for row in rows} == {"GR"}
+    assert {row["held_out_session"] for row in rows} == {"2"}
+    assert {row["authority_fingerprint"] for row in rows} == {
+        frozen["authority_fingerprint"]
+    }
+    assert all(len(row["native_model_state_sha256"]) == 64 for row in rows)
+    assert all(len(row["external_model_state_sha256"]) == 64 for row in rows)
+    assert all(row["external_representation_evidence_available"] == "False" for row in rows)
+    assert all(row["external_mechanistic_evidence_available"] == "False" for row in rows)
+
+    assert summary["descriptive_only"] is True
+    assert summary["paired_case_set_constant_across_budgets"] is True
+    assert len(summary["case_set_fingerprints"]) == 1
+    assert [item["calibration_per_class"] for item in summary["budget_summary"]] == [0, 1]
+    assert all(item["n_cases"] == 1 for item in summary["budget_summary"])
+    assert all(item["n_seed_pairs"] == 1 for item in summary["budget_summary"])
+
+    assert "same serialized source/calibration/evaluation authority" in report
+    assert "identical architecture" in report
+    assert "participant-independent inferential" not in report
+
+    expected_artifacts = {
+        "study_manifest.json",
+        "split_authority.json",
+        "native_runs.json",
+        "external_runs.json",
+        "paired_runs.json",
+        "paired_results.csv",
+        "summary.json",
+        "report.md",
+    }
+    assert set(hashes["sha256"]) == expected_artifacts
+    assert all(len(digest) == 64 for digest in hashes["sha256"].values())

--- a/packages/neuros-models/src/neuros/models/eegnet_model.py
+++ b/packages/neuros-models/src/neuros/models/eegnet_model.py
@@ -32,6 +32,7 @@ class EEGNetModel(TorchDecoderModel):
         separable_kernel: int = 15,
         dropout: float = 0.25,
         learning_rate: float = 1e-3,
+        weight_decay: float = 1e-4,
         n_epochs: int = 20,
         batch_size: int = 32,
         device: str = "auto",
@@ -44,6 +45,7 @@ class EEGNetModel(TorchDecoderModel):
         super().__init__(
             n_classes=n_classes,
             learning_rate=learning_rate,
+            weight_decay=weight_decay,
             n_epochs=n_epochs,
             batch_size=batch_size,
             device=device,

--- a/scripts/evidence/run_moabb_braindecode_pair.py
+++ b/scripts/evidence/run_moabb_braindecode_pair.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Run native neurOS EEGNet vs upstream Braindecode EEGNet under one authority.
+
+This is an isolated paired evidence study. It intentionally does not modify the
+canonical seven-lane longitudinal model ladder. Every native/external pair
+restores the same serialized subject/session/calibration authority before
+fitting and is evaluated on the exact same final examples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.metadata
+import json
+import platform
+import subprocess
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from neuros.foundation_models.longitudinal import (
+    chronological_partition,
+    make_nested_calibration_split,
+    ordered_group_values,
+)
+from neuros.foundation_models.longitudinal_authority import LongitudinalCaseAuthority
+from neuros.foundation_models.longitudinal_external import (
+    ExternalTaskDecoderMethodSpec,
+    pair_task_performance,
+    run_external_task_decoder_case,
+)
+from neuros.foundation_models.longitudinal_methods import (
+    TaskDecoderMethodSpec,
+    run_task_decoder_case,
+)
+from neuros.foundation_models.moabb_longitudinal import (
+    MOABB_LONGITUDINAL_DATASETS,
+    build_moabb_longitudinal_dataset,
+    validate_observed_sessions,
+)
+from neuros.foundation_models.real_world import collect_moabb, hold_out_groups
+
+
+def _parse_int_list(value: str) -> list[int]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated integer")
+    try:
+        return [int(item) for item in values]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("values must be integers") from exc
+
+
+def _parse_text_list(value: str) -> list[str]:
+    values = [item.strip() for item in value.split(",") if item.strip()]
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one comma-separated value")
+    return values
+
+
+def _stable_seed(base: int, *parts: Any) -> int:
+    raw = "|".join([str(base), *(str(part) for part in parts)])
+    return int.from_bytes(hashlib.sha256(raw.encode("utf-8")).digest()[:4], "big")
+
+
+def _git_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _versions() -> dict[str, str | None]:
+    names = (
+        "neuros-foundation",
+        "neuros-core",
+        "neuros-models",
+        "braindecode",
+        "moabb",
+        "mne",
+        "skorch",
+        "scikit-learn",
+        "torch",
+        "numpy",
+    )
+    result: dict[str, str | None] = {}
+    for name in names:
+        try:
+            result[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            result[name] = None
+    return result
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_dump(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return value
+
+
+def _write_csv(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    materialized = [dict(row) for row in rows]
+    if not materialized:
+        raise ValueError("cannot write an empty paired result table")
+    fields = sorted({key for row in materialized for key in row})
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for row in materialized:
+            writer.writerow({field: _csv_value(row.get(field)) for field in fields})
+
+
+def _mean(values: Sequence[float]) -> float | None:
+    array = np.asarray(values, dtype=np.float64)
+    array = array[np.isfinite(array)]
+    return None if len(array) == 0 else float(array.mean())
+
+
+def _std(values: Sequence[float]) -> float | None:
+    array = np.asarray(values, dtype=np.float64)
+    array = array[np.isfinite(array)]
+    if len(array) == 0:
+        return None
+    return 0.0 if len(array) == 1 else float(array.std(ddof=1))
+
+
+def _case_set_fingerprint(case_ids: Sequence[str]) -> str:
+    raw = json.dumps(sorted(set(case_ids)), separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _summary(rows: Sequence[Mapping[str, Any]], budgets: Sequence[int]) -> dict[str, Any]:
+    """Collapse optimization seeds inside case before summarizing cases.
+
+    This avoids treating repeated training seeds from one subject/session as
+    independent deployment units. The summary remains descriptive; promoted
+    inferential analysis should use participant-aware repeated-measures models.
+    """
+
+    by_budget_case: dict[tuple[int, str], list[Mapping[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_budget_case[(int(row["calibration_per_class"]), str(row["case_id"]))].append(row)
+
+    metric_names = (
+        "delta_external_minus_native_accuracy",
+        "delta_external_minus_native_balanced_accuracy",
+        "delta_external_minus_native_roc_auc",
+        "delta_external_minus_native_brier_score",
+        "delta_external_minus_native_expected_calibration_error",
+        "fit_ratio_external_over_native",
+        "inference_ratio_external_over_native",
+    )
+    budget_rows: list[dict[str, Any]] = []
+    case_sets: list[str] = []
+    for budget in budgets:
+        case_values: dict[str, dict[str, float | None]] = {}
+        seed_pairs = 0
+        for (row_budget, case_id), values in by_budget_case.items():
+            if row_budget != int(budget):
+                continue
+            seed_pairs += len(values)
+            collapsed: dict[str, float | None] = {}
+            for metric in metric_names:
+                numeric = [
+                    float(row[metric])
+                    for row in values
+                    if row.get(metric) is not None and np.isfinite(float(row[metric]))
+                ]
+                collapsed[metric] = _mean(numeric)
+            case_values[case_id] = collapsed
+
+        case_ids = sorted(case_values)
+        fingerprint = _case_set_fingerprint(case_ids)
+        case_sets.append(fingerprint)
+        record: dict[str, Any] = {
+            "calibration_per_class": int(budget),
+            "n_cases": len(case_ids),
+            "n_seed_pairs": seed_pairs,
+            "case_set_fingerprint": fingerprint,
+        }
+        for metric in metric_names:
+            values = [
+                float(case_values[case_id][metric])
+                for case_id in case_ids
+                if case_values[case_id][metric] is not None
+            ]
+            record[f"mean_case_{metric}"] = _mean(values)
+            record[f"std_case_{metric}"] = _std(values)
+        bal_deltas = [
+            float(case_values[case_id]["delta_external_minus_native_balanced_accuracy"])
+            for case_id in case_ids
+            if case_values[case_id]["delta_external_minus_native_balanced_accuracy"] is not None
+        ]
+        record["external_balanced_accuracy_case_win_fraction"] = (
+            None if not bal_deltas else float(np.mean(np.asarray(bal_deltas) > 0.0))
+        )
+        budget_rows.append(record)
+
+    unique_case_sets = sorted(set(case_sets))
+    return {
+        "schema_version": 1,
+        "descriptive_only": True,
+        "paired_case_set_constant_across_budgets": len(unique_case_sets) == 1,
+        "case_set_fingerprints": unique_case_sets,
+        "budget_summary": budget_rows,
+        "interpretation": [
+            "optimization seeds are averaged within subject/session case before case-level summaries",
+            "positive accuracy deltas favor upstream Braindecode; negative Brier/ECE deltas favor upstream calibration",
+            "runtime ratios above 1 mean Braindecode is slower than native neurOS in this environment",
+            "descriptive case means are not participant-independent inferential statistics",
+        ],
+    }
+
+
+def _render_report(manifest: Mapping[str, Any], summary: Mapping[str, Any]) -> str:
+    lines = [
+        "# Native neurOS EEGNet vs Braindecode EEGNet",
+        "",
+        "This report is generated from one frozen longitudinal evidence bundle.",
+        "It is a paired implementation/ecosystem comparison, not a claim that the two",
+        "EEGNet implementations have identical architecture or parameterization.",
+        "",
+        "## Study identity",
+        "",
+        f"- Dataset: `{manifest['dataset_id']}`",
+        f"- History policy: `{manifest['history_policy']}`",
+        f"- Subjects: `{manifest['subjects']}`",
+        f"- Calibration budgets / class: `{manifest['budgets_per_class']}`",
+        f"- Model seeds: `{manifest['model_seeds']}`",
+        f"- Explicit resample rate: `{manifest['resample_hz']} Hz`",
+        f"- Git revision: `{manifest['git_revision']}`",
+        "",
+        "## Paired results",
+        "",
+        "| budget/class | cases | seeds | Δ balanced accuracy | Δ Brier | Δ ECE | fit ratio | inference ratio |",
+        "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in summary["budget_summary"]:
+        def fmt(value: Any) -> str:
+            return "n/a" if value is None else f"{float(value):.4f}"
+
+        lines.append(
+            "| {budget} | {cases} | {seeds} | {bal} | {brier} | {ece} | {fit} | {infer} |".format(
+                budget=row["calibration_per_class"],
+                cases=row["n_cases"],
+                seeds=row["n_seed_pairs"],
+                bal=fmt(row["mean_case_delta_external_minus_native_balanced_accuracy"]),
+                brier=fmt(row["mean_case_delta_external_minus_native_brier_score"]),
+                ece=fmt(row["mean_case_delta_external_minus_native_expected_calibration_error"]),
+                fit=fmt(row["mean_case_fit_ratio_external_over_native"]),
+                infer=fmt(row["mean_case_inference_ratio_external_over_native"]),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Evidence boundary",
+            "",
+            "- Every pair restores the same serialized source/calibration/evaluation authority.",
+            "- Final evaluation examples do not enter fitting or model selection.",
+            "- Sampling frequency is explicit and fingerprinted rather than inferred from window length.",
+            "- Both methods use the same training epochs, batch size, learning rate, weight decay, device class, and model seed.",
+            "- Architecture defaults and parameter counts remain visible and are not represented as matched architecture.",
+            "- Braindecode representation and mechanistic evidence remain unavailable in this study.",
+            "- This is offline real-dataset evidence, not hardware, closed-loop, clinical, or biological-mechanism evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run native EEGNet and Braindecode EEGNet under identical longitudinal authority."
+    )
+    parser.add_argument(
+        "--dataset",
+        choices=sorted(MOABB_LONGITUDINAL_DATASETS),
+        default="kumar2024",
+    )
+    parser.add_argument("--subjects", type=_parse_int_list, default=[1])
+    parser.add_argument("--held-out-sessions", type=_parse_text_list, default=None)
+    parser.add_argument("--model-seeds", type=_parse_int_list, default=[101, 503, 1601])
+    parser.add_argument("--budgets", type=_parse_int_list, default=[0, 1, 2, 5, 10])
+    parser.add_argument("--history-policy", choices=("prior", "all-other"), default="prior")
+    parser.add_argument("--split-seed", type=int, default=2026)
+    parser.add_argument("--evaluation-fraction", type=float, default=0.5)
+    parser.add_argument("--fmin", type=float, default=8.0)
+    parser.add_argument("--fmax", type=float, default=30.0)
+    parser.add_argument(
+        "--resample",
+        type=float,
+        default=128.0,
+        help="Explicit common sample rate; required for physical window-duration identity.",
+    )
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--weight-decay", type=float, default=1e-4)
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not 0.0 < args.evaluation_fraction < 1.0:
+        raise SystemExit("--evaluation-fraction must lie strictly between 0 and 1")
+    if args.fmin <= 0 or args.fmax <= args.fmin:
+        raise SystemExit("require 0 < --fmin < --fmax")
+    if not np.isfinite(args.resample) or args.resample <= 0:
+        raise SystemExit("--resample must be finite and positive")
+    if args.epochs <= 0 or args.batch_size <= 0:
+        raise SystemExit("--epochs and --batch-size must be positive")
+    if args.learning_rate <= 0 or args.weight_decay < 0:
+        raise SystemExit("require positive --learning-rate and non-negative --weight-decay")
+
+    budgets = tuple(sorted(set(int(value) for value in args.budgets)))
+    if not budgets or budgets[0] < 0:
+        raise SystemExit("--budgets must contain non-negative values")
+    if 0 not in budgets:
+        budgets = (0, *budgets)
+    model_seeds = tuple(dict.fromkeys(int(value) for value in args.model_seeds))
+    if not model_seeds:
+        raise SystemExit("at least one --model-seeds value is required")
+
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "manifest": output / "study_manifest.json",
+        "authority": output / "split_authority.json",
+        "native": output / "native_runs.json",
+        "external": output / "external_runs.json",
+        "pairs": output / "paired_runs.json",
+        "results": output / "paired_results.csv",
+        "summary": output / "summary.json",
+        "report": output / "report.md",
+        "hashes": output / "artifact_hashes.json",
+    }
+    existing = [path for path in paths.values() if path.exists()]
+    if existing and not args.overwrite:
+        raise SystemExit(
+            "refusing to overwrite existing artifacts: "
+            + ", ".join(path.name for path in existing)
+        )
+
+    dataset_spec, dataset, paradigm = build_moabb_longitudinal_dataset(
+        args.dataset,
+        fmin=float(args.fmin),
+        fmax=float(args.fmax),
+        resample=float(args.resample),
+    )
+    authorities: list[LongitudinalCaseAuthority] = []
+    native_runs: list[dict[str, Any]] = []
+    external_runs: list[dict[str, Any]] = []
+    paired_runs: list[dict[str, Any]] = []
+    paired_rows: list[dict[str, Any]] = []
+    started_study = time.perf_counter()
+
+    common_training = {
+        "learning_rate": float(args.learning_rate),
+        "weight_decay": float(args.weight_decay),
+        "n_epochs": int(args.epochs),
+        "batch_size": int(args.batch_size),
+        "device": str(args.device),
+    }
+
+    for subject in args.subjects:
+        data = collect_moabb(
+            dataset,
+            paradigm,
+            subjects=[int(subject)],
+            dataset_id=dataset_spec.source_id,
+        )
+        observed = validate_observed_sessions(
+            dataset_spec,
+            ordered_group_values(data, split_unit="session"),
+        )
+        if len(observed) < 2:
+            raise RuntimeError(f"subject {subject} has fewer than two usable sessions")
+
+        if args.held_out_sessions is not None:
+            missing = [value for value in args.held_out_sessions if value not in observed]
+            if missing:
+                raise RuntimeError(
+                    f"subject {subject} missing requested session(s) {missing}; observed={list(observed)}"
+                )
+            targets = tuple(args.held_out_sessions)
+        elif args.history_policy == "prior":
+            targets = observed[1:]
+        else:
+            targets = observed
+
+        for target in targets:
+            if args.history_policy == "prior":
+                partition = chronological_partition(
+                    data,
+                    split_unit="session",
+                    held_out_value=target,
+                    order=observed,
+                )
+            else:
+                partition = hold_out_groups(
+                    data,
+                    split_unit="session",
+                    held_out_values=[target],
+                )
+            case_split_seed = _stable_seed(
+                args.split_seed,
+                dataset_spec.source_id,
+                subject,
+                target,
+            )
+            split = make_nested_calibration_split(
+                partition,
+                evaluation_fraction=float(args.evaluation_fraction),
+                seed=case_split_seed,
+            )
+            if budgets[-1] > split.max_budget_per_class:
+                raise RuntimeError(
+                    f"strict paired frontier requires {budgets[-1]}/class, but "
+                    f"subject={subject}, session={target} supports only "
+                    f"{split.max_budget_per_class}/class"
+                )
+
+            metadata = dataset_spec.case_metadata(int(subject))
+            metadata.update(
+                {
+                    "held_out_session": str(target),
+                    "split_seed": int(case_split_seed),
+                }
+            )
+            authority = LongitudinalCaseAuthority.from_split(
+                split,
+                case_id=(
+                    f"{dataset_spec.source_id}/subject-{subject}/session-{target}/"
+                    f"split-{case_split_seed}"
+                ),
+                history_policy=args.history_policy,
+                observed_group_order=observed,
+                case_metadata=metadata,
+            )
+            authority.restore(data)
+            authorities.append(authority)
+
+            for model_seed in model_seeds:
+                native = run_task_decoder_case(
+                    data,
+                    authority,
+                    spec=TaskDecoderMethodSpec(
+                        "eegnet",
+                        model_seed=int(model_seed),
+                        model_kwargs=common_training,
+                    ),
+                    budgets_per_class=budgets,
+                )
+                external = run_external_task_decoder_case(
+                    data,
+                    authority,
+                    spec=ExternalTaskDecoderMethodSpec(
+                        "braindecode-eegnet",
+                        model_seed=int(model_seed),
+                        sample_rate_hz=float(args.resample),
+                        model_kwargs=common_training,
+                    ),
+                    budgets_per_class=budgets,
+                )
+                paired = pair_task_performance(native, external)
+
+                native_payload = native.to_dict()
+                external_payload = external.to_dict()
+                paired_payload = paired.to_dict()
+                native_runs.append(native_payload)
+                external_runs.append(external_payload)
+                paired_runs.append(paired_payload)
+
+                for raw in paired.rows:
+                    row = dict(raw)
+                    row.update(dict(authority.case_metadata))
+                    row["held_out_session"] = authority.held_out_values[0]
+                    row["history_policy"] = authority.history_policy
+                    row["model_seed"] = int(model_seed)
+                    row["split_seed"] = int(case_split_seed)
+                    row["pair_fingerprint"] = paired.pair_fingerprint
+                    paired_rows.append(row)
+
+    summary = _summary(paired_rows, budgets)
+    if not summary["paired_case_set_constant_across_budgets"]:
+        raise RuntimeError("paired case membership changed across calibration budgets")
+
+    manifest = {
+        "schema_version": 1,
+        "evidence_tier": "real_dataset",
+        "study": "native_vs_braindecode_eegnet_longitudinal_pair",
+        "dataset_key": dataset_spec.key,
+        "dataset_class": dataset_spec.class_name,
+        "dataset_id": dataset_spec.source_id,
+        "subjects": [int(value) for value in args.subjects],
+        "history_policy": args.history_policy,
+        "held_out_sessions_requested": args.held_out_sessions,
+        "split_seed_base": int(args.split_seed),
+        "evaluation_fraction": float(args.evaluation_fraction),
+        "budgets_per_class": list(budgets),
+        "model_seeds": list(model_seeds),
+        "band_hz": [float(args.fmin), float(args.fmax)],
+        "resample_hz": float(args.resample),
+        "shared_training_config": common_training,
+        "native_method_id": "eegnet",
+        "external_method_id": "braindecode-eegnet",
+        "authority_fingerprints": [item.authority_fingerprint for item in authorities],
+        "git_revision": _git_revision(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "package_versions": _versions(),
+        "wall_time_s": float(time.perf_counter() - started_study),
+        "claim_boundary": [
+            "native and external methods restore byte-identical processed-data and sample authority",
+            "prior history policy excludes future sessions when selected",
+            "final evaluation examples never enter fitting or model selection",
+            "sampling frequency is explicit and fingerprinted",
+            "training epochs, batch size, optimizer hyperparameters, device and seeds are paired",
+            "EEGNet architecture defaults are not claimed to be parameter-matched across implementations",
+            "Braindecode representation and mechanistic surfaces are not claimed by this study",
+            "offline real-dataset evidence is not hardware, closed-loop, clinical or biological evidence",
+        ],
+    }
+
+    _json_dump(paths["manifest"], manifest)
+    _json_dump(
+        paths["authority"],
+        {"schema_version": 1, "cases": [item.to_dict() for item in authorities]},
+    )
+    _json_dump(paths["native"], {"schema_version": 1, "runs": native_runs})
+    _json_dump(paths["external"], {"schema_version": 1, "runs": external_runs})
+    _json_dump(paths["pairs"], {"schema_version": 1, "runs": paired_runs})
+    _write_csv(paths["results"], paired_rows)
+    _json_dump(paths["summary"], summary)
+    paths["report"].write_text(_render_report(manifest, summary), encoding="utf-8")
+    _json_dump(
+        paths["hashes"],
+        {
+            "sha256": {
+                path.name: _sha256(path)
+                for key, path in paths.items()
+                if key != "hashes"
+            }
+        },
+    )
+
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "authority_cases": len(authorities),
+                "paired_rows": len(paired_rows),
+                "case_sets_paired": summary["paired_case_set_constant_across_budgets"],
+                "artifacts": [path.name for path in paths.values()],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

PR #33 establishes Braindecode as a qualified optional decoder ecosystem at the integration-evidence tier. This PR builds the next evidence rung: native neurOS EEGNet and upstream Braindecode EEGNet are forced through the exact same frozen subject/session/calibration authority before any performance comparison is allowed.

## External longitudinal decoder contract

Adds `longitudinal_external.py` with a deliberately narrow initial external method: `braindecode-eegnet`.

The external runner:
- restores a serialized `LongitudinalCaseAuthority` before fitting;
- receives exact processed `X=(sample, channel, time)` arrays and the same source/calibration/evaluation indices as native neurOS decoders;
- fingerprints explicit sampling rate rather than inferring physical window duration from sample count;
- trains a fresh upstream model at every declared calibration budget;
- records adapter configuration fingerprint, upstream version, parameter count and learned `state_dict` SHA-256;
- reports accuracy, balanced accuracy, ROC-AUC where defined, Brier score, expected calibration error, fit time and inference time;
- explicitly records that Braindecode representation and mechanistic evidence are unavailable until those surfaces are separately qualified.

## Paired evidence

`pair_task_performance(...)` refuses comparison unless native and external runs match on authority fingerprint, processed-data SHA-256, partition fingerprint, calibration-split fingerprint, source/calibration/evaluation/fit sample counts, class vocabulary, and calibration-budget set.

The paired artifact contains native/external metrics, external-minus-native deltas, timing ratios, both learned-state hashes, upstream version and a deterministic pair fingerprint.

## Fair optimization authority

Native `EEGNetModel` now exposes its already-existing `TorchDecoderModel.weight_decay` parameter at the public constructor boundary without changing its historical default (`1e-4`). The paired study can therefore explicitly hold learning rate, AdamW weight decay, epoch count, batch size, device class and model seed constant across implementations.

This does **not** imply identical optimization trajectories or architectures. neurOS uses its maintained PyTorch training loop while Braindecode delegates to upstream `EEGClassifier`; architecture defaults and parameter counts remain visible evidence rather than being hidden under the shared EEGNet family name.

## Real MOABB paired study runner

Adds `scripts/evidence/run_moabb_braindecode_pair.py` as an isolated study rather than modifying the canonical seven-lane model ladder.

The runner uses the existing longitudinal MOABB authority machinery and emits:
- `study_manifest.json`
- `split_authority.json`
- `native_runs.json`
- `external_runs.json`
- `paired_runs.json`
- `paired_results.csv`
- `summary.json`
- `report.md`
- `artifact_hashes.json`

Optimization seeds are averaged **within subject/session case** before case-level descriptive summaries so repeated seeds are not treated as independent deployment units. Case membership is fingerprinted across calibration budgets.

Default study parameters target Kumar2024 with prior-session history, 8–30 Hz preprocessing, explicit 128 Hz resampling, calibration budgets `[0,1,2,5,10]`, and model seeds `[101,503,1601]`. These defaults are study configuration, not benchmark results.

## Dependency isolation and qualification

Adds `neuros-foundation[braindecode-evidence]` only on Python 3.11+. A dedicated workflow:
- runs the paired authority contract and complete synthetic artifact-pipeline study on Python 3.11 and 3.12 with real Braindecode 1.7;
- separately proves Python 3.10 can import the evidence contracts while remaining Braindecode-free;
- runs alongside the normal neurOS, real-world evidence, Braindecode compatibility, neural-window and ecosystem compatibility matrices when affected.

The first executed CI wave exposed a real fairness/API issue: native EEGNet inherited weight decay but did not surface it in its constructor. This PR repairs that boundary rather than weakening the paired optimization contract.

## Scientific boundary

This PR establishes controlled paired machinery and a reproducible real-MOABB study runner. It does **not** itself claim a completed MOABB performance result, upstream representation equivalence, mechanistic equivalence, identical EEGNet architecture, biological homology, hardware performance, closed-loop qualification or clinical validity. Those require separately promoted evidence.