### PR TITLE
evidence: define fail-closed hardware qualification manifests

### DIFF
--- a/.github/workflows/hardware-qualification-ci.yml
+++ b/.github/workflows/hardware-qualification-ci.yml
@@ -1,0 +1,108 @@
+name: neurOS hardware qualification contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros/src/neuros/hardware_qualification.py"
+      - "tests/test_hardware_qualification.py"
+      - "docs/HARDWARE_QUALIFICATION.md"
+      - ".github/workflows/hardware-qualification-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros/src/neuros/hardware_qualification.py"
+      - "tests/test_hardware_qualification.py"
+      - "docs/HARDWARE_QUALIFICATION.md"
+      - ".github/workflows/hardware-qualification-ci.yml"
+
+jobs:
+  hardware-evidence-contracts:
+    name: Hardware evidence contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install BCI evidence profile
+        run: |
+          python -m pip install --upgrade pip
+          python scripts/bootstrap.py --profile bci --test-tools
+      - name: Run hardware evidence contracts
+        run: pytest -q tests/test_hardware_qualification.py
+      - name: Prove CI cannot self-award hardware qualification
+        run: |
+          python - <<'PY'
+          from neuros.hardware_qualification import (
+              HardwareQualificationThresholds,
+              evaluate_hardware_qualification,
+              manifest_from_mapping,
+          )
+
+          raw = {
+              "schema_version": 1,
+              "evidence_id": "ci-perfect-synthetic",
+              "measurement_origin": "synthetic_contract_test",
+              "qualification_bundle_sha256": "a" * 64,
+              "physical_run": False,
+              "synthetic_contract_test": True,
+              "device": {
+                  "manufacturer": "Synthetic",
+                  "device": "CI Fixture",
+                  "board_id": "fixture",
+                  "firmware_version": "0",
+                  "acquisition_library": "neuros-test",
+                  "acquisition_library_version": "1",
+                  "operating_system": "ci",
+                  "transport": "memory",
+              },
+              "signal": {
+                  "channel_names": ["C3", "C4"],
+                  "channel_types": ["eeg", "eeg"],
+                  "units": ["uV", "uV"],
+                  "nominal_sample_rate_hz": 250.0,
+                  "measured_sample_rate_hz": 250.0,
+              },
+              "timing": {
+                  "timestamp_source": "synthetic",
+                  "clock_domain": "synchronized",
+                  "offset_p50_ms": 0.0,
+                  "offset_p95_ms": 0.0,
+                  "drift_ppm": 0.0,
+                  "uncertainty_p95_ms": 0.0,
+              },
+              "reliability": {
+                  "duration_s": 3600.0,
+                  "expected_samples": 900000,
+                  "observed_samples": 900000,
+                  "queue_accepted": 900000,
+                  "queue_dropped": 0,
+                  "reconnect_attempts": 1,
+                  "reconnect_successes": 1,
+                  "reconnect_tested": True,
+              },
+              "latency": {
+                  "source_to_decision_p50_ms": 1.0,
+                  "source_to_decision_p95_ms": 2.0,
+                  "source_to_decision_p99_ms": 3.0,
+                  "sample_count": 10000,
+              },
+          }
+          manifest = manifest_from_mapping(raw)
+          result = evaluate_hardware_qualification(
+              manifest,
+              HardwareQualificationThresholds(require_reconnect_test=True),
+              verified_qualification_bundle_sha256="a" * 64,
+          )
+          assert result.thresholds_pass is True
+          assert result.qualification_bundle_verified is True
+          assert result.physical_evidence is False
+          assert result.hardware_qualified is False
+          assert result.claim_boundary["closed_loop_qualified"] is False
+          assert result.claim_boundary["clinical_qualified"] is False
+          PY

--- a/docs/HARDWARE_QUALIFICATION.md
+++ b/docs/HARDWARE_QUALIFICATION.md
@@ -1,0 +1,174 @@
+# Hardware Qualification Evidence
+
+Software tests can prove a driver contract. They cannot prove a physical headset, amplifier, wireless link, firmware build, or clock behaved correctly on the bench.
+
+neurOS therefore treats **hardware qualification as a measured evidence tier**, not as a property inferred from package installation or a passing mock-device test.
+
+## Promotion boundary
+
+A hardware result is eligible for `hardware_qualified = true` only when all three conditions hold:
+
+1. the manifest represents a non-synthetic physical measurement run;
+2. the manifest references a neurOS runtime qualification bundle whose externally pinned `bundle_sha256` has actually been verified;
+3. every configured reliability, timing, sample-rate, reconnect, and source-to-decision latency threshold passes.
+
+Numerically perfect synthetic CI measurements deliberately fail condition 1. A JSON file containing a plausible root hash but no verified qualification bundle deliberately fails condition 2.
+
+This keeps the software test harness from awarding itself a physical-world badge.
+
+## Evidence object
+
+`HardwareQualificationManifest` records five classes of evidence.
+
+### Device identity
+
+- manufacturer;
+- exact device name;
+- board/device ID;
+- firmware version;
+- acquisition library and version;
+- operating system;
+- physical transport such as USB, serial, BLE, Wi-Fi, or Ethernet.
+
+The combination should identify the acquisition configuration precisely enough that a later run can determine whether it is genuinely comparable.
+
+### Signal geometry
+
+- channel names;
+- channel types;
+- units;
+- nominal device sample rate;
+- measured sample rate.
+
+Channel arrays must have identical lengths and channel names must be unique. The measured sample rate is compared against the declared nominal rate rather than silently treated as equivalent.
+
+### Timing evidence
+
+- timestamp source;
+- clock domain;
+- clock-offset p50/p95;
+- clock drift in ppm;
+- p95 clock uncertainty.
+
+These fields should come from the actual synchronization/measurement procedure used for the named run. neurOS does not synthesize an uncertainty estimate when one was never measured.
+
+### Reliability evidence
+
+- sustained run duration;
+- expected and observed samples;
+- neurOS queue accepted/dropped counts;
+- reconnect attempts/successes;
+- whether reconnect behavior was deliberately exercised.
+
+Sample loss and queue-drop fractions are derived from these counts rather than entered independently, removing one opportunity for inconsistent evidence.
+
+### Decision latency evidence
+
+- source-to-decision p50;
+- source-to-decision p95;
+- source-to-decision p99;
+- latency sample count.
+
+Percentiles must be ordered and non-negative. These are physical/end-to-end timing observations and remain distinct from semantic decoder reproducibility.
+
+## Default threshold profile
+
+The v1 software contract ships conservative **reference defaults**, not universal medical/product requirements:
+
+| Gate | Default |
+| --- | ---: |
+| Minimum sustained duration | 300 s |
+| Maximum sample loss | 0.1% |
+| Maximum neurOS queue drop | 0% |
+| Maximum sample-rate error | 1% |
+| Maximum absolute clock drift | 100 ppm |
+| Maximum p95 clock uncertainty | 5 ms |
+| Maximum source-to-decision p95 | 100 ms |
+| Maximum source-to-decision p99 | 200 ms |
+| Reconnect test | optional |
+
+A device/program may require a much tighter, task-specific threshold profile. Changing thresholds must be explicit evidence configuration, not a hidden code tweak performed after observing the result.
+
+## Relationship to `neuros qualify`
+
+First produce the runtime evidence bundle:
+
+```bash
+neuros qualify my_hardware_pipeline.yaml \
+  --output qualification/run-001
+```
+
+Preserve the emitted `bundle_sha256` independently. The hardware manifest must reference that exact root. Hardware evaluation then verifies the bundle using the referenced root before hardware promotion can become possible.
+
+Conceptually:
+
+```text
+physical acquisition run
+        │
+        ├── exact SignalFrames ──> neurOS qualification bundle
+        │                              │
+        │                              └── externally pinned bundle_sha256
+        │
+        └── measured device/timing/reliability/latency evidence
+                                       │
+                                       ▼
+                           HardwareQualificationManifest
+                                       │
+                              fail-closed gate evaluation
+                                       │
+                   ┌───────────────────┴──────────────────┐
+                   │                                      │
+             hardware_qualified=false              hardware_qualified=true
+             + failed/not-tested gates             + all evidence prerequisites
+```
+
+## Synthetic contract tests
+
+CI fixtures use:
+
+```json
+{
+  "measurement_origin": "synthetic_contract_test",
+  "physical_run": false,
+  "synthetic_contract_test": true
+}
+```
+
+Those fixtures are allowed to pass every numeric threshold so the threshold engine is exercised. They are nevertheless structurally unable to produce `hardware_qualified=true`.
+
+That distinction is intentional. Green CI means **the evidence evaluator behaves correctly**, not **a physical BCI device has been qualified**.
+
+## First real reference configuration
+
+The recommended first physical qualification target remains a named OpenBCI Cyton-class setup through the hardened BrainFlow source, optionally paired with an LSL marker stream. A real evidence run should pin at minimum:
+
+- exact OpenBCI board/hardware revision;
+- BrainFlow board ID and BrainFlow version;
+- firmware;
+- USB/serial/radio transport details;
+- host OS;
+- exact channel map and units;
+- observed device sampling rate;
+- BrainFlow/neurOS timestamp semantics;
+- measured clock drift and uncertainty;
+- sample and queue loss;
+- reconnect behavior;
+- sustained recording duration;
+- source-to-decision latency distribution;
+- the externally pinned neurOS qualification bundle root.
+
+Until those measurements are collected from the physical system, neurOS should say **hardware contract implemented, physical qualification pending**, not “OpenBCI qualified.”
+
+## Future extensions
+
+The schema is intentionally compatible with later evidence layers:
+
+- repeated qualification across multiple hosts/OS versions;
+- firmware compatibility matrices;
+- hardware regression histories;
+- signed qualification roots;
+- fleet/device certificates;
+- closed-loop actuation safety evidence;
+- device-specific ORION calibration/transfer evidence.
+
+The important invariant is that stronger claims always require stronger measured evidence. No later layer should weaken that rule.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Four Public Surfaces: PLATFORM.md
       - Ecosystem Compatibility: COMPATIBILITY.md
       - Qualification Bundles: QUALIFICATION.md
