### PR TITLE
evidence: add auditable adaptation authority and rollback contracts

### DIFF
--- a/.github/workflows/orion-adaptation-ci.yml
+++ b/.github/workflows/orion-adaptation-ci.yml
@@ -8,6 +8,7 @@ on:
       - "packages/orion/src/orion/__init__.py"
       - "packages/orion/pyproject.toml"
       - "tests/test_orion_adaptation.py"
+      - "tests/test_orion_adaptation_integrity.py"
       - "tests/test_orion_contracts.py"
       - "examples/orion/adaptation_authority.py"
       - "docs/ADAPTATION_AUTHORITY.md"
@@ -22,6 +23,7 @@ on:
       - "packages/orion/src/orion/__init__.py"
       - "packages/orion/pyproject.toml"
       - "tests/test_orion_adaptation.py"
+      - "tests/test_orion_adaptation_integrity.py"
       - "tests/test_orion_contracts.py"
       - "examples/orion/adaptation_authority.py"
       - "docs/ADAPTATION_AUTHORITY.md"
@@ -59,6 +61,7 @@ jobs:
         run: |
           pytest -q \
             tests/test_orion_adaptation.py \
+            tests/test_orion_adaptation_integrity.py \
             tests/test_orion_contracts.py
       - name: Exercise public authority example twice
         run: |

--- a/.github/workflows/orion-adaptation-ci.yml
+++ b/.github/workflows/orion-adaptation-ci.yml
@@ -1,0 +1,81 @@
+name: ORION Adaptation Authority
+
+on:
+  pull_request:
+    paths:
+      - "packages/orion/src/orion/adaptation.py"
+      - "packages/orion/src/orion/contracts.py"
+      - "packages/orion/src/orion/__init__.py"
+      - "packages/orion/pyproject.toml"
+      - "tests/test_orion_adaptation.py"
+      - "tests/test_orion_contracts.py"
+      - "examples/orion/adaptation_authority.py"
+      - "docs/ADAPTATION_AUTHORITY.md"
+      - "docs/API_REFERENCE.md"
+      - "mkdocs.yml"
+      - ".github/workflows/orion-adaptation-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/orion/src/orion/adaptation.py"
+      - "packages/orion/src/orion/contracts.py"
+      - "packages/orion/src/orion/__init__.py"
+      - "packages/orion/pyproject.toml"
+      - "tests/test_orion_adaptation.py"
+      - "tests/test_orion_contracts.py"
+      - "examples/orion/adaptation_authority.py"
+      - "docs/ADAPTATION_AUTHORITY.md"
+      - "docs/API_REFERENCE.md"
+      - "mkdocs.yml"
+      - ".github/workflows/orion-adaptation-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: orion-adaptation-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  adaptation-contracts:
+    name: Adaptation authority / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install dependency-light ORION profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/orion[test]"
+      - name: Exercise adaptation authority and legacy proposal contracts
+        run: |
+          pytest -q \
+            tests/test_orion_adaptation.py \
+            tests/test_orion_contracts.py
+      - name: Exercise public authority example twice
+        run: |
+          python examples/orion/adaptation_authority.py > "${RUNNER_TEMP}/adaptation-first.json"
+          python examples/orion/adaptation_authority.py > "${RUNNER_TEMP}/adaptation-second.json"
+          diff -u "${RUNNER_TEMP}/adaptation-first.json" "${RUNNER_TEMP}/adaptation-second.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["RUNNER_TEMP"]) / "adaptation-first.json"
+          payload = json.loads(path.read_text())
+          assert payload["outcome"]["phase"] == "retained"
+          assert payload["authority"]["authority_fingerprint"]
+          assert payload["outcome"]["outcome_fingerprint"]
+          assert payload["application"]["before_artifact"]["sha256"] != payload["application"]["after_artifact"]["sha256"]
+          PY
+      - name: Compile adaptation public modules
+        run: python -m compileall -q packages/orion/src/orion/adaptation.py examples/orion/adaptation_authority.py

