### PR TITLE
Evidence: add manual real-MOABB Braindecode paired study workflow

### DIFF
--- a/.github/workflows/braindecode-paired-study.yml
+++ b/.github/workflows/braindecode-paired-study.yml
@@ -1,0 +1,233 @@
+name: neurOS Braindecode paired real-data study
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/braindecode-paired-study.yml"
+      - "scripts/evidence/run_moabb_braindecode_pair.py"
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: Public MOABB longitudinal dataset key
+        required: true
+        type: choice
+        default: kumar2024
+        options:
+          - kumar2024
+          - ma2020
+          - lee2019-mi
+          - wang2026
+      subjects:
+        description: Comma-separated MOABB subject IDs
+        required: true
+        type: string
+        default: "1"
+      held_out_sessions:
+        description: Optional comma-separated target sessions; blank uses every eligible target
+        required: false
+        type: string
+        default: ""
+      model_seeds:
+        description: Comma-separated paired optimization seeds
+        required: true
+        type: string
+        default: "101,503,1601"
+      budgets:
+        description: Labeled target-session calibration examples per class
+        required: true
+        type: string
+        default: "0,1,2,5,10"
+      history_policy:
+        description: Prior-only is prospective-style; all-other is symmetric cross-session
+        required: true
+        type: choice
+        default: prior
+        options:
+          - prior
+          - all-other
+      split_seed:
+        description: Base split/calibration seed
+        required: true
+        type: string
+        default: "2026"
+      evaluation_fraction:
+        description: Fraction of each held-out class frozen for final evaluation
+        required: true
+        type: string
+        default: "0.5"
+      fmin:
+        description: Lower preprocessing band edge in Hz
+        required: true
+        type: string
+        default: "8.0"
+      fmax:
+        description: Upper preprocessing band edge in Hz
+        required: true
+        type: string
+        default: "30.0"
+      resample:
+        description: Explicit paired sample rate in Hz
+        required: true
+        type: string
+        default: "128.0"
+      epochs:
+        description: Fixed epochs for both implementations
+        required: true
+        type: string
+        default: "20"
+      batch_size:
+        description: Fixed training batch size for both implementations
+        required: true
+        type: string
+        default: "32"
+      learning_rate:
+        description: Fixed AdamW learning rate for both implementations
+        required: true
+        type: string
+        default: "0.001"
+      weight_decay:
+        description: Fixed AdamW weight decay for both implementations
+        required: true
+        type: string
+        default: "0.0001"
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-contract:
+    name: Paired-study workflow contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install dependency-light study contracts
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e packages/neuros-foundation
+      - name: Verify study runner remains discoverable without Braindecode
+        run: |
+          python scripts/evidence/run_moabb_braindecode_pair.py --help > /tmp/pair-help.txt
+          grep -q -- "--resample" /tmp/pair-help.txt
+          grep -q -- "--weight-decay" /tmp/pair-help.txt
+          python - <<'PY'
+          import importlib.util
+          assert importlib.util.find_spec("braindecode") is None
+          PY
+
+  study:
+    name: ${{ inputs.dataset }} / ${{ inputs.history_policy }} / native-vs-Braindecode EEGNet
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    concurrency:
+      group: braindecode-paired-study-${{ inputs.dataset }}-${{ inputs.subjects }}-${{ inputs.history_policy }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install paired real-data evidence stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-models[braindecode]"
+          python -m pip install -e "packages/neuros-foundation[evidence,braindecode-evidence]"
+
+      - name: Record execution environment
+        run: |
+          mkdir -p evidence-run
+          python -VV > evidence-run/python.txt
+          python -m pip freeze > evidence-run/pip-freeze.txt
+          git rev-parse HEAD > evidence-run/git-revision.txt
+          printf '%s\n' "${{ inputs.dataset }}" > evidence-run/requested-dataset.txt
+          printf '%s\n' "${{ inputs.subjects }}" > evidence-run/requested-subjects.txt
+          printf '%s\n' "${{ inputs.model_seeds }}" > evidence-run/requested-model-seeds.txt
+          printf '%s\n' "${{ inputs.budgets }}" > evidence-run/requested-budgets.txt
+
+      - name: Run real MOABB paired study
+        env:
+          MNE_DATA: ${{ runner.temp }}/mne-data
+        shell: bash
+        run: |
+          EXTRA=()
+          if [[ -n "${{ inputs.held_out_sessions }}" ]]; then
+            EXTRA+=(--held-out-sessions "${{ inputs.held_out_sessions }}")
+          fi
+          python scripts/evidence/run_moabb_braindecode_pair.py \
+            --dataset "${{ inputs.dataset }}" \
+            --subjects "${{ inputs.subjects }}" \
+            --model-seeds "${{ inputs.model_seeds }}" \
+            --budgets "${{ inputs.budgets }}" \
+            --history-policy "${{ inputs.history_policy }}" \
+            --split-seed "${{ inputs.split_seed }}" \
+            --evaluation-fraction "${{ inputs.evaluation_fraction }}" \
+            --fmin "${{ inputs.fmin }}" \
+            --fmax "${{ inputs.fmax }}" \
+            --resample "${{ inputs.resample }}" \
+            --epochs "${{ inputs.epochs }}" \
+            --batch-size "${{ inputs.batch_size }}" \
+            --learning-rate "${{ inputs.learning_rate }}" \
+            --weight-decay "${{ inputs.weight_decay }}" \
+            --device cpu \
+            --output evidence-run/study \
+            "${EXTRA[@]}"
+
+      - name: Verify immutable paired evidence bundle
+        run: |
+          for name in \
+            study_manifest.json \
+            split_authority.json \
+            native_runs.json \
+            external_runs.json \
+            paired_runs.json \
+            paired_results.csv \
+            summary.json \
+            report.md \
+            artifact_hashes.json; do
+            test -s "evidence-run/study/$name"
+          done
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          root = Path("evidence-run/study")
+          declared = json.loads((root / "artifact_hashes.json").read_text())["sha256"]
+          for name, expected in declared.items():
+              actual = hashlib.sha256((root / name).read_bytes()).hexdigest()
+              assert actual == expected, (name, actual, expected)
+
+          manifest = json.loads((root / "study_manifest.json").read_text())
+          summary = json.loads((root / "summary.json").read_text())
+          authority = json.loads((root / "split_authority.json").read_text())
+          assert manifest["study"] == "native_vs_braindecode_eegnet_longitudinal_pair"
+          assert manifest["evidence_tier"] == "real_dataset"
+          assert manifest["authority_fingerprints"] == [
+              item["authority_fingerprint"] for item in authority["cases"]
+          ]
+          assert summary["descriptive_only"] is True
+          assert summary["paired_case_set_constant_across_budgets"] is True
+          print("paired real-data bundle verified")
+          PY
+
+      - name: Upload immutable paired evidence bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: braindecode-paired-${{ inputs.dataset }}-${{ inputs.history_policy }}-${{ github.run_id }}
+          path: evidence-run/
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/BRAINDECODE.md
+++ b/docs/BRAINDECODE.md
@@ -132,7 +132,54 @@ The compatibility lane establishes an **integration** claim when it is green:
 
 That does **not** establish model utility on a neuroscience task.
 
-Promotion to real-dataset evidence requires a named protocol with frozen subject/session/run separation, preprocessing, calibration budget, metrics, seeds, and upstream model configuration. The natural next target is the existing longitudinal MOABB model ladder.
+## Paired longitudinal evidence
+
+neurOS now has a dedicated paired evidence contract for comparing maintained native EEGNet with upstream Braindecode EEGNet without giving either implementation authority over the evaluation split.
+
+`run_external_task_decoder_case(...)` restores the same serialized `LongitudinalCaseAuthority` used by the native decoder lane. `pair_task_performance(...)` refuses to create a paired result unless both runs agree on the authority fingerprint, processed-data SHA-256, partition fingerprint, calibration-split fingerprint, class vocabulary, sample counts, and calibration-budget set.
+
+The pair records:
+
+- native and upstream learned-state SHA-256 values;
+- adapter/method fingerprints;
+- accuracy and balanced accuracy;
+- ROC-AUC where defined;
+- Brier score and expected calibration error;
+- fit and inference cost;
+- explicit sampling frequency;
+- whether representation or mechanistic evidence is actually available.
+
+Braindecode representation and mechanistic fields remain unavailable rather than being fabricated to match the richer native decoder schema.
+
+The real-data runner is:
+
+```bash
+python scripts/evidence/run_moabb_braindecode_pair.py \
+  --dataset kumar2024 \
+  --subjects 1 \
+  --model-seeds 101,503,1601 \
+  --budgets 0,1,2,5,10 \
+  --history-policy prior \
+  --fmin 8 \
+  --fmax 30 \
+  --resample 128 \
+  --epochs 20 \
+  --batch-size 32 \
+  --learning-rate 0.001 \
+  --weight-decay 0.0001 \
+  --device cpu \
+  --output evidence-run/study
+```
+
+It emits `study_manifest.json`, `split_authority.json`, native/external/paired run JSON, paired CSV results, a descriptive summary/report, and SHA-256 declarations for the complete bundle. Optimization seeds are collapsed within subject/session case before case-level summaries so repeated training seeds are not counted as independent deployment units.
+
+## Running the real-data study in GitHub Actions
+
+The manual workflow **neurOS Braindecode paired real-data study** exposes the study authority as explicit `workflow_dispatch` inputs. It supports the maintained longitudinal MOABB dataset keys `kumar2024`, `ma2020`, `lee2019-mi`, and `wang2026`.
+
+The workflow intentionally does not run a real dataset on every pull request. Pull requests execute only a dependency-light contract check that proves the runner remains discoverable without installing Braindecode. A manual study run installs the pinned Braindecode/MOABB stack, records Python/package/Git identity, downloads data through the existing MOABB path, executes the paired study, verifies every declared artifact hash and authority fingerprint, then uploads the complete bundle for 90 days.
+
+A green manual workflow is **execution evidence**, not an automatic scientific promotion. Before a result is summarized publicly, inspect the uploaded `study_manifest.json`, `split_authority.json`, `summary.json`, `report.md`, and per-run learned-state/configuration fingerprints. Multi-subject claims should use participant-aware repeated-measures inference rather than treating subject/session cases or optimization seeds as independent participants.
 
 ## Mechanistic interpretation boundary
 


### PR DESCRIPTION
## Why

PR #34 merged the paired native-vs-Braindecode longitudinal evidence contract and reproducible MOABB runner. Real dataset execution should now be a deliberate, auditable study action rather than something every pull request downloads and trains.

## What changes

Adds the manual **neurOS Braindecode paired real-data study** GitHub Actions workflow.

The workflow exposes explicit authority inputs for:
- MOABB longitudinal dataset;
- subject IDs and optional held-out sessions;
- prior-only vs all-other history policy;
- split seed and frozen evaluation fraction;
- calibration budgets and model seeds;
- frequency band and explicit resampling rate;
- paired epoch, batch-size, learning-rate and AdamW weight-decay settings.

A `workflow_dispatch` run installs the pinned local neurOS + Braindecode + MOABB stack, records Python/package/Git identity, executes `run_moabb_braindecode_pair.py`, verifies all nine study artifacts and every declared SHA-256, checks serialized authority fingerprints, and uploads the complete evidence directory for 90 days.

## Normal PR cost stays bounded

Pull requests do **not** run the real dataset study. They execute only a Python 3.10 dependency-light workflow-contract smoke that verifies the runner CLI remains available and the base environment remains Braindecode-free.

## Documentation

`docs/BRAINDECODE.md` now documents the paired authority contract, complete CLI, artifact bundle, manual GitHub workflow, and the distinction between a green execution and a promoted scientific result.

## Scientific boundary

A successful manual study run is execution evidence. It is not automatically a population-level performance claim. Multi-subject conclusions should inspect authority/config/state identities and use participant-aware repeated-measures analysis rather than treating optimization seeds or repeated subject/session cases as independent participants.