### PR TITLE
Add protocol-grade synthetic EEG and Phantom Unicorn BCI source

### DIFF
--- a/docs/MINDFORGE_PHANTOM_UNICORN.md
+++ b/docs/MINDFORGE_PHANTOM_UNICORN.md
@@ -1,0 +1,57 @@
+# Mindforge Phantom Unicorn
+
+neurOS provides a deterministic Unicorn-like synthetic EEG source for Mindforge qualification. It is an engineering adversary, not a physiological digital twin and not evidence of human BCI performance.
+
+## Pipeline boundary
+
+```text
+neurOS synthetic EEG -> LSL UnicornMock -> Mindforge Python FBCCA -> NeuralEvent -> UDP -> Unity
+```
+
+Raw synthetic/physical EEG stays outside Unity.
+
+## Start the source
+
+```bash
+python examples/mindforge_phantom_unicorn.py --no-stdin
+```
+
+Defaults:
+
+- LSL name: `UnicornMock`
+- LSL type: `EEG`
+- source ID: `mindforge-phantom-unicorn`
+- 8 channels / 250 Hz / microvolts
+- localhost control: UDP `127.0.0.1:19744`
+
+Interactive stdin remains available if `--no-stdin` is omitted.
+
+## Deterministic control commands
+
+Send one UTF-8 datagram to port 19744:
+
+```text
+0            no attended target / resting baseline
+1            attend 10 Hz / Sight
+2            attend 12 Hz / Guard
+b            blink transient
+j            jaw contamination
+c            controller/hand contamination
+m            movement artifact
+s            saturation
+d            drop Oz
+r            restore Oz
+x            2 s source silence
+silence:2.5  explicit source-silence duration
+gain:0.65    set SSVEP response gain
++ / -        step response gain
+q            stop source
+```
+
+The control channel changes only the simulator state/fault schedule. LSL samples and metadata retain the same external contract used by Mindforge acquisition. This lets the Unity/Python calibration ritual drive Phantom automatically while preserving the eventual physical-source substitution boundary.
+
+## Transport stress
+
+Use `--drop-probability` and `--jitter-ms` for continuous delivery stress. Use `silence:SECONDS` for a coherent source-death/recovery rehearsal.
+
+Synthetic success must never be reported as physical Unicorn or human SSVEP performance.