--- a/docs/ADAPTATION_AUTHORITY.md
+++ b/docs/ADAPTATION_AUTHORITY.md
@@ -1,0 +1,233 @@
+# Adaptation Authority
+
+ORION treats adaptation as a state-changing operation that requires its own evidence authority.
+
+A decoder, local learning rule, optimizer, or representation model may decide **how** to update state. It must not also decide **which data are allowed to cause the update** or **which held-out data are used to justify keeping it**.
+
+`orion.adaptation` separates those responsibilities.
+
+## State machine
+
+```text
+AdaptationProposal
+       |
+       v
+GovernedAdaptationProposal
+  frozen authority
+  pre-update artifact
+       |
+       +--------> REJECTED
+       |
+       v
+    APPROVED
+       |
+       v
+    APPLIED
+ exact adaptation indices
+ before/after artifact SHA-256
+       |
+       v
+   EVALUATED
+ exact frozen evaluation indices
+       |
+       +--------> RETAINED
+       |
+       +--------> ROLLED BACK
+                    |
+                    v
+          exact pre-update SHA-256
+```
+
+The evidence records are immutable and deterministically fingerprinted. They do not contain wall-clock time in their semantic identity, so replaying the same authority, proposal, decision, application, and evaluation yields the same fingerprints.
+
+## Why this exists
+
+Adaptive neural systems can accidentally produce optimistic results when:
+
+- samples used to update a model are reused for evaluation;
+- the method chooses a favorable evaluation subset after adaptation;
+- a proposed update is recorded without preserving the exact pre-update state;
+- a rejected update still mutates state;
+- an update changes nothing but is counted as an adaptation event;
+- rollback restores a similar model rather than the exact previous artifact;
+- each algorithm invents different meanings for calibration, evaluation, and provenance.
+
+The authority contract makes these failure modes explicit and testable.
+
+## Core types
+
+### `ArtifactIdentity`
+
+Identifies a model, representation, optimizer, weight set, or other mutable state by:
+
+- stable artifact ID;
+- artifact type;
+- SHA-256 identity;
+- optional version;
+- immutable metadata;
+- deterministic fingerprint.
+
+The SHA-256 is the rollback authority. Human-readable names are not sufficient.
+
+### `AdaptationAuthority`
+
+Freezes:
+
+- dataset identity;
+- deployment split unit;
+- exact adaptation indices in exact order;
+- exact held-out evaluation indices in exact order;
+- processed-data SHA-256;
+- total sample count;
+- protocol fingerprint when available;
+- source evidence-authority fingerprint when available;
+- seed and structured metadata.
+
+Adaptation and evaluation indices must be disjoint. Both must be in range. Final evaluation must consume the exact frozen evaluation set, not a subset, superset, or reordered selection.
+
+### `GovernedAdaptationProposal`
+
+Binds the existing lightweight `AdaptationProposal` to:
+
+- one `AdaptationAuthority` fingerprint;
+- the exact pre-update `ArtifactIdentity`;
+- the exact authorized adaptation rows.
+
+The original proposal API remains lightweight and backward compatible. Scientific/deployment authority is added only when a proposal crosses into governed state mutation.
+
+### `AdaptationDecision`
+
+Records explicit approval or rejection with an actor and reason.
+
+A rejected proposal cannot produce an `AdaptationApplication`.
+
+### `AdaptationApplication`
+
+Records an approved mutation with:
+
+- proposal, authority, and decision fingerprints;
+- exact before/after artifact identities;
+- exact adaptation indices;
+- numerical update evidence such as update count or parameter delta.
+
+An application whose pre- and post-update SHA-256 identities are identical fails closed. A no-op is not represented as a successful state change.
+
+### `AdaptationEvaluation`
+
+Records held-out metrics before and after adaptation using the **complete frozen evaluation index set**. Before/after metric names must match so an adaptation cannot quietly change the reported scorecard after seeing results.
+
+### `AdaptationOutcome`
+
+Finalizes the evidence as either:
+
+- `retained`, where the active artifact must be the exact post-update SHA-256; or
+- `rolled-back`, where the active artifact must be the exact pre-update SHA-256.
+
+This record says what happened. It does not prescribe a universal policy for whether accuracy, calibration, latency, or another metric should dominate the retain/rollback decision.
+
+## Example
+
+```python
+from orion import (
+    AdaptationApplication,
+    AdaptationAuthority,
+    AdaptationDecision,
+    AdaptationEvaluation,
+    AdaptationOutcome,
+    AdaptationProposal,
+    ArtifactIdentity,
+    GovernedAdaptationProposal,
+)
+
+authority = AdaptationAuthority(
+    authority_id="subject-07/session-02/calibration-v1",
+    dataset_id="my-eeg-study",
+    split_unit="session",
+    adaptation_indices=(100, 101, 104, 108),
+    evaluation_indices=(102, 103, 105, 106, 107),
+    processed_data_sha256="<64 hex characters>",
+    n_samples=1000,
+    protocol_fingerprint="subject-session-disjoint-v2",
+)
+
+before = ArtifactIdentity(
+    artifact_id="decoder/subject-07/pre-calibration",
+    artifact_type="decoder-state",
+    sha256="<64 hex characters>",
+)
+
+proposal = GovernedAdaptationProposal.bind(
+    AdaptationProposal(
+        reason="target-session calibration",
+        changes={"learning_rate": 1e-3, "steps": 4},
+        requires_approval=True,
+    ),
+    authority=authority,
+    before_artifact=before,
+    adaptation_indices=authority.adaptation_indices,
+)
+
+decision = AdaptationDecision.approve(
+    proposal,
+    actor="operator/research-protocol",
+    reason="calibration budget authorized",
+)
+```
+
+After the algorithm updates only the authorized rows, hash the resulting state and create an `AdaptationApplication`. Evaluate both artifacts on `authority.evaluation_indices`, then record a retain or rollback outcome.
+
+The repository includes a complete dependency-light example at `examples/orion/adaptation_authority.py`.
+
+## Relationship to longitudinal evidence
+
+The foundation evidence layer already owns stronger dataset-specific authorities such as `LongitudinalCaseAuthority`. ORION does **not** import `neuros-foundation` to reuse them, because that would reverse the stable dependency direction.
+
+Instead, an experiment should derive the adaptation authority from the already-frozen case and carry its identity forward:
+
+```text
+LongitudinalCaseAuthority
+  processed data SHA-256
+  calibration ordering
+  immutable evaluation indices
+  authority fingerprint
+            |
+            v
+AdaptationAuthority
+  exact selected calibration budget
+  same frozen evaluation indices
+  source_authority_fingerprint
+            |
+            v
+state-changing algorithm
+```
+
+This keeps ORION dependency-light while preserving an auditable chain back to the real-dataset evaluation authority.
+
+## What this does not claim
+
+A valid adaptation ledger proves **process integrity**, not adaptation benefit.
+
+It does not prove that:
+
+- the update improves real neural decoding;
+- personalization reduces calibration cost;
+- a Hebbian or STDP rule is biologically correct;
+- an adapted representation transfers across subjects, sessions, sites, or devices;
+- the update is safe for a physical actuator or clinical system.
+
+Those require their own evidence under the project-wide scientific claim ladder.
+
+## Next qualification rung
+
+The intended next use is an ngc-learn Hebbian predictive-coding experiment in which:
+
+1. a real `LongitudinalCaseAuthority` freezes target-session calibration/evaluation data;
+2. an `AdaptationAuthority` selects one explicit calibration budget;
+3. real upstream Hebbian synapses update only those rows;
+4. before/after weights receive immutable SHA-256 identities;
+5. synapses freeze before held-out evaluation;
+6. the complete evaluation partition is scored before and after;
+7. the result is retained or rolled back under explicit policy;
+8. the same authority can be given to an ORION adaptation method for a matched comparison.
+
+That sequence lets neurOS compare biologically local learning and ORION personalization without allowing either method to move the goalposts.

