### PR TITLE
evidence: seal reproducible neurOS qualification bundles

### DIFF
--- a/.github/workflows/qualification-ci.yml
+++ b/.github/workflows/qualification-ci.yml
@@ -37,15 +37,25 @@ jobs:
           python scripts/bootstrap.py --profile bci --test-tools
       - name: Run qualification contract suite
         run: pytest -q tests/test_qualification_bundle.py
-      - name: Exercise public qualify and reproduce commands
+      - name: Exercise public qualify and pinned reproduce commands
         run: |
           OUT="${RUNNER_TEMP}/qualification"
+          RESULT="${RUNNER_TEMP}/qualification-result.json"
           neuros qualify configs/examples/mock_bci.yaml \
             --output "${OUT}" \
             --session-id ci \
             --duration 0.05 \
-            --json
-          neuros reproduce "${OUT}" --json
+            --json | tee "${RESULT}"
+          ROOT_SHA=$(python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads((Path(os.environ["RUNNER_TEMP"]) / "qualification-result.json").read_text())
+          print(result["bundle_sha256"])
+          PY
+          )
+          neuros reproduce "${OUT}" --expected-sha256 "${ROOT_SHA}" --json
           python - <<'PY'
           import json
           import os
@@ -53,8 +63,11 @@ jobs:
 
           root = Path(os.environ["RUNNER_TEMP"]) / "qualification"
           manifest = json.loads((root / "manifest.json").read_text())
+          session = json.loads((root / "session" / "manifest.json").read_text())
           assert manifest["claim_boundary"]["runtime_record_replay_qualified"] is True
           assert manifest["claim_boundary"]["hardware_qualified"] is False
           assert manifest["claim_boundary"]["closed_loop_qualified"] is False
           assert manifest["claim_boundary"]["clinical_qualified"] is False
+          assert session["metadata"]["config_path"] == "config.yaml"
+          assert session["metadata"]["config_path_scope"] == "qualification_bundle"
           PY

--- a/.github/workflows/qualification-ci.yml
+++ b/.github/workflows/qualification-ci.yml
@@ -1,0 +1,60 @@
+name: neurOS qualification bundles
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros/src/neuros/qualification.py"
+      - "packages/neuros/src/neuros/cli/app.py"
+      - "tests/test_qualification_bundle.py"
+      - "configs/examples/mock_bci.yaml"
+      - ".github/workflows/qualification-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros/src/neuros/qualification.py"
+      - "packages/neuros/src/neuros/cli/app.py"
+      - "tests/test_qualification_bundle.py"
+      - "configs/examples/mock_bci.yaml"
+      - ".github/workflows/qualification-ci.yml"
+
+jobs:
+  qualification-contracts:
+    name: Qualification contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install BCI qualification profile
+        run: |
+          python -m pip install --upgrade pip
+          python scripts/bootstrap.py --profile bci --test-tools
+      - name: Run qualification contract suite
+        run: pytest -q tests/test_qualification_bundle.py
+      - name: Exercise public qualify and reproduce commands
+        run: |
+          OUT="${RUNNER_TEMP}/qualification"
+          neuros qualify configs/examples/mock_bci.yaml \
+            --output "${OUT}" \
+            --session-id ci \
+            --duration 0.05 \
+            --json
+          neuros reproduce "${OUT}" --json
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "qualification"
+          manifest = json.loads((root / "manifest.json").read_text())
+          assert manifest["claim_boundary"]["runtime_record_replay_qualified"] is True
+          assert manifest["claim_boundary"]["hardware_qualified"] is False
+          assert manifest["claim_boundary"]["closed_loop_qualified"] is False
+          assert manifest["claim_boundary"]["clinical_qualified"] is False
+          PY

--- a/docs/QUALIFICATION.md
+++ b/docs/QUALIFICATION.md
@@ -4,7 +4,7 @@
 
 Version 1 deliberately qualifies one narrow property:
 
-> A declared neurOS runtime configuration was executed, its exact `SignalFrame` inputs were recorded with integrity hashes, and the sealed recording reproduced the same canonical decoder-output digest through deterministic replay.
+> A declared neurOS runtime configuration was executed without runtime failure or queue loss, its exact `SignalFrame` inputs were recorded with integrity hashes, and the sealed recording reproduced the same canonical semantic decoder-output digest through replay.
 
 That is an **integration-level runtime/replay claim**. It is not automatically a real-dataset, hardware, closed-loop, or clinical claim.
 
@@ -17,22 +17,39 @@ neuros qualify configs/examples/mock_bci.yaml \
   --duration 1.0
 ```
 
-The command stages the bundle outside the final path, runs the live configuration, records the canonical input frames, verifies every recorded frame hash, replays the recording through the bundled configuration, compares the canonical decoder-output digest, seals every artifact with SHA-256, verifies the completed bundle, and only then publishes the final directory.
+The command stages the bundle outside the final path, runs the live configuration, records the canonical input frames, verifies every recorded frame hash, replays the recording through the bundled configuration, requires zero runtime failures and zero queue drops in both runs, compares the canonical semantic decoder-output digest, seals every artifact with SHA-256, verifies the completed bundle, and only then publishes the final directory.
+
+Qualification also fails if no `SignalFrame`s or no decoder outputs were produced. An empty or lossy run is evidence of a problem, not a successful qualification.
 
 An existing destination is never replaced unless `--overwrite` is explicit.
 
 ## Reproduce a bundle
 
+Basic structural verification and replay:
+
 ```bash
 neuros reproduce qualification/mock
