### PR TITLE
evidence: qualify ngc-learn predictive reconstruction dynamics

### DIFF
--- a/.github/workflows/neuroai-ecosystem-ci.yml
+++ b/.github/workflows/neuroai-ecosystem-ci.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - "packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/__init__.py"
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros/src/neuros/compatibility.py"
       - "packages/neuros-foundation/tests/test_spectral_alignment.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
       - "scripts/evidence/verify_snap_upstream.py"
       - "docs/NEUROAI_ECOSYSTEM.md"
       - "docs/COMPATIBILITY.md"
@@ -20,11 +22,13 @@ on:
     paths:
       - "packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/__init__.py"
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros/src/neuros/compatibility.py"
       - "packages/neuros-foundation/tests/test_spectral_alignment.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
       - "scripts/evidence/verify_snap_upstream.py"
       - "docs/NEUROAI_ECOSYSTEM.md"
       - "docs/COMPATIBILITY.md"
@@ -64,7 +68,8 @@ jobs:
         run: |
           python -m compileall -q \
             packages/neuros-foundation/src/neuros/foundation_models/spectral_alignment.py \
-            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py
+            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py \
+            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py
 
   snap-upstream-conformance:
     name: Pinned SNAP upstream invariant conformance
@@ -89,9 +94,6 @@ jobs:
           python -m pip install -e packages/neuros-models
           python -m pip install -e packages/neuros-foundation
           python -m pip install tqdm
-          # The upstream SNAP spectral reference only needs CPU tensor algebra.
-          # Pin the same Torch release used by the first successful conformance
-          # run, but source the official CPU wheel so CI never downloads CUDA.
           python -m pip install torch==2.13.0 --index-url https://download.pytorch.org/whl/cpu
       - name: Execute authors' pinned spectral reference code
         run: |
@@ -101,7 +103,7 @@ jobs:
           test -s "${RUNNER_TEMP}/snap-conformance.json"
 
   ngclearn-integration:
-    name: ngc-learn 3.2 integration / Python ${{ matrix.python-version }}
+    name: ngc-learn 3.2 RateCell + predictive coding / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -121,8 +123,11 @@ jobs:
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[ngclearn,dev]"
-      - name: Exercise real upstream package and RateCell dynamics
-        run: pytest -q packages/neuros-foundation/tests/test_ngclearn_bridge.py
+      - name: Exercise real upstream RateCell and predictive-coding dynamics
+        run: |
+          pytest -q \
+            packages/neuros-foundation/tests/test_ngclearn_bridge.py \
+            packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py
       - name: Report exact upstream identity
         run: |
           python - <<'PY'

--- a/.github/workflows/neuroai-ecosystem-ci.yml
+++ b/.github/workflows/neuroai-ecosystem-ci.yml
@@ -12,6 +12,8 @@ on:
       - "packages/neuros-foundation/tests/test_spectral_alignment.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
       - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
+      - "tests/test_compatibility_registry.py"
+      - "examples/neuroai/ngclearn_predictive_coding.py"
       - "scripts/evidence/verify_snap_upstream.py"
       - "docs/NEUROAI_ECOSYSTEM.md"
       - "docs/COMPATIBILITY.md"
@@ -29,6 +31,8 @@ on:
       - "packages/neuros-foundation/tests/test_spectral_alignment.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
       - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
+      - "tests/test_compatibility_registry.py"
+      - "examples/neuroai/ngclearn_predictive_coding.py"
       - "scripts/evidence/verify_snap_upstream.py"
       - "docs/NEUROAI_ECOSYSTEM.md"
       - "docs/COMPATIBILITY.md"
@@ -128,6 +132,10 @@ jobs:
           pytest -q \
             packages/neuros-foundation/tests/test_ngclearn_bridge.py \
             packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py
+      - name: Exercise public predictive-coding example
+        run: |
+          python examples/neuroai/ngclearn_predictive_coding.py > "${RUNNER_TEMP}/ngclearn-pc-example.json"
+          test -s "${RUNNER_TEMP}/ngclearn-pc-example.json"
       - name: Report exact upstream identity
         run: |
           python - <<'PY'

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -202,3 +202,20 @@ DANDI / NWB / SpikeInterface
              |
              +------> Evidence
 ```
+
+The invasive lane should not force spike-sorting, dataset-client, or neuromodulation dependencies into `neuros-core`.
+
+## Adding an integration
+
+A new integration should land in this order:
+
+1. define the exact external boundary and what neurOS will not reimplement;
+2. implement an optional adapter/plugin or evidence operator outside `neuros-core`;
+3. add deterministic contract tests;
+4. add a registry entry at the weakest accurate status/evidence tier;
+5. add a clean-install CI lane with the optional dependency where appropriate;
+6. add real upstream integration evidence;
+7. add named real-data, hardware, or closed-loop evidence only when actually exercised;
+8. promote status or evidence tier only in the same change that adds the missing evidence.
+
+A README example alone is never sufficient to mark an integration supported.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -12,7 +12,7 @@ neuros compatibility snap --json
 neuros compatibility --status supported --json
 ```
 
-The registry lives in `neuros.compatibility` and is covered by contract tests. Documentation should summarize that registry rather than invent a second support matrix with different semantics.
+The registry lives in `neuros.compatibility` and is covered by contract tests. Documentation summarizes that registry rather than inventing a second support matrix with different semantics.
 
 ## Current matrix
 
@@ -25,8 +25,8 @@ The registry lives in `neuros.compatibility` and is covered by contract tests. D
 | Zarr | supported | export, session provenance | integration | export interoperability, not a replacement runtime format |
 | MOABB | experimental | dataset adapter, longitudinal split authority, model ladder | real dataset | benchmark surface is still evolving; result claims remain protocol-specific |
 | Braindecode | experimental | neural-window model adapter, upstream training bridge, decoder bridge | integration | qualified 1.7 whitelist only; stable mech-int, hardware, and closed-loop claims remain separate |
-| SNAP spectral alignment | experimental | positive-rank spectrum, task power, residual target power | software contract | invariant numerical-method contract only; no paper-reproduction or biological-alignment claim |
-| ngc-learn | experimental | RateCell transform, upstream/JAX identity, biological-dynamics bridge | integration | real ngc-learn 3.2.x RateCell only; predictive coding, spiking, plasticity, real-data and closed-loop claims remain unqualified |
+| SNAP spectral alignment | experimental | positive-rank spectrum, task power, residual target power | software contract + upstream conformance | no published-experiment reproduction or biological-alignment claim |
+| ngc-learn | experimental | RateCell transform, fixed-weight predictive reconstruction, iterative residual feedback, upstream/JAX identity | integration | real ngc-learn 3.2.x inference dynamics only; Hebbian/STDP learning, spiking, real-data, hardware, and closed-loop claims remain unqualified |
 | OpenBCI | indirect | reachable through BrainFlow | none | no named OpenBCI configuration is hardware-qualified |
 | Meta NeuralBench | planned | isolated benchmark worker, evidence extension | none | upstream runtime requirements must stay outside the kernel |
 | IBM NeuroAIKit | planned | isolated SNU reference worker | none | legacy TensorFlow-era environment is intentionally isolated |
@@ -54,7 +54,7 @@ These tiers are monotonic in responsibility, not automatic badges. A software-co
 
 ## MNE interoperability
 