--- a/examples/mindforge_phantom_unicorn.py
+++ b/examples/mindforge_phantom_unicorn.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Publish neurOS synthetic EEG as a controllable Unicorn-like LSL source.
+
+Keyboard or localhost UDP commands:
+  1 = attend 10 Hz, 2 = attend 12 Hz, 0 = no target
+  b = blink, j = jaw EMG, c = controller EMG, m = motion
+  s = saturation, d = Oz dropout, r = restore Oz
+  x = two-second stream silence, silence:2.5 = explicit silence duration
+  + / - = SSVEP gain step, gain:0.65 = explicit response gain
+  q = quit
+
+The UDP control path is intentionally localhost-only by default. It makes Mindforge
+calibration/torture rehearsals reproducible without changing the generated EEG or LSL
+contract used by the physical-source path.
+"""
+from __future__ import annotations
+
+import argparse
+import queue
+import socket
+import threading
+import time
+
+import numpy as np
+
+from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+
+
+def command_reader(commands: queue.Queue[str]) -> None:
+    while True:
+        try:
+            command = input().strip().lower()
+        except EOFError:
+            return
+        if command:
+            commands.put(command)
+        if command == "q":
+            return
+
+
+def udp_command_reader(commands: queue.Queue[str], host: str, port: int) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((host, port))
+    sock.settimeout(0.25)
+    try:
+        while True:
+            try:
+                payload, _ = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            command = payload.decode("utf-8", errors="ignore").strip().lower()
+            if command:
+                commands.put(command)
+            if command == "q":
+                return
+    finally:
+        sock.close()
+
+
+def parse_duration(command: str, prefix: str, default: float) -> float:
+    if not command.startswith(prefix + ":"):
+        return default
+    try:
+        return float(command.split(":", 1)[1])
+    except ValueError:
+        return default
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", default="UnicornMock")
+    parser.add_argument("--source-id", default="mindforge-phantom-unicorn")
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--block", type=int, default=5)
+    parser.add_argument("--drop-probability", type=float, default=0.0)
+    parser.add_argument("--jitter-ms", type=float, default=0.0,
+                        help="uniform extra delivery delay in [0, jitter-ms]")
+    parser.add_argument("--control-host", default="127.0.0.1")
+    parser.add_argument("--control-port", type=int, default=19744)
+    parser.add_argument("--no-stdin", action="store_true",
+                        help="disable interactive stdin; use UDP control only")
+    args = parser.parse_args()
+    if not 0.0 <= args.drop_probability < 1.0:
+        raise SystemExit("--drop-probability must be in [0, 1)")
+    if args.jitter_ms < 0:
+        raise SystemExit("--jitter-ms must be non-negative")
+    if not 1 <= args.control_port <= 65535:
+        raise SystemExit("--control-port must be a valid UDP port")
+
+    try:
+        from pylsl import StreamInfo, StreamOutlet, local_clock
+    except (ImportError, OSError, RuntimeError) as exc:
+        raise SystemExit("Install neuros-drivers[lsl] with a working liblsl runtime") from exc
+
+    config = SyntheticEEGConfig(seed=args.seed)
+    generator = SyntheticEEGGenerator(config)
+    transport_rng = np.random.default_rng(args.seed + 99173)
+    info = StreamInfo(args.name, "EEG", len(config.channel_names), config.sampling_rate_hz,
+                      "float32", args.source_id)
+    channels = info.desc().append_child("channels")
+    for label in config.channel_names:
+        channel = channels.append_child("channel")
+        channel.append_child_value("label", label)
+        channel.append_child_value("unit", "microvolts")
+        channel.append_child_value("type", "EEG")
+    info.desc().append_child_value("manufacturer", "neurOS synthetic source")
+    info.desc().append_child_value("synthetic", "true")
+    info.desc().append_child_value("transport_drop_probability", str(args.drop_probability))
+    info.desc().append_child_value("transport_jitter_ms", str(args.jitter_ms))
+    info.desc().append_child_value("control_port", str(args.control_port))
+    outlet = StreamOutlet(info, chunk_size=args.block, max_buffered=10)
+
+    commands: queue.Queue[str] = queue.Queue()
+    if not args.no_stdin:
+        threading.Thread(target=command_reader, args=(commands,), daemon=True,
+                         name="PhantomUnicorn-stdin").start()
+    threading.Thread(target=udp_command_reader,
+                     args=(commands, args.control_host, args.control_port), daemon=True,
+                     name="PhantomUnicorn-control").start()
+
+    attention_gain = 1.0
+    silence_until = 0.0
+    running = True
+    print(
+        f"Publishing {args.name!r} at {config.sampling_rate_hz:g} Hz; "
+        f"drop={args.drop_probability:.3f}, jitter<= {args.jitter_ms:g} ms; "
+        f"control=udp://{args.control_host}:{args.control_port}."
+    )
+    print("Commands: 1/2/0/b/j/c/m/s/d/r/x/silence:SECONDS/+/-/gain:VALUE/q")
+    deadline = time.monotonic()
+
+    while running:
+        while True:
+            try:
+                command = commands.get_nowait()
+            except queue.Empty:
+                break
+
+            if command == "1":
+                generator.set_attention(10.0, attention_gain)
+            elif command == "2":
+                generator.set_attention(12.0, attention_gain)
+            elif command == "0":
+                generator.set_attention(None)
+            elif command == "b":
+                generator.inject_artifact("blink", 0.35, 1.0)
+            elif command == "j":
+                generator.inject_artifact("jaw", 0.45, 1.0)
+            elif command == "c":
+                generator.inject_artifact("controller", 0.50, 1.0)
+            elif command == "m":
+                generator.inject_artifact("motion", 0.50, 1.0)
+            elif command == "s":
+                generator.inject_artifact("saturation", 0.40, 1.0)
+            elif command == "d":
+                generator.set_channel_gain("Oz", 0.0)
+            elif command == "r":
+                generator.set_channel_gain("Oz", 1.0)
+            elif command == "x" or command.startswith("silence:"):
+                duration = float(np.clip(parse_duration(command, "silence", 2.0), 0.1, 10.0))
+                silence_until = max(silence_until, time.monotonic() + duration)
+            elif command == "+":
+                attention_gain = min(1.5, attention_gain + 0.1)
+                if generator.target_frequency_hz is not None:
+                    generator.set_attention(generator.target_frequency_hz, attention_gain)
+            elif command == "-":
+                attention_gain = max(0.0, attention_gain - 0.1)
+                if generator.target_frequency_hz is not None:
+                    generator.set_attention(generator.target_frequency_hz, attention_gain)
+            elif command.startswith("gain:"):
+                attention_gain = float(np.clip(parse_duration(command, "gain", attention_gain), 0.0, 1.5))
+                if generator.target_frequency_hz is not None:
+                    generator.set_attention(generator.target_frequency_hz, attention_gain)
+            elif command == "q":
+                running = False
+
+        block = generator.render(args.block)
+        generated_timestamp = local_clock()
+        dropped = transport_rng.random() < args.drop_probability
+        silent = time.monotonic() < silence_until
+        if not dropped and not silent:
+            if args.jitter_ms > 0:
+                time.sleep(float(transport_rng.uniform(0.0, args.jitter_ms)) / 1000.0)
+            outlet.push_chunk(block.data_uv.T.tolist(), timestamp=generated_timestamp)
+
+        deadline += args.block / config.sampling_rate_hz
+        time.sleep(max(0.0, deadline - time.monotonic()))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/neuros-drivers/pyproject.toml
+++ b/packages/neuros-drivers/pyproject.toml
@@ -43,6 +43,7 @@ test = ["pytest>=7.4", "pytest-asyncio>=0.21"]
 
 [project.entry-points."neuros.sources"]
 mock = "neuros.drivers.mock_driver:MockDriver"
+synthetic_eeg = "neuros.drivers.synthetic_eeg_driver:SyntheticEEGDriver"
 brainflow = "neuros.drivers.brainflow_driver:BrainFlowDriver"
 lsl = "neuros.drivers.lsl_driver:LSLDriver"
 dataset = "neuros.drivers.dataset_driver:DatasetDriver"

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -7,6 +7,13 @@ from neuros.drivers.base_driver import BaseDriver  # noqa: F401
 from neuros.drivers.brainflow_driver import BrainFlowDriver  # noqa: F401
 from neuros.drivers.lsl_driver import LSLDriver  # noqa: F401
 from neuros.drivers.mock_driver import MockDriver  # noqa: F401
+from neuros.drivers.synthetic_eeg import (  # noqa: F401
+    ArtifactKind,
+    SyntheticEEGBlock,
+    SyntheticEEGConfig,
+    SyntheticEEGGenerator,
+)
+from neuros.drivers.synthetic_eeg_driver import SyntheticEEGDriver  # noqa: F401
 
 # additional drivers
 from neuros.drivers.dataset_driver import DatasetDriver  # noqa: F401

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
@@ -1,0 +1,162 @@
+"""Protocol-grade synthetic EEG generator for acquisition and BCI stress tests.
+
+The generator is deliberately not a physiological digital twin. It creates a
+controlled signal with realistic nuisance structure so downstream systems can
+be tested against weak SSVEPs, endogenous alpha, contact loss, movement and EMG
+without requiring physical hardware for every iteration.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+ArtifactKind = Literal["blink", "jaw", "controller", "motion", "saturation", "dropout"]
+
+
+@dataclass(frozen=True)
+class SyntheticEEGConfig:
+    sampling_rate_hz: float = 250.0
+    channel_names: tuple[str, ...] = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+    colored_noise_uv: float = 4.5
+    white_noise_uv: float = 1.25
+    alpha_frequency_hz: float = 9.4
+    alpha_amplitude_uv: float = 2.8
+    ssvep_amplitude_uv: float = 8.0
+    first_harmonic_ratio: float = 0.34
+    seed: int = 7
+
+    def validate(self) -> None:
+        if self.sampling_rate_hz <= 0:
+            raise ValueError("sampling_rate_hz must be positive")
+        if len(self.channel_names) != 8:
+            raise ValueError("the default synthetic EEG profile expects exactly 8 channels")
+        if self.colored_noise_uv < 0 or self.white_noise_uv < 0:
+            raise ValueError("noise amplitudes must be non-negative")
+        if self.alpha_frequency_hz <= 0 or self.alpha_amplitude_uv < 0:
+            raise ValueError("alpha parameters must be positive/non-negative")
+        if self.ssvep_amplitude_uv < 0:
+            raise ValueError("ssvep_amplitude_uv must be non-negative")
+        if not 0 <= self.first_harmonic_ratio <= 2:
+            raise ValueError("first_harmonic_ratio must be in [0, 2]")
+
+
+@dataclass(frozen=True)
+class SyntheticEEGBlock:
+    data_uv: np.ndarray
+    timestamps_s: np.ndarray
+    target_frequency_hz: float | None
+    attention_gain: float
+    artifact: str | None
+
+
+class SyntheticEEGGenerator:
+    """Stateful eight-channel EEG source with controllable SSVEP and artifacts."""
+
+    posterior_weights = np.asarray([0.05, 0.05, 0.08, 0.05, 0.45, 0.85, 1.0, 0.85])
+    central_weights = np.asarray([0.18, 0.95, 1.0, 0.95, 0.25, 0.10, 0.08, 0.10])
+    frontal_weights = np.asarray([1.0, 0.30, 0.55, 0.30, 0.22, 0.12, 0.10, 0.12])
+
+    def __init__(self, config: SyntheticEEGConfig | None = None) -> None:
+        self.config = config or SyntheticEEGConfig()
+        self.config.validate()
+        self.rng = np.random.default_rng(self.config.seed)
+        self.sample_index = 0
+        self.target_frequency_hz: float | None = None
+        self.attention_gain = 0.0
+        self.channel_gain = np.ones(8, dtype=float)
+        self._colored_state = np.zeros((8, 4), dtype=float)
+        self._phase = self.rng.uniform(0, 2 * np.pi, 8)
+        self._alpha_phase = self.rng.uniform(0, 2 * np.pi, 8)
+        self._artifact_kind: str | None = None
+        self._artifact_remaining = 0
+        self._artifact_total = 0
+        self._artifact_severity = 1.0
+
+    def set_attention(self, frequency_hz: float | None, gain: float = 1.0) -> None:
+        if frequency_hz is not None and frequency_hz <= 0:
+            raise ValueError("frequency_hz must be positive")
+        self.target_frequency_hz = None if frequency_hz is None else float(frequency_hz)
+        self.attention_gain = float(np.clip(gain, 0.0, 1.5)) if frequency_hz is not None else 0.0
+
+    def set_channel_gain(self, channel: str | int, gain: float) -> None:
+        index = self.config.channel_names.index(channel) if isinstance(channel, str) else int(channel)
+        if not 0 <= index < 8:
+            raise IndexError("channel index out of range")
+        self.channel_gain[index] = max(0.0, float(gain))
+
+    def inject_artifact(self, kind: ArtifactKind, duration_seconds: float = 0.35, severity: float = 1.0) -> None:
+        if kind not in {"blink", "jaw", "controller", "motion", "saturation", "dropout"}:
+            raise ValueError(f"unsupported artifact kind: {kind}")
+        if duration_seconds <= 0:
+            raise ValueError("duration_seconds must be positive")
+        self._artifact_kind = kind
+        self._artifact_total = max(1, int(round(duration_seconds * self.config.sampling_rate_hz)))
+        self._artifact_remaining = self._artifact_total
+        self._artifact_severity = max(0.0, float(severity))
+
+    def _colored_noise(self, samples: int) -> np.ndarray:
+        alphas = np.asarray([0.70, 0.90, 0.975, 0.995])
+        weights = np.asarray([0.55, 0.42, 0.30, 0.20])
+        out = np.empty((8, samples), dtype=float)
+        for index in range(samples):
+            innovation = self.rng.normal(size=(8, 4))
+            self._colored_state = alphas * self._colored_state + np.sqrt(1.0 - alphas**2) * innovation
+            out[:, index] = (self._colored_state * weights).sum(axis=1)
+        out /= max(float(np.std(out)), 1e-8)
+        return out * self.config.colored_noise_uv
+
+    def _render_artifact(self, samples: int, time_s: np.ndarray) -> np.ndarray:
+        if self._artifact_kind is None or self._artifact_remaining <= 0:
+            return np.zeros((8, samples), dtype=float)
+        count = min(samples, self._artifact_remaining)
+        start = self._artifact_total - self._artifact_remaining
+        phase = (np.arange(count) + start) / max(1, self._artifact_total - 1)
+        output = np.zeros((8, samples), dtype=float)
+        severity = self._artifact_severity
+        kind = self._artifact_kind
+        if kind == "blink":
+            pulse = np.sin(np.pi * np.clip(phase, 0, 1)) ** 2
+            output[:, :count] += self.frontal_weights[:, None] * (120 * severity * pulse)
+        elif kind == "jaw":
+            t = time_s[:count]
+            high_frequency = np.sin(2 * np.pi * 38 * t) + 0.8 * np.sin(2 * np.pi * 53 * t + 0.7) + 0.55 * np.sin(2 * np.pi * 71 * t + 1.1)
+            output[:, :count] += (0.55 * self.central_weights + 0.35)[:, None] * (48 * severity * high_frequency)
+        elif kind == "controller":
+            t = time_s[:count]
+            controller_emg = np.sin(2 * np.pi * 31 * t) + 0.55 * np.sin(2 * np.pi * 46 * t + 0.4) + 0.30 * self.rng.normal(size=count)
+            output[:, :count] += self.central_weights[:, None] * (24 * severity * controller_emg)
+        elif kind == "motion":
+            drift = np.sin(np.pi * np.clip(phase, 0, 1)) * np.sign(np.sin(2 * np.pi * 2.2 * time_s[:count]))
+            output[:, :count] += (0.60 + 0.40 * self.frontal_weights)[:, None] * (55 * severity * drift)
+        elif kind == "saturation":
+            output[6, :count] += 480 * severity
+        self._artifact_remaining -= count
+        if self._artifact_remaining <= 0:
+            self._artifact_kind = None
+        return output
+
+    def render(self, samples: int) -> SyntheticEEGBlock:
+        if samples <= 0:
+            raise ValueError("samples must be positive")
+        fs = self.config.sampling_rate_hz
+        sample_index = self.sample_index + np.arange(samples)
+        time_s = sample_index / fs
+        data = self._colored_noise(samples)
+        data += self.rng.normal(0, self.config.white_noise_uv, size=(8, samples))
+        alpha = np.sin(2 * np.pi * self.config.alpha_frequency_hz * time_s[None, :] + self._alpha_phase[:, None])
+        data += self.posterior_weights[:, None] * self.config.alpha_amplitude_uv * alpha
+        if self.target_frequency_hz is not None and self.attention_gain > 0:
+            frequency = self.target_frequency_hz
+            fundamental = np.sin(2 * np.pi * frequency * time_s[None, :] + self._phase[:, None])
+            harmonic = np.sin(2 * np.pi * 2 * frequency * time_s[None, :] + 0.5 * self._phase[:, None])
+            ssvep = fundamental + self.config.first_harmonic_ratio * harmonic
+            data += self.posterior_weights[:, None] * self.config.ssvep_amplitude_uv * self.attention_gain * ssvep
+        active_artifact = self._artifact_kind
+        data += self._render_artifact(samples, time_s)
+        data *= self.channel_gain[:, None]
+        if active_artifact == "dropout":
+            data[6, :] = 0.0
+        self.sample_index += samples
+        return SyntheticEEGBlock(data.astype(np.float32), time_s.astype(float), self.target_frequency_hz, self.attention_gain, active_artifact)

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py
@@ -1,0 +1,55 @@
+"""neurOS driver wrapper for the protocol-grade synthetic EEG generator."""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import AsyncIterator
+
+import numpy as np
+
+from neuros.contracts import ClockDomain, StreamDescriptor
+from neuros.drivers.base_driver import BaseDriver
+from neuros.drivers.synthetic_eeg import ArtifactKind, SyntheticEEGConfig, SyntheticEEGGenerator
+
+
+class SyntheticEEGDriver(BaseDriver):
+    """Stream controllable synthetic EEG through the canonical driver interface."""
+
+    def __init__(self, config: SyntheticEEGConfig | None = None, *, realtime: bool = True, stream_id: str = "synthetic-eeg") -> None:
+        self.generator = SyntheticEEGGenerator(config)
+        self.realtime = bool(realtime)
+        super().__init__(sampling_rate=self.generator.config.sampling_rate_hz, channels=len(self.generator.config.channel_names), stream_id=stream_id, modality="eeg")
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return StreamDescriptor(
+            stream_id=self.stream_id,
+            modality="eeg",
+            sample_rate_hz=self.sampling_rate,
+            channel_names=self.generator.config.channel_names,
+            channel_types=tuple("eeg" for _ in range(self.channels)),
+            clock_domain=ClockDomain.HOST_MONOTONIC,
+            device="SyntheticEEGGenerator",
+            metadata={"synthetic": True, "units": "microvolts", "generator": "neuros.synthetic_eeg.v1"},
+        )
+
+    def set_attention(self, frequency_hz: float | None, gain: float = 1.0) -> None:
+        self.generator.set_attention(frequency_hz, gain)
+
+    def inject_artifact(self, kind: ArtifactKind, duration_seconds: float = 0.35, severity: float = 1.0) -> None:
+        self.generator.inject_artifact(kind, duration_seconds, severity)
+
+    def set_channel_gain(self, channel: str | int, gain: float) -> None:
+        self.generator.set_channel_gain(channel, gain)
+
+    async def _stream(self) -> AsyncIterator[tuple[float, np.ndarray]]:
+        period = 1.0 / self.sampling_rate
+        next_deadline = time.monotonic()
+        while self._running:
+            block = self.generator.render(1)
+            yield time.time(), block.data_uv[:, 0]
+            if self.realtime:
+                next_deadline += period
+                await asyncio.sleep(max(0.0, next_deadline - time.monotonic()))
+            else:
+                await asyncio.sleep(0)