+      - Hardware Qualification: HARDWARE_QUALIFICATION.md
       - Architecture: ARCHITECTURE.md
       - Project Status: PROJECT_STATUS.md
   - Real-World Evidence:

--- a/packages/neuros/src/neuros/cli/app.py
+++ b/packages/neuros/src/neuros/cli/app.py
@@ -113,6 +113,25 @@ def _parse_args() -> argparse.Namespace:
     )
     _add_json_flag(reproduce_parser)
 
+    hardware_parser = subparsers.add_parser(
+        "hardware-evidence",
+        help="Evaluate measured hardware evidence against explicit qualification gates",
+    )
+    hardware_parser.add_argument("evidence", type=str, help="Hardware evidence JSON file")
+    hardware_parser.add_argument(
+        "--qualification-bundle",
+        type=str,
+        default=None,
+        help="Optional neurOS qualification bundle to verify and bind before promotion",
+    )
+    hardware_parser.add_argument(
+        "--thresholds",
+        type=str,
+        default=None,
+        help="Optional hardware threshold JSON; defaults to the v1 reference profile",
+    )
+    _add_json_flag(hardware_parser)
+
     inspect_parser = subparsers.add_parser("inspect", help="Inspect a neurOS session archive")
     inspect_parser.add_argument("archive", type=str)
     inspect_parser.add_argument("--verify", action="store_true", help="Verify every frame SHA-256")
@@ -323,6 +342,27 @@ def main() -> None:
                 )
             )
             _emit(result, machine=args.json)
+            return
+
+        if args.command == "hardware-evidence":
+            from neuros.hardware_qualification import (
+                evaluate_hardware_evidence_bundle,
+                evaluate_hardware_qualification,
+                load_hardware_evidence,
+                load_thresholds,
+            )
+
+            manifest = load_hardware_evidence(args.evidence)
+            thresholds = load_thresholds(args.thresholds) if args.thresholds else None
+            if args.qualification_bundle:
+                result = evaluate_hardware_evidence_bundle(
+                    manifest,
+                    args.qualification_bundle,
+                    thresholds,
+                )
+            else:
+                result = evaluate_hardware_qualification(manifest, thresholds)
+            _emit(result.to_dict(), machine=args.json)
             return
 
         if args.command == "inspect":

--- a/packages/neuros/src/neuros/hardware_qualification.py
+++ b/packages/neuros/src/neuros/hardware_qualification.py
@@ -48,8 +48,8 @@ class DeviceIdentity:
 
     def validate(self) -> None:
         for name, value in asdict(self).items():
-            if not str(value).strip():
-                raise ValueError(f"device.{name} must be non-empty")
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"device.{name} must be a non-empty string")
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +68,12 @@ class SignalGeometry:
             raise ValueError("signal.channel_names must be unique")
         if len(self.channel_types) != count or len(self.units) != count:
             raise ValueError("signal channel names/types/units must have identical lengths")
+        if any(not item.strip() for item in self.channel_names):
+            raise ValueError("signal.channel_names must not contain empty values")
+        if any(not item.strip() for item in self.channel_types):
+            raise ValueError("signal.channel_types must not contain empty values")
+        if any(not item.strip() for item in self.units):
+            raise ValueError("signal.units must not contain empty values")
         if self.nominal_sample_rate_hz <= 0 or not math.isfinite(self.nominal_sample_rate_hz):
             raise ValueError("signal.nominal_sample_rate_hz must be positive and finite")
         if self.measured_sample_rate_hz <= 0 or not math.isfinite(self.measured_sample_rate_hz):
@@ -84,16 +90,22 @@ class TimingEvidence:
     uncertainty_p95_ms: float
 
     def validate(self) -> None:
-        if not self.timestamp_source.strip() or not self.clock_domain.strip():
-            raise ValueError("timing timestamp_source and clock_domain must be non-empty")
+        if not isinstance(self.timestamp_source, str) or not self.timestamp_source.strip():
+            raise ValueError("timing.timestamp_source must be a non-empty string")
+        if not isinstance(self.clock_domain, str) or not self.clock_domain.strip():
+            raise ValueError("timing.clock_domain must be a non-empty string")
         values = (
             self.offset_p50_ms,
             self.offset_p95_ms,
             self.drift_ppm,
             self.uncertainty_p95_ms,
         )
-        if not all(math.isfinite(value) for value in values):
+        if not all(isinstance(value, (int, float)) and not isinstance(value, bool) for value in values):
+            raise ValueError("timing measurements must be numeric")
+        if not all(math.isfinite(float(value)) for value in values):
             raise ValueError("timing measurements must be finite")
+        if self.offset_p50_ms > self.offset_p95_ms:
+            raise ValueError("timing offset percentiles must satisfy p50 <= p95")
         if self.uncertainty_p95_ms < 0:
             raise ValueError("timing.uncertainty_p95_ms must be non-negative")
 
@@ -110,7 +122,9 @@ class ReliabilityEvidence:
     reconnect_tested: bool = False
 
     def validate(self) -> None:
-        if self.duration_s <= 0 or not math.isfinite(self.duration_s):
+        if isinstance(self.duration_s, bool) or not isinstance(self.duration_s, (int, float)):
+            raise ValueError("reliability.duration_s must be numeric")
+        if self.duration_s <= 0 or not math.isfinite(float(self.duration_s)):
             raise ValueError("reliability.duration_s must be positive and finite")
         for name in (
             "expected_samples",
@@ -120,8 +134,13 @@ class ReliabilityEvidence:
             "reconnect_attempts",
             "reconnect_successes",
         ):