--- a/examples/orion/adaptation_authority.py
+++ b/examples/orion/adaptation_authority.py
@@ -1,0 +1,102 @@
+"""Dependency-light demonstration of ORION adaptation authority.
+
+This example simulates artifact identities rather than training a real decoder.
+Its purpose is to show the governed state-transition and evidence surface that
+real ORION personalization or external local-learning rules must use.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from orion import (
+    AdaptationApplication,
+    AdaptationAuthority,
+    AdaptationDecision,
+    AdaptationEvaluation,
+    AdaptationOutcome,
+    AdaptationProposal,
+    ArtifactIdentity,
+    GovernedAdaptationProposal,
+)
+
+
+def sha(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def main() -> None:
+    authority = AdaptationAuthority(
+        authority_id="demo-subject/session-2/calibration-4",
+        dataset_id="orion-adaptation-fixture",
+        split_unit="session",
+        adaptation_indices=(0, 2, 4, 6),
+        evaluation_indices=(1, 3, 5, 7),
+        processed_data_sha256=sha("fixture-data"),
+        n_samples=8,
+        protocol_fingerprint="demo-session-disjoint-v1",
+        source_authority_fingerprint="fixture-longitudinal-authority",
+        seed=7,
+    )
+    before = ArtifactIdentity(
+        artifact_id="decoder/pre-adaptation",
+        artifact_type="decoder-state",
+        sha256=sha("decoder-before"),
+    )
+    proposal = GovernedAdaptationProposal.bind(
+        AdaptationProposal(
+            reason="target-session calibration",
+            changes={"learning_rate": 0.001, "steps": 4},
+            evidence={"calibration_error": 0.31},
+            requires_approval=True,
+        ),
+        authority=authority,
+        before_artifact=before,
+        adaptation_indices=authority.adaptation_indices,
+    )
+    decision = AdaptationDecision.approve(
+        proposal,
+        actor="policy/demo",
+        reason="fixture calibration budget authorized",
+    )
+    after = ArtifactIdentity(
+        artifact_id="decoder/post-adaptation",
+        artifact_type="decoder-state",
+        sha256=sha("decoder-after"),
+    )
+    application = AdaptationApplication.record(
+        proposal,
+        decision,
+        authority=authority,
+        after_artifact=after,
+        adaptation_indices=authority.adaptation_indices,
+        update_evidence={"updates": 4, "parameter_delta_l2": 0.14},
+    )
+    evaluation = AdaptationEvaluation.record(
+        application,
+        authority=authority,
+        evaluation_indices=authority.evaluation_indices,
+        metrics_before={"accuracy": 0.625, "ece": 0.12},
+        metrics_after={"accuracy": 0.750, "ece": 0.08},
+    )
+    outcome = AdaptationOutcome.retain(
+        application,
+        evaluation,
+        actor="policy/demo",
+        reason="held-out accuracy improved and ECE decreased",
+    )
+
+    payload = {
+        "authority": authority.to_dict(),
+        "proposal": proposal.to_dict(),
+        "decision": decision.to_dict(),
+        "application": application.to_dict(),
+        "evaluation": evaluation.to_dict(),
+        "outcome": outcome.to_dict(),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - Longitudinal EEG Showcase: LONGITUDINAL_EEG_SHOWCASE.md
       - Longitudinal Model Ladder: LONGITUDINAL_MODEL_LADDER.md
   - ORION / Neurotokenization:
+      - Adaptation Authority: ADAPTATION_AUTHORITY.md
       - Master Plan: neurotokenization/00_MASTER_PLAN.md
       - Tokenizer Specs: neurotokenization/01_TOKENIZER_SPECS.md
       - Evaluation Protocol: neurotokenization/02_EVALUATION_PROTOCOL.md

--- a/packages/orion/src/orion/__init__.py
+++ b/packages/orion/src/orion/__init__.py
@@ -1,5 +1,15 @@
 """ORION neural intelligence interfaces and tokenization research layer."""
 
+from .adaptation import (
+    AdaptationApplication,
+    AdaptationAuthority,
+    AdaptationDecision,
+    AdaptationEvaluation,
+    AdaptationOutcome,
+    AdaptationPhase,
+    ArtifactIdentity,
+    GovernedAdaptationProposal,
+)
 from .contracts import (
     AdaptationProposal,
     AdaptiveDecoder,
@@ -21,12 +31,20 @@ from .tokenization import (
 )
 
 __all__ = [
+    "AdaptationApplication",
+    "AdaptationAuthority",
+    "AdaptationDecision",
+    "AdaptationEvaluation",
+    "AdaptationOutcome",
+    "AdaptationPhase",
     "AdaptationProposal",
     "AdaptiveDecoder",
+    "ArtifactIdentity",
     "AssemblyTokenizer",
     "BinnedCountTokenizer",
     "BurstTokenizer",
     "EventSpikeTokenizer",
+    "GovernedAdaptationProposal",
     "ISIRelativeTimeTokenizer",
     "NeuralEncoder",
     "NeuroTokenBatch",

--- a/packages/orion/src/orion/adaptation.py
+++ b/packages/orion/src/orion/adaptation.py
@@ -1,0 +1,578 @@
+"""Auditable authority for state-changing ORION adaptation.
+
+The adaptation plane is intentionally separate from an algorithm's update rule.
+An optimizer, Hebbian rule, decoder, or personalization method may propose and
+apply a change, but it does not get to choose the observations used to justify
+that change. ``AdaptationAuthority`` freezes those semantics first.
+
+This module is dependency-light and lives in ORION so both learned ORION
+personalization and external biologically plausible learning systems can share
+the same governance contract without becoming dependencies of one another.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import numpy as np
+
+from .contracts import AdaptationProposal
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _jsonable(value: Any) -> Any:
+    """Convert supported evidence values to deterministic JSON primitives."""
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("adaptation evidence cannot contain NaN or infinity")
+        return value
+    if isinstance(value, np.generic):
+        return _jsonable(value.item())
+    if isinstance(value, np.ndarray):
+        return _jsonable(value.tolist())
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    raise TypeError(
+        "adaptation evidence must be composed of JSON-compatible primitives, "
+        f"NumPy scalars/arrays, mappings, lists, or tuples; got {type(value).__name__}"
+    )
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        _jsonable(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _sha256(name: str, value: str) -> str:
+    normalized = str(value).strip().lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError(f"{name} must be a 64-character lowercase SHA-256 hex digest")
+    return normalized
+
+
+def _indices(name: str, values: Any) -> tuple[int, ...]:
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if array.dtype == np.bool_:
+        raise ValueError(f"{name} must contain integer sample indices, not booleans")
+    try:
+        integer = array.astype(np.int64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain integer sample indices") from exc
+    if not np.array_equal(array, integer):
+        raise ValueError(f"{name} must contain integer sample indices")
+    result = tuple(int(value) for value in integer.tolist())
+    if not result:
+        raise ValueError(f"{name} must be non-empty")
+    if any(value < 0 for value in result):
+        raise ValueError(f"{name} cannot contain negative indices")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} cannot contain duplicate indices")
+    return result
+
+
+def _numeric_evidence(name: str, values: Mapping[str, Any]) -> Mapping[str, float]:
+    normalized: dict[str, float] = {}
+    for key, value in values.items():
+        if not str(key).strip():
+            raise ValueError(f"{name} keys must be non-empty")
+        if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+            raise ValueError(f"{name}[{key!r}] must be numeric")
+        number = float(value)
+        if not math.isfinite(number):
+            raise ValueError(f"{name}[{key!r}] must be finite")
+        normalized[str(key)] = number
+    return MappingProxyType(normalized)
+
+
+class AdaptationPhase(str, Enum):
+    PROPOSED = "proposed"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    APPLIED = "applied"
+    EVALUATED = "evaluated"
+    RETAINED = "retained"
+    ROLLED_BACK = "rolled-back"
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactIdentity:
+    """Immutable identity of model, representation, or optimizer state."""
+
+    artifact_id: str
+    sha256: str
+    artifact_type: str = "model-state"
+    version: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.artifact_id.strip():
+            raise ValueError("artifact_id must be non-empty")
+        if not self.artifact_type.strip():
+            raise ValueError("artifact_type must be non-empty")
+        object.__setattr__(self, "sha256", _sha256("artifact sha256", self.sha256))
+        object.__setattr__(self, "metadata", MappingProxyType(dict(_jsonable(self.metadata))))
+
+    @property
+    def fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "artifact_id": self.artifact_id,
+            "artifact_type": self.artifact_type,
+            "sha256": self.sha256,
+            "version": self.version,
+            "metadata": dict(self.metadata),
+        }
+        if include_fingerprint:
+            payload["fingerprint"] = self.fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptationAuthority:
+    """Frozen sample and provenance authority for one adaptation evaluation.
+
+    ``adaptation_indices`` are the only observations allowed to influence the
+    proposed state change. ``evaluation_indices`` are immutable and must never
+    be supplied to the adaptation rule. Final evaluation must use this complete
+    frozen set rather than a favorable subset.
+    """
+
+    authority_id: str
+    dataset_id: str
+    split_unit: str
+    adaptation_indices: tuple[int, ...]
+    evaluation_indices: tuple[int, ...]
+    processed_data_sha256: str
+    n_samples: int
+    protocol_fingerprint: str | None = None
+    source_authority_fingerprint: str | None = None
+    seed: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.authority_id.strip() or not self.dataset_id.strip():
+            raise ValueError("authority_id and dataset_id must be non-empty")
+        if not self.split_unit.strip():
+            raise ValueError("split_unit must be non-empty")
+        if isinstance(self.n_samples, bool) or not isinstance(self.n_samples, int) or self.n_samples < 1:
+            raise ValueError("n_samples must be a positive integer")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int) or self.seed < 0:
+            raise ValueError("seed must be a non-negative integer")
+        adaptation = _indices("adaptation_indices", self.adaptation_indices)
+        evaluation = _indices("evaluation_indices", self.evaluation_indices)
+        overlap = set(adaptation) & set(evaluation)
+        if overlap:
+            raise ValueError(
+                "adaptation and evaluation indices must be disjoint; overlap="
+                f"{sorted(overlap)[:8]}"
+            )
+        if max((*adaptation, *evaluation)) >= self.n_samples:
+            raise ValueError("adaptation authority contains out-of-range sample indices")
+        object.__setattr__(self, "adaptation_indices", adaptation)
+        object.__setattr__(self, "evaluation_indices", evaluation)
+        object.__setattr__(
+            self,
+            "processed_data_sha256",
+            _sha256("processed_data_sha256", self.processed_data_sha256),
+        )
+        object.__setattr__(self, "metadata", MappingProxyType(dict(_jsonable(self.metadata))))
+
+    @property
+    def authority_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "authority_id": self.authority_id,
+            "dataset_id": self.dataset_id,
+            "split_unit": self.split_unit,
+            "adaptation_indices": list(self.adaptation_indices),
+            "evaluation_indices": list(self.evaluation_indices),
+            "processed_data_sha256": self.processed_data_sha256,
+            "n_samples": self.n_samples,
+            "protocol_fingerprint": self.protocol_fingerprint,
+            "source_authority_fingerprint": self.source_authority_fingerprint,
+            "seed": self.seed,
+            "metadata": dict(self.metadata),
+        }
+        if include_fingerprint:
+            payload["authority_fingerprint"] = self.authority_fingerprint
+        return payload
+
+    def require_adaptation_indices(self, values: Any) -> tuple[int, ...]:
+        actual = _indices("applied adaptation indices", values)
+        if actual != self.adaptation_indices:
+            raise ValueError(
+                "adaptation must use the exact authority adaptation indices in frozen order"
+            )
+        return actual
+
+    def require_evaluation_indices(self, values: Any) -> tuple[int, ...]:
+        actual = _indices("evaluation indices", values)
+        if actual != self.evaluation_indices:
+            raise ValueError(
+                "evaluation must use the exact frozen evaluation indices; subsets, supersets, "
+                "or reordered evaluation samples are not permitted"
+            )
+        return actual
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedAdaptationProposal:
+    """One ordinary ``AdaptationProposal`` bound to immutable authority/state."""
+
+    proposal: AdaptationProposal
+    authority_fingerprint: str
+    before_artifact: ArtifactIdentity
+    adaptation_indices: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.authority_fingerprint.strip():
+            raise ValueError("authority_fingerprint must be non-empty")
+        object.__setattr__(self, "adaptation_indices", _indices("adaptation_indices", self.adaptation_indices))
+        # Force deterministic serializability at the governance boundary. The
+        # lightweight AdaptationProposal remains backward-compatible.
+        _jsonable(dict(self.proposal.changes))
+        _jsonable(dict(self.proposal.evidence))
+
+    @classmethod
+    def bind(
+        cls,
+        proposal: AdaptationProposal,
+        *,
+        authority: AdaptationAuthority,
+        before_artifact: ArtifactIdentity,
+        adaptation_indices: Any,
+    ) -> "GovernedAdaptationProposal":
+        indices = authority.require_adaptation_indices(adaptation_indices)
+        return cls(
+            proposal=proposal,
+            authority_fingerprint=authority.authority_fingerprint,
+            before_artifact=before_artifact,
+            adaptation_indices=indices,
+        )
+
+    @property
+    def proposal_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "phase": AdaptationPhase.PROPOSED.value,
+            "authority_fingerprint": self.authority_fingerprint,
+            "before_artifact": self.before_artifact.to_dict(),
+            "adaptation_indices": list(self.adaptation_indices),
+            "proposal": {
+                "reason": self.proposal.reason,
+                "changes": dict(self.proposal.changes),
+                "evidence": dict(self.proposal.evidence),
+                "requires_approval": self.proposal.requires_approval,
+            },
+        }
+        if include_fingerprint:
+            payload["proposal_fingerprint"] = self.proposal_fingerprint
+        return _jsonable(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptationDecision:
+    """Approval or rejection of a governed proposal."""
+
+    proposal_fingerprint: str
+    authority_fingerprint: str
+    phase: AdaptationPhase
+    actor: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.phase not in {AdaptationPhase.APPROVED, AdaptationPhase.REJECTED}:
+            raise ValueError("decision phase must be approved or rejected")
+        if not self.proposal_fingerprint.strip() or not self.authority_fingerprint.strip():
+            raise ValueError("proposal_fingerprint and authority_fingerprint must be non-empty")
+        if not self.actor.strip() or not self.reason.strip():
+            raise ValueError("decision actor and reason must be non-empty")
+
+    @classmethod
+    def approve(
+        cls,
+        governed: GovernedAdaptationProposal,
+        *,
+        actor: str,
+        reason: str,
+    ) -> "AdaptationDecision":
+        return cls(
+            proposal_fingerprint=governed.proposal_fingerprint,
+            authority_fingerprint=governed.authority_fingerprint,
+            phase=AdaptationPhase.APPROVED,
+            actor=actor,
+            reason=reason,
+        )
+
+    @classmethod
+    def reject(
+        cls,
+        governed: GovernedAdaptationProposal,
+        *,
+        actor: str,
+        reason: str,
+    ) -> "AdaptationDecision":
+        return cls(
+            proposal_fingerprint=governed.proposal_fingerprint,
+            authority_fingerprint=governed.authority_fingerprint,
+            phase=AdaptationPhase.REJECTED,
+            actor=actor,
+            reason=reason,
+        )
+
+    @property
+    def decision_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "phase": self.phase.value,
+            "proposal_fingerprint": self.proposal_fingerprint,
+            "authority_fingerprint": self.authority_fingerprint,
+            "actor": self.actor,
+            "reason": self.reason,
+        }
+        if include_fingerprint:
+            payload["decision_fingerprint"] = self.decision_fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptationApplication:
+    """Evidence that an approved mutation was applied to authorized data only."""
+
+    proposal_fingerprint: str
+    authority_fingerprint: str
+    decision_fingerprint: str
+    before_artifact: ArtifactIdentity
+    after_artifact: ArtifactIdentity
+    adaptation_indices: tuple[int, ...]
+    update_evidence: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.before_artifact.sha256 == self.after_artifact.sha256:
+            raise ValueError("an applied adaptation must change the artifact SHA-256 identity")
+        object.__setattr__(self, "adaptation_indices", _indices("adaptation_indices", self.adaptation_indices))
+        object.__setattr__(self, "update_evidence", _numeric_evidence("update_evidence", self.update_evidence))
+
+    @classmethod
+    def record(
+        cls,
+        governed: GovernedAdaptationProposal,
+        decision: AdaptationDecision,
+        *,
+        authority: AdaptationAuthority,
+        after_artifact: ArtifactIdentity,
+        adaptation_indices: Any,
+        update_evidence: Mapping[str, float] | None = None,
+    ) -> "AdaptationApplication":
+        if decision.phase is not AdaptationPhase.APPROVED:
+            raise ValueError("a rejected adaptation cannot be applied")
+        if decision.proposal_fingerprint != governed.proposal_fingerprint:
+            raise ValueError("decision does not belong to governed proposal")
+        if decision.authority_fingerprint != authority.authority_fingerprint:
+            raise ValueError("decision authority does not match adaptation authority")
+        indices = authority.require_adaptation_indices(adaptation_indices)
+        return cls(
+            proposal_fingerprint=governed.proposal_fingerprint,
+            authority_fingerprint=authority.authority_fingerprint,
+            decision_fingerprint=decision.decision_fingerprint,
+            before_artifact=governed.before_artifact,
+            after_artifact=after_artifact,
+            adaptation_indices=indices,
+            update_evidence={} if update_evidence is None else update_evidence,
+        )
+
+    @property
+    def application_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "phase": AdaptationPhase.APPLIED.value,
+            "proposal_fingerprint": self.proposal_fingerprint,
+            "authority_fingerprint": self.authority_fingerprint,
+            "decision_fingerprint": self.decision_fingerprint,
+            "before_artifact": self.before_artifact.to_dict(),
+            "after_artifact": self.after_artifact.to_dict(),
+            "adaptation_indices": list(self.adaptation_indices),
+            "update_evidence": dict(self.update_evidence),
+        }
+        if include_fingerprint:
+            payload["application_fingerprint"] = self.application_fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptationEvaluation:
+    """Held-out evaluation of one applied adaptation under frozen authority."""
+
+    application_fingerprint: str
+    authority_fingerprint: str
+    evaluation_indices: tuple[int, ...]
+    metrics_before: Mapping[str, float]
+    metrics_after: Mapping[str, float]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evaluation_indices", _indices("evaluation_indices", self.evaluation_indices))
+        object.__setattr__(self, "metrics_before", _numeric_evidence("metrics_before", self.metrics_before))
+        object.__setattr__(self, "metrics_after", _numeric_evidence("metrics_after", self.metrics_after))
+        if set(self.metrics_before) != set(self.metrics_after):
+            raise ValueError("metrics_before and metrics_after must contain the same metric names")
+        if not self.metrics_before:
+            raise ValueError("adaptation evaluation requires at least one metric")
+
+    @classmethod
+    def record(
+        cls,
+        application: AdaptationApplication,
+        *,
+        authority: AdaptationAuthority,
+        evaluation_indices: Any,
+        metrics_before: Mapping[str, float],
+        metrics_after: Mapping[str, float],
+    ) -> "AdaptationEvaluation":
+        if application.authority_fingerprint != authority.authority_fingerprint:
+            raise ValueError("application authority does not match evaluation authority")
+        indices = authority.require_evaluation_indices(evaluation_indices)
+        return cls(
+            application_fingerprint=application.application_fingerprint,
+            authority_fingerprint=authority.authority_fingerprint,
+            evaluation_indices=indices,
+            metrics_before=metrics_before,
+            metrics_after=metrics_after,
+        )
+
+    @property
+    def evaluation_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "phase": AdaptationPhase.EVALUATED.value,
+            "application_fingerprint": self.application_fingerprint,
+            "authority_fingerprint": self.authority_fingerprint,
+            "evaluation_indices": list(self.evaluation_indices),
+            "metrics_before": dict(self.metrics_before),
+            "metrics_after": dict(self.metrics_after),
+        }
+        if include_fingerprint:
+            payload["evaluation_fingerprint"] = self.evaluation_fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class AdaptationOutcome:
+    """Final retain-or-rollback decision after held-out evaluation."""
+
+    evaluation_fingerprint: str
+    authority_fingerprint: str
+    phase: AdaptationPhase
+    before_artifact: ArtifactIdentity
+    after_artifact: ArtifactIdentity
+    active_artifact: ArtifactIdentity
+    actor: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if self.phase not in {AdaptationPhase.RETAINED, AdaptationPhase.ROLLED_BACK}:
+            raise ValueError("outcome phase must be retained or rolled-back")
+        if not self.actor.strip() or not self.reason.strip():
+            raise ValueError("outcome actor and reason must be non-empty")
+        expected = self.after_artifact if self.phase is AdaptationPhase.RETAINED else self.before_artifact
+        if self.active_artifact.sha256 != expected.sha256:
+            if self.phase is AdaptationPhase.ROLLED_BACK:
+                raise ValueError("rollback must restore the exact pre-adaptation artifact SHA-256")
+            raise ValueError("retained outcome must keep the exact post-adaptation artifact SHA-256")
+
+    @classmethod
+    def retain(
+        cls,
+        application: AdaptationApplication,
+        evaluation: AdaptationEvaluation,
+        *,
+        actor: str,
+        reason: str,
+    ) -> "AdaptationOutcome":
+        if evaluation.application_fingerprint != application.application_fingerprint:
+            raise ValueError("evaluation does not belong to adaptation application")
+        return cls(
+            evaluation_fingerprint=evaluation.evaluation_fingerprint,
+            authority_fingerprint=application.authority_fingerprint,
+            phase=AdaptationPhase.RETAINED,
+            before_artifact=application.before_artifact,
+            after_artifact=application.after_artifact,
+            active_artifact=application.after_artifact,
+            actor=actor,
+            reason=reason,
+        )
+
+    @classmethod
+    def rollback(
+        cls,
+        application: AdaptationApplication,
+        evaluation: AdaptationEvaluation,
+        *,
+        restored_artifact: ArtifactIdentity,
+        actor: str,
+        reason: str,
+    ) -> "AdaptationOutcome":
+        if evaluation.application_fingerprint != application.application_fingerprint:
+            raise ValueError("evaluation does not belong to adaptation application")
+        return cls(
+            evaluation_fingerprint=evaluation.evaluation_fingerprint,
+            authority_fingerprint=application.authority_fingerprint,
+            phase=AdaptationPhase.ROLLED_BACK,
+            before_artifact=application.before_artifact,
+            after_artifact=application.after_artifact,
+            active_artifact=restored_artifact,
+            actor=actor,
+            reason=reason,
+        )
+
+    @property
+    def outcome_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))[:16]
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload = {
+            "phase": self.phase.value,
+            "evaluation_fingerprint": self.evaluation_fingerprint,
+            "authority_fingerprint": self.authority_fingerprint,
+            "before_artifact": self.before_artifact.to_dict(),
+            "after_artifact": self.after_artifact.to_dict(),
+            "active_artifact": self.active_artifact.to_dict(),
+            "actor": self.actor,
+            "reason": self.reason,
+        }
+        if include_fingerprint:
+            payload["outcome_fingerprint"] = self.outcome_fingerprint
+        return payload