--- a/tests/test_phantom_unicorn_control_contract.py
+++ b/tests/test_phantom_unicorn_control_contract.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "examples" / "mindforge_phantom_unicorn.py"
+
+
+def test_phantom_has_local_rehearsal_control_without_changing_lsl_contract():
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert '--control-host", default="127.0.0.1"' in src
+    assert '--control-port", type=int, default=19744' in src
+    assert "udp_command_reader" in src
+    assert 'command == "1"' in src and 'set_attention(10.0' in src
+    assert 'command == "2"' in src and 'set_attention(12.0' in src
+    assert 'command == "0"' in src and "set_attention(None)" in src
+    assert 'command.startswith("silence:")' in src
+    assert 'command.startswith("gain:")' in src
+    assert 'StreamInfo(args.name, "EEG"' in src
+    assert 'append_child_value("unit", "microvolts")' in src

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+from neuros.drivers.synthetic_eeg_driver import SyntheticEEGDriver
+
+
+def spectral_amplitude(signal: np.ndarray, sampling_rate_hz: float, frequency_hz: float) -> float:
+    spectrum = np.fft.rfft(signal - np.mean(signal))
+    frequencies = np.fft.rfftfreq(signal.size, d=1.0 / sampling_rate_hz)
+    index = int(np.argmin(np.abs(frequencies - frequency_hz)))
+    return float(np.abs(spectrum[index]))
+
+
+def test_ssvep_strength_is_controllable_and_posterior():
+    cfg = SyntheticEEGConfig(seed=11, ssvep_amplitude_uv=8.0)
+    strong = SyntheticEEGGenerator(cfg)
+    strong.set_attention(12.0, 1.0)
+    strong_block = strong.render(500).data_uv
+
+    weak = SyntheticEEGGenerator(cfg)
+    weak.set_attention(12.0, 0.2)
+    weak_block = weak.render(500).data_uv
+
+    strong_oz = spectral_amplitude(strong_block[6], cfg.sampling_rate_hz, 12.0)
+    weak_oz = spectral_amplitude(weak_block[6], cfg.sampling_rate_hz, 12.0)
+    strong_fz = spectral_amplitude(strong_block[0], cfg.sampling_rate_hz, 12.0)
+    assert strong_oz > weak_oz * 2.0
+    assert strong_oz > strong_fz * 4.0
+
+
+def test_artifacts_and_channel_contact_are_explicit():
+    cfg = SyntheticEEGConfig(seed=5)
+    generator = SyntheticEEGGenerator(cfg)
+    generator.set_attention(10.0)
+    generator.inject_artifact("blink", 0.4, 1.0)
+    blink = generator.render(100)
+    assert blink.artifact == "blink"
+    assert float(np.max(np.abs(blink.data_uv[0]))) > 40.0
+
+    generator.set_channel_gain("Oz", 0.0)
+    dropout = generator.render(64)
+    assert np.allclose(dropout.data_uv[6], 0.0)
+
+
+def test_driver_exposes_unicorn_like_descriptor():
+    driver = SyntheticEEGDriver(SyntheticEEGConfig(seed=1), realtime=False, stream_id="phantom")
+    descriptor = driver.descriptor
+    assert descriptor.stream_id == "phantom"
+    assert descriptor.modality == "eeg"
+    assert descriptor.sample_rate_hz == 250.0
+    assert descriptor.channel_names == ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+    assert descriptor.metadata["synthetic"] is True