-            if int(getattr(self, name)) < 0:
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"reliability.{name} must be an integer")
+            if value < 0:
                 raise ValueError(f"reliability.{name} must be non-negative")
+        if not isinstance(self.reconnect_tested, bool):
+            raise ValueError("reliability.reconnect_tested must be boolean")
         if self.expected_samples <= 0:
             raise ValueError("reliability.expected_samples must be positive")
         if self.observed_samples > self.expected_samples:
@@ -154,14 +173,22 @@ class LatencyEvidence:
             self.source_to_decision_p95_ms,
             self.source_to_decision_p99_ms,
         )
-        if not all(math.isfinite(value) and value >= 0 for value in values):
-            raise ValueError("latency measurements must be finite and non-negative")
+        if not all(
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(float(value))
+            and value >= 0
+            for value in values
+        ):
+            raise ValueError("latency measurements must be numeric, finite, and non-negative")
         if not (
             self.source_to_decision_p50_ms
             <= self.source_to_decision_p95_ms
             <= self.source_to_decision_p99_ms
         ):
             raise ValueError("latency percentiles must satisfy p50 <= p95 <= p99")
+        if isinstance(self.sample_count, bool) or not isinstance(self.sample_count, int):
+            raise ValueError("latency.sample_count must be an integer")
         if self.sample_count <= 0:
             raise ValueError("latency.sample_count must be positive")
 
@@ -179,6 +206,8 @@ class HardwareQualificationThresholds:
     require_reconnect_test: bool = False
 
     def validate(self) -> None:
+        if isinstance(self.min_duration_s, bool) or not isinstance(self.min_duration_s, (int, float)):
+            raise ValueError("thresholds.min_duration_s must be numeric")
         if self.min_duration_s <= 0:
             raise ValueError("thresholds.min_duration_s must be positive")
         for name in (
@@ -186,8 +215,10 @@ class HardwareQualificationThresholds:
             "max_queue_drop_fraction",
             "max_sample_rate_error_fraction",
         ):
-            value = float(getattr(self, name))
-            if not 0 <= value <= 1:
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"thresholds.{name} must be numeric")
+            if not 0 <= float(value) <= 1:
                 raise ValueError(f"thresholds.{name} must be in [0, 1]")
         for name in (
             "max_abs_clock_drift_ppm",
@@ -195,9 +226,13 @@ class HardwareQualificationThresholds:
             "max_source_to_decision_p95_ms",
             "max_source_to_decision_p99_ms",
         ):
-            value = float(getattr(self, name))
-            if value < 0 or not math.isfinite(value):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"thresholds.{name} must be numeric")
+            if value < 0 or not math.isfinite(float(value)):
                 raise ValueError(f"thresholds.{name} must be finite and non-negative")
+        if not isinstance(self.require_reconnect_test, bool):
+            raise ValueError("thresholds.require_reconnect_test must be boolean")
         if self.max_source_to_decision_p99_ms < self.max_source_to_decision_p95_ms:
             raise ValueError("p99 latency threshold cannot be stricter than p95 threshold")
 
@@ -220,8 +255,12 @@ class HardwareQualificationManifest:
     def validate(self) -> None:
         if self.schema_version != HARDWARE_QUALIFICATION_SCHEMA_VERSION:
             raise ValueError("unsupported hardware qualification schema version")
-        if not self.evidence_id.strip():
-            raise ValueError("evidence_id must be non-empty")
+        if not isinstance(self.evidence_id, str) or not self.evidence_id.strip():
+            raise ValueError("evidence_id must be a non-empty string")
+        if not isinstance(self.physical_run, bool):
+            raise ValueError("physical_run must be boolean")
+        if not isinstance(self.synthetic_contract_test, bool):
+            raise ValueError("synthetic_contract_test must be boolean")
         _normalize_sha256(self.qualification_bundle_sha256)
         self.device.validate()
         self.signal.validate()
@@ -282,7 +321,15 @@ class HardwareQualificationResult:
         }
 
 