--- a/packages/orion/src/orion/adaptation.py
+++ b/packages/orion/src/orion/adaptation.py
@@ -42,7 +42,10 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return _jsonable(value.tolist())
     if isinstance(value, Mapping):
-        return {str(key): _jsonable(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+        return {
+            str(key): _jsonable(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
     if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
     raise TypeError(
@@ -177,7 +180,11 @@ class AdaptationAuthority:
             raise ValueError("authority_id and dataset_id must be non-empty")
         if not self.split_unit.strip():
             raise ValueError("split_unit must be non-empty")
-        if isinstance(self.n_samples, bool) or not isinstance(self.n_samples, int) or self.n_samples < 1:
+        if (
+            isinstance(self.n_samples, bool)
+            or not isinstance(self.n_samples, int)
+            or self.n_samples < 1
+        ):
             raise ValueError("n_samples must be a positive integer")
         if isinstance(self.seed, bool) or not isinstance(self.seed, int) or self.seed < 0:
             raise ValueError("seed must be a non-negative integer")
@@ -253,7 +260,11 @@ class GovernedAdaptationProposal:
     def __post_init__(self) -> None:
         if not self.authority_fingerprint.strip():
             raise ValueError("authority_fingerprint must be non-empty")
-        object.__setattr__(self, "adaptation_indices", _indices("adaptation_indices", self.adaptation_indices))
+        object.__setattr__(
+            self,
+            "adaptation_indices",
+            _indices("adaptation_indices", self.adaptation_indices),
+        )
         # Force deterministic serializability at the governance boundary. The
         # lightweight AdaptationProposal remains backward-compatible.
         _jsonable(dict(self.proposal.changes))
@@ -380,8 +391,16 @@ class AdaptationApplication:
     def __post_init__(self) -> None:
         if self.before_artifact.sha256 == self.after_artifact.sha256:
             raise ValueError("an applied adaptation must change the artifact SHA-256 identity")
-        object.__setattr__(self, "adaptation_indices", _indices("adaptation_indices", self.adaptation_indices))
-        object.__setattr__(self, "update_evidence", _numeric_evidence("update_evidence", self.update_evidence))
+        object.__setattr__(
+            self,
+            "adaptation_indices",
+            _indices("adaptation_indices", self.adaptation_indices),
+        )
+        object.__setattr__(
+            self,
+            "update_evidence",
+            _numeric_evidence("update_evidence", self.update_evidence),
+        )
 
     @classmethod
     def record(
@@ -396,8 +415,14 @@ class AdaptationApplication:
     ) -> "AdaptationApplication":
         if decision.phase is not AdaptationPhase.APPROVED:
             raise ValueError("a rejected adaptation cannot be applied")
+        if governed.authority_fingerprint != authority.authority_fingerprint:
+            raise ValueError("governed proposal authority does not match adaptation authority")
+        if governed.adaptation_indices != authority.adaptation_indices:
+            raise ValueError("governed proposal adaptation indices differ from frozen authority")
         if decision.proposal_fingerprint != governed.proposal_fingerprint:
             raise ValueError("decision does not belong to governed proposal")
+        if decision.authority_fingerprint != governed.authority_fingerprint:
+            raise ValueError("decision authority does not match governed proposal authority")
         if decision.authority_fingerprint != authority.authority_fingerprint:
             raise ValueError("decision authority does not match adaptation authority")
         indices = authority.require_adaptation_indices(adaptation_indices)
@@ -442,9 +467,21 @@ class AdaptationEvaluation:
     metrics_after: Mapping[str, float]
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "evaluation_indices", _indices("evaluation_indices", self.evaluation_indices))
-        object.__setattr__(self, "metrics_before", _numeric_evidence("metrics_before", self.metrics_before))
-        object.__setattr__(self, "metrics_after", _numeric_evidence("metrics_after", self.metrics_after))
+        object.__setattr__(
+            self,
+            "evaluation_indices",
+            _indices("evaluation_indices", self.evaluation_indices),
+        )
+        object.__setattr__(
+            self,
+            "metrics_before",
+            _numeric_evidence("metrics_before", self.metrics_before),
+        )
+        object.__setattr__(
+            self,
+            "metrics_after",
+            _numeric_evidence("metrics_after", self.metrics_after),
+        )
         if set(self.metrics_before) != set(self.metrics_after):
             raise ValueError("metrics_before and metrics_after must contain the same metric names")
         if not self.metrics_before:
@@ -462,6 +499,7 @@ class AdaptationEvaluation:
     ) -> "AdaptationEvaluation":
         if application.authority_fingerprint != authority.authority_fingerprint:
             raise ValueError("application authority does not match evaluation authority")
+        authority.require_adaptation_indices(application.adaptation_indices)
         indices = authority.require_evaluation_indices(evaluation_indices)
         return cls(
             application_fingerprint=application.application_fingerprint,
@@ -507,7 +545,11 @@ class AdaptationOutcome:
             raise ValueError("outcome phase must be retained or rolled-back")
         if not self.actor.strip() or not self.reason.strip():
             raise ValueError("outcome actor and reason must be non-empty")
-        expected = self.after_artifact if self.phase is AdaptationPhase.RETAINED else self.before_artifact
+        expected = (
+            self.after_artifact
+            if self.phase is AdaptationPhase.RETAINED
+            else self.before_artifact
+        )
         if self.active_artifact.sha256 != expected.sha256:
             if self.phase is AdaptationPhase.ROLLED_BACK:
                 raise ValueError("rollback must restore the exact pre-adaptation artifact SHA-256")
@@ -524,6 +566,8 @@ class AdaptationOutcome:
     ) -> "AdaptationOutcome":
         if evaluation.application_fingerprint != application.application_fingerprint:
             raise ValueError("evaluation does not belong to adaptation application")
+        if evaluation.authority_fingerprint != application.authority_fingerprint:
+            raise ValueError("evaluation authority does not match adaptation application")
         return cls(
             evaluation_fingerprint=evaluation.evaluation_fingerprint,
             authority_fingerprint=application.authority_fingerprint,
@@ -547,6 +591,8 @@ class AdaptationOutcome:
     ) -> "AdaptationOutcome":
         if evaluation.application_fingerprint != application.application_fingerprint:
             raise ValueError("evaluation does not belong to adaptation application")
+        if evaluation.authority_fingerprint != application.authority_fingerprint:
+            raise ValueError("evaluation authority does not match adaptation application")
         return cls(
             evaluation_fingerprint=evaluation.evaluation_fingerprint,
             authority_fingerprint=application.authority_fingerprint,

--- a/tests/test_orion_adaptation.py
+++ b/tests/test_orion_adaptation.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+from orion import AdaptationProposal
+from orion.adaptation import (
+    AdaptationApplication,
+    AdaptationAuthority,
+    AdaptationDecision,
+    AdaptationEvaluation,
+    AdaptationOutcome,
+    AdaptationPhase,
+    ArtifactIdentity,
+    GovernedAdaptationProposal,
+)
+
+
+def _sha(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _authority() -> AdaptationAuthority:
+    return AdaptationAuthority(
+        authority_id="subject-07/session-02/calibration-v1",
+        dataset_id="fixture-eeg",
+        split_unit="session",
+        adaptation_indices=(0, 2, 4, 6),
+        evaluation_indices=(1, 3, 5, 7),
+        processed_data_sha256=_sha("processed-data"),
+        n_samples=8,
+        protocol_fingerprint="protocol-1234",
+        source_authority_fingerprint="longitudinal-5678",
+        seed=9,
+    )
+
+
+def _artifact(label: str) -> ArtifactIdentity:
+    return ArtifactIdentity(
+        artifact_id=f"decoder/{label}",
+        artifact_type="decoder-state",
+        sha256=_sha(label),
+        metadata={"backend": "fixture", "shape": [2, 2]},
+    )
+
+
+def _governed() -> tuple[AdaptationAuthority, GovernedAdaptationProposal]:
+    authority = _authority()
+    proposal = AdaptationProposal(
+        reason="target-session calibration",
+        changes={"learning_rate": 0.01, "steps": 4},
+        evidence={"calibration_loss": 0.42},
+        requires_approval=True,
+    )
+    governed = GovernedAdaptationProposal.bind(
+        proposal,
+        authority=authority,
+        before_artifact=_artifact("before"),
+        adaptation_indices=(0, 2, 4, 6),
+    )
+    return authority, governed
+
+
+def test_authority_rejects_adaptation_evaluation_leakage():
+    with pytest.raises(ValueError, match="must be disjoint"):
+        AdaptationAuthority(
+            authority_id="bad",
+            dataset_id="fixture",
+            split_unit="session",
+            adaptation_indices=(0, 1, 2),
+            evaluation_indices=(2, 3),
+            processed_data_sha256=_sha("data"),
+            n_samples=4,
+        )
+
+
+def test_authority_requires_exact_frozen_indices_and_order():
+    authority = _authority()
+
+    assert authority.require_adaptation_indices((0, 2, 4, 6)) == (0, 2, 4, 6)
+    assert authority.require_evaluation_indices((1, 3, 5, 7)) == (1, 3, 5, 7)
+
+    with pytest.raises(ValueError, match="exact authority adaptation indices"):
+        authority.require_adaptation_indices((0, 2))
+    with pytest.raises(ValueError, match="exact frozen evaluation indices"):
+        authority.require_evaluation_indices((1, 3, 5))
+    with pytest.raises(ValueError, match="exact frozen evaluation indices"):
+        authority.require_evaluation_indices((7, 5, 3, 1))
+
+
+def test_rejected_proposal_cannot_mutate_state():
+    authority, governed = _governed()
+    rejected = AdaptationDecision.reject(
+        governed,
+        actor="policy/calibration-budget",
+        reason="calibration error did not cross update threshold",
+    )
+
+    assert rejected.phase is AdaptationPhase.REJECTED
+    with pytest.raises(ValueError, match="rejected adaptation cannot be applied"):
+        AdaptationApplication.record(
+            governed,
+            rejected,
+            authority=authority,
+            after_artifact=_artifact("after"),
+            adaptation_indices=authority.adaptation_indices,
+        )
+
+
+def test_approved_application_binds_before_after_and_authorized_samples():
+    authority, governed = _governed()
+    approved = AdaptationDecision.approve(
+        governed,
+        actor="operator/sid",
+        reason="approved for frozen calibration partition",
+    )
+    application = AdaptationApplication.record(
+        governed,
+        approved,
+        authority=authority,
+        after_artifact=_artifact("after"),
+        adaptation_indices=authority.adaptation_indices,
+        update_evidence={"updates": 4, "weight_delta_l2": 0.125},
+    )
+
+    assert application.before_artifact.sha256 == _sha("before")
+    assert application.after_artifact.sha256 == _sha("after")
+    assert application.adaptation_indices == authority.adaptation_indices
+    assert application.update_evidence["updates"] == pytest.approx(4.0)
+
+    with pytest.raises(ValueError, match="exact authority adaptation indices"):
+        AdaptationApplication.record(
+            governed,
+            approved,
+            authority=authority,
+            after_artifact=_artifact("different-after"),
+            adaptation_indices=(0, 2, 4, 7),
+        )
+
+
+def test_application_cannot_claim_a_noop_as_an_applied_update():
+    authority, governed = _governed()
+    approved = AdaptationDecision.approve(
+        governed,
+        actor="operator/sid",
+        reason="apply fixture",
+    )
+    same_state = ArtifactIdentity(
+        artifact_id="decoder/copied-name",
+        artifact_type="decoder-state",
+        sha256=governed.before_artifact.sha256,
+    )
+
+    with pytest.raises(ValueError, match="must change the artifact SHA-256"):
+        AdaptationApplication.record(
+            governed,
+            approved,
+            authority=authority,
+            after_artifact=same_state,
+            adaptation_indices=authority.adaptation_indices,
+        )
+
+
+def test_evaluation_cannot_use_adaptation_rows_or_cherry_pick_subset():
+    authority, governed = _governed()
+    approved = AdaptationDecision.approve(
+        governed,
+        actor="operator/sid",
+        reason="apply fixture",
+    )
+    application = AdaptationApplication.record(
+        governed,
+        approved,
+        authority=authority,
+        after_artifact=_artifact("after"),
+        adaptation_indices=authority.adaptation_indices,
+    )
+
+    with pytest.raises(ValueError, match="exact frozen evaluation indices"):
+        AdaptationEvaluation.record(
+            application,
+            authority=authority,
+            evaluation_indices=(0, 1, 3, 5, 7),
+            metrics_before={"accuracy": 0.60},
+            metrics_after={"accuracy": 0.70},
+        )
+
+    with pytest.raises(ValueError, match="exact frozen evaluation indices"):
+        AdaptationEvaluation.record(
+            application,
+            authority=authority,
+            evaluation_indices=(1, 3, 5),
+            metrics_before={"accuracy": 0.60},
+            metrics_after={"accuracy": 0.70},
+        )
+
+
+def test_rollback_restores_exact_pre_adaptation_identity():
+    authority, governed = _governed()
+    approved = AdaptationDecision.approve(
+        governed,
+        actor="operator/sid",
+        reason="apply fixture",
+    )
+    application = AdaptationApplication.record(
+        governed,
+        approved,
+        authority=authority,
+        after_artifact=_artifact("after"),
+        adaptation_indices=authority.adaptation_indices,
+    )
+    evaluation = AdaptationEvaluation.record(
+        application,
+        authority=authority,
+        evaluation_indices=authority.evaluation_indices,
+        metrics_before={"accuracy": 0.72, "ece": 0.08},
+        metrics_after={"accuracy": 0.69, "ece": 0.11},
+    )
+
+    outcome = AdaptationOutcome.rollback(
+        application,
+        evaluation,
+        restored_artifact=governed.before_artifact,
+        actor="policy/held-out-regression",
+        reason="held-out accuracy and calibration regressed",
+    )
+    assert outcome.phase is AdaptationPhase.ROLLED_BACK
+    assert outcome.active_artifact.sha256 == governed.before_artifact.sha256
+
+    wrong_restore = _artifact("not-the-before-state")
+    with pytest.raises(ValueError, match="exact pre-adaptation artifact"):
+        AdaptationOutcome.rollback(
+            application,
+            evaluation,
+            restored_artifact=wrong_restore,
+            actor="policy/held-out-regression",
+            reason="attempt invalid rollback",
+        )
+
+
+def test_retain_keeps_exact_post_adaptation_identity():
+    authority, governed = _governed()
+    approved = AdaptationDecision.approve(
+        governed,
+        actor="operator/sid",
+        reason="apply fixture",
+    )
+    application = AdaptationApplication.record(
+        governed,
+        approved,
+        authority=authority,
+        after_artifact=_artifact("after"),
+        adaptation_indices=authority.adaptation_indices,
+    )
+    evaluation = AdaptationEvaluation.record(
+        application,
+        authority=authority,
+        evaluation_indices=authority.evaluation_indices,
+        metrics_before={"accuracy": 0.61, "ece": 0.12},
+        metrics_after={"accuracy": 0.74, "ece": 0.07},
+    )
+    outcome = AdaptationOutcome.retain(
+        application,
+        evaluation,
+        actor="policy/held-out-improvement",
+        reason="held-out utility improved without calibration regression",
+    )
+
+    assert outcome.phase is AdaptationPhase.RETAINED
+    assert outcome.active_artifact.sha256 == application.after_artifact.sha256
+
+
+def test_identical_replay_produces_identical_authority_and_evidence_fingerprints():
+    first_authority, first_governed = _governed()
+    second_authority, second_governed = _governed()
+
+    assert first_authority.authority_fingerprint == second_authority.authority_fingerprint
+    assert first_governed.proposal_fingerprint == second_governed.proposal_fingerprint
+
+    def run(authority: AdaptationAuthority, governed: GovernedAdaptationProposal):
+        decision = AdaptationDecision.approve(
+            governed,
+            actor="policy/replay",
+            reason="deterministic fixture approval",
+        )
+        application = AdaptationApplication.record(
+            governed,
+            decision,
+            authority=authority,
+            after_artifact=_artifact("after"),
+            adaptation_indices=authority.adaptation_indices,
+            update_evidence={"updates": 4, "weight_delta_l2": 0.125},
+        )
+        evaluation = AdaptationEvaluation.record(
+            application,
+            authority=authority,
+            evaluation_indices=authority.evaluation_indices,
+            metrics_before={"accuracy": 0.61},
+            metrics_after={"accuracy": 0.74},
+        )
+        outcome = AdaptationOutcome.retain(
+            application,
+            evaluation,
+            actor="policy/replay",
+            reason="deterministic held-out result",
+        )
+        return decision, application, evaluation, outcome
+
+    first = run(first_authority, first_governed)
+    second = run(second_authority, second_governed)
+
+    assert first[0].decision_fingerprint == second[0].decision_fingerprint
+    assert first[1].application_fingerprint == second[1].application_fingerprint
+    assert first[2].evaluation_fingerprint == second[2].evaluation_fingerprint
+    assert first[3].outcome_fingerprint == second[3].outcome_fingerprint

--- a/tests/test_orion_adaptation_integrity.py
+++ b/tests/test_orion_adaptation_integrity.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from orion import AdaptationProposal
+from orion.adaptation import (
+    AdaptationApplication,
+    AdaptationAuthority,
+    AdaptationDecision,
+    AdaptationEvaluation,
+    AdaptationOutcome,
+    AdaptationPhase,
+    ArtifactIdentity,
+    GovernedAdaptationProposal,
+)
+
+
+def _sha(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _authority() -> AdaptationAuthority:
+    return AdaptationAuthority(
+        authority_id="integrity-fixture",
+        dataset_id="fixture",
+        split_unit="session",
+        adaptation_indices=(0, 2),
+        evaluation_indices=(1, 3),
+        processed_data_sha256=_sha("data"),
+        n_samples=4,
+    )
+
+
+def _artifact(label: str) -> ArtifactIdentity:
+    return ArtifactIdentity(artifact_id=label, sha256=_sha(label))
+
+
+def test_directly_forged_governed_authority_cannot_be_applied():
+    authority = _authority()
+    proposal = AdaptationProposal(reason="fixture", changes={"step": 1})
+    forged = GovernedAdaptationProposal(
+        proposal=proposal,
+        authority_fingerprint="forged-authority",
+        before_artifact=_artifact("before"),
+        adaptation_indices=authority.adaptation_indices,
+    )
+    # Even a manually constructed decision that points at the real authority
+    # cannot launder the forged governed record into an application.
+    decision = AdaptationDecision(
+        proposal_fingerprint=forged.proposal_fingerprint,
+        authority_fingerprint=authority.authority_fingerprint,
+        phase=AdaptationPhase.APPROVED,
+        actor="adversarial-test",
+        reason="attempt forged transition",
+    )
+
+    with pytest.raises(ValueError, match="governed proposal authority"):
+        AdaptationApplication.record(
+            forged,
+            decision,
+            authority=authority,
+            after_artifact=_artifact("after"),
+            adaptation_indices=authority.adaptation_indices,
+        )
+
+
+def test_directly_forged_application_indices_cannot_reach_evaluation():
+    authority = _authority()
+    forged = AdaptationApplication(
+        proposal_fingerprint="proposal",
+        authority_fingerprint=authority.authority_fingerprint,
+        decision_fingerprint="decision",
+        before_artifact=_artifact("before"),
+        after_artifact=_artifact("after"),
+        adaptation_indices=(0,),
+    )
+
+    with pytest.raises(ValueError, match="exact authority adaptation indices"):
+        AdaptationEvaluation.record(
+            forged,
+            authority=authority,
+            evaluation_indices=authority.evaluation_indices,
+            metrics_before={"accuracy": 0.5},
+            metrics_after={"accuracy": 0.6},
+        )
+
+
+def test_forged_evaluation_authority_cannot_finalize_outcome():
+    authority = _authority()
+    application = AdaptationApplication(
+        proposal_fingerprint="proposal",
+        authority_fingerprint=authority.authority_fingerprint,
+        decision_fingerprint="decision",
+        before_artifact=_artifact("before"),
+        after_artifact=_artifact("after"),
+        adaptation_indices=authority.adaptation_indices,
+    )
+    forged_evaluation = AdaptationEvaluation(
+        application_fingerprint=application.application_fingerprint,
+        authority_fingerprint="forged-authority",
+        evaluation_indices=authority.evaluation_indices,
+        metrics_before={"accuracy": 0.5},
+        metrics_after={"accuracy": 0.6},
+    )
+
+    with pytest.raises(ValueError, match="evaluation authority"):
+        AdaptationOutcome.retain(
+            application,
+            forged_evaluation,
+            actor="adversarial-test",
+            reason="attempt forged finalization",
+        )


### PR DESCRIPTION
## Why

ORION already exposes a lightweight `AdaptationProposal`, but a proposal alone is not enough to qualify state-changing neural adaptation. An algorithm that can update itself must not also be allowed to choose its own calibration samples, held-out evaluation samples, pre-update identity, or rollback target.

This PR adds a dependency-light adaptation authority shared by future ORION personalization, decoder updates, fine-tuning, and biologically plausible/local-learning integrations.

## Governing state machine

```text
proposal
  -> governed proposal + frozen authority + pre-update artifact
  -> approved / rejected
  -> applied on exact adaptation indices
  -> evaluated on exact frozen held-out indices
  -> retained or rolled back to exact pre-update SHA-256
```

## Core contracts

Adds:

- `ArtifactIdentity`
- `AdaptationAuthority`
- `GovernedAdaptationProposal`
- `AdaptationDecision`
- `AdaptationApplication`
- `AdaptationEvaluation`
- `AdaptationOutcome`
- `AdaptationPhase`

The existing lightweight `AdaptationProposal` and `AdaptiveDecoder` protocol remain backward-compatible.

## Fail-closed authority

`AdaptationAuthority` freezes dataset identity, deployment split unit, exact ordered adaptation indices, exact ordered evaluation indices, processed-data SHA-256, sample count, optional protocol/source-authority fingerprints, seed, and metadata.

It rejects:

- adaptation/evaluation overlap;
- negative, duplicate, or out-of-range indices;
- adaptation on a subset/reordered calibration partition;
- evaluation on a subset, superset, or reordered held-out partition.

Each calibration budget receives its own authority, so sample-efficiency comparisons cannot silently change what "authorized adaptation data" means.

## Artifact and rollback integrity

An applied update must have different before/after SHA-256 identities. A no-op cannot masquerade as adaptation.

A retained outcome must keep the exact post-adaptation SHA-256. A rollback must restore the exact pre-adaptation SHA-256.

Cross-record authority fingerprints are revalidated at every transition, including adversarial tests that directly construct/forge dataclass records instead of using factory methods.

## Deterministic evidence

Every semantic record receives a deterministic content-derived fingerprint. The public example is executed twice in CI and its complete JSON output must diff byte-for-byte.

Wall-clock timestamps are intentionally excluded from semantic evidence identity.

## Longitudinal evidence connection

ORION does not import `neuros-foundation`. Instead, real-data experiments can derive an `AdaptationAuthority` from an existing `LongitudinalCaseAuthority` and carry forward:

- processed-data SHA-256;
- exact selected calibration budget;
- immutable evaluation indices;
- longitudinal authority fingerprint.

This preserves the existing dependency direction while making adaptation evidence traceable back to real-dataset authority.

## Public usability

Adds:

- `docs/ADAPTATION_AUTHORITY.md`;
- `examples/orion/adaptation_authority.py`;
- exports from the public `orion` namespace;
- a dedicated multi-version qualification workflow.

## Exact-head qualification

Final head: `6a468d7e07199fffe501563e797f81d8450c980a`

All triggered workflows are green:

- ORION Adaptation Authority
- neurOS CI
- Release Candidate Artifacts
- Public Trust Contracts
- Ecosystem Compatibility
- NeuroAI Ecosystem Evidence

Notable checks include:

- authority/state-machine tests on Python 3.10/3.11/3.12;
- adversarial forged-record tests on all three Python versions;
- exact calibration/evaluation partition enforcement;
- rejected-proposal mutation prevention;
- no-op application rejection;
- exact rollback identity;
- deterministic evidence fingerprints;
- public example executed twice with byte-identical JSON output;
- all 11 workspace wheels built and validated;
- fresh exact-wheel public SDK smoke installation;
- strict maintained-doc build with warnings as failures;
- ORION legacy contracts/tokenizer benchmark;
- kernel, recording, foundation, SourceWeigher, model/mech-int, compatibility, and NeuroAI regressions.

## Claim boundary

This PR qualifies adaptation **process integrity**, not adaptation efficacy. It does not claim that an update improves decoding, reduces calibration, transfers across people/devices, establishes biological correctness, or is safe for hardware/clinical closed-loop use.

The intended next scientific consumer is a separately qualified ngc-learn Hebbian predictive-coding experiment under this authority, followed by a matched ORION adaptation comparison under the same frozen evaluation case.
