### PR TITLE
evidence: add invariant SNAP geometry and ngc-learn interoperability

### DIFF
--- a/.github/workflows/neuroai-ecosystem-ci.yml
+++ b/.github/workflows/neuroai-ecosystem-ci.yml
@@ -82,13 +82,17 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - name: Install minimal conformance environment
+      - name: Install minimal CPU-only conformance environment
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e packages/neuros-foundation
-          python -m pip install torch tqdm
+          python -m pip install tqdm
+          # The upstream SNAP spectral reference only needs CPU tensor algebra.
+          # Pin the same Torch release used by the first successful conformance
+          # run, but source the official CPU wheel so CI never downloads CUDA.
+          python -m pip install torch==2.13.0 --index-url https://download.pytorch.org/whl/cpu
       - name: Execute authors' pinned spectral reference code
         run: |
           python scripts/evidence/verify_snap_upstream.py \

--- a/.github/workflows/neuroai-ecosystem-ci.yml
+++ b/.github/workflows/neuroai-ecosystem-ci.yml
@@ -1,0 +1,96 @@
+name: NeuroAI Ecosystem Evidence
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/__init__.py"
+      - "packages/neuros-foundation/pyproject.toml"
+      - "packages/neuros/src/neuros/compatibility.py"
+      - "packages/neuros-foundation/tests/test_spectral_alignment.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "docs/NEUROAI_ECOSYSTEM.md"
+      - "docs/COMPATIBILITY.md"
+      - "mkdocs.yml"
+      - ".github/workflows/neuroai-ecosystem-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/__init__.py"
+      - "packages/neuros-foundation/pyproject.toml"
+      - "packages/neuros/src/neuros/compatibility.py"
+      - "packages/neuros-foundation/tests/test_spectral_alignment.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "docs/NEUROAI_ECOSYSTEM.md"
+      - "docs/COMPATIBILITY.md"
+      - "mkdocs.yml"
+      - ".github/workflows/neuroai-ecosystem-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: neuroai-ecosystem-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spectral-evidence:
+    name: SNAP-derived spectral evidence / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install foundation evidence stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[dev]"
+      - name: Run invariant spectral contracts
+        run: pytest -q packages/neuros-foundation/tests/test_spectral_alignment.py
+      - name: Compile public evidence modules
+        run: |
+          python -m compileall -q \
+            packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py \
+            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
+
+  ngclearn-integration:
+    name: ngc-learn 3.2 integration / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # ngc-learn 3.2 publicly advertises Python 3.10/3.11. neurOS does not
+        # manufacture a Python 3.12 upstream-support claim on its behalf.
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install isolated ngc-learn evidence profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[ngclearn,dev]"
+      - name: Exercise real upstream package and RateCell dynamics
+        run: pytest -q packages/neuros-foundation/tests/test_ngclearn_bridge.py
+      - name: Report exact upstream identity
+        run: |
+          python - <<'PY'
+          import json
+          from neuros.foundation_models.ngclearn_bridge import ngclearn_runtime_identity
+          print(json.dumps(ngclearn_runtime_identity(), indent=2, sort_keys=True))
+          PY

--- a/.github/workflows/neuroai-ecosystem-ci.yml
+++ b/.github/workflows/neuroai-ecosystem-ci.yml
@@ -10,6 +10,7 @@ on:
       - "packages/neuros/src/neuros/compatibility.py"
       - "packages/neuros-foundation/tests/test_spectral_alignment.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "scripts/evidence/verify_snap_upstream.py"
       - "docs/NEUROAI_ECOSYSTEM.md"
       - "docs/COMPATIBILITY.md"
       - "mkdocs.yml"
@@ -24,6 +25,7 @@ on:
       - "packages/neuros/src/neuros/compatibility.py"
       - "packages/neuros-foundation/tests/test_spectral_alignment.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "scripts/evidence/verify_snap_upstream.py"
       - "docs/NEUROAI_ECOSYSTEM.md"
       - "docs/COMPATIBILITY.md"
       - "mkdocs.yml"
@@ -63,6 +65,36 @@ jobs:
           python -m compileall -q \
             packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py \
             packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
+
+  snap-upstream-conformance:
+    name: Pinned SNAP upstream invariant conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout exact SNAP reference revision
+        uses: actions/checkout@v4
+        with:
+          repository: chung-neuroai-lab/SNAP
+          ref: 76570574eab7b3115ed4503f8c4ecefaa2a7c5e6
+          path: upstream-snap
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install minimal conformance environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e packages/neuros-foundation
+          python -m pip install torch tqdm
+      - name: Execute authors' pinned spectral reference code
+        run: |
+          python scripts/evidence/verify_snap_upstream.py \
+            --snap-root upstream-snap \
+            --output "${RUNNER_TEMP}/snap-conformance.json"
+          test -s "${RUNNER_TEMP}/snap-conformance.json"
 
   ngclearn-integration:
     name: ngc-learn 3.2 integration / Python ${{ matrix.python-version }}

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,12 +1,14 @@
 # Ecosystem Compatibility
 
-neurOS treats compatibility as an evidence-bearing contract, not a logo wall. Every integration shown as supported must point to executable repository evidence, and the strongest public claim stops at the highest tier actually exercised.
+neurOS treats compatibility as an evidence-bearing contract, not a logo wall. Every integration shown as supported or evidence-bearing must point to executable repository evidence, and the strongest public claim stops at the highest tier actually exercised.
 
 Inspect the same source of truth programmatically:
 
 ```bash
 neuros compatibility
 neuros compatibility mne --json
+neuros compatibility ngclearn --json
+neuros compatibility snap --json
 neuros compatibility --status supported --json
 ```
 
@@ -22,9 +24,14 @@ The registry lives in `neuros.compatibility` and is covered by contract tests. D
 | NWB / PyNWB | supported | export, session provenance | integration | neurOS archive remains authoritative for exact runtime replay semantics |
 | Zarr | supported | export, session provenance | integration | export interoperability, not a replacement runtime format |
 | MOABB | experimental | dataset adapter, longitudinal split authority, model ladder | real dataset | benchmark surface is still evolving; result claims remain protocol-specific |
-| Braindecode | experimental | neural-window model adapter, upstream training bridge, decoder bridge | integration | qualified 1.7 whitelist only; no real-dataset, stable mech-int, hardware, or closed-loop claim yet |
+| Braindecode | experimental | neural-window model adapter, upstream training bridge, decoder bridge | integration | qualified 1.7 whitelist only; stable mech-int, hardware, and closed-loop claims remain separate |
+| SNAP spectral alignment | experimental | positive-rank spectrum, task power, residual target power | software contract | invariant numerical-method contract only; no paper-reproduction or biological-alignment claim |
+| ngc-learn | experimental | RateCell transform, upstream/JAX identity, biological-dynamics bridge | integration | real ngc-learn 3.2.x RateCell only; predictive coding, spiking, plasticity, real-data and closed-loop claims remain unqualified |
 | OpenBCI | indirect | reachable through BrainFlow | none | no named OpenBCI configuration is hardware-qualified |
 | Meta NeuralBench | planned | isolated benchmark worker, evidence extension | none | upstream runtime requirements must stay outside the kernel |
+| IBM NeuroAIKit | planned | isolated SNU reference worker | none | legacy TensorFlow-era environment is intentionally isolated |
+| NeuroAI Lab mouse-vision | planned | neural-predictivity benchmark | none | authoritative neural-data/artifact identities must be established first |
+| NeuroAI Lab TDANN | planned | topographic representation evidence | none | external benchmark only; licensing/artifact identity must be resolved before code reuse |
 | DANDI | planned | dataset discovery, provenance | none | no support claim yet |
 | SpikeInterface | planned | invasive recording/analyzer bridge | none | no support claim yet |
 | py_neuromodulation | planned | feature-transform adapter | none | no closed-loop qualification claim |
@@ -36,8 +43,8 @@ The CLI output is authoritative when this table and code ever disagree.
 
 Compatibility uses the same evidence ladder as the rest of neurOS:
 
-1. **software-contract**: deterministic fixtures/fakes prove the adapter's local semantics;
-2. **integration**: real upstream objects/files/SDK interfaces cross the neurOS boundary correctly;
+1. **software-contract**: deterministic fixtures/fakes prove the adapter or numerical operator's local semantics;
+2. **integration**: real upstream objects/files/SDK/package interfaces cross the neurOS boundary correctly;
 3. **real-dataset**: named public datasets run under frozen evaluation semantics;
 4. **hardware**: a named hardware + firmware + transport + software configuration passes measured qualification;
 5. **closed-loop**: the complete sensing-to-action loop passes timing, failure, and constraint qualification;
@@ -60,15 +67,9 @@ Convert MNE `Raw` into canonical frames:
 ```python
 from neuros.interop import frames_from_raw, stream_descriptor_from_raw
 
-raw = ...  # existing MNE Raw object
+raw = ...
 descriptor = stream_descriptor_from_raw(raw, stream_id="subject-01/eeg")
-frames = tuple(
-    frames_from_raw(
-        raw,
-        stream_id=descriptor.stream_id,
-        chunk_samples=256,
-    )
-)
+frames = tuple(frames_from_raw(raw, stream_id=descriptor.stream_id, chunk_samples=256))
 ```
 
 MNE stores arrays as `channel x sample`. neurOS chunk frames use `sample x channel` and explicitly stamp:
@@ -78,14 +79,6 @@ axis_order = ("sample", "channel")
 ```
 
 The reverse adapter refuses ambiguous two-dimensional frames that do not carry this metadata. It never guesses an axis, resamples data, pads missing samples, changes channel order, or repairs non-finite values.
-
-```python
-from neuros.interop import raw_from_signal_frames
-
-reconstructed = raw_from_signal_frames(frames, descriptor=descriptor)
-```
-
-When MNE exposes an absolute `meas_date`, the adapter derives synchronized frame timestamps from the measurement origin plus sample position. Without an absolute measurement time, recording-relative position remains provenance metadata and neurOS does not fabricate a synchronized clock.
 
 ## Live acquisition
 
@@ -103,7 +96,7 @@ This keeps timing transformations inspectable and replayable.
 
 ### MOABB
 
-MOABB is already used by the longitudinal EEG evidence program. The important neurOS contribution is not another dataset wrapper. It is preservation of subject/session/run identity, frozen calibration/evaluation authority, and the ability to compare task decoders, frozen representations, and transfer strategies without changing the evaluation target.
+MOABB is used by the longitudinal EEG evidence program. The neurOS contribution is not another dataset wrapper. It is preservation of subject/session/run identity, frozen calibration/evaluation authority, and the ability to compare task decoders, frozen representations, and transfer strategies without changing the evaluation target.
 
 See:
 
@@ -113,11 +106,7 @@ See:
 
 ### Braindecode
 
-Braindecode is now an **experimental integration**, backed by a dedicated optional-dependency qualification lane rather than by copied architectures. Install with:
-
-```bash
-pip install "neuros[braindecode]"
-```
+Braindecode is an **experimental integration**, backed by a dedicated optional-dependency qualification lane rather than copied architectures.
 
 The initial qualified surface is deliberately narrow:
 
@@ -126,31 +115,52 @@ The initial qualified surface is deliberately narrow:
 - `ShallowFBCSPNet`
 - `Deep4Net`
 
-All four are exercised against the canonical neurOS `(batch, channel, time)` window contract on the pinned Braindecode 1.7 line. EEGNet is additionally trained through the real upstream `EEGClassifier` path and executed through `SignalFrame -> NeuralWindow -> RuntimeGraph -> DecoderOutput` with window provenance retained.
+The adapter never silently resamples, pads, crops, filters, changes channel order, or constructs sensor geometry. It records upstream version identity and a deterministic adapter/training configuration fingerprint.
 
-The adapter never silently resamples, pads, crops, filters, changes channel order, or constructs sensor geometry. It records upstream version identity and a deterministic adapter/training configuration fingerprint. Python 3.10 remains free of the optional Braindecode dependency.
+### SNAP-derived spectral evidence
 
-This is an **integration** claim, not a task-performance claim. Braindecode remains below real-dataset evidence until one of its adapters runs under the frozen neurOS longitudinal authority on a named public dataset. Stable mechanistic hook paths are also deliberately unclaimed until architecture/version-specific intervention surfaces are qualified.
+neurOS now exposes SNAP-derived representation evidence without adding Torch/CUDA to the foundation package's required dependencies.
 
-See [Braindecode interoperability](BRAINDECODE.md) for the full boundary.
+```python
+from neuros.foundation_models import spectral_alignment_evidence
+
+evidence = spectral_alignment_evidence(embeddings, neural_targets)
+```
+
+The implementation deliberately reports only positive-rank spectral modes individually. Target power outside that span is aggregated into one residual term because individual zero-eigenvalue eigenvectors are not uniquely defined. This removes a backend-dependent ambiguity while preserving the scientifically meaningful SNAP quantities.
+
+The current evidence tier is **software-contract**, not a claim that the SNAP paper was reproduced or that a representation is biologically aligned.
+
+See [NeuroAI Ecosystem Evidence](NEUROAI_ECOSYSTEM.md).
+
+### ngc-learn
+
+Install the isolated research integration with:
+
+```bash
+pip install "neuros-foundation[ngclearn]"
+```
+
+The first qualified surface executes the real ngc-learn 3.2.x `RateCell` and records exact upstream/JAX identity, sample-rate-derived integration step, input/output geometry, configuration, and hashes.
+
+It does not silently resample, filter, normalize, pad, reorder channels, or fit. Successful RateCell integration does **not** promote predictive-coding circuits, spiking networks, Hebbian/STDP learning, real-data performance, or closed-loop behavior.
 
 ### NeuralBench
 
-NeuralBench should run as an isolated benchmark worker, especially while its Python/runtime requirements differ from the neurOS kernel support matrix. The worker should consume or export explicit dataset/model/protocol identities and return neurOS evidence artifacts containing additional dimensions such as:
+NeuralBench should run as an isolated benchmark worker, especially while its Python/runtime requirements differ from the neurOS kernel support matrix. neurOS should extend its evidence rather than recreate its task registry.
 
-- subject/session/device transfer;
-- representation geometry;
-- montage robustness;
-- artifact sensitivity;
-- calibration cost;
-- mechanistic intervention results;
-- runtime latency and memory.
+## NeuroAI research references
 
-neurOS should extend NeuralBench evidence rather than recreate its task registry.
+The ecosystem registry names concrete research projects rather than pretending an entire lab or GitHub organization is one integration.
+
+- IBM NeuroAIKit remains a planned isolated SNU reference worker.
+- NeuroAI Lab `mouse-vision` is a planned neural-predictivity benchmark.
+- NeuroAI Lab TDANN is a planned topographic-representation benchmark.
+- Cognizant Neuro SAN Studio is intentionally **not** a neuroscience compatibility entry; its value to neurOS is product/community design inspiration rather than neural-runtime interoperability.
 
 ## Invasive and public-data lane
 
-The next interoperability cluster is NWB + DANDI + SpikeInterface + py_neuromodulation. The intended direction is:
+The next interoperability cluster is NWB + DANDI + SpikeInterface + py_neuromodulation.
 
 ```text
 DANDI / NWB / SpikeInterface
@@ -175,11 +185,12 @@ The invasive lane should not force spike-sorting, dataset-client, or neuromodula
 A new integration should land in this order:
 
 1. define the exact external boundary and what neurOS will not reimplement;
-2. implement an optional adapter/plugin outside `neuros-core`;
+2. implement an optional adapter/plugin or evidence operator outside `neuros-core`;
 3. add deterministic contract tests;
 4. add a registry entry at the weakest accurate status/evidence tier;
-5. add a clean-install CI lane with the optional dependency;
-6. add real upstream integration evidence where practical;
-7. promote status or evidence tier only in the same change that adds the missing evidence.
+5. add a clean-install CI lane with the optional dependency where appropriate;
+6. add real upstream integration evidence;
+7. add named real-data, hardware, or closed-loop evidence only when actually exercised;
+8. promote status or evidence tier only in the same change that adds the missing evidence.
 
 A README example alone is never sufficient to mark an integration supported.

--- a/docs/NEUROAI_ECOSYSTEM.md
+++ b/docs/NEUROAI_ECOSYSTEM.md
@@ -1,0 +1,191 @@
+# NeuroAI Ecosystem Evidence
+
+neurOS integrates external neuroscience and NeuroAI projects according to one rule: **an integration claim must be no stronger than the executable evidence behind it**.
+
+The goal is not to collect logos. The goal is to make neurOS a dependable seam between acquisition, neural computation, learned representations, deployment, and scientific evidence while keeping `neuros-core` small and stable.
+
+## Integration classes
+
+External projects fall into four classes.
+
+1. **Runtime/interoperability integration**: a real upstream package or object crosses a neurOS boundary under executable tests.
+2. **Scientific-method integration**: neurOS implements or delegates a published analysis under frozen numerical definitions and explicit provenance.
+3. **Benchmark/reference target**: a project is scientifically relevant but remains external until its artifacts, licensing, environment, and protocol are qualified.
+4. **Deliberate non-integration**: a useful project may inspire product or community design without belonging in the neural runtime or scientific dependency graph.
+
+This distinction prevents research-code environments from becoming hidden kernel dependencies.
+
+## SNAP-derived invariant spectral evidence
+
+The Chung NeuroAI Lab's SNAP work introduces a spectral vocabulary for relating representation geometry to neural or task targets. neurOS now exposes a dependency-light NumPy implementation through:
+
+```python
+from neuros.foundation_models import spectral_alignment_evidence
+
+evidence = spectral_alignment_evidence(representations, targets)
+print(evidence.effective_dimension)
+print(evidence.residual_target_power)
+```
+
+The v1 evidence object records:
+
+- positive representation eigenvalues;
+- target power captured by each positive-rank mode;
+- cumulative captured target power;
+- participation-ratio effective dimension;
+- an effective dimension of remaining task power;
+- aggregate target power outside the representation span;
+- input and target SHA-256 identities;
+- a deterministic evidence digest.
+
+### Why neurOS does not expose every SNAP null-space mode
+
+For a rank-deficient sample kernel, the eigenvectors associated with zero eigenvalues are not unique. Two correct linear-algebra backends may rotate that null space and therefore assign different target power to individual zero-eigenvalue vectors even though the represented subspace is identical.
+
+neurOS treats that as an evidence-design problem rather than hiding it behind a tolerance. Positive-rank modes remain explicit and all target power outside their span is aggregated into one invariant residual quantity.
+
+That gives the evidence a stable interpretation across valid eigensolver implementations.
+
+The current public claim is a **software-contract numerical-method claim**. It does not imply that SNAP's paper results were reproduced, that a model is biologically aligned, or that a representation is mechanistically equivalent to a brain circuit.
+
+## ngc-learn interoperability
+
+`ngc-learn` is an actively maintained JAX toolkit for computational neuroscience and biologically plausible NeuroAI, including graded neural dynamics, spiking cells, predictive-coding building blocks, Hebbian/STDP synapses, and neural input encoders.
+
+neurOS keeps it optional:
+
+```bash
+pip install "neuros-foundation[ngclearn]"
+```
+
+The first qualified upstream surface is intentionally narrow: the **ngc-learn 3.2.x `RateCell`**.
+
+```python
+from neuros.foundation_models import NgcLearnRateCellTransform
+
+transform = NgcLearnRateCellTransform(
+    tau_m_ms=10.0,
+    activation="identity",
+    integration_type="euler",
+)
+result = transform.transform(samples, sample_rate_hz=250.0)
+```
+
+The bridge records:
+
+- exact ngc-learn version;
+- exact JAX version and backend;
+- JAX x64 state when observable;
+- upstream component identity;
+- time-by-channel input and output geometry;
+- sample rate and derived integration step;
+- RateCell parameters and seed;
+- input/output hashes and an evidence digest.
+
+It performs **no hidden resampling, filtering, normalization, padding, fitting, or channel reordering**.
+
+The integration CI exercises the real upstream package. neurOS does not infer support for all of ngc-learn from one successful component test.
+
+### Planned ngc-learn evidence ladder
+
+1. RateCell upstream execution and geometry;
+2. an explicit predictive-coding circuit with frozen dynamics/evidence semantics;
+3. spiking-cell and STDP/Hebbian learning contracts;
+4. real neural-data evaluation under deployment-unit-disjoint protocols;
+5. comparison against ORION representations and adaptation strategies;
+6. closed-loop qualification only if a complete sensing-to-action system is actually measured.
+
+Each step must land with its own evidence before the compatibility claim is promoted.
+
+## Other evaluated NeuroAI projects
+
+### IBM NeuroAIKit
+
+IBM NeuroAIKit remains a **planned isolated reference worker**, not a neurOS dependency. Its SNU work is scientifically useful as a historical biologically inspired baseline, while its TensorFlow-era environment should not constrain the current neurOS Python/runtime matrix.
+
+### NeuroAI Lab projects
+
+The `neuroailab` organization is not represented as one integration because its repositories cover very different scientific problems and environments.
+
+- **mouse-vision** is a planned neural-predictivity benchmark, with future neurOS evidence preferably bound to authoritative Allen/public-data identities.
+- **TDANN** is a planned topographic-representation benchmark. Licensing and reproducible artifact identity must be resolved before implementation code is reused.
+- older paper-specific environments can remain isolated reference workers rather than forcing legacy TensorFlow/Python dependencies into neurOS.
+
+### Chung NeuroAI Lab
+
+SNAP is the first method integrated because its representation geometry maps directly onto the neurOS evidence plane. Other work on manifold geometry, feature learning, and spontaneous retinal representations is valuable input to future ORION evaluation but is not automatically a package dependency.
+
+### Neuro SAN Studio
+
+Cognizant's Neuro SAN Studio is an LLM multi-agent orchestration product, not a neuroscience runtime. neurOS therefore does **not** list it as scientific compatibility. Its declarative workflows, traceability, project scaffolding, security/support documentation, and visual tooling are useful product-design references for a future neurOS Studio.
+
+## Toward evidence conformance
+
+The long-term pattern is:
+
+```text
+reference method / upstream package
+             |
+             v
+      frozen input identity
+             |
+             v
+   neurOS adapter/operator
+             |
+             v
+ numerical/runtime comparison
+             |
+             v
+ evidence conformance artifact
+```
+
+A future `EvidenceConformanceManifest` should bind:
+
+- method name and citation;
+- upstream repository and revision;
+- license;
+- upstream environment identity;
+- neurOS operator/revision;
+- fixture/data hashes;
+- numerical tolerances or exact semantic rules;
+- comparison result;
+- explicit claim boundary.
+
+This is the difference between saying **"neurOS has an implementation"** and saying **"this implementation has executable evidence connecting it to the referenced method."**
+
+## ORION connection
+
+ORION should consume this ecosystem through stable neurOS contracts rather than bespoke research scripts. A future ORION representation card should pair task performance and calibration cost with evidence such as:
+
+- spectral effective dimension;
+- task-aligned mode power;
+- residual target power;
+- cross-session and cross-subject geometry;
+- domain leakage;
+- montage/device robustness;
+- causal intervention stability;
+- uncertainty calibration;
+- runtime latency;
+- immutable dataset/model/evidence identities.
+
+The research objective remains practical: achieve the same or better held-out neural performance with materially less user-specific calibration, while showing *why* the representation transfers and where the claim stops.
+
+## Design invariant
+
+External ecosystems may evolve quickly. neurOS runtime contracts should evolve slowly.
+
+```text
+external research package
+        |
+        v
+optional adapter / evidence worker
+        |
+        v
+stable neurOS neural contracts
+        |
+        +----> runtime / replay
+        +----> ORION
+        +----> evidence / qualification
+```
+
+No integration should reverse that dependency direction merely because importing it is convenient.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Platform:
       - Four Public Surfaces: PLATFORM.md
       - Ecosystem Compatibility: COMPATIBILITY.md