+def _strict_bool(value: Any, *, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be boolean")
+    return value
+
+
 def _normalize_sha256(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("qualification_bundle_sha256 must be a string")
     normalized = value.strip().lower()
     if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
         raise ValueError("qualification_bundle_sha256 must be a 64-character SHA-256 digest")
@@ -370,8 +417,11 @@ def evaluate_hardware_qualification(
         QualificationGate(
             name="verified_runtime_bundle",
             status=(
-                GateStatus.PASS if qualification_bundle_verified else GateStatus.NOT_TESTED
-                if verified_root is None else GateStatus.FAIL
+                GateStatus.PASS
+                if qualification_bundle_verified
+                else GateStatus.NOT_TESTED
+                if verified_root is None
+                else GateStatus.FAIL
             ),
             observed={
                 "manifest_root": manifest_root,
@@ -401,7 +451,7 @@ def evaluate_hardware_qualification(
         ),
         threshold_gate(
             "sample_rate_error_fraction",
-            sample_rate_error,
+            _sample_rate_error(manifest.signal),
             thresholds.max_sample_rate_error_fraction,
         ),
         threshold_gate(
@@ -492,7 +542,10 @@ def evaluate_hardware_evidence_bundle(
 def _tuple_strings(value: Any, *, field_name: str) -> tuple[str, ...]:
     if not isinstance(value, (list, tuple)):
         raise ValueError(f"{field_name} must be an array")
-    return tuple(str(item) for item in value)
+    result = tuple(str(item) for item in value)
+    if any(not item.strip() for item in result):
+        raise ValueError(f"{field_name} must not contain empty values")
+    return result
 
 
 def manifest_from_mapping(raw: Mapping[str, Any]) -> HardwareQualificationManifest:
@@ -506,15 +559,43 @@ def manifest_from_mapping(raw: Mapping[str, Any]) -> HardwareQualificationManife
         latency_raw = raw["latency"]
     except KeyError as exc:
         raise ValueError(f"hardware evidence missing required section: {exc.args[0]}") from exc
+    for name, section in (
+        ("device", device_raw),
+        ("signal", signal_raw),
+        ("timing", timing_raw),
+        ("reliability", reliability_raw),
+        ("latency", latency_raw),
+    ):
+        if not isinstance(section, Mapping):
+            raise ValueError(f"hardware evidence section {name} must be an object")
+
+    device_values = dict(device_raw)
+    for field_name in (
+        "manufacturer",
+        "device",
+        "board_id",
+        "firmware_version",
+        "acquisition_library",
+        "acquisition_library_version",
+        "operating_system",
+        "transport",
+    ):
+        if field_name not in device_values:
+            raise ValueError(f"hardware evidence missing device.{field_name}")
+        if not isinstance(device_values[field_name], str):
+            raise ValueError(f"device.{field_name} must be a string")
 
     manifest = HardwareQualificationManifest(
         schema_version=int(raw.get("schema_version", HARDWARE_QUALIFICATION_SCHEMA_VERSION)),
         evidence_id=str(raw["evidence_id"]),
         measurement_origin=MeasurementOrigin(str(raw["measurement_origin"])),
         qualification_bundle_sha256=str(raw["qualification_bundle_sha256"]),
-        physical_run=bool(raw["physical_run"]),
-        synthetic_contract_test=bool(raw.get("synthetic_contract_test", False)),
-        device=DeviceIdentity(**dict(device_raw)),
+        physical_run=_strict_bool(raw["physical_run"], field_name="physical_run"),
+        synthetic_contract_test=_strict_bool(
+            raw.get("synthetic_contract_test", False),
+            field_name="synthetic_contract_test",
+        ),
+        device=DeviceIdentity(**device_values),
         signal=SignalGeometry(
             channel_names=_tuple_strings(
                 signal_raw["channel_names"], field_name="signal.channel_names"
@@ -523,8 +604,8 @@ def manifest_from_mapping(raw: Mapping[str, Any]) -> HardwareQualificationManife
                 signal_raw["channel_types"], field_name="signal.channel_types"
             ),
             units=_tuple_strings(signal_raw["units"], field_name="signal.units"),
-            nominal_sample_rate_hz=float(signal_raw["nominal_sample_rate_hz"]),
-            measured_sample_rate_hz=float(signal_raw["measured_sample_rate_hz"]),
+            nominal_sample_rate_hz=signal_raw["nominal_sample_rate_hz"],
+            measured_sample_rate_hz=signal_raw["measured_sample_rate_hz"],
         ),
         timing=TimingEvidence(**dict(timing_raw)),
         reliability=ReliabilityEvidence(**dict(reliability_raw)),

--- a/packages/neuros/src/neuros/hardware_qualification.py
+++ b/packages/neuros/src/neuros/hardware_qualification.py
@@ -1,0 +1,485 @@
+"""Fail-closed hardware evidence contracts for neurOS.
+
+This module defines *what must be measured* before neurOS can promote a named
+physical acquisition configuration to the hardware evidence tier. It does not
+measure hardware itself and software CI must never fabricate that distinction.
+
+A schema-valid synthetic fixture can exercise every threshold gate while still
+being structurally ineligible for ``hardware_qualified=True``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+HARDWARE_QUALIFICATION_SCHEMA_VERSION = 1
+
+
+class MeasurementOrigin(str, Enum):
+    PHYSICAL = "physical_measurement"
+    SYNTHETIC = "synthetic_contract_test"
+    IMPORTED = "imported_external_measurement"
+
+
+class GateStatus(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_TESTED = "not_tested"
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceIdentity:
+    manufacturer: str
+    device: str
+    board_id: str
+    firmware_version: str
+    acquisition_library: str
+    acquisition_library_version: str
+    operating_system: str
+    transport: str
+
+    def validate(self) -> None:
+        for name, value in asdict(self).items():
+            if not str(value).strip():
+                raise ValueError(f"device.{name} must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class SignalGeometry:
+    channel_names: tuple[str, ...]
+    channel_types: tuple[str, ...]
+    units: tuple[str, ...]
+    nominal_sample_rate_hz: float
+    measured_sample_rate_hz: float
+
+    def validate(self) -> None:
+        count = len(self.channel_names)
+        if count <= 0:
+            raise ValueError("signal.channel_names must contain at least one channel")
+        if len(set(self.channel_names)) != count:
+            raise ValueError("signal.channel_names must be unique")
+        if len(self.channel_types) != count or len(self.units) != count:
+            raise ValueError("signal channel names/types/units must have identical lengths")
+        if self.nominal_sample_rate_hz <= 0 or not math.isfinite(self.nominal_sample_rate_hz):
+            raise ValueError("signal.nominal_sample_rate_hz must be positive and finite")
+        if self.measured_sample_rate_hz <= 0 or not math.isfinite(self.measured_sample_rate_hz):
+            raise ValueError("signal.measured_sample_rate_hz must be positive and finite")
+
+
+@dataclass(frozen=True, slots=True)
+class TimingEvidence:
+    timestamp_source: str
+    clock_domain: str
+    offset_p50_ms: float
+    offset_p95_ms: float
+    drift_ppm: float
+    uncertainty_p95_ms: float
+
+    def validate(self) -> None:
+        if not self.timestamp_source.strip() or not self.clock_domain.strip():
+            raise ValueError("timing timestamp_source and clock_domain must be non-empty")
+        values = (
+            self.offset_p50_ms,
+            self.offset_p95_ms,
+            self.drift_ppm,
+            self.uncertainty_p95_ms,
+        )
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("timing measurements must be finite")
+        if self.uncertainty_p95_ms < 0:
+            raise ValueError("timing.uncertainty_p95_ms must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class ReliabilityEvidence:
+    duration_s: float
+    expected_samples: int
+    observed_samples: int
+    queue_accepted: int
+    queue_dropped: int
+    reconnect_attempts: int = 0
+    reconnect_successes: int = 0
+    reconnect_tested: bool = False
+
+    def validate(self) -> None:
+        if self.duration_s <= 0 or not math.isfinite(self.duration_s):
+            raise ValueError("reliability.duration_s must be positive and finite")
+        for name in (
+            "expected_samples",
+            "observed_samples",
+            "queue_accepted",
+            "queue_dropped",
+            "reconnect_attempts",
+            "reconnect_successes",
+        ):
+            if int(getattr(self, name)) < 0:
+                raise ValueError(f"reliability.{name} must be non-negative")
+        if self.expected_samples <= 0:
+            raise ValueError("reliability.expected_samples must be positive")
+        if self.observed_samples > self.expected_samples:
+            raise ValueError("reliability.observed_samples cannot exceed expected_samples")
+        if self.reconnect_successes > self.reconnect_attempts:
+            raise ValueError("reconnect_successes cannot exceed reconnect_attempts")
+        if not self.reconnect_tested and (self.reconnect_attempts or self.reconnect_successes):
+            raise ValueError("reconnect counters require reconnect_tested=true")
+
+    @property
+    def sample_loss_fraction(self) -> float:
+        return (self.expected_samples - self.observed_samples) / self.expected_samples
+
+    @property
+    def queue_drop_fraction(self) -> float:
+        total = self.queue_accepted + self.queue_dropped
+        return 0.0 if total == 0 else self.queue_dropped / total
+
+
+@dataclass(frozen=True, slots=True)
+class LatencyEvidence:
+    source_to_decision_p50_ms: float
+    source_to_decision_p95_ms: float
+    source_to_decision_p99_ms: float
+    sample_count: int
+
+    def validate(self) -> None:
+        values = (
+            self.source_to_decision_p50_ms,
+            self.source_to_decision_p95_ms,
+            self.source_to_decision_p99_ms,
+        )
+        if not all(math.isfinite(value) and value >= 0 for value in values):
+            raise ValueError("latency measurements must be finite and non-negative")
+        if not (
+            self.source_to_decision_p50_ms
+            <= self.source_to_decision_p95_ms
+            <= self.source_to_decision_p99_ms
+        ):
+            raise ValueError("latency percentiles must satisfy p50 <= p95 <= p99")
+        if self.sample_count <= 0:
+            raise ValueError("latency.sample_count must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareQualificationThresholds:
+    min_duration_s: float = 300.0
+    max_sample_loss_fraction: float = 0.001
+    max_queue_drop_fraction: float = 0.0
+    max_sample_rate_error_fraction: float = 0.01
+    max_abs_clock_drift_ppm: float = 100.0
+    max_clock_uncertainty_p95_ms: float = 5.0
+    max_source_to_decision_p95_ms: float = 100.0
+    max_source_to_decision_p99_ms: float = 200.0
+    require_reconnect_test: bool = False
+
+    def validate(self) -> None:
+        if self.min_duration_s <= 0:
+            raise ValueError("thresholds.min_duration_s must be positive")
+        for name in (
+            "max_sample_loss_fraction",
+            "max_queue_drop_fraction",
+            "max_sample_rate_error_fraction",
+        ):
+            value = float(getattr(self, name))
+            if not 0 <= value <= 1:
+                raise ValueError(f"thresholds.{name} must be in [0, 1]")
+        for name in (
+            "max_abs_clock_drift_ppm",
+            "max_clock_uncertainty_p95_ms",
+            "max_source_to_decision_p95_ms",
+            "max_source_to_decision_p99_ms",
+        ):
+            value = float(getattr(self, name))
+            if value < 0 or not math.isfinite(value):
+                raise ValueError(f"thresholds.{name} must be finite and non-negative")
+        if self.max_source_to_decision_p99_ms < self.max_source_to_decision_p95_ms:
+            raise ValueError("p99 latency threshold cannot be stricter than p95 threshold")
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareQualificationManifest:
+    evidence_id: str
+    measurement_origin: MeasurementOrigin
+    qualification_bundle_sha256: str
+    device: DeviceIdentity
+    signal: SignalGeometry
+    timing: TimingEvidence
+    reliability: ReliabilityEvidence
+    latency: LatencyEvidence
+    physical_run: bool
+    synthetic_contract_test: bool = False
+    notes: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = HARDWARE_QUALIFICATION_SCHEMA_VERSION
+
+    def validate(self) -> None:
+        if self.schema_version != HARDWARE_QUALIFICATION_SCHEMA_VERSION:
+            raise ValueError("unsupported hardware qualification schema version")
+        if not self.evidence_id.strip():
+            raise ValueError("evidence_id must be non-empty")
+        _normalize_sha256(self.qualification_bundle_sha256)
+        self.device.validate()
+        self.signal.validate()
+        self.timing.validate()
+        self.reliability.validate()
+        self.latency.validate()
+        if self.measurement_origin is MeasurementOrigin.PHYSICAL and not self.physical_run:
+            raise ValueError("physical_measurement origin requires physical_run=true")
+        if self.measurement_origin is MeasurementOrigin.SYNTHETIC and not self.synthetic_contract_test:
+            raise ValueError("synthetic_contract_test origin requires synthetic_contract_test=true")
+        if self.synthetic_contract_test and self.measurement_origin is MeasurementOrigin.PHYSICAL:
+            raise ValueError("synthetic contract evidence cannot claim physical_measurement origin")
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationGate:
+    name: str
+    status: GateStatus
+    observed: Any
+    requirement: str
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareQualificationResult:
+    evidence_id: str
+    schema_valid: bool
+    measurements_complete: bool
+    thresholds_pass: bool
+    physical_evidence: bool
+    hardware_qualified: bool
+    gates: tuple[QualificationGate, ...]
+    evidence_sha256: str
+    claim_boundary: Mapping[str, bool]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "evidence_id": self.evidence_id,
+            "schema_valid": self.schema_valid,
+            "measurements_complete": self.measurements_complete,
+            "thresholds_pass": self.thresholds_pass,
+            "physical_evidence": self.physical_evidence,
+            "hardware_qualified": self.hardware_qualified,
+            "gates": [asdict(gate) for gate in self.gates],
+            "evidence_sha256": self.evidence_sha256,
+            "claim_boundary": dict(self.claim_boundary),
+        }
+
+
+def _normalize_sha256(value: str) -> str:
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        raise ValueError("qualification_bundle_sha256 must be a 64-character SHA-256 digest")
+    return normalized
+
+
+def _sample_rate_error(signal: SignalGeometry) -> float:
+    return abs(signal.measured_sample_rate_hz - signal.nominal_sample_rate_hz) / signal.nominal_sample_rate_hz
+
+
+def _canonical_payload(manifest: HardwareQualificationManifest) -> dict[str, Any]:
+    payload = asdict(manifest)
+    payload["measurement_origin"] = manifest.measurement_origin.value
+    payload["notes"] = dict(manifest.notes)
+    return payload
+
+
+def evidence_sha256(manifest: HardwareQualificationManifest) -> str:
+    raw = json.dumps(
+        _canonical_payload(manifest),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def evaluate_hardware_qualification(
+    manifest: HardwareQualificationManifest,
+    thresholds: HardwareQualificationThresholds | None = None,
+) -> HardwareQualificationResult:
+    """Evaluate a named hardware evidence record without inventing measurements."""
+
+    thresholds = thresholds or HardwareQualificationThresholds()
+    manifest.validate()
+    thresholds.validate()
+
+    sample_rate_error = _sample_rate_error(manifest.signal)
+    physical_evidence = (
+        manifest.physical_run
+        and not manifest.synthetic_contract_test
+        and manifest.measurement_origin in {
+            MeasurementOrigin.PHYSICAL,
+            MeasurementOrigin.IMPORTED,
+        }
+    )
+
+    def threshold_gate(name: str, observed: float, maximum: float) -> QualificationGate:
+        return QualificationGate(
+            name=name,
+            status=GateStatus.PASS if observed <= maximum else GateStatus.FAIL,
+            observed=observed,
+            requirement=f"<= {maximum}",
+        )
+
+    gates: list[QualificationGate] = [
+        QualificationGate(
+            name="physical_measurement",
+            status=GateStatus.PASS if physical_evidence else GateStatus.FAIL,
+            observed={
+                "measurement_origin": manifest.measurement_origin.value,
+                "physical_run": manifest.physical_run,
+                "synthetic_contract_test": manifest.synthetic_contract_test,
+            },
+            requirement="physical/imported measured evidence, physical_run=true, synthetic_contract_test=false",
+        ),
+        QualificationGate(
+            name="minimum_duration",
+            status=(
+                GateStatus.PASS
+                if manifest.reliability.duration_s >= thresholds.min_duration_s
+                else GateStatus.FAIL
+            ),
+            observed=manifest.reliability.duration_s,
+            requirement=f">= {thresholds.min_duration_s} s",
+        ),
+        threshold_gate(
+            "sample_loss_fraction",
+            manifest.reliability.sample_loss_fraction,
+            thresholds.max_sample_loss_fraction,
+        ),
+        threshold_gate(
+            "queue_drop_fraction",
+            manifest.reliability.queue_drop_fraction,
+            thresholds.max_queue_drop_fraction,
+        ),
+        threshold_gate(
+            "sample_rate_error_fraction",
+            sample_rate_error,
+            thresholds.max_sample_rate_error_fraction,
+        ),
+        threshold_gate(
+            "absolute_clock_drift_ppm",
+            abs(manifest.timing.drift_ppm),
+            thresholds.max_abs_clock_drift_ppm,
+        ),
+        threshold_gate(
+            "clock_uncertainty_p95_ms",
+            manifest.timing.uncertainty_p95_ms,
+            thresholds.max_clock_uncertainty_p95_ms,
+        ),
+        threshold_gate(
+            "source_to_decision_p95_ms",
+            manifest.latency.source_to_decision_p95_ms,
+            thresholds.max_source_to_decision_p95_ms,
+        ),
+        threshold_gate(
+            "source_to_decision_p99_ms",
+            manifest.latency.source_to_decision_p99_ms,
+            thresholds.max_source_to_decision_p99_ms,
+        ),
+    ]
+    if thresholds.require_reconnect_test:
+        reconnect_pass = (
+            manifest.reliability.reconnect_tested
+            and manifest.reliability.reconnect_attempts > 0
+            and manifest.reliability.reconnect_successes == manifest.reliability.reconnect_attempts
+        )
+        gates.append(
+            QualificationGate(
+                name="reconnect_recovery",
+                status=GateStatus.PASS if reconnect_pass else GateStatus.FAIL,
+                observed={
+                    "tested": manifest.reliability.reconnect_tested,
+                    "attempts": manifest.reliability.reconnect_attempts,
+                    "successes": manifest.reliability.reconnect_successes,
+                },
+                requirement="tested and every reconnect attempt succeeds",
+            )
+        )
+
+    non_physical_gates = [gate for gate in gates if gate.name != "physical_measurement"]
+    thresholds_pass = all(gate.status is GateStatus.PASS for gate in non_physical_gates)
+    hardware_qualified = physical_evidence and thresholds_pass
+
+    return HardwareQualificationResult(
+        evidence_id=manifest.evidence_id,
+        schema_valid=True,
+        measurements_complete=True,
+        thresholds_pass=thresholds_pass,
+        physical_evidence=physical_evidence,
+        hardware_qualified=hardware_qualified,
+        gates=tuple(gates),
+        evidence_sha256=evidence_sha256(manifest),
+        claim_boundary={
+            "runtime_record_replay_qualified": False,
+            "real_dataset_qualified": False,
+            "hardware_qualified": hardware_qualified,
+            "closed_loop_qualified": False,
+            "clinical_qualified": False,
+        },
+    )
+
+
+def _tuple_strings(value: Any, *, field_name: str) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"{field_name} must be an array")
+    return tuple(str(item) for item in value)
+
+
+def manifest_from_mapping(raw: Mapping[str, Any]) -> HardwareQualificationManifest:
+    """Parse and validate one JSON-like hardware evidence mapping."""
+
+    try:
+        device_raw = raw["device"]
+        signal_raw = raw["signal"]
+        timing_raw = raw["timing"]
+        reliability_raw = raw["reliability"]
+        latency_raw = raw["latency"]
+    except KeyError as exc:
+        raise ValueError(f"hardware evidence missing required section: {exc.args[0]}") from exc
+
+    manifest = HardwareQualificationManifest(
+        schema_version=int(raw.get("schema_version", HARDWARE_QUALIFICATION_SCHEMA_VERSION)),
+        evidence_id=str(raw["evidence_id"]),
+        measurement_origin=MeasurementOrigin(str(raw["measurement_origin"])),
+        qualification_bundle_sha256=str(raw["qualification_bundle_sha256"]),
+        physical_run=bool(raw["physical_run"]),
+        synthetic_contract_test=bool(raw.get("synthetic_contract_test", False)),
+        device=DeviceIdentity(**dict(device_raw)),
+        signal=SignalGeometry(
+            channel_names=_tuple_strings(signal_raw["channel_names"], field_name="signal.channel_names"),
+            channel_types=_tuple_strings(signal_raw["channel_types"], field_name="signal.channel_types"),
+            units=_tuple_strings(signal_raw["units"], field_name="signal.units"),
+            nominal_sample_rate_hz=float(signal_raw["nominal_sample_rate_hz"]),
+            measured_sample_rate_hz=float(signal_raw["measured_sample_rate_hz"]),
+        ),
+        timing=TimingEvidence(**dict(timing_raw)),
+        reliability=ReliabilityEvidence(**dict(reliability_raw)),
+        latency=LatencyEvidence(**dict(latency_raw)),
+        notes=dict(raw.get("notes", {})),
+    )
+    manifest.validate()
+    return manifest
+
+
+def thresholds_from_mapping(raw: Mapping[str, Any]) -> HardwareQualificationThresholds:
+    thresholds = HardwareQualificationThresholds(**dict(raw))
+    thresholds.validate()
+    return thresholds
+
+
+def load_hardware_evidence(path: str | Path) -> HardwareQualificationManifest:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("hardware evidence root must be a JSON object")
+    return manifest_from_mapping(raw)
+
+
+def load_thresholds(path: str | Path) -> HardwareQualificationThresholds:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("hardware threshold root must be a JSON object")
+    return thresholds_from_mapping(raw)

--- a/packages/neuros/src/neuros/hardware_qualification.py
+++ b/packages/neuros/src/neuros/hardware_qualification.py
@@ -5,7 +5,9 @@ physical acquisition configuration to the hardware evidence tier. It does not
 measure hardware itself and software CI must never fabricate that distinction.
 
 A schema-valid synthetic fixture can exercise every threshold gate while still
-being structurally ineligible for ``hardware_qualified=True``.
+being structurally ineligible for ``hardware_qualified=True``. Hardware
+promotion additionally requires an independently verified neurOS qualification
+bundle root so physical measurements are bound to the exact computational run.
 """
 
 from __future__ import annotations
@@ -228,10 +230,12 @@ class HardwareQualificationManifest:
         self.latency.validate()
         if self.measurement_origin is MeasurementOrigin.PHYSICAL and not self.physical_run:
             raise ValueError("physical_measurement origin requires physical_run=true")
+        if self.measurement_origin is MeasurementOrigin.IMPORTED and not self.physical_run:
+            raise ValueError("imported_external_measurement origin requires physical_run=true")
         if self.measurement_origin is MeasurementOrigin.SYNTHETIC and not self.synthetic_contract_test:
             raise ValueError("synthetic_contract_test origin requires synthetic_contract_test=true")
-        if self.synthetic_contract_test and self.measurement_origin is MeasurementOrigin.PHYSICAL:
-            raise ValueError("synthetic contract evidence cannot claim physical_measurement origin")
+        if self.synthetic_contract_test and self.measurement_origin is not MeasurementOrigin.SYNTHETIC:
+            raise ValueError("synthetic contract evidence must use synthetic_contract_test origin")
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,6 +253,7 @@ class HardwareQualificationResult:
     measurements_complete: bool
     thresholds_pass: bool
     physical_evidence: bool
+    qualification_bundle_verified: bool
     hardware_qualified: bool
     gates: tuple[QualificationGate, ...]
     evidence_sha256: str
@@ -261,8 +266,17 @@ class HardwareQualificationResult:
             "measurements_complete": self.measurements_complete,
             "thresholds_pass": self.thresholds_pass,
             "physical_evidence": self.physical_evidence,
+            "qualification_bundle_verified": self.qualification_bundle_verified,
             "hardware_qualified": self.hardware_qualified,
-            "gates": [asdict(gate) for gate in self.gates],
+            "gates": [
+                {
+                    "name": gate.name,
+                    "status": gate.status.value,
+                    "observed": gate.observed,
+                    "requirement": gate.requirement,
+                }
+                for gate in self.gates
+            ],
             "evidence_sha256": self.evidence_sha256,
             "claim_boundary": dict(self.claim_boundary),
         }
@@ -299,13 +313,28 @@ def evidence_sha256(manifest: HardwareQualificationManifest) -> str:
 def evaluate_hardware_qualification(
     manifest: HardwareQualificationManifest,
     thresholds: HardwareQualificationThresholds | None = None,
+    *,
+    verified_qualification_bundle_sha256: str | None = None,
 ) -> HardwareQualificationResult:
-    """Evaluate a named hardware evidence record without inventing measurements."""
+    """Evaluate named hardware evidence without inventing measurements.
+
+    Passing numerical thresholds is deliberately insufficient for promotion.
+    ``hardware_qualified`` additionally requires non-synthetic physical evidence
+    and an independently verified neurOS qualification-bundle root that exactly
+    matches the root named by the hardware manifest.
+    """
 
     thresholds = thresholds or HardwareQualificationThresholds()
     manifest.validate()
     thresholds.validate()
 
+    manifest_root = _normalize_sha256(manifest.qualification_bundle_sha256)
+    verified_root = (
+        _normalize_sha256(verified_qualification_bundle_sha256)
+        if verified_qualification_bundle_sha256 is not None
+        else None
+    )
+    qualification_bundle_verified = verified_root == manifest_root
     sample_rate_error = _sample_rate_error(manifest.signal)
     physical_evidence = (
         manifest.physical_run
@@ -333,7 +362,22 @@ def evaluate_hardware_qualification(
                 "physical_run": manifest.physical_run,
                 "synthetic_contract_test": manifest.synthetic_contract_test,
             },
-            requirement="physical/imported measured evidence, physical_run=true, synthetic_contract_test=false",
+            requirement=(
+                "physical/imported measured evidence, physical_run=true, "
+                "synthetic_contract_test=false"
+            ),
+        ),
+        QualificationGate(
+            name="verified_runtime_bundle",
+            status=(
+                GateStatus.PASS if qualification_bundle_verified else GateStatus.NOT_TESTED
+                if verified_root is None else GateStatus.FAIL
+            ),
+            observed={
+                "manifest_root": manifest_root,
+                "verified_root": verified_root,
+            },
+            requirement="verified neurOS qualification bundle root exactly matches manifest root",
         ),
         QualificationGate(
             name="minimum_duration",
@@ -400,9 +444,10 @@ def evaluate_hardware_qualification(
             )
         )
 
-    non_physical_gates = [gate for gate in gates if gate.name != "physical_measurement"]
-    thresholds_pass = all(gate.status is GateStatus.PASS for gate in non_physical_gates)
-    hardware_qualified = physical_evidence and thresholds_pass
+    prerequisite_names = {"physical_measurement", "verified_runtime_bundle"}
+    threshold_gates = [gate for gate in gates if gate.name not in prerequisite_names]
+    thresholds_pass = all(gate.status is GateStatus.PASS for gate in threshold_gates)
+    hardware_qualified = physical_evidence and qualification_bundle_verified and thresholds_pass
 
     return HardwareQualificationResult(
         evidence_id=manifest.evidence_id,
@@ -410,16 +455,37 @@ def evaluate_hardware_qualification(
         measurements_complete=True,
         thresholds_pass=thresholds_pass,
         physical_evidence=physical_evidence,
+        qualification_bundle_verified=qualification_bundle_verified,
         hardware_qualified=hardware_qualified,
         gates=tuple(gates),
         evidence_sha256=evidence_sha256(manifest),
         claim_boundary={
-            "runtime_record_replay_qualified": False,
+            "runtime_record_replay_qualified": qualification_bundle_verified,
             "real_dataset_qualified": False,
             "hardware_qualified": hardware_qualified,
             "closed_loop_qualified": False,
             "clinical_qualified": False,
         },
+    )
+
+
+def evaluate_hardware_evidence_bundle(
+    manifest: HardwareQualificationManifest,
+    qualification_bundle: str | Path,
+    thresholds: HardwareQualificationThresholds | None = None,
+) -> HardwareQualificationResult:
+    """Verify the referenced runtime bundle before evaluating hardware promotion."""
+
+    from neuros.qualification import verify_qualification_bundle
+
+    verification = verify_qualification_bundle(
+        qualification_bundle,
+        expected_sha256=manifest.qualification_bundle_sha256,
+    )
+    return evaluate_hardware_qualification(
+        manifest,
+        thresholds,
+        verified_qualification_bundle_sha256=str(verification["bundle_sha256"]),
     )
 
 
@@ -450,8 +516,12 @@ def manifest_from_mapping(raw: Mapping[str, Any]) -> HardwareQualificationManife
         synthetic_contract_test=bool(raw.get("synthetic_contract_test", False)),
         device=DeviceIdentity(**dict(device_raw)),
         signal=SignalGeometry(
-            channel_names=_tuple_strings(signal_raw["channel_names"], field_name="signal.channel_names"),
-            channel_types=_tuple_strings(signal_raw["channel_types"], field_name="signal.channel_types"),
+            channel_names=_tuple_strings(
+                signal_raw["channel_names"], field_name="signal.channel_names"
+            ),
+            channel_types=_tuple_strings(
+                signal_raw["channel_types"], field_name="signal.channel_types"
+            ),
             units=_tuple_strings(signal_raw["units"], field_name="signal.units"),
             nominal_sample_rate_hz=float(signal_raw["nominal_sample_rate_hz"]),
             measured_sample_rate_hz=float(signal_raw["measured_sample_rate_hz"]),

--- a/tests/test_hardware_qualification.py
+++ b/tests/test_hardware_qualification.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neuros.hardware_qualification import (
+    HardwareQualificationThresholds,
+    MeasurementOrigin,
+    evaluate_hardware_qualification,
+    manifest_from_mapping,
+)
+
+
+def synthetic_evidence() -> dict:
+    return {
+        "schema_version": 1,
+        "evidence_id": "contract-fixture",
+        "measurement_origin": "synthetic_contract_test",
+        "qualification_bundle_sha256": "a" * 64,
+        "physical_run": False,
+        "synthetic_contract_test": True,
+        "device": {
+            "manufacturer": "Synthetic",
+            "device": "Contract Fixture",
+            "board_id": "fixture-0",
+            "firmware_version": "0",
+            "acquisition_library": "neuros-test",
+            "acquisition_library_version": "1",
+            "operating_system": "ci",
+            "transport": "memory",
+        },
+        "signal": {
+            "channel_names": ["C3", "C4"],
+            "channel_types": ["eeg", "eeg"],
+            "units": ["uV", "uV"],
+            "nominal_sample_rate_hz": 250.0,
+            "measured_sample_rate_hz": 249.95,
+        },
+        "timing": {
+            "timestamp_source": "synthetic_monotonic",
+            "clock_domain": "synchronized",
+            "offset_p50_ms": 0.2,
+            "offset_p95_ms": 0.5,
+            "drift_ppm": 5.0,
+            "uncertainty_p95_ms": 0.8,
+        },
+        "reliability": {
+            "duration_s": 600.0,
+            "expected_samples": 150000,
+            "observed_samples": 150000,
+            "queue_accepted": 150000,
+            "queue_dropped": 0,
+            "reconnect_attempts": 1,
+            "reconnect_successes": 1,
+            "reconnect_tested": True,
+        },
+        "latency": {
+            "source_to_decision_p50_ms": 18.0,
+            "source_to_decision_p95_ms": 35.0,
+            "source_to_decision_p99_ms": 52.0,
+            "sample_count": 1000,
+        },
+        "notes": {"purpose": "contract test only"},
+    }
+
+
+def test_synthetic_fixture_can_pass_thresholds_but_never_hardware_qualification():
+    manifest = manifest_from_mapping(synthetic_evidence())
+    result = evaluate_hardware_qualification(
+        manifest,
+        HardwareQualificationThresholds(require_reconnect_test=True),
+    )
+
+    assert manifest.measurement_origin is MeasurementOrigin.SYNTHETIC
+    assert result.schema_valid is True
+    assert result.measurements_complete is True
+    assert result.thresholds_pass is True
+    assert result.physical_evidence is False
+    assert result.hardware_qualified is False
+    assert result.claim_boundary["hardware_qualified"] is False
+    physical_gate = next(gate for gate in result.gates if gate.name == "physical_measurement")
+    assert physical_gate.status.value == "fail"
+
+
+def test_threshold_failure_is_reported_without_changing_measurements():
+    raw = synthetic_evidence()
+    raw["reliability"]["observed_samples"] = 149000
+    manifest = manifest_from_mapping(raw)
+    thresholds = HardwareQualificationThresholds(max_sample_loss_fraction=0.001)
+    result = evaluate_hardware_qualification(manifest, thresholds)
+
+    assert result.thresholds_pass is False
+    loss_gate = next(gate for gate in result.gates if gate.name == "sample_loss_fraction")
+    assert loss_gate.status.value == "fail"
+    assert loss_gate.observed == pytest.approx(1000 / 150000)
+    assert result.hardware_qualified is False
+
+
+def test_physical_origin_cannot_be_declared_without_physical_run():
+    raw = synthetic_evidence()
+    raw["measurement_origin"] = "physical_measurement"
+    raw["synthetic_contract_test"] = False
+
+    with pytest.raises(ValueError, match="requires physical_run=true"):
+        manifest_from_mapping(raw)
+
+
+def test_synthetic_flag_blocks_physical_origin():
+    raw = synthetic_evidence()
+    raw["measurement_origin"] = "physical_measurement"
+    raw["physical_run"] = True
+
+    with pytest.raises(ValueError, match="cannot claim physical_measurement"):
+        manifest_from_mapping(raw)
+
+
+def test_geometry_and_percentiles_are_fail_closed():
+    raw = synthetic_evidence()
+    raw["signal"]["channel_types"] = ["eeg"]
+    with pytest.raises(ValueError, match="identical lengths"):
+        manifest_from_mapping(raw)
+
+    raw = synthetic_evidence()
+    raw["latency"]["source_to_decision_p50_ms"] = 60.0
+    with pytest.raises(ValueError, match="p50 <= p95 <= p99"):
+        manifest_from_mapping(raw)
+
+
+def test_invalid_qualification_root_is_rejected():
+    raw = synthetic_evidence()
+    raw["qualification_bundle_sha256"] = "not-a-digest"
+    with pytest.raises(ValueError, match="64-character SHA-256"):
+        manifest_from_mapping(raw)
+
+
+def test_serialized_result_exposes_gate_evidence(tmp_path: Path):
+    manifest = manifest_from_mapping(synthetic_evidence())
+    result = evaluate_hardware_qualification(manifest)
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(result.to_dict(), indent=2, default=str), encoding="utf-8")
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+
+    assert parsed["hardware_qualified"] is False
+    assert parsed["thresholds_pass"] is True
+    assert len(parsed["evidence_sha256"]) == 64
+    assert {gate["name"] for gate in parsed["gates"]} >= {
+        "physical_measurement",
+        "minimum_duration",
+        "sample_loss_fraction",
+        "queue_drop_fraction",
+        "absolute_clock_drift_ppm",
+        "source_to_decision_p95_ms",
+    }

--- a/tests/test_hardware_qualification.py
+++ b/tests/test_hardware_qualification.py
@@ -8,9 +8,11 @@ import pytest
 from neuros.hardware_qualification import (
     HardwareQualificationThresholds,
     MeasurementOrigin,
+    evaluate_hardware_evidence_bundle,
     evaluate_hardware_qualification,
     manifest_from_mapping,
 )
+from neuros.qualification import qualify_config
 
 
 def synthetic_evidence() -> dict:
@@ -78,10 +80,44 @@ def test_synthetic_fixture_can_pass_thresholds_but_never_hardware_qualification(
     assert result.measurements_complete is True
     assert result.thresholds_pass is True
     assert result.physical_evidence is False
+    assert result.qualification_bundle_verified is False
     assert result.hardware_qualified is False
     assert result.claim_boundary["hardware_qualified"] is False
     physical_gate = next(gate for gate in result.gates if gate.name == "physical_measurement")
     assert physical_gate.status.value == "fail"
+    bundle_gate = next(gate for gate in result.gates if gate.name == "verified_runtime_bundle")
+    assert bundle_gate.status.value == "not_tested"
+
+
+def test_matching_root_value_without_actual_bundle_verification_is_not_enough():
+    manifest = manifest_from_mapping(synthetic_evidence())
+    result = evaluate_hardware_qualification(
+        manifest,
+        verified_qualification_bundle_sha256="a" * 64,
+    )
+
+    assert result.qualification_bundle_verified is True
+    assert result.thresholds_pass is True
+    assert result.hardware_qualified is False
+    assert result.physical_evidence is False
+
+
+@pytest.mark.asyncio
+async def test_synthetic_evidence_can_bind_real_runtime_bundle_but_still_cannot_promote(tmp_path: Path):
+    config = Path("configs/examples/mock_bci.yaml").resolve()
+    bundle = tmp_path / "qualification"
+    qualification = await qualify_config(config, bundle, duration_s=0.04)
+
+    raw = synthetic_evidence()
+    raw["qualification_bundle_sha256"] = qualification["bundle_sha256"]
+    manifest = manifest_from_mapping(raw)
+    result = evaluate_hardware_evidence_bundle(manifest, bundle)
+
+    assert result.qualification_bundle_verified is True
+    assert result.claim_boundary["runtime_record_replay_qualified"] is True
+    assert result.thresholds_pass is True
+    assert result.physical_evidence is False
+    assert result.hardware_qualified is False
 
 
 def test_threshold_failure_is_reported_without_changing_measurements():
@@ -112,7 +148,16 @@ def test_synthetic_flag_blocks_physical_origin():
     raw["measurement_origin"] = "physical_measurement"
     raw["physical_run"] = True
 
-    with pytest.raises(ValueError, match="cannot claim physical_measurement"):
+    with pytest.raises(ValueError, match="must use synthetic_contract_test origin"):
+        manifest_from_mapping(raw)
+
+
+def test_imported_measurement_also_requires_a_physical_run():
+    raw = synthetic_evidence()
+    raw["measurement_origin"] = "imported_external_measurement"
+    raw["synthetic_contract_test"] = False
+
+    with pytest.raises(ValueError, match="requires physical_run=true"):
         manifest_from_mapping(raw)
 
 
@@ -144,9 +189,11 @@ def test_serialized_result_exposes_gate_evidence(tmp_path: Path):
 
     assert parsed["hardware_qualified"] is False
     assert parsed["thresholds_pass"] is True
+    assert parsed["qualification_bundle_verified"] is False
     assert len(parsed["evidence_sha256"]) == 64
     assert {gate["name"] for gate in parsed["gates"]} >= {
         "physical_measurement",
+        "verified_runtime_bundle",
         "minimum_duration",
         "sample_loss_fraction",
         "queue_drop_fraction",


### PR DESCRIPTION
## Why

PR #37 established a reproducible runtime record/replay evidence bundle. The next evidence rung must define what neurOS means by **hardware qualification** without allowing software CI, mock drivers, or hand-authored JSON to manufacture a physical-world claim.

This PR introduces `HardwareQualificationManifest` and a fail-closed hardware evidence evaluator.

## Promotion rule

`hardware_qualified=true` requires all three:

1. non-synthetic physical/imported measured evidence with `physical_run=true`;
2. an independently verified neurOS qualification-bundle root that exactly matches the root referenced by the hardware manifest;
3. every configured reliability, sample-rate, clock, reconnect, and source-to-decision latency gate passes.

Passing numerical thresholds alone is insufficient. Supplying a matching SHA string without actually verifying the referenced qualification bundle is insufficient. A perfect synthetic CI fixture is structurally ineligible for hardware promotion.

## Evidence schema

The v1 manifest records:

- exact manufacturer/device/board identity;
- firmware, acquisition library/version, host OS, and physical transport;
- channel names/types/units;
- nominal and measured sampling rate;
- timestamp source and clock domain;
- clock offset p50/p95, drift ppm, and p95 uncertainty;
- sustained duration;
- expected/observed sample counts;
- neurOS queue accepted/dropped counts;
- reconnect attempts/successes/test status;
- source-to-decision p50/p95/p99 latency and sample count;
- the externally pinned runtime qualification `bundle_sha256`.

Loss fractions and queue-drop fractions are derived from counts instead of being independently supplied.

## Default reference gates

Defaults are explicitly reference engineering thresholds, not universal clinical/product requirements:

- >= 300 s sustained duration
- <= 0.1% sample loss
- 0% neurOS queue drop
- <= 1% sample-rate error
- <= 100 ppm absolute clock drift
- <= 5 ms p95 clock uncertainty
- <= 100 ms source-to-decision p95
- <= 200 ms source-to-decision p99
- reconnect testing optional unless a threshold profile requires it

Threshold profiles validate fail-closed and remain explicit evidence configuration.

## Synthetic CI boundary

The dedicated Python 3.10/3.11/3.12 workflow deliberately constructs a synthetic one-hour fixture with perfect reliability and timing, passes every numerical gate, supplies a matching root string, and asserts:

```text
thresholds_pass = true
qualification_bundle_verified = true
physical_evidence = false
hardware_qualified = false
```

A second integration contract creates a real neurOS runtime qualification bundle from the mock pipeline and binds synthetic hardware evidence to its actually verified root. The runtime claim becomes verified, but hardware qualification remains false because no physical measurement occurred.

## Claim boundary

This PR implements the hardware evidence **contract and evaluator**. It does not claim that OpenBCI, BrainFlow, LSL, or any other named physical configuration has already passed that evidence tier.

The recommended first real target remains an OpenBCI Cyton-class configuration through hardened BrainFlow, optionally paired with an LSL marker stream. That promotion should happen only after the actual measured evidence is collected.