### PR DESCRIPTION
## Summary

Adds a reusable, protocol-grade synthetic EEG laboratory to `neuros-drivers` for closed-loop BCI development and adversarial qualification.

The existing `MockDriver` remains useful for simple pipeline smoke tests. This PR adds a harder source for frequency-decoder and game-loop qualification:

- deterministic 8-channel / 250 Hz Unicorn-like EEG;
- colored background activity and endogenous alpha;
- posterior SSVEP plus first harmonic;
- tunable response strength;
- per-channel contact gain;
- blink, jaw, controller/hand, motion, saturation and dropout stressors;
- canonical `SyntheticEEGDriver` / `StreamDescriptor` integration;
- `synthetic_eeg` source entry point;
- deterministic tests;
- `UnicornMock` LSL publisher for Mindforge and other BCI clients;
- deterministic transport drop probability and delivery jitter;
- explicit source-silence fault injection;
- localhost-only UDP rehearsal control on `127.0.0.1:19744`.

## Deterministic rehearsal control

`examples/mindforge_phantom_unicorn.py` supports both interactive commands and a localhost UDP control plane without changing the external LSL EEG contract.

Supported rehearsal controls include:

- `0` = no attended target / resting baseline;
- `1` = 10 Hz / Sight;
- `2` = 12 Hz / Guard;
- blink/jaw/controller/motion/saturation injection;
- Oz dropout/restore;
- `silence:SECONDS`;
- `gain:VALUE`;
- continuous delivery loss/jitter flags.