-MNE is the first direct scientific object bridge added under the convergence architecture.
+MNE is a direct scientific object bridge under the convergence architecture.
 
 Install:
 
@@ -119,7 +119,7 @@ The adapter never silently resamples, pads, crops, filters, changes channel orde
 
 ### SNAP-derived spectral evidence
 
-neurOS now exposes SNAP-derived representation evidence without adding Torch/CUDA to the foundation package's required dependencies.
+neurOS exposes SNAP-derived representation evidence without adding Torch/CUDA to the foundation package's required dependencies.
 
 ```python
 from neuros.foundation_models import spectral_alignment_evidence
@@ -127,9 +127,9 @@ from neuros.foundation_models import spectral_alignment_evidence
 evidence = spectral_alignment_evidence(embeddings, neural_targets)
 ```
 
-The implementation deliberately reports only positive-rank spectral modes individually. Target power outside that span is aggregated into one residual term because individual zero-eigenvalue eigenvectors are not uniquely defined. This removes a backend-dependent ambiguity while preserving the scientifically meaningful SNAP quantities.
+The implementation reports positive-rank spectral modes individually and aggregates target power outside that span into one invariant residual term because individual zero-eigenvalue eigenvectors are not uniquely defined. A dedicated CI lane also executes a pinned copy of the authors' real SNAP metric code and compares invariant quantities.
 
-The current evidence tier is **software-contract**, not a claim that the SNAP paper was reproduced or that a representation is biologically aligned.
+This is not a claim that the paper's experiments were reproduced or that a representation is biologically aligned.
 
 See [NeuroAI Ecosystem Evidence](NEUROAI_ECOSYSTEM.md).
 
@@ -141,9 +141,34 @@ Install the isolated research integration with:
 pip install "neuros-foundation[ngclearn]"
 ```
 
-The first qualified surface executes the real ngc-learn 3.2.x `RateCell` and records exact upstream/JAX identity, sample-rate-derived integration step, input/output geometry, configuration, and hashes.
+Two real upstream ngc-learn 3.2.x surfaces are now qualified at the **integration** tier.
 
-It does not silently resample, filter, normalize, pad, reorder channels, or fit. Successful RateCell integration does **not** promote predictive-coding circuits, spiking networks, Hebbian/STDP learning, real-data performance, or closed-loop behavior.
+#### RateCell transform
+
+The basic transform records exact upstream/JAX identity, sample-rate-derived integration step, time-by-channel geometry, configuration, and hashes. It does not silently resample, filter, normalize, pad, reorder channels, or fit.
+
+#### Fixed-weight predictive reconstruction
+
+```python
+from neuros.foundation_models import NgcLearnPredictiveCodingTransform
+
+pc = NgcLearnPredictiveCodingTransform(
+    latent_dim=4,
+    settling_steps=30,
+    seed=7,
+)
+result = pc.transform(samples, sample_rate_hz=250.0)
+```
+
+The circuit uses a real upstream `RateCell` latent, `GaussianErrorCell` reconstruction residual, and `StaticSynapse` generative/feedback connections. It resets per observation, clamps the input as the prediction-error target, ties feedback to the transpose of the fixed generative weights, and iteratively settles the latent.
+
+Evidence includes latent/reconstruction shapes, exact component/runtime identity, settling parameters, weight/input/latent/reconstruction/trajectory hashes, and reconstruction-error reduction.
+
+The known-ground-truth upstream test uses an identity generative dictionary and requires the real circuit to reduce reconstruction error by more than 90% on Python 3.10 and 3.11. This is evidence that the residual-feedback computation actually works, not merely that its objects instantiate.
+
+The weights are deliberately fixed. **Hebbian learning, STDP, online adaptation, spiking networks, real-dataset utility, hardware behavior, and closed-loop behavior are not qualified by this circuit.**
+
+See [NeuroAI Ecosystem Evidence](NEUROAI_ECOSYSTEM.md) for the scientific rationale and ORION comparison path.
 
 ### NeuralBench
 
@@ -177,20 +202,3 @@ DANDI / NWB / SpikeInterface
              |
              +------> Evidence
 ```
-
-The invasive lane should not force spike-sorting, dataset-client, or neuromodulation dependencies into `neuros-core`.
-
-## Adding an integration
-
-A new integration should land in this order:
-
-1. define the exact external boundary and what neurOS will not reimplement;
-2. implement an optional adapter/plugin or evidence operator outside `neuros-core`;
-3. add deterministic contract tests;
-4. add a registry entry at the weakest accurate status/evidence tier;
-5. add a clean-install CI lane with the optional dependency where appropriate;
-6. add real upstream integration evidence;
-7. add named real-data, hardware, or closed-loop evidence only when actually exercised;
-8. promote status or evidence tier only in the same change that adds the missing evidence.
-
-A README example alone is never sufficient to mark an integration supported.

--- a/docs/NEUROAI_ECOSYSTEM.md
+++ b/docs/NEUROAI_ECOSYSTEM.md
@@ -17,7 +17,7 @@ This distinction prevents research-code environments from becoming hidden kernel
 
 ## SNAP-derived invariant spectral evidence
 
-The Chung NeuroAI Lab's SNAP work introduces a spectral vocabulary for relating representation geometry to neural or task targets. neurOS now exposes a dependency-light NumPy implementation through:
+The Chung NeuroAI Lab's SNAP work introduces a spectral vocabulary for relating representation geometry to neural or task targets. neurOS exposes a dependency-light NumPy implementation through:
 
 ```python
 from neuros.foundation_models import spectral_alignment_evidence
@@ -27,30 +27,19 @@ print(evidence.effective_dimension)
 print(evidence.residual_target_power)
 ```
 
-The v1 evidence object records:
-
-- positive representation eigenvalues;
-- target power captured by each positive-rank mode;
-- cumulative captured target power;
-- participation-ratio effective dimension;
-- an effective dimension of remaining task power;
-- aggregate target power outside the representation span;
-- input and target SHA-256 identities;
-- a deterministic evidence digest.
+The evidence object records positive representation eigenvalues, target power captured by positive-rank modes, cumulative captured target power, effective dimensions, aggregate residual target power, input/target SHA-256 identities, and a deterministic evidence digest.
 
 ### Why neurOS does not expose every SNAP null-space mode
 
-For a rank-deficient sample kernel, the eigenvectors associated with zero eigenvalues are not unique. Two correct linear-algebra backends may rotate that null space and therefore assign different target power to individual zero-eigenvalue vectors even though the represented subspace is identical.
+For a rank-deficient sample kernel, the eigenvectors associated with zero eigenvalues are not unique. Two correct linear-algebra backends may rotate that null space and assign different target power to individual zero-eigenvalue vectors even though the represented subspace is identical.
 
-neurOS treats that as an evidence-design problem rather than hiding it behind a tolerance. Positive-rank modes remain explicit and all target power outside their span is aggregated into one invariant residual quantity.
+neurOS therefore leaves positive-rank modes explicit and aggregates all target power outside their span into one invariant residual quantity. The dedicated CI lane also checks out a pinned SNAP revision and executes the authors' real `snap/metrics.py` against the neurOS implementation for invariant quantities.
 