+```
+
+For externally anchored bundle identity, preserve the `bundle_sha256` emitted by `neuros qualify` outside the bundle and use it during reproduction:
+
+```bash
+neuros reproduce qualification/mock \
+  --expected-sha256 <published-bundle-sha256>
 ```
 
 Reproduction happens in two stages:
 
 1. every sealed file hash, artifact size, artifact-set membership, bundle digest, and embedded session-frame hash is verified;
-2. only after integrity verification succeeds is the recorded session replayed through the bundled config and compared with the sealed decoder-output digest.
+2. only after integrity verification succeeds is the recorded session replayed through the bundled config and compared with the sealed semantic decoder-output digest.
 
 A modified file therefore fails before its contents can silently influence the reproduction result.
+
+### Integrity versus authenticity
+
+A self-contained hash index can prove that a bundle is internally consistent. By itself it cannot prove who authored that bundle, because an attacker able to rewrite every file could also rewrite an unanchored hash index.
+
+For provenance-sensitive exchange, publish or otherwise preserve `bundle_sha256` independently of the bundle and pass it back with `--expected-sha256`. The verifier then labels origin identity `externally_pinned` only when the computed root matches that outside value. A future signing layer can replace manual root pinning with public-key signatures without changing the underlying qualification schema.
 
 ## Bundle layout
 
@@ -66,13 +83,16 @@ The top-level authority for the qualification claim. It records:
 - embedded archive identity;
 - record/replay integrity status;
 - canonical decoder-output digest;
+- the integrity/authenticity model;
 - the explicit claim boundary.
 
-All internal artifact references are bundle-relative. Temporary staging paths are never sealed into the portable manifest.
+All internal artifact references are bundle-relative. Temporary or host-local source config paths are normalized before the session enters the portable evidence bundle.
 
 ### `artifact_hashes.json`
 
-Contains the byte size and SHA-256 of every other file in the bundle and a canonical digest over the complete artifact index. Unexpected files are considered a mutation of the sealed evidence bundle and make verification fail.
+Contains the byte size and SHA-256 of every other file in the bundle and a canonical root digest over the complete artifact index. Unexpected files are considered a mutation of the sealed evidence bundle and make verification fail.
+
+The root digest is emitted as `bundle_sha256`. Preserve it externally when authorship or distribution integrity matters.
 
 ### `environment.json`
 
@@ -93,6 +113,8 @@ Records the decoder config and any `ModelArtifactManifest` entries bound to the 
 ### `runtime.json`
 
 Contains both the record and replay runtime snapshots, including node failure counts, queue acceptance/drop statistics, and node latency summaries.
+
+Version 1 promotes a bundle only when both record and replay finish in the `stopped` state with no node failure and no queue drops. This is intentionally stricter than merely completing the process.
 
 Latency is evidence in its own right. It is intentionally not mixed into semantic decoder identity because the duration of an inference call is expected to differ between the original run and replay.
 
@@ -145,6 +167,7 @@ The goal is to make neurOS results transportable as evidence. A collaborator sho
 - Did queues drop data or nodes fail?
 - Was a promoted learned-weight artifact bound?
 - Can the computational path reproduce the same semantic decoder outputs from the recorded neural stream?
+- Is the bundle merely self-consistent, or does it match an independently pinned root digest?
 - What stronger claims are explicitly unsupported?
 
 That evidence contract is more valuable than a generic "pipeline completed successfully" flag and becomes the substrate for real-device, ORION, closed-loop, and eventually regulated qualification layers.

--- a/docs/QUALIFICATION.md
+++ b/docs/QUALIFICATION.md
@@ -68,6 +68,8 @@ The top-level authority for the qualification claim. It records:
 - canonical decoder-output digest;
 - the explicit claim boundary.
 
+All internal artifact references are bundle-relative. Temporary staging paths are never sealed into the portable manifest.
+
 ### `artifact_hashes.json`
 
 Contains the byte size and SHA-256 of every other file in the bundle and a canonical digest over the complete artifact index. Unexpected files are considered a mutation of the sealed evidence bundle and make verification fail.
@@ -92,9 +94,13 @@ Records the decoder config and any `ModelArtifactManifest` entries bound to the 
 
 Contains both the record and replay runtime snapshots, including node failure counts, queue acceptance/drop statistics, and node latency summaries.
 
+Latency is evidence in its own right. It is intentionally not mixed into semantic decoder identity because the duration of an inference call is expected to differ between the original run and replay.
+
 ### `decoder_outputs.json`
 
-Stores only the canonical output count/digest, not a second unbounded copy of every prediction. Version 1 uses SHA-256 over canonical JSONL serialization.
+Stores only the canonical semantic output count/digest, not a second unbounded copy of every prediction. Version 1 uses SHA-256 over canonical JSONL serialization of decoder semantics: prediction, confidence/uncertainty, probability/logit/embedding values, model identity, and output metadata. The volatile `DecoderOutput.inference_time_ns` measurement is excluded from this semantic digest and remains represented by runtime/performance evidence instead.
+
+This means changing only measured execution time does not manufacture a reproducibility failure, while changing the actual model decision or representation does.
 
 ## Claim boundary
 
@@ -138,7 +144,7 @@ The goal is to make neurOS results transportable as evidence. A collaborator sho
 - Which device/timing metadata were actually observed?
 - Did queues drop data or nodes fail?
 - Was a promoted learned-weight artifact bound?
-- Can the computational path reproduce the same outputs from the recorded neural stream?
+- Can the computational path reproduce the same semantic decoder outputs from the recorded neural stream?
 - What stronger claims are explicitly unsupported?
 
 That evidence contract is more valuable than a generic "pipeline completed successfully" flag and becomes the substrate for real-device, ORION, closed-loop, and eventually regulated qualification layers.

--- a/docs/QUALIFICATION.md
+++ b/docs/QUALIFICATION.md
@@ -1,0 +1,144 @@
+# Qualification Bundles
+
+`neurOS` qualification is evidence generation, not a badge generator.
+
+Version 1 deliberately qualifies one narrow property:
+
+> A declared neurOS runtime configuration was executed, its exact `SignalFrame` inputs were recorded with integrity hashes, and the sealed recording reproduced the same canonical decoder-output digest through deterministic replay.
+
+That is an **integration-level runtime/replay claim**. It is not automatically a real-dataset, hardware, closed-loop, or clinical claim.
+
+## Create a bundle
+
+```bash
+neuros qualify configs/examples/mock_bci.yaml \
+  --output qualification/mock \
+  --session-id mock-reference \
+  --duration 1.0
+```
+
+The command stages the bundle outside the final path, runs the live configuration, records the canonical input frames, verifies every recorded frame hash, replays the recording through the bundled configuration, compares the canonical decoder-output digest, seals every artifact with SHA-256, verifies the completed bundle, and only then publishes the final directory.
+
+An existing destination is never replaced unless `--overwrite` is explicit.
+
+## Reproduce a bundle
+
+```bash
+neuros reproduce qualification/mock
+```
+
+Reproduction happens in two stages:
+
+1. every sealed file hash, artifact size, artifact-set membership, bundle digest, and embedded session-frame hash is verified;
+2. only after integrity verification succeeds is the recorded session replayed through the bundled config and compared with the sealed decoder-output digest.
+
+A modified file therefore fails before its contents can silently influence the reproduction result.
+
+## Bundle layout
+
+```text
+qualification/
+├── manifest.json
+├── artifact_hashes.json
+├── config.yaml
+├── config.json
+├── environment.json
+├── compatibility.json
+├── devices.json
+├── clocks.json
+├── model.json
+├── runtime.json
+├── decoder_outputs.json
+└── session/
+    ├── manifest.json
+    ├── config.json
+    └── streams/...
+```
+
+### `manifest.json`
+
+The top-level authority for the qualification claim. It records:
+
+- qualification schema version;
+- bundle identity and creation time;
+- Git identity when available;
+- exact config-file SHA-256 and semantic config hash;
+- embedded archive identity;
+- record/replay integrity status;
+- canonical decoder-output digest;
+- the explicit claim boundary.
+
+### `artifact_hashes.json`
+
+Contains the byte size and SHA-256 of every other file in the bundle and a canonical digest over the complete artifact index. Unexpected files are considered a mutation of the sealed evidence bundle and make verification fail.
+
+### `environment.json`
+
+Captures Python/platform identity and installed versions of neurOS plus relevant neuroscience/runtime ecosystems when present.
+
+### `compatibility.json`
+
+Records compatibility-registry entries for recognized external runtime integrations actually selected by the config, such as BrainFlow, LSL, or Braindecode. It does not promote their evidence tier.
+
+### `devices.json` and `clocks.json`
+
+Extract exact stream-descriptor evidence from the recorded session. These files are useful inputs to future hardware qualification, but their presence does not imply hardware qualification.
+
+### `model.json`
+
+Records the decoder config and any `ModelArtifactManifest` entries bound to the recorded session. If no promoted model artifact is bound, the bundle says so explicitly and does **not** claim learned-weight identity.
+
+### `runtime.json`
+
+Contains both the record and replay runtime snapshots, including node failure counts, queue acceptance/drop statistics, and node latency summaries.
+
+### `decoder_outputs.json`
+
+Stores only the canonical output count/digest, not a second unbounded copy of every prediction. Version 1 uses SHA-256 over canonical JSONL serialization.
+
+## Claim boundary
+
+A successful v1 bundle sets:
+
+```text
+runtime_record_replay_qualified = true
+real_dataset_qualified          = false
+hardware_qualified              = false
+closed_loop_qualified           = false
+clinical_qualified              = false
+```
+
+This distinction is foundational. A software replay passing on a laptop does not demonstrate packet-loss behavior, device clock uncertainty, firmware correctness, wireless reliability, source-to-decision latency on named hardware, intervention safety, or clinical validity.
+
+## Hardware qualification is the next evidence tier
+
+A future named hardware profile should extend the same evidence object with measured fields such as:
+
+- physical device and board ID;
+- firmware and acquisition-library versions;
+- operating system and transport;
+- channel names/types/units and actual sampling rate;
+- source timestamp and clock domain;
+- measured clock offset/drift/uncertainty;
+- packet/sample loss and neurOS queue loss;
+- reconnect/recovery behavior;
+- sustained run duration;
+- source-to-decision p50/p95/p99 latency;
+- exact recording/replay integrity.
+
+Only a bundle containing those measurements under a named configuration should be eligible for `hardware_qualified = true`.
+
+## Why this matters
+
+The goal is to make neurOS results transportable as evidence. A collaborator should be able to receive a bundle and answer:
+
+- What configuration ran?
+- What exact neural frames entered the computational path?
+- Which software and ecosystem versions were installed?
+- Which device/timing metadata were actually observed?
+- Did queues drop data or nodes fail?
+- Was a promoted learned-weight artifact bound?
+- Can the computational path reproduce the same outputs from the recorded neural stream?
+- What stronger claims are explicitly unsupported?
+
+That evidence contract is more valuable than a generic "pipeline completed successfully" flag and becomes the substrate for real-device, ORION, closed-loop, and eventually regulated qualification layers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Platform:
       - Four Public Surfaces: PLATFORM.md
       - Ecosystem Compatibility: COMPATIBILITY.md
+      - Qualification Bundles: QUALIFICATION.md
       - Architecture: ARCHITECTURE.md
       - Project Status: PROJECT_STATUS.md
   - Real-World Evidence:

--- a/packages/neuros/src/neuros/cli/app.py
+++ b/packages/neuros/src/neuros/cli/app.py
@@ -89,6 +89,24 @@ def _parse_args() -> argparse.Namespace:
     record_parser.add_argument("--show-outputs", action="store_true")
     _add_json_flag(record_parser)
 
+    qualify_parser = subparsers.add_parser(
+        "qualify",
+        help="Run, record, replay, and seal a reproducible qualification bundle",
+    )
+    qualify_parser.add_argument("config", type=str)
+    qualify_parser.add_argument("--output", type=str, required=True, help="Qualification bundle directory")
+    qualify_parser.add_argument("--session-id", type=str, default="qualification")
+    qualify_parser.add_argument("--duration", type=float, default=1.0)
+    qualify_parser.add_argument("--overwrite", action="store_true")
+    _add_json_flag(qualify_parser)
+
+    reproduce_parser = subparsers.add_parser(
+        "reproduce",
+        help="Verify a sealed qualification bundle and replay its computational path",
+    )
+    reproduce_parser.add_argument("bundle", type=str)
+    _add_json_flag(reproduce_parser)
+
     inspect_parser = subparsers.add_parser("inspect", help="Inspect a neurOS session archive")
     inspect_parser.add_argument("archive", type=str)
     inspect_parser.add_argument("--verify", action="store_true", help="Verify every frame SHA-256")
@@ -264,6 +282,30 @@ def main() -> None:
                     on_output=callback,
                 )
             )
+            _emit(result, machine=args.json)
+            return
+
+        if args.command == "qualify":
+            from neuros.qualification import qualify_config
+
+            if args.duration <= 0:
+                raise ConfigurationError("qualification duration must be positive")
+            result = cli_api.asyncio.run(
+                qualify_config(
+                    args.config,
+                    args.output,
+                    session_id=args.session_id,
+                    duration_s=args.duration,
+                    overwrite=args.overwrite,
+                )
+            )
+            _emit(result, machine=args.json)
+            return
+
+        if args.command == "reproduce":
+            from neuros.qualification import reproduce_qualification
+
+            result = cli_api.asyncio.run(reproduce_qualification(args.bundle))
             _emit(result, machine=args.json)
             return
 

--- a/packages/neuros/src/neuros/cli/app.py
+++ b/packages/neuros/src/neuros/cli/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import asdict, is_dataclass
+from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -105,6 +105,12 @@ def _parse_args() -> argparse.Namespace:
         help="Verify a sealed qualification bundle and replay its computational path",
     )
     reproduce_parser.add_argument("bundle", type=str)
+    reproduce_parser.add_argument(
+        "--expected-sha256",
+        type=str,
+        default=None,
+        help="Optional externally pinned qualification root digest",
+    )
     _add_json_flag(reproduce_parser)
 
     inspect_parser = subparsers.add_parser("inspect", help="Inspect a neurOS session archive")
@@ -179,13 +185,18 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _jsonable(value: Any) -> Any:
-    if is_dataclass(value):
-        return {key: _jsonable(item) for key, item in asdict(value).items()}
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _jsonable(getattr(value, field.name))
+            for field in fields(value)
+        }
     if isinstance(value, np.ndarray):
         return value.tolist()
     if isinstance(value, np.generic):
         return value.item()
     if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if hasattr(value, "items"):
         return {str(key): _jsonable(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
@@ -305,7 +316,12 @@ def main() -> None:
         if args.command == "reproduce":
             from neuros.qualification import reproduce_qualification
 
-            result = cli_api.asyncio.run(reproduce_qualification(args.bundle))
+            result = cli_api.asyncio.run(
+                reproduce_qualification(
+                    args.bundle,
+                    expected_sha256=args.expected_sha256,
+                )
+            )
             _emit(result, machine=args.json)
             return
 

--- a/packages/neuros/src/neuros/qualification.py
+++ b/packages/neuros/src/neuros/qualification.py
@@ -18,7 +18,7 @@ import platform
 import shutil
 import sys
 import uuid
-from dataclasses import asdict, is_dataclass
+from dataclasses import fields, is_dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from importlib import metadata as importlib_metadata
@@ -60,8 +60,20 @@ _RELEVANT_PACKAGES = (
 
 
 def _jsonable(value: Any) -> Any:
-    if is_dataclass(value):
-        return _jsonable(asdict(value))
+    """Convert evidence values without deepcopying immutable mapping proxies.
+
+    ``dataclasses.asdict`` recursively deep-copies values. neurOS contracts use
+    immutable ``MappingProxyType`` metadata by design, and deep-copying those
+    objects fails. Evidence serialization instead walks dataclass fields and
+    mappings directly so the digest reflects values without mutating or copying
+    their authority wrappers.
+    """
+
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _jsonable(getattr(value, field.name))
+            for field in fields(value)
+        }
     if isinstance(value, Enum):
         return value.value
     if isinstance(value, np.ndarray):
@@ -287,6 +299,13 @@ async def qualify_config(
             overwrite=False,
             on_output=live_outputs,
         )
+        # ``record_config`` correctly reports the path it wrote to, but this run
+        # occurs inside a temporary staging directory that is renamed once the
+        # bundle has verified. Persist only portable bundle-relative references.
+        record_summary = dict(record_summary)
+        record_summary["archive"] = "session"
+        record_summary["exports"] = {}
+
         archive_summary = inspect_archive(session_root, verify_hashes=True)
         replay_snapshot = await replay_archive(
             session_root,

--- a/packages/neuros/src/neuros/qualification.py
+++ b/packages/neuros/src/neuros/qualification.py
@@ -29,13 +29,14 @@ import numpy as np
 import yaml
 
 from neuros.compatibility import compatibility_payload
+from neuros.contracts import DecoderOutput
 from neuros.quality import BenchmarkManifest
 from neuros.recording import SessionArchiveReader, canonical_hash
 
 from .cli.recording_commands import inspect_archive, record_config, replay_archive
 
 QUALIFICATION_SCHEMA_VERSION = 1
-_OUTPUT_DIGEST_ALGORITHM = "sha256-canonical-jsonl-v1"
+_OUTPUT_DIGEST_ALGORITHM = "sha256-semantic-decoder-jsonl-v1"
 _RELEVANT_PACKAGES = (
     "neuros",
     "neuros-core",
@@ -99,6 +100,23 @@ def _canonical_bytes(value: Any) -> bytes:
     ).encode("utf-8")
 
 
+def _canonical_output_payload(output: Any) -> Any:
+    """Return the replay-stable semantic identity of one runtime output.
+
+    ``DecoderOutput.inference_time_ns`` measures how long this particular
+    execution took. It is intentionally expected to change between live and
+    replay execution, so including it in decision identity would make every
+    honest performance measurement look like a reproducibility failure.
+    Latency remains preserved separately in runtime telemetry.
+    """
+
+    payload = _jsonable(output)
+    if isinstance(output, DecoderOutput):
+        payload = dict(payload)
+        payload.pop("inference_time_ns", None)
+    return payload
+
+
 def _write_json(path: Path, value: Any) -> None:
     path.write_text(
         json.dumps(_jsonable(value), indent=2, sort_keys=True, default=str) + "\n",
@@ -137,7 +155,7 @@ class _OutputDigest:
         self.count = 0
 
     async def __call__(self, output: Any) -> None:
-        self._digest.update(_canonical_bytes(output))
+        self._digest.update(_canonical_bytes(_canonical_output_payload(output)))
         self._digest.update(b"\n")
         self.count += 1
 

--- a/packages/neuros/src/neuros/qualification.py
+++ b/packages/neuros/src/neuros/qualification.py
@@ -13,6 +13,7 @@ bundle.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import platform
 import shutil
@@ -132,6 +133,13 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _normalize_sha256(value: str) -> str:
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        raise ValueError("expected_sha256 must be a 64-character hexadecimal SHA-256 digest")
+    return normalized
+
+
 def _installed_versions() -> dict[str, str]:
     versions: dict[str, str] = {}
     for name in _RELEVANT_PACKAGES:
@@ -183,6 +191,22 @@ def _runtime_quality(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "max_node_p99_latency_ms": max(p99_values, default=0.0),
         "runtime_failure": snapshot.get("failure"),
     }
+
+
+def _assert_runtime_qualifiable(label: str, quality: Mapping[str, Any]) -> None:
+    problems: list[str] = []
+    if quality.get("runtime_state") != "stopped":
+        problems.append(f"state={quality.get('runtime_state')!r}")
+    if int(quality.get("node_failures", 0)) != 0:
+        problems.append(f"node_failures={quality.get('node_failures')}")
+    if int(quality.get("edge_items_dropped", 0)) != 0:
+        problems.append(f"edge_items_dropped={quality.get('edge_items_dropped')}")
+    if quality.get("runtime_failure") is not None:
+        problems.append(f"runtime_failure={quality.get('runtime_failure')!r}")
+    if problems:
+        raise RuntimeError(
+            f"{label} runtime is not eligible for qualification: " + ", ".join(problems)
+        )
 
 
 def _stream_evidence(reader: SessionArchiveReader) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -264,6 +288,18 @@ def _artifact_index(root: Path) -> dict[str, Any]:
     }
 
 
+def _normalize_session_metadata(session_root: Path) -> None:
+    """Remove host-local config paths before the session enters a portable bundle."""
+
+    path = session_root / "manifest.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    metadata = dict(raw.get("metadata", {}))
+    metadata["config_path"] = "config.yaml"
+    metadata["config_path_scope"] = "qualification_bundle"
+    raw["metadata"] = metadata
+    _write_json(path, raw)
+
+
 def _safe_replace_directory(staging: Path, destination: Path, *, overwrite: bool) -> None:
     if destination.exists():
         if not overwrite:
@@ -323,8 +359,12 @@ async def qualify_config(
         record_summary = dict(record_summary)
         record_summary["archive"] = "session"
         record_summary["exports"] = {}
+        _normalize_session_metadata(session_root)
 
         archive_summary = inspect_archive(session_root, verify_hashes=True)
+        if sum(int(count) for count in archive_summary.get("streams", {}).values()) <= 0:
+            raise RuntimeError("Qualification recording contains no SignalFrames")
+
         replay_snapshot = await replay_archive(
             session_root,
             bundled_config,
@@ -336,15 +376,21 @@ async def qualify_config(
 
         live_digest = live_outputs.to_dict()
         replay_digest = replay_outputs.to_dict()
+        if int(live_digest["count"]) <= 0:
+            raise RuntimeError("Qualification runtime produced no decoder outputs")
         if live_digest != replay_digest:
             raise RuntimeError(
                 "Qualification replay output mismatch: the recorded session did not "
-                "reproduce the canonical decoder-output digest"
+                "reproduce the canonical semantic decoder-output digest"
             )
 
         reader = SessionArchiveReader(session_root, verify_hashes=True)
         devices, clocks = _stream_evidence(reader)
         session_manifest = reader.manifest
+        config_hash = canonical_hash(raw_config)
+        if session_manifest.get("config_hash") != config_hash:
+            raise RuntimeError("Recorded session config hash differs from qualification config")
+
         environment = _environment_payload(raw_config)
         integrations = _used_integrations(raw_config)
         compatibility = {
@@ -371,6 +417,8 @@ async def qualify_config(
         record_runtime = session_manifest.get("runtime_metrics", {})
         replay_quality = _runtime_quality(replay_snapshot)
         record_quality = _runtime_quality(record_runtime)
+        _assert_runtime_qualifiable("record", record_quality)
+        _assert_runtime_qualifiable("replay", replay_quality)
 
         _write_json(staging / "environment.json", environment)
         _write_json(staging / "compatibility.json", compatibility)
@@ -402,7 +450,7 @@ async def qualify_config(
             "session_id": session_id,
             "git_sha": environment.get("git_sha"),
             "config_file_sha256": _sha256_file(bundled_config),
-            "config_semantic_hash": canonical_hash(raw_config),
+            "config_semantic_hash": config_hash,
             "archive_config_hash": session_manifest.get("config_hash"),
             "archive": "session",
             "record_summary": record_summary,
@@ -412,6 +460,11 @@ async def qualify_config(
                 "replay_completed": replay_snapshot.get("state") == "stopped",
                 "decoder_output_digest_exact": True,
                 "decoder_output_digest": live_digest,
+            },
+            "integrity_model": {
+                "artifact_hashes": "sha256",
+                "structural_integrity": "self-verifiable",
+                "origin_authenticity": "requires_external_bundle_sha256_pin_or_future_signature",
             },
             "claim_boundary": {
                 "runtime_record_replay_qualified": True,
@@ -449,8 +502,17 @@ async def qualify_config(
         raise
 
 
-def verify_qualification_bundle(path: str | Path) -> dict[str, Any]:
-    """Verify the sealed artifact index and embedded session archive."""
+def verify_qualification_bundle(
+    path: str | Path,
+    *,
+    expected_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Verify the sealed artifact index and embedded session archive.
+
+    ``expected_sha256`` is an optional externally pinned root digest. Without
+    an external pin (or a future signature), a self-contained bundle can prove
+    structural consistency but cannot by itself establish who authored it.
+    """
 
     root = Path(path).resolve()
     manifest_path = root / "manifest.json"
@@ -491,17 +553,26 @@ def verify_qualification_bundle(path: str | Path) -> dict[str, Any]:
     bundle_sha256 = hashlib.sha256(_canonical_bytes(rows)).hexdigest()
     if bundle_sha256 != index.get("bundle_sha256"):
         raise IOError("Qualification bundle digest mismatch")
+    if expected_sha256 is not None:
+        expected = _normalize_sha256(expected_sha256)
+        if not hmac.compare_digest(bundle_sha256, expected):
+            raise IOError(
+                "Qualification bundle SHA-256 does not match the externally pinned digest"
+            )
 
     reader = SessionArchiveReader(root / str(manifest.get("archive", "session")), verify_hashes=True)
     frame_count = 0
     for stream_id in reader.stream_ids:
         frame_count += sum(1 for _ in reader.iter_frames(stream_id))
+    if frame_count <= 0:
+        raise IOError("Qualification session contains no verified SignalFrames")
 
     return {
         "bundle": str(root),
         "bundle_id": manifest.get("bundle_id"),
         "schema_version": QUALIFICATION_SCHEMA_VERSION,
         "integrity": "verified",
+        "origin_authenticity": "externally_pinned" if expected_sha256 is not None else "not_established",
         "artifact_count": len(rows),
         "frame_count": frame_count,
         "bundle_sha256": bundle_sha256,
@@ -509,10 +580,14 @@ def verify_qualification_bundle(path: str | Path) -> dict[str, Any]:
     }
 
 
-async def reproduce_qualification(path: str | Path) -> dict[str, Any]:
+async def reproduce_qualification(
+    path: str | Path,
+    *,
+    expected_sha256: str | None = None,
+) -> dict[str, Any]:
     """Verify a bundle and deterministically replay its recorded computational path."""
 
-    verification = verify_qualification_bundle(path)
+    verification = verify_qualification_bundle(path, expected_sha256=expected_sha256)
     root = Path(path).resolve()
     expected = json.loads((root / "decoder_outputs.json").read_text(encoding="utf-8"))["record"]
     capture = _OutputDigest()
@@ -527,8 +602,11 @@ async def reproduce_qualification(path: str | Path) -> dict[str, Any]:
     observed = capture.to_dict()
     if observed != expected:
         raise RuntimeError(
-            "Qualification reproduction failed: decoder-output digest differs from sealed bundle"
+            "Qualification reproduction failed: semantic decoder-output digest differs "
+            "from the sealed bundle"
         )
+    quality = _runtime_quality(snapshot)
+    _assert_runtime_qualifiable("reproduction", quality)
     return {
         **verification,
         "reproduced": True,

--- a/packages/neuros/src/neuros/qualification.py
+++ b/packages/neuros/src/neuros/qualification.py
@@ -1,0 +1,500 @@
+"""Reproducible neurOS qualification bundles.
+
+A qualification bundle is an evidence artifact, not a blanket product claim.
+Version 1 proves a narrower property: a declared runtime configuration was run,
+its exact input frames were recorded with integrity hashes, and the recorded
+session reproduced the same canonical decoder-output digest through replay.
+
+Hardware, real-dataset, closed-loop, and clinical qualification require
+additional evidence and are explicitly *not* inferred from a successful v1
+bundle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import shutil
+import sys
+import uuid
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+import yaml
+
+from neuros.compatibility import compatibility_payload
+from neuros.quality import BenchmarkManifest
+from neuros.recording import SessionArchiveReader, canonical_hash
+
+from .cli.recording_commands import inspect_archive, record_config, replay_archive
+
+QUALIFICATION_SCHEMA_VERSION = 1
+_OUTPUT_DIGEST_ALGORITHM = "sha256-canonical-jsonl-v1"
+_RELEVANT_PACKAGES = (
+    "neuros",
+    "neuros-core",
+    "neuros-drivers",
+    "neuros-models",
+    "neuros-foundation",
+    "neuros-sourceweigher",
+    "neuros-mechint",
+    "neuros-orion",
+    "numpy",
+    "scipy",
+    "torch",
+    "scikit-learn",
+    "mne",
+    "moabb",
+    "braindecode",
+    "brainflow",
+    "pylsl",
+    "pynwb",
+    "zarr",
+)
+
+
+def _jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        _jsonable(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(
+        json.dumps(_jsonable(value), indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _installed_versions() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for name in _RELEVANT_PACKAGES:
+        try:
+            versions[name] = importlib_metadata.version(name)
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    return versions
+
+
+def _load_raw_config(path: Path) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("qualification config root must be a mapping")
+    return raw
+
+
+class _OutputDigest:
+    def __init__(self) -> None:
+        self._digest = hashlib.sha256()
+        self.count = 0
+
+    async def __call__(self, output: Any) -> None:
+        self._digest.update(_canonical_bytes(output))
+        self._digest.update(b"\n")
+        self.count += 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "algorithm": _OUTPUT_DIGEST_ALGORITHM,
+            "count": self.count,
+            "sha256": self._digest.hexdigest(),
+        }
+
+
+def _runtime_quality(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    nodes = snapshot.get("nodes", {})
+    edges = snapshot.get("edges", {})
+    dropped = sum(int(item.get("dropped", 0)) for item in edges.values())
+    accepted = sum(int(item.get("accepted", 0)) for item in edges.values())
+    failed = sum(int(item.get("failed", 0)) for item in nodes.values())
+    p99_values = [float(item.get("p99_latency_ms", 0.0)) for item in nodes.values()]
+    return {
+        "runtime_state": snapshot.get("state"),
+        "runtime_seconds": float(snapshot.get("runtime_seconds", 0.0)),
+        "node_failures": failed,
+        "edge_items_accepted": accepted,
+        "edge_items_dropped": dropped,
+        "max_node_p99_latency_ms": max(p99_values, default=0.0),
+        "runtime_failure": snapshot.get("failure"),
+    }
+
+
+def _stream_evidence(reader: SessionArchiveReader) -> tuple[dict[str, Any], dict[str, Any]]:
+    devices: dict[str, Any] = {}
+    clocks: dict[str, Any] = {}
+    for stream_id in reader.stream_ids:
+        descriptor = reader.descriptor(stream_id)
+        devices[stream_id] = {
+            "modality": descriptor.modality,
+            "sample_rate_hz": descriptor.sample_rate_hz,
+            "channel_names": list(descriptor.channel_names),
+            "channel_types": list(descriptor.channel_types),
+            "units": list(descriptor.units),
+            "device": descriptor.device,
+            "manufacturer": descriptor.manufacturer,
+            "descriptor_metadata": dict(descriptor.metadata),
+        }
+        clocks[stream_id] = {
+            "clock_domain": descriptor.clock_domain.value,
+            "timing_semantics": descriptor.metadata.get("timing_semantics"),
+            "clock_uncertainty_ns": descriptor.metadata.get("clock_uncertainty_ns"),
+            "clock_drift_ppm": descriptor.metadata.get("clock_drift_ppm"),
+        }
+    return devices, clocks
+
+
+def _used_integrations(config: Mapping[str, Any]) -> list[str]:
+    integration_ids: set[str] = set()
+    for stream in config.get("streams", []):
+        if not isinstance(stream, Mapping):
+            continue
+        source = stream.get("source", {})
+        if isinstance(source, Mapping):
+            plugin = str(source.get("plugin", "")).lower()
+            if plugin in {"brainflow", "lsl"}:
+                integration_ids.add(plugin)
+    decoder = config.get("decoder", {})
+    if isinstance(decoder, Mapping):
+        plugin = str(decoder.get("plugin", "")).lower()
+        if plugin == "braindecode":
+            integration_ids.add("braindecode")
+    return sorted(integration_ids)
+
+
+def _environment_payload(config: Mapping[str, Any]) -> dict[str, Any]:
+    benchmark = BenchmarkManifest.capture(
+        "qualification-runtime-replay-v1",
+        config=config,
+        metadata={"qualification_schema_version": QUALIFICATION_SCHEMA_VERSION},
+    )
+    return {
+        "created_at": benchmark.created_at,
+        "git_sha": benchmark.git_sha,
+        "python": sys.version,
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "packages": _installed_versions(),
+    }
+
+
+def _artifact_index(root: Path) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name == "artifact_hashes.json":
+            continue
+        relative = path.relative_to(root).as_posix()
+        rows.append(
+            {
+                "path": relative,
+                "bytes": path.stat().st_size,
+                "sha256": _sha256_file(path),
+            }
+        )
+    return {
+        "algorithm": "sha256",
+        "artifacts": rows,
+        "bundle_sha256": hashlib.sha256(_canonical_bytes(rows)).hexdigest(),
+    }
+
+
+def _safe_replace_directory(staging: Path, destination: Path, *, overwrite: bool) -> None:
+    if destination.exists():
+        if not overwrite:
+            raise FileExistsError(f"Qualification output already exists: {destination}")
+        if destination.is_symlink() or not destination.is_dir():
+            raise ValueError("--overwrite only supports an existing directory")
+        resolved = destination.resolve()
+        if resolved == Path(resolved.anchor) or resolved == Path.home().resolve():
+            raise ValueError("Refusing to overwrite a filesystem root or home directory")
+        shutil.rmtree(destination)
+    staging.replace(destination)
+
+
+async def qualify_config(
+    config_path: str | Path,
+    output: str | Path,
+    *,
+    session_id: str = "qualification",
+    duration_s: float = 1.0,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Run, record, replay, and seal one immutable qualification bundle."""
+
+    if duration_s <= 0:
+        raise ValueError("qualification duration must be positive")
+    source_config = Path(config_path).resolve()
+    if not source_config.is_file():
+        raise FileNotFoundError(source_config)
+    raw_config = _load_raw_config(source_config)
+
+    destination = Path(output).resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists() and not overwrite:
+        raise FileExistsError(f"Qualification output already exists: {destination}")
+    staging = destination.parent / f".{destination.name}.staging-{uuid.uuid4().hex}"
+    staging.mkdir(parents=False, exist_ok=False)
+
+    live_outputs = _OutputDigest()
+    replay_outputs = _OutputDigest()
+    try:
+        bundled_config = staging / "config.yaml"
+        shutil.copyfile(source_config, bundled_config)
+        _write_json(staging / "config.json", raw_config)
+
+        session_root = staging / "session"
+        record_summary = await record_config(
+            source_config,
+            session_root,
+            session_id=session_id,
+            duration_s=duration_s,
+            overwrite=False,
+            on_output=live_outputs,
+        )
+        archive_summary = inspect_archive(session_root, verify_hashes=True)
+        replay_snapshot = await replay_archive(
+            session_root,
+            bundled_config,
+            realtime=False,
+            speed=1.0,
+            duration_s=None,
+            on_output=replay_outputs,
+        )
+
+        live_digest = live_outputs.to_dict()
+        replay_digest = replay_outputs.to_dict()
+        if live_digest != replay_digest:
+            raise RuntimeError(
+                "Qualification replay output mismatch: the recorded session did not "
+                "reproduce the canonical decoder-output digest"
+            )
+
+        reader = SessionArchiveReader(session_root, verify_hashes=True)
+        devices, clocks = _stream_evidence(reader)
+        session_manifest = reader.manifest
+        environment = _environment_payload(raw_config)
+        integrations = _used_integrations(raw_config)
+        compatibility = {
+            "used_integrations": integrations,
+            "records": [
+                record
+                for integration_id in integrations
+                for record in compatibility_payload(integration_id)
+            ],
+        }
+        model_artifacts = list(session_manifest.get("model_artifacts", []))
+        decoder_config = raw_config.get("decoder", {})
+        model_identity = {
+            "decoder_config": decoder_config,
+            "artifact_bound": bool(model_artifacts),
+            "model_artifacts": model_artifacts,
+            "limitation": None
+            if model_artifacts
+            else (
+                "No promoted ModelArtifactManifest was bound to this session. The decoder "
+                "configuration is recorded, but learned-weight identity is not claimed."
+            ),
+        }
+        record_runtime = session_manifest.get("runtime_metrics", {})
+        replay_quality = _runtime_quality(replay_snapshot)
+        record_quality = _runtime_quality(record_runtime)
+
+        _write_json(staging / "environment.json", environment)
+        _write_json(staging / "compatibility.json", compatibility)
+        _write_json(staging / "devices.json", devices)
+        _write_json(staging / "clocks.json", clocks)
+        _write_json(staging / "model.json", model_identity)
+        _write_json(
+            staging / "runtime.json",
+            {
+                "record": record_runtime,
+                "replay": replay_snapshot,
+                "record_quality": record_quality,
+                "replay_quality": replay_quality,
+            },
+        )
+        _write_json(
+            staging / "decoder_outputs.json",
+            {"record": live_digest, "replay": replay_digest, "exact_match": True},
+        )
+
+        created_at = datetime.now(timezone.utc).isoformat()
+        manifest = {
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "bundle_id": f"qualification:{session_id}:{uuid.uuid4().hex}",
+            "created_at": created_at,
+            "status": "complete",
+            "qualification_scope": "runtime-record-replay",
+            "evidence_tier": "integration",
+            "session_id": session_id,
+            "git_sha": environment.get("git_sha"),
+            "config_file_sha256": _sha256_file(bundled_config),
+            "config_semantic_hash": canonical_hash(raw_config),
+            "archive_config_hash": session_manifest.get("config_hash"),
+            "archive": "session",
+            "record_summary": record_summary,
+            "archive_summary": archive_summary,
+            "reproducibility": {
+                "archive_integrity_verified": archive_summary.get("integrity") == "verified",
+                "replay_completed": replay_snapshot.get("state") == "stopped",
+                "decoder_output_digest_exact": True,
+                "decoder_output_digest": live_digest,
+            },
+            "claim_boundary": {
+                "runtime_record_replay_qualified": True,
+                "real_dataset_qualified": False,
+                "hardware_qualified": False,
+                "closed_loop_qualified": False,
+                "clinical_qualified": False,
+                "statement": (
+                    "This bundle qualifies the recorded software/runtime replay boundary only. "
+                    "It does not establish real-dataset utility, physical-device timing or "
+                    "reliability, closed-loop safety, or clinical validity."
+                ),
+            },
+        }
+        _write_json(staging / "manifest.json", manifest)
+        artifact_index = _artifact_index(staging)
+        _write_json(staging / "artifact_hashes.json", artifact_index)
+
+        verification = verify_qualification_bundle(staging)
+        _safe_replace_directory(staging, destination, overwrite=overwrite)
+        return {
+            "bundle": str(destination),
+            "bundle_id": manifest["bundle_id"],
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "status": "complete",
+            "evidence_tier": "integration",
+            "session_id": session_id,
+            "decoder_outputs": live_digest,
+            "bundle_sha256": verification["bundle_sha256"],
+            "claim_boundary": manifest["claim_boundary"],
+        }
+    except BaseException:
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def verify_qualification_bundle(path: str | Path) -> dict[str, Any]:
+    """Verify the sealed artifact index and embedded session archive."""
+
+    root = Path(path).resolve()
+    manifest_path = root / "manifest.json"
+    hashes_path = root / "artifact_hashes.json"
+    if not manifest_path.is_file() or not hashes_path.is_file():
+        raise IOError("Not a complete neurOS qualification bundle")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if int(manifest.get("schema_version", -1)) != QUALIFICATION_SCHEMA_VERSION:
+        raise ValueError("Unsupported neurOS qualification schema")
+    if manifest.get("status") != "complete":
+        raise IOError("Qualification bundle is not marked complete")
+
+    index = json.loads(hashes_path.read_text(encoding="utf-8"))
+    rows = index.get("artifacts")
+    if not isinstance(rows, list):
+        raise IOError("Qualification artifact index is malformed")
+    expected_paths = {str(row["path"]) for row in rows}
+    actual_paths = {
+        item.relative_to(root).as_posix()
+        for item in root.rglob("*")
+        if item.is_file() and item.name != "artifact_hashes.json"
+    }
+    if actual_paths != expected_paths:
+        missing = sorted(expected_paths - actual_paths)
+        unexpected = sorted(actual_paths - expected_paths)
+        raise IOError(
+            f"Qualification artifact set mismatch; missing={missing}, unexpected={unexpected}"
+        )
+
+    for row in rows:
+        artifact = root / str(row["path"])
+        if artifact.stat().st_size != int(row["bytes"]):
+            raise IOError(f"Qualification artifact size mismatch: {row['path']}")
+        if _sha256_file(artifact) != str(row["sha256"]):
+            raise IOError(f"Qualification artifact hash mismatch: {row['path']}")
+
+    bundle_sha256 = hashlib.sha256(_canonical_bytes(rows)).hexdigest()
+    if bundle_sha256 != index.get("bundle_sha256"):
+        raise IOError("Qualification bundle digest mismatch")
+
+    reader = SessionArchiveReader(root / str(manifest.get("archive", "session")), verify_hashes=True)
+    frame_count = 0
+    for stream_id in reader.stream_ids:
+        frame_count += sum(1 for _ in reader.iter_frames(stream_id))
+
+    return {
+        "bundle": str(root),
+        "bundle_id": manifest.get("bundle_id"),
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "integrity": "verified",
+        "artifact_count": len(rows),
+        "frame_count": frame_count,
+        "bundle_sha256": bundle_sha256,
+        "claim_boundary": manifest.get("claim_boundary", {}),
+    }
+
+
+async def reproduce_qualification(path: str | Path) -> dict[str, Any]:
+    """Verify a bundle and deterministically replay its recorded computational path."""
+
+    verification = verify_qualification_bundle(path)
+    root = Path(path).resolve()
+    expected = json.loads((root / "decoder_outputs.json").read_text(encoding="utf-8"))["record"]
+    capture = _OutputDigest()
+    snapshot = await replay_archive(
+        root / "session",
+        root / "config.yaml",
+        realtime=False,
+        speed=1.0,
+        duration_s=None,
+        on_output=capture,
+    )
+    observed = capture.to_dict()
+    if observed != expected:
+        raise RuntimeError(
+            "Qualification reproduction failed: decoder-output digest differs from sealed bundle"
+        )
+    return {
+        **verification,
+        "reproduced": True,
+        "runtime_state": snapshot.get("state"),
+        "decoder_outputs": observed,
+    }

--- a/tests/test_qualification_bundle.py
+++ b/tests/test_qualification_bundle.py
@@ -5,12 +5,52 @@ from pathlib import Path
 
 import pytest
 
+from neuros.contracts import DecoderOutput
 from neuros.qualification import (
     QUALIFICATION_SCHEMA_VERSION,
+    _OutputDigest,
     qualify_config,
     reproduce_qualification,
     verify_qualification_bundle,
 )
+
+
+@pytest.mark.asyncio
+async def test_semantic_output_digest_ignores_latency_not_decision():
+    first = _OutputDigest()
+    second = _OutputDigest()
+    changed = _OutputDigest()
+
+    await first(
+        DecoderOutput(
+            prediction=1,
+            model_id="semantic-test",
+            model_version="1",
+            inference_time_ns=100,
+            metadata={"score": 0.75},
+        )
+    )
+    await second(
+        DecoderOutput(
+            prediction=1,
+            model_id="semantic-test",
+            model_version="1",
+            inference_time_ns=999999,
+            metadata={"score": 0.75},
+        )
+    )
+    await changed(
+        DecoderOutput(
+            prediction=0,
+            model_id="semantic-test",
+            model_version="1",
+            inference_time_ns=100,
+            metadata={"score": 0.75},
+        )
+    )
+
+    assert first.to_dict() == second.to_dict()
+    assert first.to_dict()["sha256"] != changed.to_dict()["sha256"]
 
 
 @pytest.mark.asyncio
@@ -61,6 +101,8 @@ async def test_qualification_bundle_is_sealed_and_reproducible(tmp_path: Path):
     assert manifest["reproducibility"]["replay_completed"] is True
     assert manifest["reproducibility"]["decoder_output_digest_exact"] is True
     assert manifest["config_semantic_hash"] == manifest["archive_config_hash"]
+    assert manifest["record_summary"]["archive"] == "session"
+    assert ".staging-" not in json.dumps(manifest, sort_keys=True)
 
     model = json.loads((bundle / "model.json").read_text(encoding="utf-8"))
     assert model["artifact_bound"] is False

--- a/tests/test_qualification_bundle.py
+++ b/tests/test_qualification_bundle.py
@@ -102,7 +102,22 @@ async def test_qualification_bundle_is_sealed_and_reproducible(tmp_path: Path):
     assert manifest["reproducibility"]["decoder_output_digest_exact"] is True
     assert manifest["config_semantic_hash"] == manifest["archive_config_hash"]
     assert manifest["record_summary"]["archive"] == "session"
+    assert manifest["integrity_model"]["origin_authenticity"].startswith("requires_external")
     assert ".staging-" not in json.dumps(manifest, sort_keys=True)
+
+    session_manifest = json.loads(
+        (bundle / "session" / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert session_manifest["metadata"]["config_path"] == "config.yaml"
+    assert session_manifest["metadata"]["config_path_scope"] == "qualification_bundle"
+
+    runtime = json.loads((bundle / "runtime.json").read_text(encoding="utf-8"))
+    assert runtime["record_quality"]["runtime_state"] == "stopped"
+    assert runtime["record_quality"]["node_failures"] == 0
+    assert runtime["record_quality"]["edge_items_dropped"] == 0
+    assert runtime["replay_quality"]["runtime_state"] == "stopped"
+    assert runtime["replay_quality"]["node_failures"] == 0
+    assert runtime["replay_quality"]["edge_items_dropped"] == 0
 
     model = json.loads((bundle / "model.json").read_text(encoding="utf-8"))
     assert model["artifact_bound"] is False
@@ -110,10 +125,21 @@ async def test_qualification_bundle_is_sealed_and_reproducible(tmp_path: Path):
 
     verification = verify_qualification_bundle(bundle)
     assert verification["integrity"] == "verified"
+    assert verification["origin_authenticity"] == "not_established"
     assert verification["frame_count"] > 0
 
-    reproduced = await reproduce_qualification(bundle)
+    pinned = verify_qualification_bundle(bundle, expected_sha256=result["bundle_sha256"])
+    assert pinned["origin_authenticity"] == "externally_pinned"
+
+    with pytest.raises(IOError, match="externally pinned"):
+        verify_qualification_bundle(bundle, expected_sha256="0" * 64)
+
+    reproduced = await reproduce_qualification(
+        bundle,
+        expected_sha256=result["bundle_sha256"],
+    )
     assert reproduced["reproduced"] is True
+    assert reproduced["origin_authenticity"] == "externally_pinned"
     assert reproduced["runtime_state"] == "stopped"
     assert reproduced["decoder_outputs"] == result["decoder_outputs"]
 

--- a/tests/test_qualification_bundle.py
+++ b/tests/test_qualification_bundle.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neuros.qualification import (
+    QUALIFICATION_SCHEMA_VERSION,
+    qualify_config,
+    reproduce_qualification,
+    verify_qualification_bundle,
+)
+
+
+@pytest.mark.asyncio
+async def test_qualification_bundle_is_sealed_and_reproducible(tmp_path: Path):
+    config = Path("configs/examples/mock_bci.yaml").resolve()
+    bundle = tmp_path / "qualification"
+
+    result = await qualify_config(
+        config,
+        bundle,
+        session_id="ci-qualification",
+        duration_s=0.05,
+    )
+
+    assert result["schema_version"] == QUALIFICATION_SCHEMA_VERSION
+    assert result["status"] == "complete"
+    assert result["evidence_tier"] == "integration"
+    assert result["decoder_outputs"]["count"] > 0
+    assert result["claim_boundary"]["runtime_record_replay_qualified"] is True
+    assert result["claim_boundary"]["hardware_qualified"] is False
+    assert result["claim_boundary"]["closed_loop_qualified"] is False
+    assert result["claim_boundary"]["clinical_qualified"] is False
+
+    required = {
+        "manifest.json",
+        "artifact_hashes.json",
+        "config.yaml",
+        "config.json",
+        "environment.json",
+        "compatibility.json",
+        "devices.json",
+        "clocks.json",
+        "model.json",
+        "runtime.json",
+        "decoder_outputs.json",
+        "session/manifest.json",
+    }
+    actual = {
+        path.relative_to(bundle).as_posix()
+        for path in bundle.rglob("*")
+        if path.is_file()
+    }
+    assert required <= actual
+
+    manifest = json.loads((bundle / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["qualification_scope"] == "runtime-record-replay"
+    assert manifest["reproducibility"]["archive_integrity_verified"] is True
+    assert manifest["reproducibility"]["replay_completed"] is True
+    assert manifest["reproducibility"]["decoder_output_digest_exact"] is True
+    assert manifest["config_semantic_hash"] == manifest["archive_config_hash"]
+
+    model = json.loads((bundle / "model.json").read_text(encoding="utf-8"))
+    assert model["artifact_bound"] is False
+    assert "learned-weight identity is not claimed" in model["limitation"]
+
+    verification = verify_qualification_bundle(bundle)
+    assert verification["integrity"] == "verified"
+    assert verification["frame_count"] > 0
+
+    reproduced = await reproduce_qualification(bundle)
+    assert reproduced["reproduced"] is True
+    assert reproduced["runtime_state"] == "stopped"
+    assert reproduced["decoder_outputs"] == result["decoder_outputs"]
+
+
+@pytest.mark.asyncio
+async def test_qualification_refuses_existing_output_without_overwrite(tmp_path: Path):
+    config = Path("configs/examples/mock_bci.yaml").resolve()
+    bundle = tmp_path / "qualification"
+    bundle.mkdir()
+    (bundle / "sentinel.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        await qualify_config(config, bundle, duration_s=0.01)
+
+    assert (bundle / "sentinel.txt").read_text(encoding="utf-8") == "keep"
+
+
+@pytest.mark.asyncio
+async def test_qualification_explicit_overwrite_replaces_directory(tmp_path: Path):
+    config = Path("configs/examples/mock_bci.yaml").resolve()
+    bundle = tmp_path / "qualification"
+    bundle.mkdir()
+    (bundle / "obsolete.txt").write_text("old", encoding="utf-8")
+
+    await qualify_config(config, bundle, duration_s=0.03, overwrite=True)
+
+    assert not (bundle / "obsolete.txt").exists()
+    assert verify_qualification_bundle(bundle)["integrity"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_qualification_detects_tampering_before_reproduction(tmp_path: Path):
+    config = Path("configs/examples/mock_bci.yaml").resolve()
+    bundle = tmp_path / "qualification"
+    await qualify_config(config, bundle, duration_s=0.03)
+
+    runtime_path = bundle / "runtime.json"
+    runtime_path.write_text(runtime_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(IOError, match="artifact (size|hash) mismatch"):
+        verify_qualification_bundle(bundle)
+
+    with pytest.raises(IOError, match="artifact (size|hash) mismatch"):
+        await reproduce_qualification(bundle)


### PR DESCRIPTION
## Why

neurOS already records canonical SignalFrames, preserves runtime provenance, exposes evidence-aware ecosystem compatibility, and has real-dataset longitudinal benchmark authority. The missing platform primitive is a portable artifact that binds those pieces together into one verifiable runtime evidence object.

This PR introduces the first `neuros qualify` / `neuros reproduce` contract.

## Qualification scope

Version 1 proves one deliberately narrow property:

> A declared neurOS runtime configuration was executed, its exact input frames were recorded with integrity hashes, and the sealed recording reproduced the same canonical decoder-output digest through deterministic replay.

That is an **integration-level runtime/replay qualification**. It does **not** infer real-dataset, hardware, closed-loop, or clinical qualification.

## Public commands

```bash
neuros qualify CONFIG --output qualification/ --duration 1.0
neuros reproduce qualification/
```

`qualify` stages outside the final path, runs the live config, records the canonical session archive, verifies frame hashes, replays the session through the bundled config, requires an exact canonical decoder-output digest match, seals every artifact with SHA-256, verifies the completed bundle, and only then publishes the final directory.

`reproduce` verifies the complete sealed artifact set and embedded session hashes before replaying anything, then requires the reproduced decoder-output digest to match the sealed original digest.

## Bundle

```text
manifest.json
artifact_hashes.json
config.yaml
config.json
environment.json
compatibility.json
devices.json
clocks.json
model.json
runtime.json
decoder_outputs.json
session/...
```

The bundle records environment/package identity, relevant compatibility claims, exact stream/device/clock descriptors, record/replay runtime telemetry, decoder configuration/model-artifact status, and the explicit qualification claim boundary.

Unexpected files, changed byte sizes, changed SHA-256 values, changed session frame payloads, or changed decoder-output reproduction all fail closed.

## Claim boundary

A successful v1 bundle explicitly records:

- `runtime_record_replay_qualified = true`
- `real_dataset_qualified = false`
- `hardware_qualified = false`
- `closed_loop_qualified = false`
- `clinical_qualified = false`

If no promoted `ModelArtifactManifest` is bound to the session, the bundle records the decoder configuration but explicitly states that learned-weight identity is **not** claimed.

## Qualification gates

Adds a dedicated Python 3.10 / 3.11 / 3.12 workflow covering:

- sealed bundle generation;
- public `neuros qualify` CLI;
- public `neuros reproduce` CLI;
- exact record/replay decoder-output digest equality;
- complete artifact-set and SHA-256 verification;
- embedded SessionArchive frame integrity;
- tamper detection before reproduction;
- non-destructive default output behavior;
- explicit overwrite behavior;
- evidence-tier claim boundaries.

## Next evidence rung

This schema is intentionally the base for named `HardwareQualificationManifest` evidence. Physical-device promotion should add measured board/firmware/transport identity, packet/sample loss, clock offset/drift/uncertainty, reconnect behavior, sustained duration, and source-to-decision latency to the same evidence object rather than redefining what qualification means.