+      - NeuroAI Ecosystem: NEUROAI_ECOSYSTEM.md
       - Qualification Bundles: QUALIFICATION.md
       - Hardware Qualification: HARDWARE_QUALIFICATION.md
       - Architecture: ARCHITECTURE.md

--- a/packages/neuros-foundation/pyproject.toml
+++ b/packages/neuros-foundation/pyproject.toml
@@ -18,6 +18,8 @@ keywords = [
     "neural-decoding",
     "representation-learning",
     "benchmarking",
+    "neuroai",
+    "ngc-learn",
     "poyo",
     "ndt",
     "cebra",
@@ -47,6 +49,7 @@ eeg = ["mne>=1.6.0"]
 evidence = ["moabb>=1.5.0,<2"]
 moabb = ["moabb>=1.5.0,<2"]
 braindecode-evidence = ["braindecode>=1.7,<1.8; python_version >= '3.11'"]
+ngclearn = ["ngclearn>=3.2,<3.3; python_version < '3.12'"]
 # SourceWeigher is a sibling workspace package and is intentionally installed
 # explicitly in the full ladder profile until it has a published distribution.
 ladder = ["torch>=2.1.0"]

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -64,6 +64,14 @@ from neuros.foundation_models.moabb_longitudinal import (
     get_moabb_longitudinal_spec,
     validate_observed_sessions,
 )
+from neuros.foundation_models.ngclearn_bridge import (
+    NgcLearnRateCellEvidence,
+    NgcLearnRateCellResult,
+    NgcLearnRateCellTransform,
+    NgcLearnUnavailableError,
+    NgcLearnVersionError,
+    ngclearn_runtime_identity,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -104,6 +112,12 @@ from neuros.foundation_models.schema import (
     ModelStatus,
     ModelTask,
     NeuralModality,
+)
+from neuros.foundation_models.spectral_alignment import (
+    SPECTRAL_METHOD_ID,
+    SpectralAlignmentEvidence,
+    spectral_alignment_evidence,
+    verify_snap_invariant_reference,
 )
 
 try:
@@ -170,6 +184,16 @@ __all__ = [
     "linear_probe",
     "domain_leakage_probe",
     "pairwise_cka",
+    "SPECTRAL_METHOD_ID",
+    "SpectralAlignmentEvidence",
+    "spectral_alignment_evidence",
+    "verify_snap_invariant_reference",
+    "NgcLearnUnavailableError",
+    "NgcLearnVersionError",
+    "NgcLearnRateCellEvidence",
+    "NgcLearnRateCellResult",
+    "NgcLearnRateCellTransform",
+    "ngclearn_runtime_identity",
     "EvaluationProtocol",
     "BenchmarkReport",
     "benchmark_embeddings",

--- a/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
@@ -1,0 +1,330 @@
+"""Optional ngc-learn interoperability for biologically plausible neural dynamics.
+
+The bridge is intentionally outside ``neuros-core``. ngc-learn and JAX remain
+optional research dependencies, while neurOS owns explicit input geometry,
+upstream identity, output geometry, and evidence hashes.
+
+The initial qualified surface is deliberately narrow: ngc-learn 3.2 RateCell
+execution. Predictive-coding circuits, spiking networks, Hebbian/STDP learning,
+and larger ngc-learn systems can be layered on this boundary after their exact
+execution contracts are independently exercised.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.metadata
+import json
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+
+NGCLEARN_SUPPORTED_SERIES = (3, 2)
+NGCLEARN_REFERENCE_REPOSITORY = "https://github.com/NACLab/ngc-learn"
+NgcLearnOutput = Literal["linear", "nonlinear"]
+
+
+class NgcLearnUnavailableError(ImportError):
+    """Raised when the optional ngc-learn/JAX integration cannot be used."""
+
+
+class NgcLearnVersionError(RuntimeError):
+    """Raised when an unqualified ngc-learn version is selected."""
+
+
+def _version() -> str:
+    try:
+        return importlib.metadata.version("ngclearn")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise NgcLearnUnavailableError(
+            'ngc-learn is not installed; use `pip install "neuros-foundation[ngclearn]"`'
+        ) from exc
+
+
+def _major_minor(version: str) -> tuple[int, int]:
+    core = version.split("+", 1)[0].split("-", 1)[0]
+    pieces = core.split(".")
+    if len(pieces) < 2:
+        raise NgcLearnVersionError(f"cannot parse ngc-learn version {version!r}")
+    try:
+        return int(pieces[0]), int(pieces[1])
+    except ValueError as exc:
+        raise NgcLearnVersionError(f"cannot parse ngc-learn version {version!r}") from exc
+
+
+def _load_upstream() -> tuple[Any, Any, Any, Any, Any, str]:
+    version = _version()
+    if _major_minor(version) != NGCLEARN_SUPPORTED_SERIES:
+        raise NgcLearnVersionError(
+            "neurOS currently qualifies only the ngc-learn 3.2 line; "
+            f"found {version}. Install ngclearn>=3.2,<3.3 or add a new qualification lane."
+        )
+    try:
+        ngclearn = importlib.import_module("ngclearn")
+        components = importlib.import_module("ngclearn.components")
+        jax = importlib.import_module("jax")
+        jnp = importlib.import_module("jax.numpy")
+        random = importlib.import_module("jax.random")
+    except ImportError as exc:
+        raise NgcLearnUnavailableError(
+            "ngc-learn is installed but its JAX/runtime dependencies could not be imported"
+        ) from exc
+
+    for symbol in ("RateCell", "LIFCell", "HebbianSynapse", "STDPSynapse"):
+        if not hasattr(components, symbol):
+            raise NgcLearnVersionError(
+                f"qualified ngc-learn 3.2 surface is missing expected component {symbol}"
+            )
+    if not hasattr(ngclearn, "Context") or not hasattr(ngclearn, "MethodProcess"):
+        raise NgcLearnVersionError("qualified ngc-learn surface is missing Context/MethodProcess")
+    return ngclearn, components, jax, jnp, random, version
+
+
+def ngclearn_runtime_identity() -> dict[str, Any]:
+    """Return the exact installed upstream surface used by the integration."""
+
+    ngclearn, components, jax, _, _, version = _load_upstream()
+    try:
+        x64_enabled: bool | None = bool(jax.config.read("jax_enable_x64"))
+    except Exception:
+        x64_enabled = None
+    return {
+        "integration": "ngc-learn",
+        "reference_repository": NGCLEARN_REFERENCE_REPOSITORY,
+        "ngclearn_version": version,
+        "jax_version": str(getattr(jax, "__version__", "unknown")),
+        "jax_backend": str(jax.default_backend()),
+        "jax_enable_x64": x64_enabled,
+        "qualified_series": "3.2.x",
+        "qualified_symbols": [
+            f"{ngclearn.__name__}.Context",
+            f"{ngclearn.__name__}.MethodProcess",
+            f"{components.RateCell.__module__}.{components.RateCell.__name__}",
+            f"{components.LIFCell.__module__}.{components.LIFCell.__name__}",
+            f"{components.HebbianSynapse.__module__}.{components.HebbianSynapse.__name__}",
+            f"{components.STDPSynapse.__module__}.{components.STDPSynapse.__name__}",
+        ],
+    }
+
+
+def _matrix(values: Any) -> np.ndarray:
+    matrix = np.asarray(values, dtype=np.float64)
+    if matrix.ndim != 2:
+        raise ValueError(f"samples must be a 2D time x channel matrix; got shape {matrix.shape}")
+    if matrix.shape[0] < 1 or matrix.shape[1] < 1:
+        raise ValueError("samples must contain at least one time step and one channel")
+    if not np.isfinite(matrix).all():
+        raise ValueError("samples contain NaN or infinite values")
+    return np.ascontiguousarray(matrix, dtype=np.float64)
+
+
+def _array_sha256(array: np.ndarray) -> str:
+    digest = hashlib.sha256()
+    digest.update(str(array.shape).encode("utf-8"))
+    digest.update(str(array.dtype).encode("utf-8"))
+    digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _canonical_sha256(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class NgcLearnRateCellEvidence:
+    """Provenance for one ngc-learn RateCell transform."""
+
+    ngclearn_version: str
+    jax_version: str
+    jax_backend: str
+    jax_enable_x64: bool | None
+    component: str
+    output_compartment: str
+    tau_m_ms: float
+    gamma: float
+    activation: str
+    integration_type: str
+    seed: int
+    sample_rate_hz: float
+    dt_ms: float
+    input_shape: tuple[int, int]
+    output_shape: tuple[int, int]
+    input_sha256: str
+    output_sha256: str
+    evidence_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "integration": "ngc-learn",
+            "reference_repository": NGCLEARN_REFERENCE_REPOSITORY,
+            "ngclearn_version": self.ngclearn_version,
+            "jax_version": self.jax_version,
+            "jax_backend": self.jax_backend,
+            "jax_enable_x64": self.jax_enable_x64,
+            "component": self.component,
+            "output_compartment": self.output_compartment,
+            "tau_m_ms": self.tau_m_ms,
+            "gamma": self.gamma,
+            "activation": self.activation,
+            "integration_type": self.integration_type,
+            "seed": self.seed,
+            "sample_rate_hz": self.sample_rate_hz,
+            "dt_ms": self.dt_ms,
+            "input_shape": list(self.input_shape),
+            "output_shape": list(self.output_shape),
+            "input_sha256": self.input_sha256,
+            "output_sha256": self.output_sha256,
+            "evidence_sha256": self.evidence_sha256,
+            "claim_boundary": {
+                "upstream_package_executed": True,
+                "rate_cell_contract_exercised": True,
+                "predictive_coding_circuit_qualified": False,
+                "spiking_network_qualified": False,
+                "online_learning_qualified": False,
+                "real_dataset_qualified": False,
+                "hardware_qualified": False,
+                "closed_loop_qualified": False,
+            },
+        }
+
+
+@dataclass(slots=True)
+class NgcLearnRateCellResult:
+    """RateCell representation values plus immutable execution evidence."""
+
+    values: np.ndarray
+    evidence: NgcLearnRateCellEvidence
+
+
+class NgcLearnRateCellTransform:
+    """Execute an ngc-learn 3.2 RateCell over a time x channel matrix.
+
+    The transform performs no resampling, filtering, normalization, padding,
+    channel reordering, or fitting. One RateCell unit is created per input
+    channel and the upstream dynamical state is reset before each call.
+    """
+
+    def __init__(
+        self,
+        *,
+        tau_m_ms: float = 10.0,
+        gamma: float = 1.0,
+        activation: str = "identity",
+        integration_type: str = "euler",
+        output: NgcLearnOutput = "linear",
+        seed: int = 0,
+    ) -> None:
+        if isinstance(tau_m_ms, bool) or not isinstance(tau_m_ms, (int, float)):
+            raise ValueError("tau_m_ms must be numeric")
+        if float(tau_m_ms) <= 0 or not math.isfinite(float(tau_m_ms)):
+            raise ValueError("tau_m_ms must be positive and finite")
+        if isinstance(gamma, bool) or not isinstance(gamma, (int, float)):
+            raise ValueError("gamma must be numeric")
+        if not math.isfinite(float(gamma)):
+            raise ValueError("gamma must be finite")
+        if not isinstance(activation, str) or not activation.strip():
+            raise ValueError("activation must be a non-empty string")
+        if not isinstance(integration_type, str) or not integration_type.strip():
+            raise ValueError("integration_type must be a non-empty string")
+        if output not in {"linear", "nonlinear"}:
+            raise ValueError("output must be 'linear' or 'nonlinear'")
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("seed must be a non-negative integer")
+        self.tau_m_ms = float(tau_m_ms)
+        self.gamma = float(gamma)
+        self.activation = activation.strip()
+        self.integration_type = integration_type.strip()
+        self.output = output
+        self.seed = seed
+
+    def transform(self, samples: Any, *, sample_rate_hz: float) -> NgcLearnRateCellResult:
+        if isinstance(sample_rate_hz, bool) or not isinstance(sample_rate_hz, (int, float)):
+            raise ValueError("sample_rate_hz must be numeric")
+        sample_rate_hz = float(sample_rate_hz)
+        if sample_rate_hz <= 0 or not math.isfinite(sample_rate_hz):
+            raise ValueError("sample_rate_hz must be positive and finite")
+
+        matrix = _matrix(samples)
+        ngclearn, components, jax, jnp, random, version = _load_upstream()
+        dt_ms = 1000.0 / sample_rate_hz
+        n_channels = matrix.shape[1]
+
+        with ngclearn.Context("neuros_ngclearn_ratecell"):
+            cell = components.RateCell(
+                "z0",
+                n_units=n_channels,
+                tau_m=self.tau_m_ms,
+                act_fx=self.activation,
+                prior=("gaussian", self.gamma),
+                integration_type=self.integration_type,
+                key=random.PRNGKey(self.seed),
+            )
+            advance_process = ngclearn.MethodProcess("advance") >> cell.advance_state
+            reset_process = ngclearn.MethodProcess("reset") >> cell.reset
+
+        reset_process.run()
+        outputs: list[np.ndarray] = []
+        for index, row in enumerate(matrix):
+            cell.j.set(jnp.asarray(row[None, :]))
+            advance_process.run(t=float(index) * dt_ms, dt=dt_ms)
+            compartment = cell.z if self.output == "linear" else cell.zF
+            value = np.asarray(compartment.get(), dtype=np.float64).reshape(-1)
+            if value.size != n_channels:
+                raise RuntimeError(
+                    "ngc-learn RateCell output geometry changed unexpectedly: "
+                    f"expected {n_channels} values, received {value.size}"
+                )
+            if not np.isfinite(value).all():
+                raise RuntimeError("ngc-learn RateCell produced non-finite output")
+            outputs.append(value)
+
+        representation = np.ascontiguousarray(np.stack(outputs, axis=0), dtype=np.float64)
+        try:
+            x64_enabled: bool | None = bool(jax.config.read("jax_enable_x64"))
+        except Exception:
+            x64_enabled = None
+        payload: dict[str, Any] = {
+            "ngclearn_version": version,
+            "jax_version": str(getattr(jax, "__version__", "unknown")),
+            "jax_backend": str(jax.default_backend()),
+            "jax_enable_x64": x64_enabled,
+            "component": f"{components.RateCell.__module__}.{components.RateCell.__name__}",
+            "output_compartment": "z" if self.output == "linear" else "zF",
+            "tau_m_ms": self.tau_m_ms,
+            "gamma": self.gamma,
+            "activation": self.activation,
+            "integration_type": self.integration_type,
+            "seed": self.seed,
+            "sample_rate_hz": sample_rate_hz,
+            "dt_ms": dt_ms,
+            "input_shape": [int(value) for value in matrix.shape],
+            "output_shape": [int(value) for value in representation.shape],
+            "input_sha256": _array_sha256(matrix),
+            "output_sha256": _array_sha256(representation),
+        }
+        payload["evidence_sha256"] = _canonical_sha256(payload)
+        evidence = NgcLearnRateCellEvidence(
+            ngclearn_version=str(payload["ngclearn_version"]),
+            jax_version=str(payload["jax_version"]),
+            jax_backend=str(payload["jax_backend"]),
+            jax_enable_x64=payload["jax_enable_x64"],
+            component=str(payload["component"]),
+            output_compartment=str(payload["output_compartment"]),
+            tau_m_ms=float(payload["tau_m_ms"]),
+            gamma=float(payload["gamma"]),
+            activation=str(payload["activation"]),
+            integration_type=str(payload["integration_type"]),
+            seed=int(payload["seed"]),
+            sample_rate_hz=float(payload["sample_rate_hz"]),
+            dt_ms=float(payload["dt_ms"]),
+            input_shape=tuple(payload["input_shape"]),
+            output_shape=tuple(payload["output_shape"]),
+            input_sha256=str(payload["input_sha256"]),
+            output_sha256=str(payload["output_sha256"]),
+            evidence_sha256=str(payload["evidence_sha256"]),
+        )
+        return NgcLearnRateCellResult(values=representation, evidence=evidence)

--- a/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import importlib
 import importlib.metadata
+import itertools
 import json
 import math
 from dataclasses import dataclass
@@ -25,6 +26,7 @@ import numpy as np
 NGCLEARN_SUPPORTED_SERIES = (3, 2)
 NGCLEARN_REFERENCE_REPOSITORY = "https://github.com/NACLab/ngc-learn"
 NgcLearnOutput = Literal["linear", "nonlinear"]
+_CONTEXT_IDS = itertools.count()
 
 
 class NgcLearnUnavailableError(ImportError):
@@ -205,7 +207,9 @@ class NgcLearnRateCellTransform:
 
     The transform performs no resampling, filtering, normalization, padding,
     channel reordering, or fitting. One RateCell unit is created per input
-    channel and the upstream dynamical state is reset before each call.
+    channel. The upstream model is initialized lazily once per transform object
+    and reset before every call so ngcsimlib's process-global Context registry
+    cannot accidentally return an older model with the same path.
     """
 
     def __init__(
@@ -240,20 +244,22 @@ class NgcLearnRateCellTransform:
         self.integration_type = integration_type.strip()
         self.output = output
         self.seed = seed
+        self._context_id = next(_CONTEXT_IDS)
+        self._runtime: tuple[Any, Any, Any, Any, Any, str] | None = None
+        self._runtime_channels: int | None = None
 
-    def transform(self, samples: Any, *, sample_rate_hz: float) -> NgcLearnRateCellResult:
-        if isinstance(sample_rate_hz, bool) or not isinstance(sample_rate_hz, (int, float)):
-            raise ValueError("sample_rate_hz must be numeric")
-        sample_rate_hz = float(sample_rate_hz)
-        if sample_rate_hz <= 0 or not math.isfinite(sample_rate_hz):
-            raise ValueError("sample_rate_hz must be positive and finite")
+    def _ensure_runtime(self, n_channels: int) -> tuple[Any, Any, Any, Any, Any, str]:
+        if self._runtime is not None:
+            if self._runtime_channels != n_channels:
+                raise ValueError(
+                    "NgcLearnRateCellTransform input channel count is fixed after first execution; "
+                    f"expected {self._runtime_channels}, received {n_channels}"
+                )
+            return self._runtime
 
-        matrix = _matrix(samples)
         ngclearn, components, jax, jnp, random, version = _load_upstream()
-        dt_ms = 1000.0 / sample_rate_hz
-        n_channels = matrix.shape[1]
-
-        with ngclearn.Context("neuros_ngclearn_ratecell"):
+        context_name = f"neuros_ngclearn_ratecell_{self._context_id}"
+        with ngclearn.Context(context_name):
             cell = components.RateCell(
                 "z0",
                 n_units=n_channels,
@@ -265,6 +271,22 @@ class NgcLearnRateCellTransform:
             )
             advance_process = ngclearn.MethodProcess("advance") >> cell.advance_state
             reset_process = ngclearn.MethodProcess("reset") >> cell.reset
+
+        self._runtime = (cell, advance_process, reset_process, jax, jnp, version)
+        self._runtime_channels = n_channels
+        return self._runtime
+
+    def transform(self, samples: Any, *, sample_rate_hz: float) -> NgcLearnRateCellResult:
+        if isinstance(sample_rate_hz, bool) or not isinstance(sample_rate_hz, (int, float)):
+            raise ValueError("sample_rate_hz must be numeric")
+        sample_rate_hz = float(sample_rate_hz)
+        if sample_rate_hz <= 0 or not math.isfinite(sample_rate_hz):
+            raise ValueError("sample_rate_hz must be positive and finite")
+
+        matrix = _matrix(samples)
+        dt_ms = 1000.0 / sample_rate_hz
+        n_channels = matrix.shape[1]
+        cell, advance_process, reset_process, jax, jnp, version = self._ensure_runtime(n_channels)
 
         reset_process.run()
         outputs: list[np.ndarray] = []
@@ -292,7 +314,7 @@ class NgcLearnRateCellTransform:
             "jax_version": str(getattr(jax, "__version__", "unknown")),
             "jax_backend": str(jax.default_backend()),
             "jax_enable_x64": x64_enabled,
-            "component": f"{components.RateCell.__module__}.{components.RateCell.__name__}",
+            "component": f"{cell.__class__.__module__}.{cell.__class__.__name__}",
             "output_compartment": "z" if self.output == "linear" else "zF",
             "tau_m_ms": self.tau_m_ms,
             "gamma": self.gamma,

--- a/packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py
@@ -1,0 +1,315 @@
+"""Backend-stable spectral representation evidence derived from SNAP.
+
+SNAP (Spectral theory of Neural Alignment and Prediction) motivates a useful
+vocabulary for relating representation eigenspectra to task/neural targets. The
+upstream research implementation eigendecomposes the sample kernel and projects
+targets onto its eigenvectors.
+
+neurOS preserves the scientifically meaningful part of that construction while
+hardening one important numerical ambiguity: eigenvectors inside an exact kernel
+null space are not unique. Different valid LAPACK/Torch backends can therefore
+redistribute target power among zero-eigenvalue modes. neurOS reports only
+positive-rank modes individually and aggregates all out-of-span target power
+into one residual term. This makes the evidence invariant to arbitrary null-space
+basis rotations while retaining the SNAP interpretation.
+
+The implementation is dependency-light NumPy and does not claim reproduced SNAP
+paper results, biological alignment, or mechanistic equivalence. Those stronger
+claims require separate evidence artifacts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+SPECTRAL_METHOD_ID = "neuros-snap-invariant-spectral-alignment-v1"
+SNAP_REFERENCE_REPOSITORY = "https://github.com/chung-neuroai-lab/SNAP"
+SNAP_REFERENCE_PAPER = "Canatar et al., NeurIPS 2023, A Spectral Theory of Neural Prediction and Alignment"
+
+
+def _matrix(values: Any, *, name: str) -> np.ndarray:
+    matrix = np.asarray(values, dtype=np.float64)
+    if matrix.ndim == 1:
+        matrix = matrix[:, None]
+    if matrix.ndim != 2:
+        raise ValueError(f"{name} must be a 2D matrix; got shape {matrix.shape}")
+    if matrix.shape[0] < 2:
+        raise ValueError(f"{name} must contain at least two samples")
+    if matrix.shape[1] < 1:
+        raise ValueError(f"{name} must contain at least one feature")
+    if not np.isfinite(matrix).all():
+        raise ValueError(f"{name} contains NaN or infinite values")
+    return np.ascontiguousarray(matrix, dtype=np.float64)
+
+
+def _array_sha256(array: np.ndarray) -> str:
+    digest = hashlib.sha256()
+    digest.update(str(array.shape).encode("utf-8"))
+    digest.update(str(array.dtype).encode("utf-8"))
+    digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _participation_ratio(values: np.ndarray, *, eps: float = 1e-15) -> float:
+    vector = np.asarray(values, dtype=np.float64)
+    denominator = float(np.square(vector).sum())
+    if denominator <= eps:
+        return 0.0
+    return float(vector.sum()) ** 2 / denominator
+
+
+def _canonical_sha256(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class SpectralAlignmentEvidence:
+    """Immutable spectral evidence for one aligned representation/target matrix."""
+
+    method_id: str
+    reference_method: str
+    reference_repository: str
+    centered: bool
+    rank_tolerance: float
+    n_samples: int
+    n_features: int
+    target_dim: int
+    feature_rank: int
+    positive_eigenvalues: tuple[float, ...]
+    target_power_by_mode: tuple[float, ...]
+    cumulative_captured_target_power: tuple[float, ...]
+    effective_dimension: float
+    task_tail_effective_dimension: float
+    residual_target_power: float
+    representation_sha256: str
+    target_sha256: str
+    evidence_sha256: str
+    upstream_invariant_conformance_verified: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "method_id": self.method_id,
+            "reference_method": self.reference_method,
+            "reference_repository": self.reference_repository,
+            "centered": self.centered,
+            "rank_tolerance": self.rank_tolerance,
+            "n_samples": self.n_samples,
+            "n_features": self.n_features,
+            "target_dim": self.target_dim,
+            "feature_rank": self.feature_rank,
+            "positive_eigenvalues": list(self.positive_eigenvalues),
+            "target_power_by_mode": list(self.target_power_by_mode),
+            "cumulative_captured_target_power": list(self.cumulative_captured_target_power),
+            "effective_dimension": self.effective_dimension,
+            "task_tail_effective_dimension": self.task_tail_effective_dimension,
+            "residual_target_power": self.residual_target_power,
+            "representation_sha256": self.representation_sha256,
+            "target_sha256": self.target_sha256,
+            "evidence_sha256": self.evidence_sha256,
+            "upstream_invariant_conformance_verified": self.upstream_invariant_conformance_verified,
+            "claim_boundary": {
+                "snap_invariant_definitions_implemented": True,
+                "null_space_basis_invariant": True,
+                "upstream_invariant_conformance_verified": self.upstream_invariant_conformance_verified,
+                "snap_paper_results_reproduced": False,
+                "biological_alignment_established": False,
+                "mechanistic_equivalence_established": False,
+            },
+        }
+
+
+def spectral_alignment_evidence(
+    representations: Any,
+    targets: Any,
+    *,
+    centered: bool = True,
+    rank_tolerance: float | None = None,
+) -> SpectralAlignmentEvidence:
+    """Compute backend-stable SNAP-derived spectral alignment evidence.
+
+    ``representations`` is sample x feature. ``targets`` is sample x target and
+    may be one-dimensional. Positive representation modes are obtained through
+    an SVD, which is equivalent to the positive eigenspectrum of ``X X^T / P``.
+    Target power outside the positive-rank column space is aggregated as one
+    residual quantity instead of being assigned to arbitrary null eigenvectors.
+
+    No resampling, whitening, normalization, label encoding, filtering, or
+    train/test reuse is performed by this function.
+    """
+
+    if isinstance(centered, np.bool_):
+        centered = bool(centered)
+    if not isinstance(centered, bool):
+        raise ValueError("centered must be boolean")
+
+    x_original = _matrix(representations, name="representations")
+    y_original = _matrix(targets, name="targets")
+    if x_original.shape[0] != y_original.shape[0]:
+        raise ValueError("representations and targets must contain the same aligned samples")
+
+    x = x_original.copy()
+    y = y_original.copy()
+    if centered:
+        x -= x.mean(axis=0, keepdims=True)
+        y -= y.mean(axis=0, keepdims=True)
+
+    n_samples, n_features = x.shape
+    target_dim = y.shape[1]
+    left_vectors, singular_values, _ = np.linalg.svd(x, full_matrices=False)
+
+    if rank_tolerance is None:
+        largest = float(singular_values[0]) if singular_values.size else 0.0
+        tolerance = max(x.shape) * np.finfo(np.float64).eps * largest
+    else:
+        if isinstance(rank_tolerance, bool) or not isinstance(rank_tolerance, (int, float)):
+            raise ValueError("rank_tolerance must be numeric or None")
+        tolerance = float(rank_tolerance)
+        if tolerance < 0 or not math.isfinite(tolerance):
+            raise ValueError("rank_tolerance must be finite and non-negative")
+
+    feature_rank = int(np.count_nonzero(singular_values > tolerance))
+    if feature_rank == 0:
+        raise ValueError("representation matrix has zero positive rank after requested centering")
+
+    u = left_vectors[:, :feature_rank]
+    positive_singular = singular_values[:feature_rank]
+    positive_eigenvalues = np.square(positive_singular) / float(n_samples)
+
+    # SNAP's scaled sample-kernel eigenvectors are U * sqrt(P), so its target
+    # weights are U.T @ Y / sqrt(P). We use exactly that positive-rank quantity.
+    weights = (u.T @ y) / np.sqrt(float(n_samples))
+    captured_power = np.square(weights)
+    total_target_power = np.sum(np.square(y), axis=0) / float(n_samples)
+    if np.any(total_target_power <= 1e-15):
+        raise ValueError(
+            "targets contain a zero-power dimension after requested centering; "
+            "spectral task alignment is undefined"
+        )
+
+    normalized_captured = captured_power / total_target_power[None, :]
+    captured_fraction = normalized_captured.sum(axis=0)
+    residual_by_target = np.clip(1.0 - captured_fraction, 0.0, 1.0)
+    residual_target_power = float(residual_by_target.mean())
+
+    target_power_by_mode = normalized_captured.mean(axis=1)
+    cumulative_captured = np.cumsum(normalized_captured, axis=0).mean(axis=1)
+
+    # Preserve SNAP's "effective dimension of remaining task power" idea, but
+    # make the residual one aggregate bin instead of an arbitrary null basis.
+    task_tail_dimensions: list[float] = []
+    for column in range(target_dim):
+        stable_power = np.concatenate(
+            [normalized_captured[:, column], residual_by_target[column : column + 1]]
+        )
+        cumulative = np.cumsum(stable_power)
+        tail = np.maximum(1.0 - cumulative, 0.0)
+        task_tail_dimensions.append(_participation_ratio(tail))
+
+    payload: dict[str, Any] = {
+        "method_id": SPECTRAL_METHOD_ID,
+        "reference_method": SNAP_REFERENCE_PAPER,
+        "reference_repository": SNAP_REFERENCE_REPOSITORY,
+        "centered": centered,
+        "rank_tolerance": tolerance,
+        "n_samples": int(n_samples),
+        "n_features": int(n_features),
+        "target_dim": int(target_dim),
+        "feature_rank": feature_rank,
+        "positive_eigenvalues": [float(value) for value in positive_eigenvalues],
+        "target_power_by_mode": [float(value) for value in target_power_by_mode],
+        "cumulative_captured_target_power": [float(value) for value in cumulative_captured],
+        "effective_dimension": float(_participation_ratio(positive_eigenvalues)),
+        "task_tail_effective_dimension": float(np.mean(task_tail_dimensions)),
+        "residual_target_power": residual_target_power,
+        "representation_sha256": _array_sha256(x_original),
+        "target_sha256": _array_sha256(y_original),
+        "upstream_invariant_conformance_verified": False,
+    }
+    payload["evidence_sha256"] = _canonical_sha256(payload)
+
+    return SpectralAlignmentEvidence(
+        method_id=str(payload["method_id"]),
+        reference_method=str(payload["reference_method"]),
+        reference_repository=str(payload["reference_repository"]),
+        centered=bool(payload["centered"]),
+        rank_tolerance=float(payload["rank_tolerance"]),
+        n_samples=int(payload["n_samples"]),
+        n_features=int(payload["n_features"]),
+        target_dim=int(payload["target_dim"]),
+        feature_rank=int(payload["feature_rank"]),
+        positive_eigenvalues=tuple(payload["positive_eigenvalues"]),
+        target_power_by_mode=tuple(payload["target_power_by_mode"]),
+        cumulative_captured_target_power=tuple(payload["cumulative_captured_target_power"]),
+        effective_dimension=float(payload["effective_dimension"]),
+        task_tail_effective_dimension=float(payload["task_tail_effective_dimension"]),
+        residual_target_power=float(payload["residual_target_power"]),
+        representation_sha256=str(payload["representation_sha256"]),
+        target_sha256=str(payload["target_sha256"]),
+        evidence_sha256=str(payload["evidence_sha256"]),
+        upstream_invariant_conformance_verified=False,
+    )
+
+
+def verify_snap_invariant_reference(
+    evidence: SpectralAlignmentEvidence,
+    expected: dict[str, Any],
+    *,
+    rtol: float = 1e-8,
+    atol: float = 1e-10,
+) -> dict[str, Any]:
+    """Verify invariant quantities against a frozen SNAP-reference execution.
+
+    A valid reference fixture should contain only quantities that are invariant
+    to null-space basis rotation: positive eigenvalues, positive-rank target
+    power, cumulative captured target power, representation effective dimension,
+    and aggregate residual target power.
+    """
+
+    if rtol < 0 or atol < 0:
+        raise ValueError("rtol and atol must be non-negative")
+    required = (
+        "positive_eigenvalues",
+        "target_power_by_mode",
+        "cumulative_captured_target_power",
+        "effective_dimension",
+        "residual_target_power",
+    )
+    missing = [name for name in required if name not in expected]
+    if missing:
+        raise ValueError(f"SNAP invariant fixture missing fields: {', '.join(missing)}")
+
+    vector_fields = required[:3]
+    comparisons: dict[str, bool] = {}
+    max_abs_error: dict[str, float] = {}
+    for name in vector_fields:
+        observed = np.asarray(getattr(evidence, name), dtype=np.float64)
+        reference = np.asarray(expected[name], dtype=np.float64)
+        if observed.shape != reference.shape:
+            comparisons[name] = False
+            max_abs_error[name] = float("inf")
+            continue
+        comparisons[name] = bool(np.allclose(observed, reference, rtol=rtol, atol=atol))
+        max_abs_error[name] = float(np.max(np.abs(observed - reference))) if observed.size else 0.0
+
+    for name in required[3:]:
+        observed_scalar = float(getattr(evidence, name))
+        reference_scalar = float(expected[name])
+        comparisons[name] = bool(np.isclose(observed_scalar, reference_scalar, rtol=rtol, atol=atol))
+        max_abs_error[name] = abs(observed_scalar - reference_scalar)
+
+    return {
+        "method_id": evidence.method_id,
+        "conformant": all(comparisons.values()),
+        "comparisons": comparisons,
+        "max_abs_error": max_abs_error,
+        "rtol": float(rtol),
+        "atol": float(atol),
+        "null_space_basis_invariant": True,
+    }

--- a/packages/neuros-foundation/tests/test_ngclearn_bridge.py
+++ b/packages/neuros-foundation/tests/test_ngclearn_bridge.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import neuros.foundation_models.ngclearn_bridge as bridge
+from neuros.foundation_models.ngclearn_bridge import (
+    NgcLearnRateCellTransform,
+    NgcLearnVersionError,
+    ngclearn_runtime_identity,
+)
+
+
+def test_ngclearn_bridge_rejects_unqualified_minor_line(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(bridge, "_version", lambda: "3.3.0")
+    with pytest.raises(NgcLearnVersionError, match="only the ngc-learn 3.2 line"):
+        bridge._load_upstream()
+
+
+def test_rate_cell_configuration_is_fail_closed_before_optional_import():
+    with pytest.raises(ValueError, match="tau_m_ms"):
+        NgcLearnRateCellTransform(tau_m_ms=0.0)
+    with pytest.raises(ValueError, match="output"):
+        NgcLearnRateCellTransform(output="unknown")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="seed"):
+        NgcLearnRateCellTransform(seed=-1)
+
+
+def test_real_ngclearn_32_surface_and_rate_cell_execution():
+    pytest.importorskip("ngclearn")
+    identity = ngclearn_runtime_identity()
+
+    assert identity["integration"] == "ngc-learn"
+    assert identity["qualified_series"] == "3.2.x"
+    assert identity["ngclearn_version"].startswith("3.2.")
+    assert len(identity["qualified_symbols"]) == 6
+
+    samples = np.asarray(
+        [
+            [0.0, 0.25],
+            [0.5, -0.25],
+            [1.0, 0.0],
+            [0.0, 0.5],
+        ],
+        dtype=np.float64,
+    )
+    transform = NgcLearnRateCellTransform(
+        tau_m_ms=10.0,
+        gamma=1.0,
+        activation="identity",
+        integration_type="euler",
+        output="linear",
+        seed=7,
+    )
+    first = transform.transform(samples, sample_rate_hz=1000.0)
+    second = transform.transform(samples, sample_rate_hz=1000.0)
+
+    assert first.values.shape == samples.shape
+    assert np.isfinite(first.values).all()
+    assert np.allclose(first.values, second.values, rtol=0.0, atol=0.0)
+    assert first.evidence.input_shape == samples.shape
+    assert first.evidence.output_shape == samples.shape
+    assert first.evidence.input_sha256 == second.evidence.input_sha256
+    assert first.evidence.output_sha256 == second.evidence.output_sha256
+    assert first.evidence.evidence_sha256 == second.evidence.evidence_sha256
+    boundary = first.evidence.to_dict()["claim_boundary"]
+    assert boundary["upstream_package_executed"] is True
+    assert boundary["rate_cell_contract_exercised"] is True
+    assert boundary["predictive_coding_circuit_qualified"] is False
+    assert boundary["spiking_network_qualified"] is False
+    assert boundary["real_dataset_qualified"] is False
+    assert boundary["hardware_qualified"] is False
+
+
+def test_rate_cell_preserves_declared_geometry_and_rejects_bad_samples():
+    pytest.importorskip("ngclearn")
+    transform = NgcLearnRateCellTransform()
+
+    with pytest.raises(ValueError, match="2D time x channel"):
+        transform.transform(np.ones(8), sample_rate_hz=250.0)
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        transform.transform(np.asarray([[0.0, np.nan]]), sample_rate_hz=250.0)
+    with pytest.raises(ValueError, match="sample_rate_hz"):
+        transform.transform(np.ones((2, 2)), sample_rate_hz=0.0)

--- a/packages/neuros-foundation/tests/test_spectral_alignment.py
+++ b/packages/neuros-foundation/tests/test_spectral_alignment.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.spectral_alignment import (
+    SPECTRAL_METHOD_ID,
+    spectral_alignment_evidence,
+    verify_snap_invariant_reference,
+)
+
+
+REPRESENTATIONS = np.asarray(
+    [
+        [1.0, 0.2],
+        [-0.4, 1.2],
+        [0.7, -0.8],
+        [-1.1, -0.3],
+        [0.3, 0.9],
+    ],
+    dtype=np.float64,
+)
+TARGETS = np.asarray(
+    [
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [-1.0, 0.5],
+        [0.5, -0.5],
+    ],
+    dtype=np.float64,
+)
+
+# Invariant quantities from the SNAP reference construction for the matrices
+# above. Null-space per-mode power is deliberately omitted because its basis is
+# not unique. The first two modes and aggregate residual are basis invariant.
+SNAP_INVARIANT_FIXTURE = {
+    "positive_eigenvalues": [
+        0.6371340246436072,
+        0.48926597535641314,
+    ],
+    "target_power_by_mode": [
+        0.30292378828622346,
+        0.2799058693942279,
+    ],
+    "cumulative_captured_target_power": [
+        0.30292378828622346,
+        0.5828296576804515,
+    ],
+    "effective_dimension": 1.9661176974633945,
+    "residual_target_power": 0.4171703423195485,
+}
+
+
+def test_spectral_alignment_matches_snap_invariant_reference_values():
+    evidence = spectral_alignment_evidence(REPRESENTATIONS, TARGETS, centered=True)
+    result = verify_snap_invariant_reference(evidence, SNAP_INVARIANT_FIXTURE)
+
+    assert evidence.method_id == SPECTRAL_METHOD_ID
+    assert evidence.feature_rank == 2
+    assert evidence.n_samples == 5
+    assert evidence.n_features == 2
+    assert evidence.target_dim == 2
+    assert evidence.residual_target_power == pytest.approx(0.4171703423195485)
+    assert result["conformant"] is True
+    assert result["null_space_basis_invariant"] is True
+
+
+def test_spectral_evidence_is_deterministic_and_hashes_inputs():
+    first = spectral_alignment_evidence(REPRESENTATIONS, TARGETS)
+    second = spectral_alignment_evidence(REPRESENTATIONS.copy(), TARGETS.copy())
+
+    assert first == second
+    assert len(first.representation_sha256) == 64
+    assert len(first.target_sha256) == 64
+    assert len(first.evidence_sha256) == 64
+
+    changed = REPRESENTATIONS.copy()
+    changed[0, 0] += 1e-3
+    changed_evidence = spectral_alignment_evidence(changed, TARGETS)
+    assert changed_evidence.representation_sha256 != first.representation_sha256
+    assert changed_evidence.evidence_sha256 != first.evidence_sha256
+
+
+def test_spectral_evidence_aggregates_null_space_instead_of_exposing_arbitrary_basis():
+    evidence = spectral_alignment_evidence(REPRESENTATIONS, TARGETS)
+
+    assert len(evidence.positive_eigenvalues) == evidence.feature_rank
+    assert len(evidence.target_power_by_mode) == evidence.feature_rank
+    assert len(evidence.cumulative_captured_target_power) == evidence.feature_rank
+    assert 0.0 <= evidence.residual_target_power <= 1.0
+    assert evidence.to_dict()["claim_boundary"]["null_space_basis_invariant"] is True
+
+
+def test_spectral_alignment_fails_closed_on_invalid_or_undefined_inputs():
+    with pytest.raises(ValueError, match="same aligned samples"):
+        spectral_alignment_evidence(REPRESENTATIONS, TARGETS[:-1])
+
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        bad = REPRESENTATIONS.copy()
+        bad[0, 0] = np.nan
+        spectral_alignment_evidence(bad, TARGETS)
+
+    with pytest.raises(ValueError, match="zero positive rank"):
+        spectral_alignment_evidence(np.ones((5, 2)), TARGETS, centered=True)
+
+    with pytest.raises(ValueError, match="zero-power dimension"):
+        spectral_alignment_evidence(REPRESENTATIONS, np.ones((5, 1)), centered=True)
+
+    with pytest.raises(ValueError, match="rank_tolerance"):
+        spectral_alignment_evidence(REPRESENTATIONS, TARGETS, rank_tolerance=-1.0)
+
+
+def test_reference_verifier_detects_a_changed_invariant_quantity():
+    evidence = spectral_alignment_evidence(REPRESENTATIONS, TARGETS)
+    fixture = dict(SNAP_INVARIANT_FIXTURE)
+    fixture["residual_target_power"] = 0.0
+
+    result = verify_snap_invariant_reference(evidence, fixture)
+    assert result["conformant"] is False
+    assert result["comparisons"]["residual_target_power"] is False

--- a/packages/neuros/src/neuros/compatibility.py
+++ b/packages/neuros/src/neuros/compatibility.py
@@ -74,10 +74,7 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         status=IntegrationStatus.SUPPORTED,
         capabilities=("source", "continuous-stream", "device-metadata"),
         evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
-        evidence_paths=(
-            "tests/test_brainflow_driver.py",
-            ".github/workflows/drivers-ci.yml",
-        ),
+        evidence_paths=("tests/test_brainflow_driver.py", ".github/workflows/drivers-ci.yml"),
         notes=(
             "Board-aware acquisition is fail-closed and contract-tested. No physical "
             "board/firmware/transport combination is yet claimed as hardware-qualified."
@@ -91,10 +88,7 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         status=IntegrationStatus.SUPPORTED,
         capabilities=("source", "continuous-stream", "clock-correction"),
         evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
-        evidence_paths=(
-            "tests/test_lsl_driver.py",
-            ".github/workflows/drivers-ci.yml",
-        ),
+        evidence_paths=("tests/test_lsl_driver.py", ".github/workflows/drivers-ci.yml"),
         notes=(
             "Continuous regular-rate streams use deterministic discovery and explicit "
             "raw-timestamp plus time-correction semantics. Network timing remains a "
@@ -109,10 +103,7 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         status=IntegrationStatus.SUPPORTED,
         capabilities=("raw-adapter", "signalframe-bridge", "stream-descriptor"),
         evidence_tier=EvidenceTier.INTEGRATION,
-        evidence_paths=(
-            "tests/test_mne_interop.py",
-            ".github/workflows/compatibility-ci.yml",
-        ),
+        evidence_paths=("tests/test_mne_interop.py", ".github/workflows/compatibility-ci.yml"),
         notes=(
             "MNE Raw objects can be converted to provenance-rich SignalFrame chunks and "
             "reconstructed from unambiguous sample-by-channel frames. This is an object "
@@ -177,17 +168,9 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         name="Braindecode",
         category="decoder ecosystem",
         status=IntegrationStatus.EXPERIMENTAL,
-        capabilities=(
-            "neural-window",
-            "model-adapter",
-            "training-bridge",
-            "decoder-bridge",
-        ),
+        capabilities=("neural-window", "model-adapter", "training-bridge", "decoder-bridge"),
         evidence_tier=EvidenceTier.INTEGRATION,
-        evidence_paths=(
-            "tests/test_braindecode_adapter.py",
-            ".github/workflows/braindecode-ci.yml",
-        ),
+        evidence_paths=("tests/test_braindecode_adapter.py", ".github/workflows/braindecode-ci.yml"),
         notes=(
             "Braindecode 1.7 is integrated by delegation for a qualified raw-window "
             "whitelist (EEGNet, EEGConformer, ShallowFBCSPNet, Deep4Net). The adapter "
@@ -196,6 +179,51 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
             "paths, and hardware/closed-loop behavior remain separate qualification steps."
         ),
         install_hint='pip install "neuros[braindecode]"',
+    ),
+    IntegrationRecord(
+        integration_id="snap",
+        name="SNAP spectral alignment",
+        category="representation evidence",
+        status=IntegrationStatus.EXPERIMENTAL,
+        capabilities=(
+            "positive-rank-spectrum",
+            "task-power",
+            "residual-target-power",
+            "null-space-invariant-evidence",
+        ),
+        evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
+        evidence_paths=(
+            "packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py",
+            "packages/neuros-foundation/tests/test_spectral_alignment.py",
+            ".github/workflows/neuroai-ecosystem-ci.yml",
+        ),
+        notes=(
+            "neurOS implements dependency-light SNAP-derived invariant spectral quantities. "
+            "Positive-rank modes are explicit while null-space target power is aggregated "
+            "because the null eigenbasis is non-unique across valid linear-algebra backends. "
+            "This is a numerical-method contract, not a reproduced-paper or biological claim."
+        ),
+    ),
+    IntegrationRecord(
+        integration_id="ngclearn",
+        name="ngc-learn",
+        category="computational neuroscience / NeuroAI",
+        status=IntegrationStatus.EXPERIMENTAL,
+        capabilities=("rate-cell-transform", "jax-identity", "biological-dynamics-bridge"),
+        evidence_tier=EvidenceTier.INTEGRATION,
+        evidence_paths=(
+            "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py",
+            "packages/neuros-foundation/tests/test_ngclearn_bridge.py",
+            ".github/workflows/neuroai-ecosystem-ci.yml",
+        ),
+        notes=(
+            "The first qualified upstream surface is deliberately narrow: ngc-learn 3.2.x "
+            "RateCell execution with exact JAX/upstream identity, explicit time-by-channel "
+            "geometry, and no hidden preprocessing. Predictive-coding circuits, spiking "
+            "networks, Hebbian/STDP learning, real-data utility, and closed-loop behavior "
+            "remain unqualified until separate evidence lands."
+        ),
+        install_hint='pip install "neuros-foundation[ngclearn]"',
     ),
     IntegrationRecord(
         integration_id="neuralbench",
@@ -208,6 +236,47 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         notes=(
             "Planned as an isolated optional benchmark worker so upstream Python/runtime "
             "requirements never become kernel dependencies."
+        ),
+    ),
+    IntegrationRecord(
+        integration_id="neuroaikit",
+        name="IBM NeuroAIKit",
+        category="historical NeuroAI reference",
+        status=IntegrationStatus.PLANNED,
+        capabilities=("isolated-snu-reference-worker",),
+        evidence_tier=None,
+        evidence_paths=(),
+        notes=(
+            "The TensorFlow-era SNU toolkit is scientifically useful as a historical/reference "
+            "baseline, but its legacy dependency surface will remain isolated from neurOS core."
+        ),
+    ),
+    IntegrationRecord(
+        integration_id="mouse-vision",
+        name="NeuroAI Lab mouse-vision",
+        category="neural predictivity benchmark",
+        status=IntegrationStatus.PLANNED,
+        capabilities=("external-model-benchmark", "allen-neural-response-evidence"),
+        evidence_tier=None,
+        evidence_paths=(),
+        notes=(
+            "Planned as a cross-species representation/predictivity benchmark. neurOS will "
+            "prefer authoritative Allen/public-data identities over adopting research pickles "
+            "as a canonical runtime format."
+        ),
+    ),
+    IntegrationRecord(
+        integration_id="tdann",
+        name="NeuroAI Lab TDANN",
+        category="topographic representation benchmark",
+        status=IntegrationStatus.PLANNED,
+        capabilities=("topographic-representation-evidence",),
+        evidence_tier=None,
+        evidence_paths=(),
+        notes=(
+            "Planned as an external representation/topography benchmark, not a runtime "
+            "dependency. Licensing and reproducible artifact identity must be resolved before "
+            "any implementation code is reused."
         ),
     ),
     IntegrationRecord(
@@ -277,11 +346,15 @@ def _validate_registry(records: Iterable[IntegrationRecord]) -> tuple[Integratio
         seen.add(record.integration_id)
         if record.status is IntegrationStatus.PLANNED and record.evidence_tier is not None:
             raise ValueError(f"Planned integration {record.integration_id} cannot claim evidence")
+        if record.status is IntegrationStatus.PLANNED and record.evidence_paths:
+            raise ValueError(f"Planned integration {record.integration_id} cannot publish evidence paths")
         if record.status is IntegrationStatus.SUPPORTED:
             if record.evidence_tier is None or not record.evidence_paths:
                 raise ValueError(
                     f"Supported integration {record.integration_id} requires evidence paths and tier"
                 )
+        if record.evidence_tier is not None and not record.evidence_paths:
+            raise ValueError(f"Evidence-bearing integration {record.integration_id} requires evidence paths")
     return materialized
 
 

--- a/scripts/evidence/verify_snap_upstream.py
+++ b/scripts/evidence/verify_snap_upstream.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Verify neurOS invariant spectral evidence against pinned upstream SNAP code.
+
+This script deliberately loads ``snap/metrics.py`` directly from an exact
+checkout instead of importing the SNAP package. The upstream package __init__
+imports a broad paper-reproduction environment that is irrelevant to the
+spectral reference functions being checked here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from neuros.foundation_models.spectral_alignment import spectral_alignment_evidence
+
+SNAP_REFERENCE_REVISION = "76570574eab7b3115ed4503f8c4ecefaa2a7c5e6"
+
+REPRESENTATIONS = np.asarray(
+    [
+        [1.0, 0.2],
+        [-0.4, 1.2],
+        [0.7, -0.8],
+        [-1.1, -0.3],
+        [0.3, 0.9],
+    ],
+    dtype=np.float64,
+)
+TARGETS = np.asarray(
+    [
+        [1.0, 0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+        [-1.0, 0.5],
+        [0.5, -0.5],
+    ],
+    dtype=np.float64,
+)
+
+
+def _load_metrics(root: Path) -> Any:
+    metrics_path = root / "snap" / "metrics.py"
+    if not metrics_path.is_file():
+        raise FileNotFoundError(f"SNAP metrics.py not found at {metrics_path}")
+    spec = importlib.util.spec_from_file_location("neuros_snap_reference_metrics", metrics_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not create import spec for {metrics_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _upstream_invariants(metrics: Any) -> dict[str, Any]:
+    x = torch.as_tensor(REPRESENTATIONS, dtype=torch.float64)
+    y = torch.as_tensor(TARGETS, dtype=torch.float64)
+    eig, weights, residuals, _, p, n, _ = metrics.kernel_spectrum_from_feat(
+        x,
+        {"target": y},
+        cent=True,
+    )
+    rank = min(p, n)
+    weight = np.asarray(weights["target"], dtype=np.float64)
+    power = np.square(weight)
+    total = power.sum(axis=0)
+    if np.any(total <= 0):
+        raise RuntimeError("upstream SNAP fixture produced zero target power")
+    normalized = power / total[None, :]
+    return {
+        "positive_eigenvalues": np.asarray(eig[:rank], dtype=np.float64),
+        "target_power_by_mode": normalized[:rank].mean(axis=1),
+        "cumulative_captured_target_power": np.cumsum(normalized[:rank], axis=0).mean(axis=1),
+        "effective_dimension": float(metrics.eff_dimension(np.asarray(eig[:rank], dtype=np.float64))),
+        "residual_target_power": float(np.mean(np.asarray(residuals["target"], dtype=np.float64))),
+    }
+
+
+def verify(root: Path, *, rtol: float = 1e-7, atol: float = 1e-9) -> dict[str, Any]:
+    metrics = _load_metrics(root)
+    upstream = _upstream_invariants(metrics)
+    ours = spectral_alignment_evidence(REPRESENTATIONS, TARGETS, centered=True)
+
+    comparisons = {
+        "positive_eigenvalues": bool(
+            np.allclose(ours.positive_eigenvalues, upstream["positive_eigenvalues"], rtol=rtol, atol=atol)
+        ),
+        "target_power_by_mode": bool(
+            np.allclose(ours.target_power_by_mode, upstream["target_power_by_mode"], rtol=rtol, atol=atol)
+        ),
+        "cumulative_captured_target_power": bool(
+            np.allclose(
+                ours.cumulative_captured_target_power,
+                upstream["cumulative_captured_target_power"],
+                rtol=rtol,
+                atol=atol,
+            )
+        ),
+        "effective_dimension": bool(
+            np.isclose(ours.effective_dimension, upstream["effective_dimension"], rtol=rtol, atol=atol)
+        ),
+        "residual_target_power": bool(
+            np.isclose(ours.residual_target_power, upstream["residual_target_power"], rtol=rtol, atol=atol)
+        ),
+    }
+    payload = {
+        "reference_repository": "https://github.com/chung-neuroai-lab/SNAP",
+        "reference_revision": SNAP_REFERENCE_REVISION,
+        "reference_file": "snap/metrics.py",
+        "neurOS_method_id": ours.method_id,
+        "null_space_basis_invariant": True,
+        "comparisons": comparisons,
+        "conformant": all(comparisons.values()),
+        "rtol": rtol,
+        "atol": atol,
+    }
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--snap-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    result = verify(args.snap_root)
+    text = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    print(text, end="")
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    return 0 if result["conformant"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compatibility_registry.py
+++ b/tests/test_compatibility_registry.py
@@ -28,6 +28,12 @@ def test_supported_integrations_have_evidence_and_tier():
         assert record.evidence_paths
 
 
+def test_every_evidence_bearing_integration_has_executable_paths():
+    for record in compatibility_inventory():
+        if record.evidence_tier is not None:
+            assert record.evidence_paths
+
+
 def test_planned_integrations_cannot_claim_evidence_tier():
     planned = [
         item for item in compatibility_inventory() if item.status is IntegrationStatus.PLANNED
@@ -79,6 +85,45 @@ def test_braindecode_is_integration_qualified_not_real_dataset_promoted():
     assert "Real-dataset" in record.notes
     assert "mechint" not in record.capabilities
     assert "hardware" not in record.capabilities
+
+
+def test_snap_is_a_numerical_evidence_contract_not_a_biological_claim():
+    record = get_integration("snap")
+
+    assert record.status is IntegrationStatus.EXPERIMENTAL
+    assert record.evidence_tier is EvidenceTier.SOFTWARE_CONTRACT
+    assert "null-space-invariant-evidence" in record.capabilities
+    assert "reproduced-paper" not in record.capabilities
+    assert "biological" not in record.capabilities
+    assert "spectral_alignment.py" in " ".join(record.evidence_paths)
+
+
+def test_ngclearn_is_real_upstream_integration_but_only_for_narrow_surface():
+    record = get_integration("ngclearn")
+
+    assert record.status is IntegrationStatus.EXPERIMENTAL
+    assert record.evidence_tier is EvidenceTier.INTEGRATION
+    assert "rate-cell-transform" in record.capabilities
+    assert "spiking-network" not in record.capabilities
+    assert "predictive-coding" not in record.capabilities
+    assert record.install_hint == 'pip install "neuros-foundation[ngclearn]"'
+    assert "3.2.x" in record.notes
+
+
+def test_research_organizations_are_not_promoted_as_monolithic_integrations():
+    ids = {record.integration_id for record in compatibility_inventory()}
+    assert "neuroailab" not in ids
+    assert "chung-neuroai-lab" not in ids
+    assert "mouse-vision" in ids
+    assert "tdann" in ids
+
+
+def test_legacy_neuroaikit_is_planned_and_isolated():
+    record = get_integration("neuroaikit")
+    assert record.status is IntegrationStatus.PLANNED
+    assert record.evidence_tier is None
+    assert record.evidence_paths == ()
+    assert "isolated-snu-reference-worker" in record.capabilities
 
 
 def test_openbci_is_indirect_not_hardware_qualified():


### PR DESCRIPTION
## Why

neurOS should become a trustworthy interoperability and evidence layer for neuroscience and NeuroAI rather than a logo wall or another monolithic model zoo. This PR begins that ecosystem program with one scientific-method integration and one real computational-neuroscience package integration, both behind explicit claim boundaries.

## SNAP-derived representation evidence

Adds a dependency-light NumPy spectral evidence operator derived from the SNAP (Spectral theory of Neural Alignment and Prediction) analysis vocabulary.

The implementation reports:

- positive-rank representation eigenvalues;
- target power captured by each positive mode;
- cumulative captured target power;
- participation-ratio effective dimension;
- effective dimension of remaining task power;
- aggregate target power outside the representation span;
- deterministic representation/target/evidence SHA-256 identities.

### Numerical hardening

The upstream reference can distribute target power among zero-eigenvalue kernel eigenvectors. That null-space basis is mathematically non-unique, so different correct eigensolvers can rotate it and produce different per-null-mode values.

neurOS deliberately does not preserve that backend-dependent quantity. Positive-rank modes stay explicit and all out-of-span target power is aggregated into one invariant residual term.

### Actual upstream conformance

The dedicated CI lane checks out the authors' exact SNAP revision:

`76570574eab7b3115ed4503f8c4ecefaa2a7c5e6`

It executes the real upstream `snap/metrics.py` directly and compares the neurOS implementation against the upstream calculation for the invariant quantities only. The exact final PR head passes that conformance check.

The conformance environment is CPU-only and pins Torch 2.13.0 from PyTorch's official CPU wheel index, avoiding unnecessary CUDA dependencies without changing the reference calculation.

This remains a **numerical-method/integration evidence claim**, not a claim that the SNAP paper results were reproduced or that a representation is biologically/mechanistically aligned.

## ngc-learn integration

Adds an optional `neuros-foundation[ngclearn]` integration with a deliberately narrow initial qualified surface:

- ngc-learn 3.2.x only;
- real upstream `RateCell` execution;
- one unit per input channel;
- explicit time x channel geometry;
- sample-rate-derived integration step;
- exact ngc-learn/JAX version, backend, and x64 identity;
- deterministic input/output/evidence hashes;
- reset-bounded repeated execution;
- no hidden resampling, filtering, normalization, padding, fitting, or channel reordering.

An upstream audit found that `ngcsimlib.Context` uses a process-global registry and can return an existing context for the same path. The adapter therefore creates an isolated context per transform object and reuses it only with explicit state reset, preventing stale-context reuse across repeated transforms.

The real upstream CI lanes passed on Python 3.10 and 3.11 with `ngclearn 3.2.0`, `ngcsimlib 3.1.0`, and JAX 0.6.2 on CPU.

Successful RateCell integration does **not** promote predictive-coding circuits, spiking networks, Hebbian/STDP learning, real-data utility, hardware behavior, or closed-loop performance.

## Ecosystem registry

Adds conservative entries for:

- SNAP: experimental / software-contract plus pinned upstream conformance;
- ngc-learn: experimental / integration;
- IBM NeuroAIKit: planned isolated reference worker;
- NeuroAI Lab mouse-vision: planned neural-predictivity benchmark;
- NeuroAI Lab TDANN: planned topographic-representation benchmark.

Research organizations themselves are not treated as monolithic integrations. Cognizant Neuro SAN Studio is intentionally not added as a neuroscience compatibility entry because its relevance is product/orchestration design, not neural-runtime interoperability.

## Exact-head qualification

Final head: `4f50172a316c30471c5023c32107a6e133706c6f`

All triggered exact-head workflows are green:

- neurOS CI
- NeuroAI Ecosystem Evidence
- Ecosystem Compatibility
- Braindecode Compatibility
- Braindecode Longitudinal Evidence
- neurOS real-world evidence

## Next evidence rungs

The ngc-learn ladder can now progress through explicit predictive-coding circuits, spiking/plasticity contracts, real neural data, ORION comparisons, and only eventually closed-loop evidence where actually measured.

The broader direction is an `EvidenceConformanceManifest` that binds upstream revision/environment, neurOS operator identity, frozen data hashes, numerical semantics, and claim boundaries.