-That gives the evidence a stable interpretation across valid eigensolver implementations.
-
-The current public claim is a **software-contract numerical-method claim**. It does not imply that SNAP's paper results were reproduced, that a model is biologically aligned, or that a representation is mechanistically equivalent to a brain circuit.
+The current public claim is a **numerical method / upstream conformance claim**. It does not imply that SNAP's published experiments were reproduced, that a model is biologically aligned, or that a representation is mechanistically equivalent to a brain circuit.
 
 ## ngc-learn interoperability
 
-`ngc-learn` is an actively maintained JAX toolkit for computational neuroscience and biologically plausible NeuroAI, including graded neural dynamics, spiking cells, predictive-coding building blocks, Hebbian/STDP synapses, and neural input encoders.
+`ngc-learn` is a JAX toolkit for computational neuroscience and biologically plausible NeuroAI, including graded neural dynamics, spiking cells, predictive-coding building blocks, and Hebbian/STDP synapses.
 
 neurOS keeps it optional:
 
@@ -58,7 +47,9 @@ neurOS keeps it optional:
 pip install "neuros-foundation[ngclearn]"
 ```
 
-The first qualified upstream surface is intentionally narrow: the **ngc-learn 3.2.x `RateCell`**.
+The qualified upstream surface is deliberately narrower than the upstream library.
+
+### RateCell execution
 
 ```python
 from neuros.foundation_models import NgcLearnRateCellTransform