This lets Mindforge synchronize its diegetic REST → SIGHT → GUARD calibration presentation with the synthetic source and reproduce source-death/recovery tests without an operator racing a terminal prompt.

The control channel is simulator-only. It does not alter the LSL stream schema and is not part of the physical Unicorn path.

## Intended Mindforge boundary

`neurOS synthetic EEG -> LSL -> Mindforge acquisition/FBCCA -> derived NeuralEvent -> UDP -> Unity`

Raw synthetic or physical EEG stays outside Unity. This makes the Phantom source and a future physical Unicorn exercise the same Mindforge decoder/game boundary.

The corresponding Mindforge integration is in `sidhulyalkar/mindforge` PR #1.

## Qualification

The branch was rebuilt as one reviewable commit directly on current `main` without changing the intended Phantom implementation.

Exact head `2534f5e91ee8937d6114ac15750b6bbc84d317aa` is green across:

- neurOS CI;
- Ecosystem Compatibility;
- neurOS driver contracts;
- Public Trust Contracts;
- Release Candidate Artifacts.

## Evidence boundary

This generator is not a physiological digital twin. Synthetic results are useful for falsifying software and gameplay assumptions, not for claiming human BCI performance. Physical hardware, display timing, real participant calibration and live closed-loop testing remain separate qualification gates.