@@ -71,31 +62,81 @@ transform = NgcLearnRateCellTransform(
 result = transform.transform(samples, sample_rate_hz=250.0)
 ```
 
-The bridge records:
+This surface records exact ngc-learn/JAX identity, explicit time-by-channel geometry, integration step, parameters, and deterministic input/output/evidence hashes. It performs no hidden resampling, filtering, normalization, padding, fitting, or channel reordering.
 
-- exact ngc-learn version;
-- exact JAX version and backend;
-- JAX x64 state when observable;
-- upstream component identity;
-- time-by-channel input and output geometry;
-- sample rate and derived integration step;
-- RateCell parameters and seed;
-- input/output hashes and an evidence digest.
+### Predictive reconstruction
 
-It performs **no hidden resampling, filtering, normalization, padding, fitting, or channel reordering**.
+neurOS now also qualifies an **inference-only fixed-weight predictive-coding circuit** using real ngc-learn 3.2 components:
 
-The integration CI exercises the real upstream package. neurOS does not infer support for all of ngc-learn from one successful component test.
+```text
+input target x -> GaussianErrorCell e0 -> transpose feedback E -> latent RateCell z
+                    ^                                         |
+                    |                                         v
+                    +----------- fixed generative W <---------+
+```
 
-### Planned ngc-learn evidence ladder
+```python
+from neuros.foundation_models import NgcLearnPredictiveCodingTransform
 
-1. RateCell upstream execution and geometry;
-2. an explicit predictive-coding circuit with frozen dynamics/evidence semantics;
-3. spiking-cell and STDP/Hebbian learning contracts;
-4. real neural-data evaluation under deployment-unit-disjoint protocols;
-5. comparison against ORION representations and adaptation strategies;
-6. closed-loop qualification only if a complete sensing-to-action system is actually measured.
+pc = NgcLearnPredictiveCodingTransform(
+    latent_dim=4,
+    settling_steps=30,
+    seed=7,
+)
+result = pc.transform(samples, sample_rate_hz=250.0)
 
-Each step must land with its own evidence before the compatibility claim is promoted.
+latents = result.values
+reconstruction = result.reconstruction
+print(result.evidence.error_reduction_fraction)
+```
+
+Each observation begins from a reset circuit. The observation is clamped as the `GaussianErrorCell` target; the latent `RateCell` iteratively changes under residual feedback; a fixed generative `StaticSynapse` reconstructs the input; and the feedback matrix is explicitly tied to the transpose of that fixed generative matrix.
+
+The result records:
+
+- exact ngc-learn and JAX runtime identity;
+- actual `RateCell`, `GaussianErrorCell`, and `StaticSynapse` class identities;
+- latent and reconstruction geometry;
+- settling count, settling timestep, membrane constant, prior, activation, and integration method;
+- reset-per-observation and tied-transpose-feedback semantics;
+- input, weight, latent, reconstruction, and error-trajectory SHA-256 identities;
+- initial/final reconstruction MSE and reduction fraction;
+- fraction of observations that improve during settling.
+
+The real-upstream CI contract goes beyond object construction. With an identity generative dictionary, the installed ngc-learn 3.2 circuit must reduce known reconstruction error by more than 90%, and repeated executions must be bit-identical after reset. That behavior passed on the qualified Python 3.10 and 3.11 lanes.
+
+The circuit does **not** learn its weights. That is intentional. Fixed weights make inference dynamics, state reset, geometry, and provenance independently testable before introducing another source of state mutation.
+
+### Current ngc-learn evidence ladder
+
+1. **Qualified:** RateCell upstream execution and geometry.
+2. **Qualified:** fixed-weight predictive reconstruction with iterative Gaussian residual feedback.
+3. **Not yet qualified:** Hebbian/STDP synaptic adaptation and explicit adaptation/evaluation authority.
+4. **Not yet qualified:** spiking-network representation contracts.
+5. **Not yet qualified:** real neural-data utility under deployment-unit-disjoint evaluation.
+6. **Not yet qualified:** comparison against ORION under matched downstream capacity and calibration budgets.
+7. **Not yet qualified:** hardware or closed-loop behavior.
+
+This ordering matters. A working predictive-coding circuit is not evidence that biologically local learning improves a BCI, and neither is evidence of a biological mechanism.
+
+## Why predictive coding matters to ORION
+
+The value of the ngc-learn bridge is not merely adding another model family. It gives ORION a scientifically different representation baseline.
+
+A conventional frozen encoder, an ORION tokenizer/encoder, and a predictive-coding latent can eventually be compared under the same evaluation authority for:
+
+- held-out task utility;
+- user-specific calibration examples/minutes;
+- cross-session and cross-subject transfer;
+- representation effective dimension and task-aligned spectral power;
+- residual target power;
+- artifact, channel, montage, and jitter sensitivity;
+- uncertainty calibration;
+- latency and memory;
+- intervention/adaptation stability;
+- immutable data/model/evidence identity.
+
+That allows a useful question: **does iterative error-correcting inference provide transferable neural structure, and if so, does it reduce calibration cost compared with simpler or learned alternatives?**
 
 ## Other evaluated NeuroAI projects
 
@@ -139,34 +180,13 @@ reference method / upstream package
  evidence conformance artifact
 ```
 
-A future `EvidenceConformanceManifest` should bind:
-
-- method name and citation;
-- upstream repository and revision;
-- license;
-- upstream environment identity;
-- neurOS operator/revision;
-- fixture/data hashes;
-- numerical tolerances or exact semantic rules;
-- comparison result;
-- explicit claim boundary.
+A future `EvidenceConformanceManifest` should bind method/citation, upstream repository and revision, license, upstream environment, neurOS operator/revision, fixture/data hashes, numerical semantics/tolerances, comparison result, and explicit claim boundary.
 
 This is the difference between saying **"neurOS has an implementation"** and saying **"this implementation has executable evidence connecting it to the referenced method."**
 
 ## ORION connection
 
-ORION should consume this ecosystem through stable neurOS contracts rather than bespoke research scripts. A future ORION representation card should pair task performance and calibration cost with evidence such as:
-
-- spectral effective dimension;
-- task-aligned mode power;
-- residual target power;
-- cross-session and cross-subject geometry;
-- domain leakage;
-- montage/device robustness;
-- causal intervention stability;
-- uncertainty calibration;
-- runtime latency;
-- immutable dataset/model/evidence identities.
+ORION should consume this ecosystem through stable neurOS contracts rather than bespoke research scripts. A future ORION representation card should pair task performance and calibration cost with spectral geometry, cross-session/subject invariance, domain leakage, montage/device robustness, causal/adaptation stability, uncertainty, runtime, and immutable identities.
 
 The research objective remains practical: achieve the same or better held-out neural performance with materially less user-specific calibration, while showing *why* the representation transfers and where the claim stops.
 

--- a/examples/neuroai/ngclearn_predictive_coding.py
+++ b/examples/neuroai/ngclearn_predictive_coding.py
@@ -1,0 +1,60 @@
+"""Minimal evidence-producing ngc-learn predictive-coding example.
+
+Run after installing the optional integration:
+
+    pip install "neuros-foundation[ngclearn]"
+    python examples/neuroai/ngclearn_predictive_coding.py
+
+The fixture is intentionally tiny and deterministic. It demonstrates the
+qualified software/integration surface; it is not a real-neural-data benchmark.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from neuros.foundation_models import NgcLearnPredictiveCodingTransform
+
+
+def main() -> None:
+    samples = np.asarray(
+        [
+            [0.50, -0.25],
+            [1.00, 0.50],
+            [-0.75, 0.25],
+            [0.20, 0.80],
+        ],
+        dtype=np.float64,
+    )
+
+    # Identity weights make the expected reconstruction behavior transparent:
+    # the latent has enough capacity to represent both observed channels, while
+    # the circuit still has to reach that representation through iterative
+    # ngc-learn residual-feedback dynamics.
+    transform = NgcLearnPredictiveCodingTransform(
+        latent_dim=2,
+        settling_steps=80,
+        settling_dt_ms=1.0,
+        tau_m_ms=20.0,
+        prior_gamma=0.0,
+        activation="identity",
+        integration_type="euler",
+        output="linear",
+        weights=np.eye(2, dtype=np.float64),
+        seed=11,
+    )
+    result = transform.transform(samples, sample_rate_hz=250.0)
+
+    payload = {
+        "latent_shape": list(result.values.shape),
+        "reconstruction_shape": list(result.reconstruction.shape),
+        "mean_squared_error_by_step": result.mean_squared_error_by_step.tolist(),
+        "evidence": result.evidence.to_dict(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -72,6 +72,12 @@ from neuros.foundation_models.ngclearn_bridge import (
     NgcLearnVersionError,
     ngclearn_runtime_identity,
 )
+from neuros.foundation_models.ngclearn_predictive_coding import (
+    PC_METHOD_ID,
+    NgcLearnPredictiveCodingEvidence,
+    NgcLearnPredictiveCodingResult,
+    NgcLearnPredictiveCodingTransform,
+)
 from neuros.foundation_models.probes import (
     domain_leakage_probe,
     effective_rank,
@@ -194,6 +200,10 @@ __all__ = [
     "NgcLearnRateCellResult",
     "NgcLearnRateCellTransform",
     "ngclearn_runtime_identity",
+    "PC_METHOD_ID",
+    "NgcLearnPredictiveCodingEvidence",
+    "NgcLearnPredictiveCodingResult",
+    "NgcLearnPredictiveCodingTransform",
     "EvaluationProtocol",
     "BenchmarkReport",
     "benchmark_embeddings",

--- a/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py
@@ -1,0 +1,470 @@
+"""Qualified ngc-learn predictive-coding representation dynamics.
+
+This module intentionally qualifies a small, inference-only predictive-coding
+surface. It uses real ngc-learn 3.2 components to infer a latent representation
+by iteratively reducing reconstruction mismatch. Synaptic learning is not part
+of this contract; fixed generative weights make state mutation, replay, and
+claim boundaries explicit.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+
+from neuros.foundation_models.ngclearn_bridge import (
+    NGCLEARN_REFERENCE_REPOSITORY,
+    NgcLearnVersionError,
+    _array_sha256,
+    _canonical_sha256,
+    _load_upstream,
+    _matrix,
+)
+
+NgcLearnPredictiveOutput = Literal["linear", "nonlinear"]
+_PC_CONTEXT_IDS = itertools.count()
+PC_METHOD_ID = "neuros-ngclearn-predictive-reconstruction-v1"
+
+
+def _positive_finite(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if result <= 0 or not math.isfinite(result):
+        raise ValueError(f"{name} must be positive and finite")
+    return result
+
+
+def _finite(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _default_weights(*, latent_dim: int, input_dim: int, seed: int, scale: float) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    raw = rng.standard_normal((latent_dim, input_dim)).astype(np.float64)
+    singular_values = np.linalg.svd(raw, compute_uv=False)
+    spectral_norm = float(singular_values[0]) if singular_values.size else 0.0
+    if spectral_norm <= np.finfo(np.float64).eps:
+        raise RuntimeError("could not construct a non-degenerate predictive-coding weight matrix")
+    return np.ascontiguousarray(raw * (scale / spectral_norm), dtype=np.float64)
+
+
+@dataclass(frozen=True, slots=True)
+class NgcLearnPredictiveCodingEvidence:
+    """Immutable provenance for one predictive-coding transform execution."""
+
+    method_id: str
+    ngclearn_version: str
+    jax_version: str
+    jax_backend: str
+    jax_enable_x64: bool | None
+    latent_component: str
+    error_component: str
+    generative_synapse_component: str
+    feedback_synapse_component: str
+    activation: str
+    integration_type: str
+    output_compartment: str
+    latent_dim: int
+    settling_steps: int
+    settling_dt_ms: float
+    tau_m_ms: float
+    prior_gamma: float
+    weight_scale: float
+    seed: int
+    sample_rate_hz: float
+    reset_per_sample: bool
+    tied_transpose_feedback: bool
+    learning_enabled: bool
+    input_shape: tuple[int, int]
+    latent_shape: tuple[int, int]
+    reconstruction_shape: tuple[int, int]
+    input_sha256: str
+    weights_sha256: str
+    latent_sha256: str
+    reconstruction_sha256: str
+    error_trajectory_sha256: str
+    initial_mse: float
+    final_mse: float
+    error_reduction_fraction: float | None
+    samples_improved_fraction: float
+    evidence_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "method_id": self.method_id,
+            "integration": "ngc-learn",
+            "reference_repository": NGCLEARN_REFERENCE_REPOSITORY,
+            "ngclearn_version": self.ngclearn_version,
+            "jax_version": self.jax_version,
+            "jax_backend": self.jax_backend,
+            "jax_enable_x64": self.jax_enable_x64,
+            "components": {
+                "latent": self.latent_component,
+                "error": self.error_component,
+                "generative_synapse": self.generative_synapse_component,
+                "feedback_synapse": self.feedback_synapse_component,
+            },
+            "activation": self.activation,
+            "integration_type": self.integration_type,
+            "output_compartment": self.output_compartment,
+            "latent_dim": self.latent_dim,
+            "settling_steps": self.settling_steps,
+            "settling_dt_ms": self.settling_dt_ms,
+            "tau_m_ms": self.tau_m_ms,
+            "prior_gamma": self.prior_gamma,
+            "weight_scale": self.weight_scale,
+            "seed": self.seed,
+            "sample_rate_hz": self.sample_rate_hz,
+            "reset_per_sample": self.reset_per_sample,
+            "tied_transpose_feedback": self.tied_transpose_feedback,
+            "learning_enabled": self.learning_enabled,
+            "input_shape": list(self.input_shape),
+            "latent_shape": list(self.latent_shape),
+            "reconstruction_shape": list(self.reconstruction_shape),
+            "input_sha256": self.input_sha256,
+            "weights_sha256": self.weights_sha256,
+            "latent_sha256": self.latent_sha256,
+            "reconstruction_sha256": self.reconstruction_sha256,
+            "error_trajectory_sha256": self.error_trajectory_sha256,
+            "initial_mse": self.initial_mse,
+            "final_mse": self.final_mse,
+            "error_reduction_fraction": self.error_reduction_fraction,
+            "samples_improved_fraction": self.samples_improved_fraction,
+            "evidence_sha256": self.evidence_sha256,
+            "claim_boundary": {
+                "upstream_package_executed": True,
+                "predictive_coding_circuit_qualified": True,
+                "iterative_error_feedback_exercised": True,
+                "fixed_weight_inference_only": True,
+                "hebbian_learning_qualified": False,
+                "stdp_learning_qualified": False,
+                "online_learning_qualified": False,
+                "real_dataset_qualified": False,
+                "hardware_qualified": False,
+                "closed_loop_qualified": False,
+                "clinical_qualified": False,
+            },
+        }
+
+
+@dataclass(slots=True)
+class NgcLearnPredictiveCodingResult:
+    """Latent values, reconstructions, and settling evidence."""
+
+    values: np.ndarray
+    reconstruction: np.ndarray
+    mean_squared_error_by_step: np.ndarray
+    evidence: NgcLearnPredictiveCodingEvidence
+
+
+class NgcLearnPredictiveCodingTransform:
+    """Infer fixed-weight predictive-coding latents for time x channel samples.
+
+    Each row is treated as an independent observation. The circuit is reset,
+    the observation is clamped to a Gaussian prediction-error target, and a
+    latent ``RateCell`` settles under residual feedback from the reconstruction.
+    The generative synapse is fixed and the feedback synapse is tied to its
+    transpose. No fitting, filtering, resampling, padding, or channel reordering
+    occurs inside this transform.
+    """
+
+    def __init__(
+        self,
+        *,
+        latent_dim: int = 8,
+        settling_steps: int = 20,
+        settling_dt_ms: float = 1.0,
+        tau_m_ms: float = 20.0,
+        prior_gamma: float = 0.0,
+        activation: str = "identity",
+        integration_type: str = "euler",
+        output: NgcLearnPredictiveOutput = "nonlinear",
+        weight_scale: float = 0.75,
+        seed: int = 0,
+        weights: Any | None = None,
+    ) -> None:
+        if isinstance(latent_dim, bool) or not isinstance(latent_dim, int) or latent_dim < 1:
+            raise ValueError("latent_dim must be a positive integer")
+        if isinstance(settling_steps, bool) or not isinstance(settling_steps, int) or settling_steps < 1:
+            raise ValueError("settling_steps must be a positive integer")
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("seed must be a non-negative integer")
+        if not isinstance(activation, str) or not activation.strip():
+            raise ValueError("activation must be a non-empty string")
+        if not isinstance(integration_type, str) or not integration_type.strip():
+            raise ValueError("integration_type must be a non-empty string")
+        if output not in {"linear", "nonlinear"}:
+            raise ValueError("output must be 'linear' or 'nonlinear'")
+        self.latent_dim = latent_dim
+        self.settling_steps = settling_steps
+        self.settling_dt_ms = _positive_finite("settling_dt_ms", settling_dt_ms)
+        self.tau_m_ms = _positive_finite("tau_m_ms", tau_m_ms)
+        self.prior_gamma = _finite("prior_gamma", prior_gamma)
+        if self.prior_gamma < 0:
+            raise ValueError("prior_gamma must be non-negative")
+        self.weight_scale = _positive_finite("weight_scale", weight_scale)
+        self.activation = activation.strip()
+        self.integration_type = integration_type.strip()
+        self.output = output
+        self.seed = seed
+        self._provided_weights = None if weights is None else np.asarray(weights, dtype=np.float64)
+        if self._provided_weights is not None:
+            if self._provided_weights.ndim != 2:
+                raise ValueError("weights must be a 2D latent x input matrix")
+            if self._provided_weights.shape[0] != latent_dim:
+                raise ValueError(
+                    "weights first dimension must equal latent_dim; "
+                    f"expected {latent_dim}, received {self._provided_weights.shape[0]}"
+                )
+            if not np.isfinite(self._provided_weights).all():
+                raise ValueError("weights contain NaN or infinite values")
+            self._provided_weights = np.ascontiguousarray(self._provided_weights, dtype=np.float64)
+        self._context_id = next(_PC_CONTEXT_IDS)
+        self._runtime: tuple[Any, ...] | None = None
+        self._input_dim: int | None = None
+        self._weights: np.ndarray | None = None
+
+    def _ensure_runtime(self, input_dim: int) -> tuple[Any, ...]:
+        if self._runtime is not None:
+            if self._input_dim != input_dim:
+                raise ValueError(
+                    "NgcLearnPredictiveCodingTransform input channel count is fixed after first execution; "
+                    f"expected {self._input_dim}, received {input_dim}"
+                )
+            return self._runtime
+
+        ngclearn, components, jax, jnp, random, version = _load_upstream()
+        for symbol in ("GaussianErrorCell", "StaticSynapse", "RateCell"):
+            if not hasattr(components, symbol):
+                raise NgcLearnVersionError(
+                    f"qualified ngc-learn 3.2 predictive-coding surface is missing {symbol}"
+                )
+
+        if self._provided_weights is not None:
+            if self._provided_weights.shape[1] != input_dim:
+                raise ValueError(
+                    "weights second dimension must equal input channel count; "
+                    f"expected {input_dim}, received {self._provided_weights.shape[1]}"
+                )
+            weights = self._provided_weights.copy()
+        else:
+            weights = _default_weights(
+                latent_dim=self.latent_dim,
+                input_dim=input_dim,
+                seed=self.seed,
+                scale=self.weight_scale,
+            )
+
+        context_name = f"neuros_ngclearn_pc_{self._context_id}"
+        with ngclearn.Context(context_name):
+            latent = components.RateCell(
+                "z",
+                n_units=self.latent_dim,
+                tau_m=self.tau_m_ms,
+                act_fx=self.activation,
+                prior=("gaussian", self.prior_gamma),
+                integration_type=self.integration_type,
+                key=random.PRNGKey(self.seed),
+            )
+            error = components.GaussianErrorCell("e0", n_units=input_dim)
+            generative = components.StaticSynapse(
+                "W",
+                shape=(self.latent_dim, input_dim),
+                key=random.PRNGKey(self.seed + 1),
+            )
+            feedback = components.StaticSynapse(
+                "E",
+                shape=(input_dim, self.latent_dim),
+                key=random.PRNGKey(self.seed + 2),
+            )
+
+            latent.zF >> generative.inputs
+            generative.outputs >> error.mu
+            error.dmu >> feedback.inputs
+            feedback.outputs >> latent.j
+
+            # Follow the upstream Rao/Ballard-style discrete message-passing
+            # order: previous residual -> latent update -> reconstruction -> new residual.
+            advance = (
+                ngclearn.MethodProcess("pc_advance")
+                >> feedback.advance_state
+                >> latent.advance_state
+                >> generative.advance_state
+                >> error.advance_state
+            )
+            reset = (
+                ngclearn.MethodProcess("pc_reset")
+                >> latent.reset
+                >> error.reset
+                >> generative.reset
+                >> feedback.reset
+            )
+
+        generative.weights.set(jnp.asarray(weights))
+        feedback.weights.set(jnp.asarray(weights.T))
+        self._weights = np.ascontiguousarray(weights, dtype=np.float64)
+        self._input_dim = input_dim
+        self._runtime = (
+            latent,
+            error,
+            generative,
+            feedback,
+            advance,
+            reset,
+            jax,
+            jnp,
+            version,
+        )
+        return self._runtime
+
+    def transform(self, samples: Any, *, sample_rate_hz: float) -> NgcLearnPredictiveCodingResult:
+        sample_rate_hz = _positive_finite("sample_rate_hz", sample_rate_hz)
+        matrix = _matrix(samples)
+        input_dim = matrix.shape[1]
+        (
+            latent,
+            error,
+            generative,
+            feedback,
+            advance,
+            reset,
+            jax,
+            jnp,
+            version,
+        ) = self._ensure_runtime(input_dim)
+        assert self._weights is not None
+
+        latents: list[np.ndarray] = []
+        reconstructions: list[np.ndarray] = []
+        trajectories: list[np.ndarray] = []
+        sample_improved: list[bool] = []
+
+        for row in matrix:
+            reset.run()
+            target = jnp.asarray(row[None, :])
+            error.target.set(target)
+            initial_mse = float(np.mean(np.square(row)))
+            mse_steps = [initial_mse]
+
+            for step in range(self.settling_steps):
+                advance.run(t=float(step) * self.settling_dt_ms, dt=self.settling_dt_ms)
+                reconstruction = np.asarray(error.mu.get(), dtype=np.float64).reshape(-1)
+                if reconstruction.size != input_dim or not np.isfinite(reconstruction).all():
+                    raise RuntimeError("ngc-learn predictive-coding reconstruction is invalid")
+                mse_steps.append(float(np.mean(np.square(row - reconstruction))))
+
+            compartment = latent.z if self.output == "linear" else latent.zF
+            latent_value = np.asarray(compartment.get(), dtype=np.float64).reshape(-1)
+            reconstruction = np.asarray(error.mu.get(), dtype=np.float64).reshape(-1)
+            if latent_value.size != self.latent_dim or not np.isfinite(latent_value).all():
+                raise RuntimeError("ngc-learn predictive-coding latent geometry is invalid")
+            latents.append(latent_value)
+            reconstructions.append(reconstruction)
+            trajectory = np.asarray(mse_steps, dtype=np.float64)
+            trajectories.append(trajectory)
+            sample_improved.append(bool(trajectory[-1] <= trajectory[0] + 1e-12))
+
+        representation = np.ascontiguousarray(np.stack(latents), dtype=np.float64)
+        reconstruction_matrix = np.ascontiguousarray(np.stack(reconstructions), dtype=np.float64)
+        trajectory_matrix = np.ascontiguousarray(np.stack(trajectories), dtype=np.float64)
+        mean_trajectory = np.ascontiguousarray(trajectory_matrix.mean(axis=0), dtype=np.float64)
+        initial_mse = float(mean_trajectory[0])
+        final_mse = float(mean_trajectory[-1])
+        reduction = None if initial_mse <= np.finfo(np.float64).eps else float(1.0 - final_mse / initial_mse)
+        try:
+            x64_enabled: bool | None = bool(jax.config.read("jax_enable_x64"))
+        except Exception:
+            x64_enabled = None
+
+        payload: dict[str, Any] = {
+            "method_id": PC_METHOD_ID,
+            "ngclearn_version": version,
+            "jax_version": str(getattr(jax, "__version__", "unknown")),
+            "jax_backend": str(jax.default_backend()),
+            "jax_enable_x64": x64_enabled,
+            "latent_component": f"{latent.__class__.__module__}.{latent.__class__.__name__}",
+            "error_component": f"{error.__class__.__module__}.{error.__class__.__name__}",
+            "generative_synapse_component": f"{generative.__class__.__module__}.{generative.__class__.__name__}",
+            "feedback_synapse_component": f"{feedback.__class__.__module__}.{feedback.__class__.__name__}",
+            "activation": self.activation,
+            "integration_type": self.integration_type,
+            "output_compartment": "z" if self.output == "linear" else "zF",
+            "latent_dim": self.latent_dim,
+            "settling_steps": self.settling_steps,
+            "settling_dt_ms": self.settling_dt_ms,
+            "tau_m_ms": self.tau_m_ms,
+            "prior_gamma": self.prior_gamma,
+            "weight_scale": self.weight_scale,
+            "seed": self.seed,
+            "sample_rate_hz": sample_rate_hz,
+            "reset_per_sample": True,
+            "tied_transpose_feedback": True,
+            "learning_enabled": False,
+            "input_shape": [int(v) for v in matrix.shape],
+            "latent_shape": [int(v) for v in representation.shape],
+            "reconstruction_shape": [int(v) for v in reconstruction_matrix.shape],
+            "input_sha256": _array_sha256(matrix),
+            "weights_sha256": _array_sha256(self._weights),
+            "latent_sha256": _array_sha256(representation),
+            "reconstruction_sha256": _array_sha256(reconstruction_matrix),
+            "error_trajectory_sha256": _array_sha256(mean_trajectory),
+            "initial_mse": initial_mse,
+            "final_mse": final_mse,
+            "error_reduction_fraction": reduction,
+            "samples_improved_fraction": float(np.mean(sample_improved)),
+        }
+        payload["evidence_sha256"] = _canonical_sha256(payload)
+        evidence = NgcLearnPredictiveCodingEvidence(
+            method_id=PC_METHOD_ID,
+            ngclearn_version=str(payload["ngclearn_version"]),
+            jax_version=str(payload["jax_version"]),
+            jax_backend=str(payload["jax_backend"]),
+            jax_enable_x64=payload["jax_enable_x64"],
+            latent_component=str(payload["latent_component"]),
+            error_component=str(payload["error_component"]),
+            generative_synapse_component=str(payload["generative_synapse_component"]),
+            feedback_synapse_component=str(payload["feedback_synapse_component"]),
+            activation=str(payload["activation"]),
+            integration_type=str(payload["integration_type"]),
+            output_compartment=str(payload["output_compartment"]),
+            latent_dim=int(payload["latent_dim"]),
+            settling_steps=int(payload["settling_steps"]),
+            settling_dt_ms=float(payload["settling_dt_ms"]),
+            tau_m_ms=float(payload["tau_m_ms"]),
+            prior_gamma=float(payload["prior_gamma"]),
+            weight_scale=float(payload["weight_scale"]),
+            seed=int(payload["seed"]),
+            sample_rate_hz=float(payload["sample_rate_hz"]),
+            reset_per_sample=True,
+            tied_transpose_feedback=True,
+            learning_enabled=False,
+            input_shape=tuple(payload["input_shape"]),
+            latent_shape=tuple(payload["latent_shape"]),
+            reconstruction_shape=tuple(payload["reconstruction_shape"]),
+            input_sha256=str(payload["input_sha256"]),
+            weights_sha256=str(payload["weights_sha256"]),
+            latent_sha256=str(payload["latent_sha256"]),
+            reconstruction_sha256=str(payload["reconstruction_sha256"]),
+            error_trajectory_sha256=str(payload["error_trajectory_sha256"]),
+            initial_mse=float(payload["initial_mse"]),
+            final_mse=float(payload["final_mse"]),
+            error_reduction_fraction=payload["error_reduction_fraction"],
+            samples_improved_fraction=float(payload["samples_improved_fraction"]),
+            evidence_sha256=str(payload["evidence_sha256"]),
+        )
+        return NgcLearnPredictiveCodingResult(
+            values=representation,
+            reconstruction=reconstruction_matrix,
+            mean_squared_error_by_step=mean_trajectory,
+            evidence=evidence,
+        )

--- a/packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py
+++ b/packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.ngclearn_predictive_coding import (
+    PC_METHOD_ID,
+    NgcLearnPredictiveCodingTransform,
+)
+
+
+def test_predictive_coding_configuration_fails_before_optional_import():
+    with pytest.raises(ValueError, match="latent_dim"):
+        NgcLearnPredictiveCodingTransform(latent_dim=0)
+    with pytest.raises(ValueError, match="settling_steps"):
+        NgcLearnPredictiveCodingTransform(settling_steps=0)
+    with pytest.raises(ValueError, match="settling_dt_ms"):
+        NgcLearnPredictiveCodingTransform(settling_dt_ms=0.0)
+    with pytest.raises(ValueError, match="prior_gamma"):
+        NgcLearnPredictiveCodingTransform(prior_gamma=-0.1)
+    with pytest.raises(ValueError, match="weights first dimension"):
+        NgcLearnPredictiveCodingTransform(latent_dim=2, weights=np.ones((3, 4)))
+
+
+def test_real_ngclearn_predictive_coding_reduces_identity_reconstruction_error():
+    pytest.importorskip("ngclearn")
+    samples = np.asarray(
+        [
+            [0.50, -0.25],
+            [1.00, 0.50],
+            [-0.75, 0.25],
+            [0.20, 0.80],
+        ],
+        dtype=np.float64,
+    )
+    transform = NgcLearnPredictiveCodingTransform(
+        latent_dim=2,
+        settling_steps=80,
+        settling_dt_ms=1.0,
+        tau_m_ms=20.0,
+        prior_gamma=0.0,
+        activation="identity",
+        integration_type="euler",
+        output="linear",
+        weights=np.eye(2, dtype=np.float64),
+        seed=11,
+    )
+
+    first = transform.transform(samples, sample_rate_hz=250.0)
+    second = transform.transform(samples, sample_rate_hz=250.0)
+
+    assert first.values.shape == samples.shape
+    assert first.reconstruction.shape == samples.shape
+    assert first.mean_squared_error_by_step.shape == (81,)
+    assert np.isfinite(first.values).all()
+    assert np.isfinite(first.reconstruction).all()
+    assert np.isfinite(first.mean_squared_error_by_step).all()
+
+    # This known-ground-truth identity dictionary establishes that the real
+    # upstream error-feedback dynamics actually correct a prediction rather
+    # than merely executing a graph with the right class names.
+    assert first.evidence.initial_mse > 0.0
+    assert first.evidence.final_mse < first.evidence.initial_mse
+    assert first.evidence.error_reduction_fraction is not None
+    assert first.evidence.error_reduction_fraction > 0.90
+    assert first.evidence.samples_improved_fraction == 1.0
+    assert first.mean_squared_error_by_step[-1] < first.mean_squared_error_by_step[1]
+
+    # Reset-per-sample and fixed weights make repeated execution exact on the
+    # same installed upstream/runtime surface.
+    assert np.allclose(first.values, second.values, rtol=0.0, atol=0.0)
+    assert np.allclose(first.reconstruction, second.reconstruction, rtol=0.0, atol=0.0)
+    assert np.allclose(
+        first.mean_squared_error_by_step,
+        second.mean_squared_error_by_step,
+        rtol=0.0,
+        atol=0.0,
+    )
+    assert first.evidence.evidence_sha256 == second.evidence.evidence_sha256
+    assert first.evidence.method_id == PC_METHOD_ID
+
+    boundary = first.evidence.to_dict()["claim_boundary"]
+    assert boundary["upstream_package_executed"] is True
+    assert boundary["predictive_coding_circuit_qualified"] is True
+    assert boundary["iterative_error_feedback_exercised"] is True
+    assert boundary["fixed_weight_inference_only"] is True
+    assert boundary["hebbian_learning_qualified"] is False
+    assert boundary["stdp_learning_qualified"] is False
+    assert boundary["online_learning_qualified"] is False
+    assert boundary["real_dataset_qualified"] is False
+    assert boundary["hardware_qualified"] is False
+    assert boundary["closed_loop_qualified"] is False
+    assert boundary["clinical_qualified"] is False
+
+
+def test_predictive_coding_hashes_and_geometry_are_explicit():
+    pytest.importorskip("ngclearn")
+    weights = np.asarray(
+        [
+            [0.7, 0.0, 0.2],
+            [0.0, 0.6, -0.1],
+        ],
+        dtype=np.float64,
+    )
+    samples = np.asarray([[0.2, 0.4, -0.1], [0.1, -0.3, 0.5]], dtype=np.float64)
+    transform = NgcLearnPredictiveCodingTransform(
+        latent_dim=2,
+        settling_steps=10,
+        weights=weights,
+        seed=3,
+    )
+    result = transform.transform(samples, sample_rate_hz=500.0)
+
+    assert result.evidence.input_shape == (2, 3)
+    assert result.evidence.latent_shape == (2, 2)
+    assert result.evidence.reconstruction_shape == (2, 3)
+    assert len(result.evidence.input_sha256) == 64
+    assert len(result.evidence.weights_sha256) == 64
+    assert len(result.evidence.latent_sha256) == 64
+    assert len(result.evidence.reconstruction_sha256) == 64
+    assert len(result.evidence.error_trajectory_sha256) == 64
+    assert len(result.evidence.evidence_sha256) == 64
+    assert result.evidence.tied_transpose_feedback is True
+    assert result.evidence.reset_per_sample is True
+    assert result.evidence.learning_enabled is False
+
+
+def test_predictive_coding_rejects_input_or_weight_geometry_drift():
+    pytest.importorskip("ngclearn")
+    transform = NgcLearnPredictiveCodingTransform(
+        latent_dim=2,
+        weights=np.eye(2, dtype=np.float64),
+    )
+    transform.transform(np.ones((2, 2)), sample_rate_hz=250.0)
+
+    with pytest.raises(ValueError, match="input channel count is fixed"):
+        transform.transform(np.ones((2, 3)), sample_rate_hz=250.0)
+
+    mismatched = NgcLearnPredictiveCodingTransform(
+        latent_dim=2,
+        weights=np.ones((2, 3), dtype=np.float64),
+    )
+    with pytest.raises(ValueError, match="weights second dimension"):
+        mismatched.transform(np.ones((2, 2)), sample_rate_hz=250.0)

--- a/packages/neuros/src/neuros/compatibility.py
+++ b/packages/neuros/src/neuros/compatibility.py
@@ -209,19 +209,29 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         name="ngc-learn",
         category="computational neuroscience / NeuroAI",
         status=IntegrationStatus.EXPERIMENTAL,
-        capabilities=("rate-cell-transform", "jax-identity", "biological-dynamics-bridge"),
+        capabilities=(
+            "rate-cell-transform",
+            "predictive-reconstruction",
+            "iterative-error-feedback",
+            "jax-identity",
+            "biological-dynamics-bridge",
+        ),
         evidence_tier=EvidenceTier.INTEGRATION,
         evidence_paths=(
             "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py",
+            "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py",
             "packages/neuros-foundation/tests/test_ngclearn_bridge.py",
+            "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py",
             ".github/workflows/neuroai-ecosystem-ci.yml",
         ),
         notes=(
-            "The first qualified upstream surface is deliberately narrow: ngc-learn 3.2.x "
-            "RateCell execution with exact JAX/upstream identity, explicit time-by-channel "
-            "geometry, and no hidden preprocessing. Predictive-coding circuits, spiking "
-            "networks, Hebbian/STDP learning, real-data utility, and closed-loop behavior "
-            "remain unqualified until separate evidence lands."
+            "Qualified upstream ngc-learn 3.2.x surfaces include RateCell execution and a "
+            "fixed-weight predictive reconstruction circuit using real RateCell, "
+            "GaussianErrorCell, and StaticSynapse residual-feedback dynamics. The circuit "
+            "resets per observation, ties feedback to the generative-weight transpose, and "
+            "records reconstruction-error trajectories and artifact identities. Hebbian/STDP "
+            "learning, online adaptation, spiking networks, real-data utility, hardware, and "
+            "closed-loop behavior remain unqualified until separate evidence lands."
         ),
         install_hint='pip install "neuros-foundation[ngclearn]"',
     ),

--- a/tests/test_compatibility_registry.py
+++ b/tests/test_compatibility_registry.py
@@ -98,16 +98,26 @@ def test_snap_is_a_numerical_evidence_contract_not_a_biological_claim():
     assert "spectral_alignment.py" in " ".join(record.evidence_paths)
 
 
-def test_ngclearn_is_real_upstream_integration_but_only_for_narrow_surface():
+def test_ngclearn_predictive_coding_is_integration_qualified_but_learning_is_not():
     record = get_integration("ngclearn")
 
     assert record.status is IntegrationStatus.EXPERIMENTAL
     assert record.evidence_tier is EvidenceTier.INTEGRATION
     assert "rate-cell-transform" in record.capabilities
+    assert "predictive-reconstruction" in record.capabilities
+    assert "iterative-error-feedback" in record.capabilities
     assert "spiking-network" not in record.capabilities
-    assert "predictive-coding" not in record.capabilities
+    assert "hebbian-learning" not in record.capabilities
+    assert "stdp-learning" not in record.capabilities
+    assert "online-adaptation" not in record.capabilities
     assert record.install_hint == 'pip install "neuros-foundation[ngclearn]"'
+    evidence = " ".join(record.evidence_paths)
+    assert "ngclearn_predictive_coding.py" in evidence
+    assert "test_ngclearn_predictive_coding.py" in evidence
     assert "3.2.x" in record.notes
+    assert "fixed-weight predictive reconstruction" in record.notes
+    assert "Hebbian/STDP" in record.notes
+    assert "remain unqualified" in record.notes
 
 
 def test_research_organizations_are_not_promoted_as_monolithic_integrations():


### PR DESCRIPTION
## Why

The first ngc-learn integration deliberately qualified only a single RateCell. This PR advances one scientific rung without collapsing the whole predictive-coding ecosystem into a support claim: it adds a fixed-weight, inference-only predictive reconstruction circuit whose iterative error-feedback dynamics are executed through the real ngc-learn 3.2 runtime.

## Circuit

For each time x channel observation, neurOS builds an isolated upstream circuit:

```text
input target x -> GaussianErrorCell e0 -> transpose feedback E -> latent RateCell z
                    ^                                         |
                    |                                         v
                    +----------- fixed generative W <---------+
```

The observation is clamped to `e0.target`. The latent starts from reset state, receives residual feedback through `E = W.T`, predicts the observation through `W`, and settles for an explicit number of internal integration steps.

This is aligned with the Rao/Ballard-style error-feedback formulation documented by ngc-learn, while intentionally removing synaptic learning from the first qualified contract.

## Explicit behavior

`NgcLearnPredictiveCodingTransform` records:

- exact ngc-learn/JAX version and backend;
- actual RateCell, GaussianErrorCell, and StaticSynapse class identities;
- latent/output geometry;
- settling steps, dt, membrane time constant, prior, activation, and integration type;
- fixed generative weights and tied-transpose feedback semantics;
- reset-per-sample behavior;
- input, weight, latent, reconstruction, and error-trajectory SHA-256 identities;
- initial/final reconstruction MSE and reduction fraction;
- fraction of samples whose final reconstruction improves over the reset prediction.

No hidden filtering, resampling, fitting, padding, or channel reordering occurs.

## Known-ground-truth upstream test

The real ngc-learn CI lane exercises both the existing RateCell boundary and the predictive-coding circuit on Python 3.10/3.11.

A deterministic identity-dictionary fixture must reduce reconstruction error by >90% through actual upstream residual-feedback dynamics. Repeated transforms must be bit-identical after reset. Geometry drift and invalid weight/input contracts fail closed.

This is stronger than checking that the right class names instantiate: the dynamics must do the expected corrective computation.

## Public usability

The qualified capability is now surfaced through:

- `neuros compatibility ngclearn --json`;
- the evidence-backed compatibility registry;
- `docs/NEUROAI_ECOSYSTEM.md` and `docs/COMPATIBILITY.md`;
- `examples/neuroai/ngclearn_predictive_coding.py`.

The public example is itself executed inside the real ngc-learn Python 3.10/3.11 CI lane. The compatibility documentation also preserves the repository-wide integration-promotion rule: new integrations begin at the weakest accurate evidence tier and are promoted only in the same change that adds the missing executable evidence.

## Claim boundary

A passing circuit establishes an **ngc-learn predictive-coding integration contract**. It does not qualify:

- Hebbian synaptic learning;
- STDP/plasticity;
- online adaptation;
- real-dataset utility;
- superiority over ORION or conventional encoders;
- real-time latency;
- hardware;
- closed-loop behavior;
- biological mechanism or clinical claims.

Those remain separate evidence rungs.

## Exact-head qualification

Final head: `67f8a9ce300a511d8fcdb3bd28537ecb331a1a40`

All triggered workflows are green:

- neurOS CI
- NeuroAI Ecosystem Evidence
- Public Trust Contracts
- Ecosystem Compatibility
- neurOS real-world evidence
- Braindecode Compatibility
- Braindecode Longitudinal Evidence

Notable exact-head checks include:

- real ngc-learn 3.2 predictive dynamics on Python 3.10 and 3.11;
- public predictive-coding example on both qualified ngc-learn Python lanes;
- pinned upstream SNAP invariant conformance;
- ORION contracts/tokenization;
- model/mech-int contracts;
- MOABB and longitudinal evaluation authority;
- Braindecode upstream training/inference and paired evidence;
- MNE round trips on Python 3.10/3.11/3.12;
- kernel dependency firewall;
- recording interoperability;
- all workspace wheel builds;
- strict documentation build with warnings as failures.
