### PR TITLE
evidence: qualify governed ngc-learn Hebbian adaptation

### DIFF
--- a/.github/workflows/ngclearn-hebbian-ci.yml
+++ b/.github/workflows/ngclearn-hebbian-ci.yml
@@ -3,28 +3,40 @@ name: ngc-learn Hebbian Adaptation
 on:
   pull_request:
     paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/__init__.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
       - "packages/orion/src/orion/adaptation.py"
+      - "packages/neuros/src/neuros/compatibility.py"
       - "packages/neuros-foundation/tests/test_ngclearn_hebbian.py"
       - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
       - "tests/test_ngclearn_hebbian_authority.py"
+      - "tests/test_compatibility_registry.py"
       - "scripts/evidence/run_ngclearn_hebbian_authority.py"
+      - "docs/ADAPTATION_AUTHORITY.md"
+      - "docs/COMPATIBILITY.md"
+      - "docs/NEUROAI_ECOSYSTEM.md"
       - ".github/workflows/ngclearn-hebbian-ci.yml"
   push:
     branches: [main]
     paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/__init__.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
       - "packages/orion/src/orion/adaptation.py"
+      - "packages/neuros/src/neuros/compatibility.py"
       - "packages/neuros-foundation/tests/test_ngclearn_hebbian.py"
       - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
       - "tests/test_ngclearn_hebbian_authority.py"
+      - "tests/test_compatibility_registry.py"
       - "scripts/evidence/run_ngclearn_hebbian_authority.py"
+      - "docs/ADAPTATION_AUTHORITY.md"
+      - "docs/COMPATIBILITY.md"
+      - "docs/NEUROAI_ECOSYSTEM.md"
       - ".github/workflows/ngclearn-hebbian-ci.yml"
 
 permissions:
@@ -55,13 +67,15 @@ jobs:
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[ngclearn,dev]"
           python -m pip install -e "packages/orion[test]"
-      - name: Exercise fixed, adaptive, and authority-bound real-upstream contracts
+          python -m pip install -e packages/neuros
+      - name: Exercise fixed, adaptive, authority, and public-claim contracts
         run: |
           pytest -q \
             packages/neuros-foundation/tests/test_ngclearn_bridge.py \
             packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py \
             packages/neuros-foundation/tests/test_ngclearn_hebbian.py \
-            tests/test_ngclearn_hebbian_authority.py
+            tests/test_ngclearn_hebbian_authority.py \
+            tests/test_compatibility_registry.py
       - name: Exercise governed public evidence worker twice
         run: |
           python scripts/evidence/run_ngclearn_hebbian_authority.py > "${RUNNER_TEMP}/hebbian-authority-first.json"
@@ -79,6 +93,25 @@ jobs:
           assert payload["learner_adaptation"]["adaptation_input_sha256"] == payload["inputs"]["adaptation_input_sha256"]
           assert payload["outcome"]["phase"] in {"retained", "rolled-back"}
           assert payload["evidence_sha256"]
+          PY
+      - name: Exercise installed compatibility claim
+        run: |
+          neuros compatibility ngclearn --json > "${RUNNER_TEMP}/ngclearn-compatibility.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "ngclearn-compatibility.json").read_text())
+          assert len(payload) == 1
+          record = payload[0]
+          assert record["integration_id"] == "ngclearn"
+          assert record["evidence_tier"] == "integration"
+          assert "hebbian-predictive-adaptation" in record["capabilities"]
+          assert "adaptation-authority-binding" in record["capabilities"]
+          assert "exact-learning-state-rollback" in record["capabilities"]
+          assert "real-dataset-utility" not in record["capabilities"]
+          assert "calibration-reduction" not in record["capabilities"]
           PY
       - name: Compile adaptive evidence modules
         run: |

--- a/.github/workflows/ngclearn-hebbian-ci.yml
+++ b/.github/workflows/ngclearn-hebbian-ci.yml
@@ -1,0 +1,67 @@
+name: ngc-learn Hebbian Adaptation
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_hebbian.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - ".github/workflows/ngclearn-hebbian-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_hebbian.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
+      - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - ".github/workflows/ngclearn-hebbian-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ngclearn-hebbian-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hebbian-adaptation:
+    name: ngc-learn 3.2 Hebbian adaptation / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install isolated ngc-learn evidence profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[ngclearn,dev]"
+      - name: Exercise fixed and adaptive real-upstream contracts
+        run: |
+          pytest -q \
+            packages/neuros-foundation/tests/test_ngclearn_bridge.py \
+            packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py \
+            packages/neuros-foundation/tests/test_ngclearn_hebbian.py
+      - name: Compile adaptive integration module
+        run: |
+          python -m compileall -q \
+            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py
+      - name: Report exact upstream identity
+        run: |
+          python - <<'PY'
+          import json
+          from neuros.foundation_models.ngclearn_bridge import ngclearn_runtime_identity
+          print(json.dumps(ngclearn_runtime_identity(), indent=2, sort_keys=True))
+          PY

--- a/.github/workflows/ngclearn-hebbian-ci.yml
+++ b/.github/workflows/ngclearn-hebbian-ci.yml
@@ -6,9 +6,12 @@ on:
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/orion/src/orion/adaptation.py"
       - "packages/neuros-foundation/tests/test_ngclearn_hebbian.py"
       - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "tests/test_ngclearn_hebbian_authority.py"
+      - "scripts/evidence/run_ngclearn_hebbian_authority.py"
       - ".github/workflows/ngclearn-hebbian-ci.yml"
   push:
     branches: [main]
@@ -16,9 +19,12 @@ on:
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py"
+      - "packages/orion/src/orion/adaptation.py"
       - "packages/neuros-foundation/tests/test_ngclearn_hebbian.py"
       - "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py"
       - "packages/neuros-foundation/tests/test_ngclearn_bridge.py"
+      - "tests/test_ngclearn_hebbian_authority.py"
+      - "scripts/evidence/run_ngclearn_hebbian_authority.py"
       - ".github/workflows/ngclearn-hebbian-ci.yml"
 
 permissions:
@@ -30,7 +36,7 @@ concurrency:
 
 jobs:
   hebbian-adaptation:
-    name: ngc-learn 3.2 Hebbian adaptation / Python ${{ matrix.python-version }}
+    name: ngc-learn 3.2 governed Hebbian adaptation / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -42,22 +48,43 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: Install isolated ngc-learn evidence profile
+      - name: Install isolated governed ngc-learn evidence profile
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[ngclearn,dev]"
-      - name: Exercise fixed and adaptive real-upstream contracts
+          python -m pip install -e "packages/orion[test]"
+      - name: Exercise fixed, adaptive, and authority-bound real-upstream contracts
         run: |
           pytest -q \
             packages/neuros-foundation/tests/test_ngclearn_bridge.py \
             packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py \
-            packages/neuros-foundation/tests/test_ngclearn_hebbian.py
-      - name: Compile adaptive integration module
+            packages/neuros-foundation/tests/test_ngclearn_hebbian.py \
+            tests/test_ngclearn_hebbian_authority.py
+      - name: Exercise governed public evidence worker twice
+        run: |
+          python scripts/evidence/run_ngclearn_hebbian_authority.py > "${RUNNER_TEMP}/hebbian-authority-first.json"
+          python scripts/evidence/run_ngclearn_hebbian_authority.py > "${RUNNER_TEMP}/hebbian-authority-second.json"
+          diff -u "${RUNNER_TEMP}/hebbian-authority-first.json" "${RUNNER_TEMP}/hebbian-authority-second.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "hebbian-authority-first.json").read_text())
+          assert payload["claim_boundary"]["orion_adaptation_authority_enforced"] is True
+          assert payload["claim_boundary"]["exact_adaptation_rows_verified"] is True
+          assert payload["claim_boundary"]["exact_evaluation_rows_verified"] is True
+          assert payload["learner_adaptation"]["adaptation_input_sha256"] == payload["inputs"]["adaptation_input_sha256"]
+          assert payload["outcome"]["phase"] in {"retained", "rolled-back"}
+          assert payload["evidence_sha256"]
+          PY
+      - name: Compile adaptive evidence modules
         run: |
           python -m compileall -q \
-            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py
+            packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py \
+            scripts/evidence/run_ngclearn_hebbian_authority.py
       - name: Report exact upstream identity
         run: |
           python - <<'PY'

--- a/.github/workflows/ngclearn-hebbian-ci.yml
+++ b/.github/workflows/ngclearn-hebbian-ci.yml
@@ -60,14 +60,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: Install isolated governed ngc-learn evidence profile
+      - name: Install exact local governed ngc-learn evidence profile
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-drivers
           python -m pip install -e packages/neuros-models
           python -m pip install -e "packages/neuros-foundation[ngclearn,dev]"
           python -m pip install -e "packages/orion[test]"
           python -m pip install -e packages/neuros
+          python -m pip check
       - name: Exercise fixed, adaptive, authority, and public-claim contracts
         run: |
           pytest -q \

--- a/docs/ADAPTATION_AUTHORITY.md
+++ b/docs/ADAPTATION_AUTHORITY.md
@@ -28,7 +28,7 @@ GovernedAdaptationProposal
        |
        v
    EVALUATED
- exact frozen evaluation indices
+ exact frozen qualification indices
        |
        +--------> RETAINED
        |
@@ -40,17 +40,21 @@ GovernedAdaptationProposal
 
 The evidence records are immutable and deterministically fingerprinted. They do not contain wall-clock time in their semantic identity, so replaying the same authority, proposal, decision, application, and evaluation yields the same fingerprints.
 
+The API field remains named `evaluation_indices` for compatibility, but when those rows are used to choose `RETAINED` versus `ROLLED_BACK`, they are scientifically a **qualification/state-selection partition**. They are not an untouched final test set.
+
 ## Why this exists
 
 Adaptive neural systems can accidentally produce optimistic results when:
 
 - samples used to update a model are reused for evaluation;
-- the method chooses a favorable evaluation subset after adaptation;
+- the method chooses a favorable qualification subset after adaptation;
+- held-out data influence the proposal or update before the state is frozen;
+- a qualification set used for model selection is later reported as if it were an untouched final assessment;
 - a proposed update is recorded without preserving the exact pre-update state;
 - a rejected update still mutates state;
 - an update changes nothing but is counted as an adaptation event;
 - rollback restores a similar model rather than the exact previous artifact;
-- each algorithm invents different meanings for calibration, evaluation, and provenance.
+- each algorithm invents different meanings for calibration, qualification, final assessment, and provenance.
 
 The authority contract makes these failure modes explicit and testable.
 
@@ -67,7 +71,7 @@ Identifies a model, representation, optimizer, weight set, or other mutable stat
 - immutable metadata;
 - deterministic fingerprint.
 
-The SHA-256 is the rollback authority. Human-readable names are not sufficient.
+The SHA-256 is the rollback authority. Human-readable names are not sufficient. For adaptive algorithms with optimizer state, the artifact SHA should represent the **complete mutable state**, not only visible weights.
 
 ### `AdaptationAuthority`
 
@@ -76,14 +80,14 @@ Freezes:
 - dataset identity;
 - deployment split unit;
 - exact adaptation indices in exact order;
-- exact held-out evaluation indices in exact order;
+- exact held-out qualification/evaluation indices in exact order;
 - processed-data SHA-256;
 - total sample count;
 - protocol fingerprint when available;
 - source evidence-authority fingerprint when available;
 - seed and structured metadata.
 
-Adaptation and evaluation indices must be disjoint. Both must be in range. Final evaluation must consume the exact frozen evaluation set, not a subset, superset, or reordered selection.
+Adaptation and evaluation indices must be disjoint. Both must be in range. Qualification must consume the exact frozen evaluation set, not a subset, superset, or reordered selection.
 
 ### `GovernedAdaptationProposal`
 
@@ -114,7 +118,9 @@ An application whose pre- and post-update SHA-256 identities are identical fails
 
 ### `AdaptationEvaluation`
 
-Records held-out metrics before and after adaptation using the **complete frozen evaluation index set**. Before/after metric names must match so an adaptation cannot quietly change the reported scorecard after seeing results.
+Records held-out metrics before and after adaptation using the **complete frozen evaluation index set**. Before/after metric names must match so an adaptation cannot quietly change the scorecard after seeing results.
+
+If this record is used only to report a predetermined frozen model, it may be an evaluation. If it influences retain/rollback or hyperparameter selection, it is a qualification/state-selection record and a separate final-assessment partition is required for an unbiased efficacy claim.
 
 ### `AdaptationOutcome`
 
@@ -123,17 +129,14 @@ Finalizes the evidence as either:
 - `retained`, where the active artifact must be the exact post-update SHA-256; or
 - `rolled-back`, where the active artifact must be the exact pre-update SHA-256.
 
-This record says what happened. It does not prescribe a universal policy for whether accuracy, calibration, latency, or another metric should dominate the retain/rollback decision.
+This record says what happened. It does not prescribe a universal policy for whether accuracy, calibration, latency, reconstruction error, or another metric should dominate the retain/rollback decision.
 
 ## Example
 
 ```python
 from orion import (
-    AdaptationApplication,
     AdaptationAuthority,
     AdaptationDecision,
-    AdaptationEvaluation,
-    AdaptationOutcome,
     AdaptationProposal,
     ArtifactIdentity,
     GovernedAdaptationProposal,
@@ -174,34 +177,107 @@ decision = AdaptationDecision.approve(
 )
 ```
 
-After the algorithm updates only the authorized rows, hash the resulting state and create an `AdaptationApplication`. Evaluate both artifacts on `authority.evaluation_indices`, then record a retain or rollback outcome.
+After the algorithm updates only the authorized rows, hash the resulting complete state and create an `AdaptationApplication`. Evaluate both artifacts on `authority.evaluation_indices`, then record a retain or rollback outcome.
 
 The repository includes a complete dependency-light example at `examples/orion/adaptation_authority.py`.
+
+## Real ngc-learn consumer
+
+The first state-changing consumer is the governed ngc-learn predictive-reconstruction integration:
+
+```text
+AdaptationAuthority
+      |
+      +--> exact calibration rows
+      |        |
+      |        v
+      |   NgcLearnHebbianPredictiveCoding.adapt()
+      |        |
+      |        +--> weight SHA-256
+      |        +--> optimizer-state SHA-256
+      |        +--> combined state SHA-256
+      |
+      +--> exact qualification rows
+               |
+               v
+         read-only before/after
+               |
+        retain or exact rollback
+```
+
+`scripts/evidence/run_ngclearn_hebbian_authority.py` verifies that the canonical calibration matrix selected by the authority has the same SHA-256 that the real upstream learner records as its adaptation input. Proposal/approval evidence contains calibration evidence only. Qualification data appears only after mutation, in the state-selection step.
+
+The worker runs against installed ngc-learn 3.2 on Python 3.10 and 3.11 and its complete evidence JSON is replayed twice for byte-identical output.
+
+This qualifies **process integrity** for that integration. It does not establish real neural-data efficacy.
 
 ## Relationship to longitudinal evidence
 
 The foundation evidence layer already owns stronger dataset-specific authorities such as `LongitudinalCaseAuthority`. ORION does **not** import `neuros-foundation` to reuse them, because that would reverse the stable dependency direction.
 
-Instead, an experiment should derive the adaptation authority from the already-frozen case and carry its identity forward:
+Instead, a real experiment should derive adaptation authority from an already-frozen case and carry identity forward:
 
 ```text
 LongitudinalCaseAuthority
   processed data SHA-256
   calibration ordering
-  immutable evaluation indices
-  authority fingerprint
+  qualification ordering
+  source authority fingerprint
             |
             v
 AdaptationAuthority
   exact selected calibration budget
-  same frozen evaluation indices
+  exact qualification indices
   source_authority_fingerprint
             |
             v
 state-changing algorithm
 ```
 
-This keeps ORION dependency-light while preserving an auditable chain back to the real-dataset evaluation authority.
+The selected state must then be frozen before an independent final assessment.
+
+## Three-way authority for efficacy studies
+
+Two partitions are sufficient to qualify **adaptation process integrity**:
+
+1. adaptation/calibration rows;
+2. held-out qualification rows used to retain or roll back.
+
+They are not sufficient for an unbiased final efficacy claim if the second partition influences model-state selection.
+
+Real adaptation studies should therefore use:
+
+```text
+source / historical data
+        |
+        v
+CALIBRATION AUTHORITY
+state may change
+        |
+        v
+QUALIFICATION AUTHORITY
+state is read-only; may choose retain/rollback
+        |
+        v
+frozen selected state
+        |
+        v
+FINAL-ASSESSMENT AUTHORITY
+state and policy are immutable
+        |
+        v
+scientific result
+```
+
+The final-assessment partition must not influence:
+
+- whether adaptation occurs;
+- learning rate, epoch count, calibration budget, or other hyperparameters;
+- retain/rollback decisions;
+- metric selection;
+- threshold selection.
+
+This is the authority neurOS should use for claims such as “X requires fewer calibration examples than Y” or “X transfers better across sessions.”
 
 ## What this does not claim
 
@@ -219,15 +295,16 @@ Those require their own evidence under the project-wide scientific claim ladder.
 
 ## Next qualification rung
 
-The intended next use is an ngc-learn Hebbian predictive-coding experiment in which:
+The next use should be a real longitudinal governed-adaptation study in which:
 
-1. a real `LongitudinalCaseAuthority` freezes target-session calibration/evaluation data;
-2. an `AdaptationAuthority` selects one explicit calibration budget;
-3. real upstream Hebbian synapses update only those rows;
-4. before/after weights receive immutable SHA-256 identities;
-5. synapses freeze before held-out evaluation;
-6. the complete evaluation partition is scored before and after;
-7. the result is retained or rolled back under explicit policy;
-8. the same authority can be given to an ORION adaptation method for a matched comparison.
+1. a real `LongitudinalCaseAuthority` freezes target-session chronology and processed-data identity;
+2. one explicit calibration budget becomes the adaptation partition;
+3. a second held-out target partition becomes the retention/rollback qualification partition;
+4. real upstream Hebbian synapses update only calibration rows;
+5. before/after complete learning states receive immutable identities;
+6. the state is retained or exactly rolled back under a predeclared policy;
+7. the selected state is frozen;
+8. a third independent final-assessment partition is scored once;
+9. the identical three-way authority is given to ORION and frozen baselines for matched comparison.
 
 That sequence lets neurOS compare biologically local learning and ORION personalization without allowing either method to move the goalposts.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -26,7 +26,7 @@ The registry lives in `neuros.compatibility` and is covered by contract tests. D
 | MOABB | experimental | dataset adapter, longitudinal split authority, model ladder | real dataset | benchmark surface is still evolving; result claims remain protocol-specific |
 | Braindecode | experimental | neural-window model adapter, upstream training bridge, decoder bridge | integration | qualified 1.7 whitelist only; stable mech-int, hardware, and closed-loop claims remain separate |
 | SNAP spectral alignment | experimental | positive-rank spectrum, task power, residual target power | software contract + upstream conformance | no published-experiment reproduction or biological-alignment claim |
-| ngc-learn | experimental | RateCell transform, fixed-weight predictive reconstruction, iterative residual feedback, upstream/JAX identity | integration | real ngc-learn 3.2.x inference dynamics only; Hebbian/STDP learning, spiking, real-data, hardware, and closed-loop claims remain unqualified |
+| ngc-learn | experimental | RateCell, fixed predictive reconstruction, governed Hebbian predictive adaptation, exact learning-state rollback | integration | deterministic upstream integration only; real-data efficacy, calibration reduction, STDP/spiking, online adaptation, hardware, and closed loop remain unqualified |
 | OpenBCI | indirect | reachable through BrainFlow | none | no named OpenBCI configuration is hardware-qualified |
 | Meta NeuralBench | planned | isolated benchmark worker, evidence extension | none | upstream runtime requirements must stay outside the kernel |
 | IBM NeuroAIKit | planned | isolated SNU reference worker | none | legacy TensorFlow-era environment is intentionally isolated |
@@ -141,7 +141,7 @@ Install the isolated research integration with:
 pip install "neuros-foundation[ngclearn]"
 ```
 
-Two real upstream ngc-learn 3.2.x surfaces are now qualified at the **integration** tier.
+Three real upstream ngc-learn 3.2.x surfaces are now qualified at the **integration** tier.
 
 #### RateCell transform
 
@@ -162,11 +162,42 @@ result = pc.transform(samples, sample_rate_hz=250.0)
 
 The circuit uses a real upstream `RateCell` latent, `GaussianErrorCell` reconstruction residual, and `StaticSynapse` generative/feedback connections. It resets per observation, clamps the input as the prediction-error target, ties feedback to the transpose of the fixed generative weights, and iteratively settles the latent.
 
-Evidence includes latent/reconstruction shapes, exact component/runtime identity, settling parameters, weight/input/latent/reconstruction/trajectory hashes, and reconstruction-error reduction.
+Evidence includes latent/reconstruction shapes, exact component/runtime identity, settling parameters, weight/input/latent/reconstruction/trajectory hashes, and reconstruction-error reduction. The known-ground-truth upstream test uses an identity generative dictionary and requires the real circuit to reduce reconstruction error by more than 90% on Python 3.10 and 3.11.
 
-The known-ground-truth upstream test uses an identity generative dictionary and requires the real circuit to reduce reconstruction error by more than 90% on Python 3.10 and 3.11. This is evidence that the residual-feedback computation actually works, not merely that its objects instantiate.
+#### Governed Hebbian predictive adaptation
 
-The weights are deliberately fixed. **Hebbian learning, STDP, online adaptation, spiking networks, real-dataset utility, hardware behavior, and closed-loop behavior are not qualified by this circuit.**
+```python
+from neuros.foundation_models import NgcLearnHebbianPredictiveCoding
+
+learner = NgcLearnHebbianPredictiveCoding(
+    latent_dim=8,
+    settling_steps=20,
+    learning_rate=1e-3,
+    optimizer="adam",
+    seed=7,
+)
+
+adaptation = learner.adapt(calibration_samples, sample_rate_hz=250.0, epochs=2)
+```
+
+The adaptive circuit performs iterative predictive inference before every real upstream `HebbianSynapse.evolve()` M-step. The final latent activity is the pre statistic and the `GaussianErrorCell.dmu` residual is the post statistic. Feedback is retied to the current generative transpose before inference. No hidden post-update row normalization is applied.
+
+A snapshot binds the exact upstream weight array and optimizer pytree into one combined state identity. This matters for Adam: restoring weights while leaving moments or the optimizer timestep changed is not a valid rollback. The integration tests require exact full-state restoration and the same future learning trajectory after rollback.
+
+The cross-package evidence worker in `scripts/evidence/run_ngclearn_hebbian_authority.py` composes this learner with ORION's `AdaptationAuthority` without creating a foundation-to-ORION package dependency. It proves:
+
+- adaptation receives exactly the complete authority-selected canonical calibration matrix;
+- the learner's own adaptation-input SHA-256 matches the authority worker's hash;
+- proposal/approval evidence is calibration-only;
+- qualification inference is read-only;
+- retain or exact full-state rollback follows a predeclared metric threshold;
+- repeated complete evidence runs are byte-identical.
+
+The dedicated real-upstream lane executes this on Python 3.10 and 3.11.
+
+**Important statistical boundary:** the held-out qualification partition may determine whether the adapted state is retained or rolled back. It is therefore a state-selection set, not an untouched final scientific assessment set. Real efficacy and calibration-reduction studies require a third independent final-assessment partition after state selection.
+
+The current integration does **not** qualify STDP, spiking-network adaptation, real-neural-data efficacy, calibration reduction, cross-subject/device transfer superiority, online adaptation, hardware behavior, closed-loop behavior, or clinical use.
 
 See [NeuroAI Ecosystem Evidence](NEUROAI_ECOSYSTEM.md) for the scientific rationale and ORION comparison path.
 

--- a/docs/NEUROAI_ECOSYSTEM.md
+++ b/docs/NEUROAI_ECOSYSTEM.md
@@ -47,7 +47,7 @@ neurOS keeps it optional:
 pip install "neuros-foundation[ngclearn]"
 ```
 
-The qualified upstream surface is deliberately narrower than the upstream library.
+The qualified upstream surface remains deliberately narrower than the upstream library.
 
 ### RateCell execution
 
@@ -64,9 +64,9 @@ result = transform.transform(samples, sample_rate_hz=250.0)
 
 This surface records exact ngc-learn/JAX identity, explicit time-by-channel geometry, integration step, parameters, and deterministic input/output/evidence hashes. It performs no hidden resampling, filtering, normalization, padding, fitting, or channel reordering.
 
-### Predictive reconstruction
+### Fixed-weight predictive reconstruction
 
-neurOS now also qualifies an **inference-only fixed-weight predictive-coding circuit** using real ngc-learn 3.2 components:
+neurOS qualifies an inference-only predictive-coding circuit using real ngc-learn 3.2 components:
 
 ```text
 input target x -> GaussianErrorCell e0 -> transpose feedback E -> latent RateCell z
@@ -84,59 +84,167 @@ pc = NgcLearnPredictiveCodingTransform(
     seed=7,
 )
 result = pc.transform(samples, sample_rate_hz=250.0)
-
-latents = result.values
-reconstruction = result.reconstruction
-print(result.evidence.error_reduction_fraction)
 ```
 
-Each observation begins from a reset circuit. The observation is clamped as the `GaussianErrorCell` target; the latent `RateCell` iteratively changes under residual feedback; a fixed generative `StaticSynapse` reconstructs the input; and the feedback matrix is explicitly tied to the transpose of that fixed generative matrix.
+Each observation begins from a reset circuit. The observation is clamped as the `GaussianErrorCell` target; the latent `RateCell` iteratively changes under residual feedback; a fixed generative `StaticSynapse` reconstructs the input; and the feedback matrix is explicitly tied to the transpose of the fixed generative matrix.
 
-The result records:
+The result records exact runtime/component identity, latent/reconstruction geometry, settling semantics, input/weight/output hashes, and reconstruction-error trajectories. The real-upstream identity-dictionary test requires the installed ngc-learn 3.2 circuit to reduce reconstruction error by more than 90%. That behavior is qualified on Python 3.10 and 3.11.
 
-- exact ngc-learn and JAX runtime identity;
-- actual `RateCell`, `GaussianErrorCell`, and `StaticSynapse` class identities;
-- latent and reconstruction geometry;
-- settling count, settling timestep, membrane constant, prior, activation, and integration method;
-- reset-per-observation and tied-transpose-feedback semantics;
-- input, weight, latent, reconstruction, and error-trajectory SHA-256 identities;
-- initial/final reconstruction MSE and reduction fraction;
-- fraction of observations that improve during settling.
+The fixed circuit intentionally does not learn. It establishes inference and reset semantics independently before mutable state is introduced.
 
-The real-upstream CI contract goes beyond object construction. With an identity generative dictionary, the installed ngc-learn 3.2 circuit must reduce known reconstruction error by more than 90%, and repeated executions must be bit-identical after reset. That behavior passed on the qualified Python 3.10 and 3.11 lanes.
+### Governed Hebbian predictive adaptation
 
-The circuit does **not** learn its weights. That is intentional. Fixed weights make inference dynamics, state reset, geometry, and provenance independently testable before introducing another source of state mutation.
+The next evidence rung adds a real ngc-learn `HebbianSynapse` M-step while preserving the same predictive-inference structure:
+
+```text
+observation
+    |
+    v
+predictive E-step / settling
+    |
+    +--> latent zF -------------------+
+    |                                 |
+    +--> Gaussian residual dmu        |
+                                      v
+                         upstream HebbianSynapse.evolve()
+                                      |
+                                      v
+                              generative weights
+```
+
+The public learner is available from the dependency-light foundation namespace:
+
+```python
+from neuros.foundation_models import NgcLearnHebbianPredictiveCoding
+
+learner = NgcLearnHebbianPredictiveCoding(
+    latent_dim=8,
+    settling_steps=20,
+    learning_rate=1e-3,
+    optimizer="adam",
+    seed=7,
+)
+
+before = learner.infer(calibration_samples, sample_rate_hz=250.0)
+adaptation = learner.adapt(calibration_samples, sample_rate_hz=250.0, epochs=2)
+after = learner.infer(qualification_samples, sample_rate_hz=250.0)
+```
+
+The integration executes the real upstream two-factor learning rule after each predictive E-step:
+
+- `latent.zF` is the Hebbian **pre** statistic;
+- `GaussianErrorCell.dmu` is the Hebbian **post** residual statistic;
+- `sign_value=-1` gives the reconstruction-minimization direction used by the qualified fixture;
+- feedback is retied to the current generative transpose before each inference;
+- no hidden post-update row normalization is performed;
+- inference is required to preserve the complete learning-state identity.
+
+#### Complete mutable-state identity
+
+A learned model is not just its visible weight matrix. Adam, for example, contains first/second moments and an update counter that change future learning even when weights are restored separately.
+
+neurOS therefore defines the adaptive state as:
+
+```text
+Hebbian learning state
+    |
+    +--> exact upstream weight array identity
+    |
+    +--> exact optimizer pytree identity
+    |
+    +--> combined state SHA-256
+```
+
+Snapshots preserve the upstream weight dtype and include the optimizer state. Rollback validation checks checkpoint content before mutating the learner, restores both weight and optimizer state, reties feedback, resets transient neural activity, and then verifies the exact combined state again.
+
+The real-upstream tests exercise both SGD and Adam. They require deterministic independent learners, read-only inference after learning, exact Adam rollback, replay of the same future learning trajectory after rollback, and failure of corrupt checkpoints before the live learner is changed.
+
+#### ORION adaptation authority binding
+
+The learning mechanism stays in `neuros-foundation`. ORION stays independent. Their composition occurs in the evidence layer:
+
+```text
+AdaptationAuthority
+  | exact ordered calibration rows
+  | exact ordered qualification rows
+  | processed-data identity
+  v
+scripts/evidence/run_ngclearn_hebbian_authority.py
+  |
+  +--> calibration-only proposal evidence
+  +--> governed approval
+  +--> ngc-learn adapt(exact calibration rows)
+  +--> learner input SHA == authority-selected input SHA
+  +--> read-only qualification before/after
+  +--> retain OR exact full-state rollback
+  v
+deterministic evidence JSON
+```
+
+The worker verifies that the canonical time-by-channel matrix selected by the authority is exactly the matrix whose SHA-256 is recorded by the learner. The public worker is run twice in CI and the complete JSON output must be byte-identical.
+
+This is an **integration/process-integrity qualification**, not an efficacy result. The current deterministic fixture proves that real upstream learning obeys the authority and rollback contract. It does not prove the learned representation helps real neural decoding.
+
+#### Qualification data is not final-assessment data
+
+The authority used by the worker has adaptation rows and held-out qualification rows. The qualification rows are read-only with respect to learning, but their metric may decide whether the update is retained or rolled back. Therefore they are part of **model-state selection**.
+
+They must not later be described as an untouched final test set.
+
+A real efficacy experiment should use three authorities:
+
+```text
+historical/source data
+        |
+target calibration partition
+        |
+        v
+state-changing adaptation
+        |
+retention / rollback qualification partition
+        |
+        v
+selected frozen state
+        |
+independent final-assessment partition
+        |
+        v
+scientific efficacy claim
+```
+
+This distinction is required before neurOS can make claims about calibration reduction, transfer, or superiority over ORION/frozen baselines.
 
 ### Current ngc-learn evidence ladder
 
 1. **Qualified:** RateCell upstream execution and geometry.
 2. **Qualified:** fixed-weight predictive reconstruction with iterative Gaussian residual feedback.
-3. **Not yet qualified:** Hebbian/STDP synaptic adaptation and explicit adaptation/evaluation authority.
-4. **Not yet qualified:** spiking-network representation contracts.
-5. **Not yet qualified:** real neural-data utility under deployment-unit-disjoint evaluation.
-6. **Not yet qualified:** comparison against ORION under matched downstream capacity and calibration budgets.
-7. **Not yet qualified:** hardware or closed-loop behavior.
+3. **Qualified at integration tier:** real `HebbianSynapse` predictive adaptation with exact weight + optimizer-state identity, deterministic replay, ORION adaptation-authority binding, and exact retain-or-rollback semantics.
+4. **Not yet qualified:** STDP or spiking-network adaptation contracts.
+5. **Not yet qualified:** real neural-data adaptation utility under a three-way calibration/qualification/final-assessment protocol.
+6. **Not yet qualified:** calibration-reduction or transfer superiority versus ORION under matched downstream capacity and budgets.
+7. **Not yet qualified:** hardware or closed-loop adaptive behavior.
 
-This ordering matters. A working predictive-coding circuit is not evidence that biologically local learning improves a BCI, and neither is evidence of a biological mechanism.
+This ordering matters. A working local-learning circuit is not evidence that local learning improves a BCI, and neither is evidence that the circuit is a biological mechanism.
 
-## Why predictive coding matters to ORION
+## Why predictive/local learning matters to ORION
 
-The value of the ngc-learn bridge is not merely adding another model family. It gives ORION a scientifically different representation baseline.
+The value of the ngc-learn bridge is not merely adding another model family. It gives ORION scientifically different representation and adaptation baselines.
 
-A conventional frozen encoder, an ORION tokenizer/encoder, and a predictive-coding latent can eventually be compared under the same evaluation authority for:
+A conventional frozen encoder, fixed predictive-coding latent, locally adapted predictive-coding latent, and ORION representation can eventually be compared under the same independent evidence authority for:
 
 - held-out task utility;
 - user-specific calibration examples/minutes;
 - cross-session and cross-subject transfer;
 - representation effective dimension and task-aligned spectral power;
 - residual target power;
+- domain leakage;
 - artifact, channel, montage, and jitter sensitivity;
 - uncertainty calibration;
 - latency and memory;
 - intervention/adaptation stability;
 - immutable data/model/evidence identity.
 
-That allows a useful question: **does iterative error-correcting inference provide transferable neural structure, and if so, does it reduce calibration cost compared with simpler or learned alternatives?**
+That makes the commercially meaningful ORION question falsifiable: **can ORION preserve or improve neural utility with materially less user-specific calibration than frozen or locally adapted alternatives, and can neurOS show exactly where that advantage survives?**
 
 ## Other evaluated NeuroAI projects
 

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -72,6 +72,14 @@ from neuros.foundation_models.ngclearn_bridge import (
     NgcLearnVersionError,
     ngclearn_runtime_identity,
 )
+from neuros.foundation_models.ngclearn_hebbian import (
+    HEBBIAN_PC_METHOD_ID,
+    NgcLearnHebbianAdaptationEvidence,
+    NgcLearnHebbianAdaptationResult,
+    NgcLearnHebbianInferenceResult,
+    NgcLearnHebbianPredictiveCoding,
+    NgcLearnHebbianState,
+)
 from neuros.foundation_models.ngclearn_predictive_coding import (
     PC_METHOD_ID,
     NgcLearnPredictiveCodingEvidence,
@@ -204,6 +212,12 @@ __all__ = [
     "NgcLearnPredictiveCodingEvidence",
     "NgcLearnPredictiveCodingResult",
     "NgcLearnPredictiveCodingTransform",
+    "HEBBIAN_PC_METHOD_ID",
+    "NgcLearnHebbianAdaptationEvidence",
+    "NgcLearnHebbianAdaptationResult",
+    "NgcLearnHebbianInferenceResult",
+    "NgcLearnHebbianPredictiveCoding",
+    "NgcLearnHebbianState",
     "EvaluationProtocol",
     "BenchmarkReport",
     "benchmark_embeddings",

--- a/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py
@@ -1,0 +1,552 @@
+"""Auditable ngc-learn Hebbian adaptation for predictive reconstruction.
+
+This module qualifies one deliberately narrow state-mutating surface: a
+one-layer predictive reconstruction circuit whose generative synapse is a real
+ngc-learn 3.2 ``HebbianSynapse``. Inference settles before each M-step, feedback
+is tied to the current generative transpose, and evaluation can be run without
+mutating learned state.
+
+ORION adaptation authority is intentionally not imported here. The foundation
+integration owns the external learning mechanism; evidence scripts compose it
+with ORION's authority without reversing package dependencies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from neuros.foundation_models.ngclearn_bridge import (
+    NGCLEARN_REFERENCE_REPOSITORY,
+    NgcLearnVersionError,
+    _array_sha256,
+    _canonical_sha256,
+    _load_upstream,
+    _matrix,
+)
+from neuros.foundation_models.ngclearn_predictive_coding import _default_weights
+
+HEBBIAN_PC_METHOD_ID = "neuros-ngclearn-hebbian-predictive-reconstruction-v1"
+
+
+def _positive_finite(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if result <= 0 or not math.isfinite(result):
+        raise ValueError(f"{name} must be positive and finite")
+    return result
+
+
+def _nonnegative_finite(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if result < 0 or not math.isfinite(result):
+        raise ValueError(f"{name} must be non-negative and finite")
+    return result
+
+
+def _tree_sha256(jax: Any, tree: Any) -> str:
+    """Hash a JAX pytree by deterministic leaf order, dtype, shape, and bytes."""
+
+    digest = hashlib.sha256()
+    digest.update(b"neuros.ngclearn.optimizer-state.v1\0")
+    leaves = jax.tree_util.tree_leaves(tree)
+    digest.update(str(len(leaves)).encode("ascii"))
+    digest.update(b"\0")
+    for index, leaf in enumerate(leaves):
+        array = np.ascontiguousarray(np.asarray(leaf))
+        if array.dtype.hasobject:
+            raise TypeError("optimizer state contains object-dtype leaf")
+        digest.update(str(index).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(array.dtype.str.encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(tuple(int(v) for v in array.shape)).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(array.tobytes(order="C"))
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _state_sha256(weights_sha256: str, optimizer_sha256: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"neuros.ngclearn.hebbian-state.v1\0")
+    digest.update(weights_sha256.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(optimizer_sha256.encode("ascii"))
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class NgcLearnHebbianState:
+    """Exact mutable learning state required for identity and rollback."""
+
+    weights: np.ndarray
+    optimizer_state: Any
+    weights_sha256: str
+    optimizer_sha256: str
+    state_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class NgcLearnHebbianAdaptationEvidence:
+    method_id: str
+    ngclearn_version: str
+    jax_version: str
+    jax_backend: str
+    jax_enable_x64: bool | None
+    latent_component: str
+    error_component: str
+    generative_synapse_component: str
+    feedback_synapse_component: str
+    latent_dim: int
+    settling_steps: int
+    settling_dt_ms: float
+    tau_m_ms: float
+    prior_gamma: float
+    activation: str
+    learning_rate: float
+    optimizer: str
+    sign_value: float
+    weight_bound: float
+    row_normalization_after_update: bool
+    epochs: int
+    n_observations: int
+    update_count: int
+    sample_rate_hz: float
+    adaptation_input_sha256: str
+    state_before_sha256: str
+    state_after_sha256: str
+    weights_before_sha256: str
+    weights_after_sha256: str
+    optimizer_before_sha256: str
+    optimizer_after_sha256: str
+    weight_delta_l2: float
+    evidence_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "method_id": self.method_id,
+            "integration": "ngc-learn",
+            "reference_repository": NGCLEARN_REFERENCE_REPOSITORY,
+            "ngclearn_version": self.ngclearn_version,
+            "jax_version": self.jax_version,
+            "jax_backend": self.jax_backend,
+            "jax_enable_x64": self.jax_enable_x64,
+            "components": {
+                "latent": self.latent_component,
+                "error": self.error_component,
+                "generative_synapse": self.generative_synapse_component,
+                "feedback_synapse": self.feedback_synapse_component,
+            },
+            "latent_dim": self.latent_dim,
+            "settling_steps": self.settling_steps,
+            "settling_dt_ms": self.settling_dt_ms,
+            "tau_m_ms": self.tau_m_ms,
+            "prior_gamma": self.prior_gamma,
+            "activation": self.activation,
+            "learning_rate": self.learning_rate,
+            "optimizer": self.optimizer,
+            "sign_value": self.sign_value,
+            "weight_bound": self.weight_bound,
+            "row_normalization_after_update": self.row_normalization_after_update,
+            "epochs": self.epochs,
+            "n_observations": self.n_observations,
+            "update_count": self.update_count,
+            "sample_rate_hz": self.sample_rate_hz,
+            "adaptation_input_sha256": self.adaptation_input_sha256,
+            "state_before_sha256": self.state_before_sha256,
+            "state_after_sha256": self.state_after_sha256,
+            "weights_before_sha256": self.weights_before_sha256,
+            "weights_after_sha256": self.weights_after_sha256,
+            "optimizer_before_sha256": self.optimizer_before_sha256,
+            "optimizer_after_sha256": self.optimizer_after_sha256,
+            "weight_delta_l2": self.weight_delta_l2,
+            "evidence_sha256": self.evidence_sha256,
+            "claim_boundary": {
+                "upstream_package_executed": True,
+                "hebbian_synapse_executed": True,
+                "predictive_coding_inference_before_update": True,
+                "state_identity_includes_optimizer": True,
+                "rollback_state_supported": True,
+                "transactional_checkpoint_validation": True,
+                "row_normalization_after_update": False,
+                "orion_authority_applied_here": False,
+                "real_dataset_qualified": False,
+                "calibration_reduction_qualified": False,
+                "stdp_learning_qualified": False,
+                "hardware_qualified": False,
+                "closed_loop_qualified": False,
+                "clinical_qualified": False,
+            },
+        }
+
+
+@dataclass(slots=True)
+class NgcLearnHebbianAdaptationResult:
+    state_before: NgcLearnHebbianState
+    state_after: NgcLearnHebbianState
+    evidence: NgcLearnHebbianAdaptationEvidence
+
+
+@dataclass(slots=True)
+class NgcLearnHebbianInferenceResult:
+    values: np.ndarray
+    reconstruction: np.ndarray
+    mean_squared_error: float
+    state_sha256: str
+
+
+class NgcLearnHebbianPredictiveCoding:
+    """One-layer predictive coding with real ngc-learn Hebbian M-steps.
+
+    The object keeps learned synaptic/optimizer state across ``adapt`` calls.
+    ``infer`` never calls ``HebbianSynapse.evolve`` and must preserve the full
+    state SHA-256. No filtering, resampling, normalization, padding, channel
+    reordering, or hidden row normalization is performed.
+    """
+
+    def __init__(
+        self,
+        *,
+        latent_dim: int = 8,
+        settling_steps: int = 20,
+        settling_dt_ms: float = 1.0,
+        tau_m_ms: float = 20.0,
+        prior_gamma: float = 0.0,
+        activation: str = "identity",
+        learning_rate: float = 1e-3,
+        optimizer: str = "sgd",
+        sign_value: float = -1.0,
+        weight_bound: float = 0.0,
+        weight_scale: float = 0.25,
+        seed: int = 0,
+        weights: Any | None = None,
+    ) -> None:
+        if isinstance(latent_dim, bool) or not isinstance(latent_dim, int) or latent_dim < 1:
+            raise ValueError("latent_dim must be a positive integer")
+        if isinstance(settling_steps, bool) or not isinstance(settling_steps, int) or settling_steps < 1:
+            raise ValueError("settling_steps must be a positive integer")
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("seed must be a non-negative integer")
+        if optimizer not in {"sgd", "adam"}:
+            raise ValueError("optimizer must be 'sgd' or 'adam'")
+        if not isinstance(activation, str) or not activation.strip():
+            raise ValueError("activation must be a non-empty string")
+        self.latent_dim = latent_dim
+        self.settling_steps = settling_steps
+        self.settling_dt_ms = _positive_finite("settling_dt_ms", settling_dt_ms)
+        self.tau_m_ms = _positive_finite("tau_m_ms", tau_m_ms)
+        self.prior_gamma = _nonnegative_finite("prior_gamma", prior_gamma)
+        self.learning_rate = _positive_finite("learning_rate", learning_rate)
+        self.sign_value = float(sign_value)
+        if not math.isfinite(self.sign_value) or self.sign_value == 0.0:
+            raise ValueError("sign_value must be finite and non-zero")
+        self.weight_bound = _nonnegative_finite("weight_bound", weight_bound)
+        self.weight_scale = _positive_finite("weight_scale", weight_scale)
+        self.activation = activation.strip()
+        self.optimizer = optimizer
+        self.seed = seed
+        self._provided_weights = None if weights is None else np.asarray(weights)
+        if self._provided_weights is not None:
+            if self._provided_weights.ndim != 2 or self._provided_weights.shape[0] != latent_dim:
+                raise ValueError("weights must be a 2D latent_dim x input_dim matrix")
+            if not np.issubdtype(self._provided_weights.dtype, np.number):
+                raise ValueError("weights must be numeric")
+            if not np.isfinite(self._provided_weights).all():
+                raise ValueError("weights contain NaN or infinite values")
+            self._provided_weights = np.ascontiguousarray(self._provided_weights)
+        self._runtime: tuple[Any, ...] | None = None
+        self._input_dim: int | None = None
+
+    def _ensure_runtime(self, input_dim: int) -> tuple[Any, ...]:
+        if self._runtime is not None:
+            if self._input_dim != input_dim:
+                raise ValueError(
+                    "input channel count is fixed after first execution; "
+                    f"expected {self._input_dim}, received {input_dim}"
+                )
+            return self._runtime
+
+        ngclearn, components, jax, jnp, random, version = _load_upstream()
+        for symbol in ("RateCell", "GaussianErrorCell", "HebbianSynapse", "StaticSynapse"):
+            if not hasattr(components, symbol):
+                raise NgcLearnVersionError(
+                    f"qualified ngc-learn 3.2 Hebbian surface is missing {symbol}"
+                )
+
+        if self._provided_weights is not None:
+            if self._provided_weights.shape[1] != input_dim:
+                raise ValueError(
+                    "weights second dimension must equal input channel count; "
+                    f"expected {input_dim}, received {self._provided_weights.shape[1]}"
+                )
+            initial_weights = self._provided_weights.copy()
+        else:
+            initial_weights = _default_weights(
+                latent_dim=self.latent_dim,
+                input_dim=input_dim,
+                seed=self.seed,
+                scale=self.weight_scale,
+            )
+
+        # ngcsimlib keeps a process-global Context registry. UUID naming avoids
+        # collisions even after notebook/module reloads that reset module counters.
+        context_name = f"neuros_ngclearn_hebbian_pc_{uuid.uuid4().hex}"
+        with ngclearn.Context(context_name):
+            latent = components.RateCell(
+                "z",
+                n_units=self.latent_dim,
+                tau_m=self.tau_m_ms,
+                act_fx=self.activation,
+                prior=("gaussian", self.prior_gamma),
+                integration_type="euler",
+                key=random.PRNGKey(self.seed),
+            )
+            error = components.GaussianErrorCell("e0", n_units=input_dim)
+            generative = components.HebbianSynapse(
+                "W",
+                shape=(self.latent_dim, input_dim),
+                eta=self.learning_rate,
+                w_bound=self.weight_bound,
+                is_nonnegative=False,
+                prior=("constant", 0.0),
+                sign_value=self.sign_value,
+                optim_type=self.optimizer,
+                key=random.PRNGKey(self.seed + 1),
+            )
+            feedback = components.StaticSynapse(
+                "E",
+                shape=(input_dim, self.latent_dim),
+                key=random.PRNGKey(self.seed + 2),
+            )
+
+            latent.zF >> generative.inputs
+            generative.outputs >> error.mu
+            error.dmu >> feedback.inputs
+            feedback.outputs >> latent.j
+            latent.zF >> generative.pre
+            error.dmu >> generative.post
+
+            advance = (
+                ngclearn.MethodProcess("hebbian_pc_advance")
+                >> feedback.advance_state
+                >> latent.advance_state
+                >> generative.advance_state
+                >> error.advance_state
+            )
+            reset = (
+                ngclearn.MethodProcess("hebbian_pc_reset")
+                >> latent.reset
+                >> error.reset
+                >> generative.reset
+                >> feedback.reset
+            )
+            evolve = ngclearn.MethodProcess("hebbian_pc_evolve") >> generative.evolve
+
+        generative.weights.set(jnp.asarray(initial_weights))
+        feedback.weights.set(jnp.asarray(initial_weights.T))
+        self._input_dim = input_dim
+        self._runtime = (
+            latent,
+            error,
+            generative,
+            feedback,
+            advance,
+            reset,
+            evolve,
+            jax,
+            jnp,
+            version,
+        )
+        return self._runtime
+
+    def snapshot_state(self) -> NgcLearnHebbianState:
+        if self._runtime is None:
+            raise RuntimeError("state is unavailable before the first infer/adapt call")
+        _, _, generative, _, _, _, _, jax, _, _ = self._runtime
+        # Preserve the upstream dtype exactly. State identity is defined on the
+        # actual JAX weight array, not a float64-normalized convenience copy.
+        weights = np.ascontiguousarray(np.asarray(generative.weights.get())).copy()
+        weights.setflags(write=False)
+        weights_sha = _array_sha256(weights)
+        # JAX leaves are immutable; tree_map clones all list/tuple/dict container
+        # structure so the checkpoint never aliases the live optimizer container.
+        optimizer_state = jax.tree_util.tree_map(
+            lambda leaf: leaf,
+            generative.opt_params.get(),
+        )
+        optimizer_sha = _tree_sha256(jax, optimizer_state)
+        return NgcLearnHebbianState(
+            weights=weights,
+            optimizer_state=optimizer_state,
+            weights_sha256=weights_sha,
+            optimizer_sha256=optimizer_sha,
+            state_sha256=_state_sha256(weights_sha, optimizer_sha),
+        )
+
+    def _validate_checkpoint(self, state: NgcLearnHebbianState) -> None:
+        if self._runtime is None:
+            raise RuntimeError("runtime must be initialized before state validation")
+        _, _, generative, _, _, _, _, jax, _, _ = self._runtime
+        expected_shape = tuple(int(v) for v in generative.weights.get().shape)
+        if tuple(state.weights.shape) != expected_shape:
+            raise ValueError(
+                f"rollback weight shape mismatch: expected {expected_shape}, received {state.weights.shape}"
+            )
+        actual_weights_sha = _array_sha256(np.ascontiguousarray(state.weights))
+        if actual_weights_sha != state.weights_sha256:
+            raise ValueError("rollback checkpoint weight SHA-256 does not match checkpoint contents")
+        actual_optimizer_sha = _tree_sha256(jax, state.optimizer_state)
+        if actual_optimizer_sha != state.optimizer_sha256:
+            raise ValueError("rollback checkpoint optimizer SHA-256 does not match checkpoint contents")
+        actual_state_sha = _state_sha256(actual_weights_sha, actual_optimizer_sha)
+        if actual_state_sha != state.state_sha256:
+            raise ValueError("rollback checkpoint state SHA-256 does not match checkpoint contents")
+
+    def restore_state(self, state: NgcLearnHebbianState) -> None:
+        if self._runtime is None:
+            raise RuntimeError("runtime must be initialized before state restoration")
+        # Validate the complete checkpoint before mutating live state. A corrupt
+        # rollback object must fail transactionally and leave the learner intact.
+        self._validate_checkpoint(state)
+        _, _, generative, feedback, _, reset, _, _, jnp, _ = self._runtime
+        generative.weights.set(jnp.asarray(state.weights))
+        generative.opt_params.set(state.optimizer_state)
+        feedback.weights.set(jnp.asarray(state.weights.T))
+        reset.run()
+        restored = self.snapshot_state()
+        if restored.state_sha256 != state.state_sha256:
+            raise RuntimeError("restored ngc-learn state does not match requested rollback identity")
+
+    def _settle_row(self, row: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        assert self._runtime is not None
+        latent, error, generative, feedback, advance, reset, _, _, jnp, _ = self._runtime
+        reset.run()
+        # Feedback is tied to the current generative state before each inference.
+        feedback.weights.set(jnp.transpose(generative.weights.get()))
+        error.target.set(jnp.asarray(row[None, :]))
+        for step in range(self.settling_steps):
+            advance.run(t=float(step) * self.settling_dt_ms, dt=self.settling_dt_ms)
+        latent_value = np.asarray(latent.zF.get()).reshape(-1)
+        reconstruction = np.asarray(error.mu.get()).reshape(-1)
+        if latent_value.size != self.latent_dim or not np.isfinite(latent_value).all():
+            raise RuntimeError("ngc-learn Hebbian predictive latent is invalid")
+        if reconstruction.size != row.size or not np.isfinite(reconstruction).all():
+            raise RuntimeError("ngc-learn Hebbian predictive reconstruction is invalid")
+        return latent_value, reconstruction
+
+    def infer(self, samples: Any, *, sample_rate_hz: float) -> NgcLearnHebbianInferenceResult:
+        sample_rate_hz = _positive_finite("sample_rate_hz", sample_rate_hz)
+        matrix = _matrix(samples)
+        self._ensure_runtime(matrix.shape[1])
+        state_before = self.snapshot_state()
+        latents: list[np.ndarray] = []
+        reconstructions: list[np.ndarray] = []
+        for row in matrix:
+            latent, reconstruction = self._settle_row(row)
+            latents.append(latent)
+            reconstructions.append(reconstruction)
+        state_after = self.snapshot_state()
+        if state_after.state_sha256 != state_before.state_sha256:
+            raise RuntimeError("inference mutated ngc-learn Hebbian learning state")
+        latent_matrix = np.ascontiguousarray(np.stack(latents))
+        reconstruction_matrix = np.ascontiguousarray(np.stack(reconstructions))
+        mse = float(np.mean(np.square(matrix - reconstruction_matrix)))
+        return NgcLearnHebbianInferenceResult(
+            values=latent_matrix,
+            reconstruction=reconstruction_matrix,
+            mean_squared_error=mse,
+            state_sha256=state_after.state_sha256,
+        )
+
+    def adapt(
+        self,
+        samples: Any,
+        *,
+        sample_rate_hz: float,
+        epochs: int = 1,
+    ) -> NgcLearnHebbianAdaptationResult:
+        sample_rate_hz = _positive_finite("sample_rate_hz", sample_rate_hz)
+        if isinstance(epochs, bool) or not isinstance(epochs, int) or epochs < 1:
+            raise ValueError("epochs must be a positive integer")
+        matrix = _matrix(samples)
+        runtime = self._ensure_runtime(matrix.shape[1])
+        latent, error, generative, feedback, _, _, evolve, jax, jnp, version = runtime
+        before = self.snapshot_state()
+        update_count = 0
+
+        for _ in range(epochs):
+            for row in matrix:
+                # E-step: reset activities, tie feedback, and settle on one observation.
+                self._settle_row(row)
+                # M-step: real upstream two-factor Hebbian update using the final
+                # latent pre statistic and Gaussian residual post statistic.
+                evolve.run(
+                    t=float(self.settling_steps) * self.settling_dt_ms,
+                    dt=self.settling_dt_ms,
+                )
+                feedback.weights.set(jnp.transpose(generative.weights.get()))
+                update_count += 1
+
+        after = self.snapshot_state()
+        if after.state_sha256 == before.state_sha256:
+            raise RuntimeError("Hebbian adaptation produced no mutable-state change")
+        weight_delta_l2 = float(
+            np.linalg.norm(after.weights.astype(np.float64) - before.weights.astype(np.float64))
+        )
+        if not math.isfinite(weight_delta_l2) or weight_delta_l2 <= 0:
+            raise RuntimeError("Hebbian adaptation produced invalid weight delta")
+        try:
+            x64_enabled: bool | None = bool(jax.config.read("jax_enable_x64"))
+        except Exception:
+            x64_enabled = None
+
+        payload: dict[str, Any] = {
+            "method_id": HEBBIAN_PC_METHOD_ID,
+            "ngclearn_version": version,
+            "jax_version": str(getattr(jax, "__version__", "unknown")),
+            "jax_backend": str(jax.default_backend()),
+            "jax_enable_x64": x64_enabled,
+            "latent_component": f"{latent.__class__.__module__}.{latent.__class__.__name__}",
+            "error_component": f"{error.__class__.__module__}.{error.__class__.__name__}",
+            "generative_synapse_component": f"{generative.__class__.__module__}.{generative.__class__.__name__}",
+            "feedback_synapse_component": f"{feedback.__class__.__module__}.{feedback.__class__.__name__}",
+            "latent_dim": self.latent_dim,
+            "settling_steps": self.settling_steps,
+            "settling_dt_ms": self.settling_dt_ms,
+            "tau_m_ms": self.tau_m_ms,
+            "prior_gamma": self.prior_gamma,
+            "activation": self.activation,
+            "learning_rate": self.learning_rate,
+            "optimizer": self.optimizer,
+            "sign_value": self.sign_value,
+            "weight_bound": self.weight_bound,
+            "row_normalization_after_update": False,
+            "epochs": epochs,
+            "n_observations": int(matrix.shape[0]),
+            "update_count": update_count,
+            "sample_rate_hz": sample_rate_hz,
+            "adaptation_input_sha256": _array_sha256(matrix),
+            "state_before_sha256": before.state_sha256,
+            "state_after_sha256": after.state_sha256,
+            "weights_before_sha256": before.weights_sha256,
+            "weights_after_sha256": after.weights_sha256,
+            "optimizer_before_sha256": before.optimizer_sha256,
+            "optimizer_after_sha256": after.optimizer_sha256,
+            "weight_delta_l2": weight_delta_l2,
+        }
+        payload["evidence_sha256"] = _canonical_sha256(payload)
+        evidence = NgcLearnHebbianAdaptationEvidence(**payload)
+        return NgcLearnHebbianAdaptationResult(
+            state_before=before,
+            state_after=after,
+            evidence=evidence,
+        )

--- a/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py
@@ -52,9 +52,25 @@ def _nonnegative_finite(name: str, value: Any) -> float:
     return result
 
 
+def _tree_schema(jax: Any, tree: Any) -> tuple[Any, tuple[tuple[str, tuple[int, ...]], ...]]:
+    """Return optimizer pytree structure plus exact leaf dtype/shape schema."""
+
+    treedef = jax.tree_util.tree_structure(tree)
+    specs: list[tuple[str, tuple[int, ...]]] = []
+    for leaf in jax.tree_util.tree_leaves(tree):
+        array = np.asarray(leaf)
+        if array.dtype.hasobject or not np.issubdtype(array.dtype, np.number):
+            raise TypeError("optimizer state contains non-numeric leaf")
+        if not np.isfinite(array).all():
+            raise ValueError("optimizer state contains NaN or infinite values")
+        specs.append((array.dtype.str, tuple(int(v) for v in array.shape)))
+    return treedef, tuple(specs)
+
+
 def _tree_sha256(jax: Any, tree: Any) -> str:
     """Hash a JAX pytree by deterministic leaf order, dtype, shape, and bytes."""
 
+    _tree_schema(jax, tree)
     digest = hashlib.sha256()
     digest.update(b"neuros.ngclearn.optimizer-state.v1\0")
     leaves = jax.tree_util.tree_leaves(tree)
@@ -62,8 +78,6 @@ def _tree_sha256(jax: Any, tree: Any) -> str:
     digest.update(b"\0")
     for index, leaf in enumerate(leaves):
         array = np.ascontiguousarray(np.asarray(leaf))
-        if array.dtype.hasobject:
-            raise TypeError("optimizer state contains object-dtype leaf")
         digest.update(str(index).encode("ascii"))
         digest.update(b"\0")
         digest.update(array.dtype.str.encode("ascii"))
@@ -177,6 +191,7 @@ class NgcLearnHebbianAdaptationEvidence:
                 "state_identity_includes_optimizer": True,
                 "rollback_state_supported": True,
                 "transactional_checkpoint_validation": True,
+                "optimizer_schema_validated_before_rollback": True,
                 "row_normalization_after_update": False,
                 "orion_authority_applied_here": False,
                 "real_dataset_qualified": False,
@@ -396,11 +411,30 @@ class NgcLearnHebbianPredictiveCoding:
         if self._runtime is None:
             raise RuntimeError("runtime must be initialized before state validation")
         _, _, generative, _, _, _, _, jax, _, _ = self._runtime
-        expected_shape = tuple(int(v) for v in generative.weights.get().shape)
+        live_weights = np.asarray(generative.weights.get())
+        expected_shape = tuple(int(v) for v in live_weights.shape)
         if tuple(state.weights.shape) != expected_shape:
             raise ValueError(
                 f"rollback weight shape mismatch: expected {expected_shape}, received {state.weights.shape}"
             )
+        if np.dtype(state.weights.dtype) != np.dtype(live_weights.dtype):
+            raise ValueError(
+                "rollback weight dtype mismatch: "
+                f"expected {live_weights.dtype}, received {state.weights.dtype}"
+            )
+        if not np.issubdtype(state.weights.dtype, np.number) or not np.isfinite(state.weights).all():
+            raise ValueError("rollback checkpoint weights must be finite numeric values")
+
+        live_optimizer = generative.opt_params.get()
+        live_treedef, live_schema = _tree_schema(jax, live_optimizer)
+        state_treedef, state_schema = _tree_schema(jax, state.optimizer_state)
+        if state_treedef != live_treedef:
+            raise ValueError("rollback checkpoint optimizer pytree structure is incompatible")
+        if state_schema != live_schema:
+            raise ValueError(
+                "rollback checkpoint optimizer leaf dtype/shape schema is incompatible"
+            )
+
         actual_weights_sha = _array_sha256(np.ascontiguousarray(state.weights))
         if actual_weights_sha != state.weights_sha256:
             raise ValueError("rollback checkpoint weight SHA-256 does not match checkpoint contents")
@@ -415,7 +449,7 @@ class NgcLearnHebbianPredictiveCoding:
         if self._runtime is None:
             raise RuntimeError("runtime must be initialized before state restoration")
         # Validate the complete checkpoint before mutating live state. A corrupt
-        # rollback object must fail transactionally and leave the learner intact.
+        # or optimizer-incompatible rollback object must fail transactionally.
         self._validate_checkpoint(state)
         _, _, generative, feedback, _, reset, _, _, jnp, _ = self._runtime
         generative.weights.set(jnp.asarray(state.weights))

--- a/packages/neuros-foundation/tests/test_ngclearn_hebbian.py
+++ b/packages/neuros-foundation/tests/test_ngclearn_hebbian.py
@@ -8,6 +8,8 @@ from neuros.foundation_models.ngclearn_hebbian import (
     HEBBIAN_PC_METHOD_ID,
     NgcLearnHebbianPredictiveCoding,
     NgcLearnHebbianState,
+    _state_sha256,
+    _tree_sha256,
 )
 
 
@@ -64,7 +66,6 @@ def test_real_upstream_hebbian_adaptation_changes_complete_state():
     model = _model(optimizer="sgd")
     samples = _samples()
 
-    # Initializes the runtime while proving the first held-out-style inference is read-only.
     inference = model.infer(samples[:2], sample_rate_hz=250.0)
     before = model.snapshot_state()
     assert inference.state_sha256 == before.state_sha256
@@ -89,14 +90,13 @@ def test_real_upstream_hebbian_adaptation_changes_complete_state():
     assert before.weights_sha256 != after.weights_sha256
     assert before.optimizer_sha256 != after.optimizer_sha256
     assert result.evidence.weight_delta_l2 > 0.0
-    # Evidence identity is defined on the canonical float64 time x channel matrix
-    # that the ngc-learn bridge actually consumes, not the caller's source dtype.
     assert result.evidence.adaptation_input_sha256 == _array_sha256(_matrix(samples[2:]))
 
     boundary = result.evidence.to_dict()["claim_boundary"]
     assert boundary["hebbian_synapse_executed"] is True
     assert boundary["state_identity_includes_optimizer"] is True
     assert boundary["transactional_checkpoint_validation"] is True
+    assert boundary["optimizer_schema_validated_before_rollback"] is True
     assert boundary["orion_authority_applied_here"] is False
     assert boundary["real_dataset_qualified"] is False
     assert boundary["calibration_reduction_qualified"] is False
@@ -143,7 +143,6 @@ def test_adam_rollback_restores_weights_optimizer_and_future_trajectory():
     model = _model(optimizer="adam")
     reference = _model(optimizer="adam")
 
-    # Initialize both runtimes without changing learnable state.
     model.infer(samples[:1], sample_rate_hz=250.0)
     reference.infer(samples[:1], sample_rate_hz=250.0)
     checkpoint = model.snapshot_state()
@@ -187,6 +186,34 @@ def test_corrupt_checkpoint_fails_before_live_state_is_modified():
 
     with pytest.raises(ValueError, match="weight SHA-256"):
         model.restore_state(corrupted)
+
+    live_after = model.snapshot_state()
+    assert live_after.state_sha256 == live_before.state_sha256
+    assert np.array_equal(live_after.weights, live_before.weights)
+
+
+def test_self_consistent_incompatible_optimizer_checkpoint_fails_transactionally():
+    pytest.importorskip("ngclearn")
+    jax = pytest.importorskip("jax")
+    model = _model(optimizer="adam")
+    samples = _samples()
+    model.adapt(samples[:2], sample_rate_hz=250.0, epochs=1)
+    live_before = model.snapshot_state()
+
+    # Forge a self-consistent SGD-like scalar optimizer state. Its hashes all
+    # agree with its contents, but it is structurally invalid for this Adam learner.
+    forged_optimizer = np.asarray(1.0, dtype=np.float32)
+    forged_optimizer_sha = _tree_sha256(jax, forged_optimizer)
+    forged = NgcLearnHebbianState(
+        weights=live_before.weights,
+        optimizer_state=forged_optimizer,
+        weights_sha256=live_before.weights_sha256,
+        optimizer_sha256=forged_optimizer_sha,
+        state_sha256=_state_sha256(live_before.weights_sha256, forged_optimizer_sha),
+    )
+
+    with pytest.raises(ValueError, match="optimizer pytree structure"):
+        model.restore_state(forged)
 
     live_after = model.snapshot_state()
     assert live_after.state_sha256 == live_before.state_sha256

--- a/packages/neuros-foundation/tests/test_ngclearn_hebbian.py
+++ b/packages/neuros-foundation/tests/test_ngclearn_hebbian.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from neuros.foundation_models.ngclearn_bridge import _array_sha256
+from neuros.foundation_models.ngclearn_bridge import _array_sha256, _matrix
 from neuros.foundation_models.ngclearn_hebbian import (
     HEBBIAN_PC_METHOD_ID,
     NgcLearnHebbianPredictiveCoding,
@@ -89,7 +89,9 @@ def test_real_upstream_hebbian_adaptation_changes_complete_state():
     assert before.weights_sha256 != after.weights_sha256
     assert before.optimizer_sha256 != after.optimizer_sha256
     assert result.evidence.weight_delta_l2 > 0.0
-    assert result.evidence.adaptation_input_sha256 == _array_sha256(samples[2:])
+    # Evidence identity is defined on the canonical float64 time x channel matrix
+    # that the ngc-learn bridge actually consumes, not the caller's source dtype.
+    assert result.evidence.adaptation_input_sha256 == _array_sha256(_matrix(samples[2:]))
 
     boundary = result.evidence.to_dict()["claim_boundary"]
     assert boundary["hebbian_synapse_executed"] is True

--- a/packages/neuros-foundation/tests/test_ngclearn_hebbian.py
+++ b/packages/neuros-foundation/tests/test_ngclearn_hebbian.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.ngclearn_bridge import _array_sha256
+from neuros.foundation_models.ngclearn_hebbian import (
+    HEBBIAN_PC_METHOD_ID,
+    NgcLearnHebbianPredictiveCoding,
+    NgcLearnHebbianState,
+)
+
+
+def _samples() -> np.ndarray:
+    return np.asarray(
+        [
+            [0.40, -0.20],
+            [0.15, 0.35],
+            [-0.30, 0.10],
+            [0.25, 0.45],
+        ],
+        dtype=np.float32,
+    )
+
+
+def _weights() -> np.ndarray:
+    return np.asarray([[0.30, 0.00], [0.00, 0.30]], dtype=np.float32)
+
+
+def _model(*, optimizer: str = "sgd") -> NgcLearnHebbianPredictiveCoding:
+    return NgcLearnHebbianPredictiveCoding(
+        latent_dim=2,
+        settling_steps=16,
+        settling_dt_ms=1.0,
+        tau_m_ms=12.0,
+        prior_gamma=0.0,
+        activation="identity",
+        learning_rate=0.005,
+        optimizer=optimizer,
+        sign_value=-1.0,
+        weight_bound=0.0,
+        seed=17,
+        weights=_weights(),
+    )
+
+
+def test_hebbian_configuration_fails_closed_before_optional_runtime_import():
+    with pytest.raises(ValueError, match="latent_dim"):
+        NgcLearnHebbianPredictiveCoding(latent_dim=0)
+    with pytest.raises(ValueError, match="settling_steps"):
+        NgcLearnHebbianPredictiveCoding(settling_steps=0)
+    with pytest.raises(ValueError, match="optimizer"):
+        NgcLearnHebbianPredictiveCoding(optimizer="mystery")
+    with pytest.raises(ValueError, match="learning_rate"):
+        NgcLearnHebbianPredictiveCoding(learning_rate=0.0)
+    with pytest.raises(ValueError, match="weight_bound"):
+        NgcLearnHebbianPredictiveCoding(weight_bound=-1.0)
+    with pytest.raises(ValueError, match="weights"):
+        NgcLearnHebbianPredictiveCoding(latent_dim=2, weights=np.ones((3, 2)))
+
+
+def test_real_upstream_hebbian_adaptation_changes_complete_state():
+    pytest.importorskip("ngclearn")
+    model = _model(optimizer="sgd")
+    samples = _samples()
+
+    # Initializes the runtime while proving the first held-out-style inference is read-only.
+    inference = model.infer(samples[:2], sample_rate_hz=250.0)
+    before = model.snapshot_state()
+    assert inference.state_sha256 == before.state_sha256
+    assert before.weights.dtype == np.dtype(np.float32)
+    assert before.weights.flags.writeable is False
+
+    result = model.adapt(samples[2:], sample_rate_hz=250.0, epochs=2)
+    after = model.snapshot_state()
+
+    assert result.evidence.method_id == HEBBIAN_PC_METHOD_ID
+    assert result.evidence.ngclearn_version.startswith("3.2.")
+    assert result.evidence.update_count == 4
+    assert result.evidence.n_observations == 2
+    assert result.evidence.epochs == 2
+    assert "HebbianSynapse" in result.evidence.generative_synapse_component
+    assert "GaussianErrorCell" in result.evidence.error_component
+    assert result.evidence.row_normalization_after_update is False
+    assert result.evidence.sign_value == pytest.approx(-1.0)
+    assert result.evidence.state_before_sha256 == before.state_sha256
+    assert result.evidence.state_after_sha256 == after.state_sha256
+    assert before.state_sha256 != after.state_sha256
+    assert before.weights_sha256 != after.weights_sha256
+    assert before.optimizer_sha256 != after.optimizer_sha256
+    assert result.evidence.weight_delta_l2 > 0.0
+    assert result.evidence.adaptation_input_sha256 == _array_sha256(samples[2:])
+
+    boundary = result.evidence.to_dict()["claim_boundary"]
+    assert boundary["hebbian_synapse_executed"] is True
+    assert boundary["state_identity_includes_optimizer"] is True
+    assert boundary["transactional_checkpoint_validation"] is True
+    assert boundary["orion_authority_applied_here"] is False
+    assert boundary["real_dataset_qualified"] is False
+    assert boundary["calibration_reduction_qualified"] is False
+    assert boundary["stdp_learning_qualified"] is False
+
+
+def test_inference_after_adaptation_is_strictly_read_only():
+    pytest.importorskip("ngclearn")
+    model = _model(optimizer="adam")
+    samples = _samples()
+
+    model.adapt(samples[:2], sample_rate_hz=250.0, epochs=1)
+    before = model.snapshot_state()
+    first = model.infer(samples[2:], sample_rate_hz=250.0)
+    middle = model.snapshot_state()
+    second = model.infer(samples[2:], sample_rate_hz=250.0)
+    after = model.snapshot_state()
+
+    assert before.state_sha256 == first.state_sha256 == middle.state_sha256
+    assert middle.state_sha256 == second.state_sha256 == after.state_sha256
+    assert np.array_equal(first.values, second.values)
+    assert np.array_equal(first.reconstruction, second.reconstruction)
+    assert first.mean_squared_error == pytest.approx(second.mean_squared_error, rel=0, abs=0)
+
+
+def test_identical_models_and_data_produce_identical_learning_state():
+    pytest.importorskip("ngclearn")
+    samples = _samples()
+    first = _model(optimizer="adam")
+    second = _model(optimizer="adam")
+
+    first_result = first.adapt(samples, sample_rate_hz=250.0, epochs=2)
+    second_result = second.adapt(samples, sample_rate_hz=250.0, epochs=2)
+
+    assert first_result.state_before.state_sha256 == second_result.state_before.state_sha256
+    assert first_result.state_after.state_sha256 == second_result.state_after.state_sha256
+    assert first_result.evidence.evidence_sha256 == second_result.evidence.evidence_sha256
+    assert np.array_equal(first_result.state_after.weights, second_result.state_after.weights)
+
+
+def test_adam_rollback_restores_weights_optimizer_and_future_trajectory():
+    pytest.importorskip("ngclearn")
+    samples = _samples()
+    model = _model(optimizer="adam")
+    reference = _model(optimizer="adam")
+
+    # Initialize both runtimes without changing learnable state.
+    model.infer(samples[:1], sample_rate_hz=250.0)
+    reference.infer(samples[:1], sample_rate_hz=250.0)
+    checkpoint = model.snapshot_state()
+    reference_checkpoint = reference.snapshot_state()
+    assert checkpoint.state_sha256 == reference_checkpoint.state_sha256
+
+    first_adaptation = model.adapt(samples[:2], sample_rate_hz=250.0, epochs=2)
+    assert first_adaptation.state_after.state_sha256 != checkpoint.state_sha256
+    assert first_adaptation.state_after.optimizer_sha256 != checkpoint.optimizer_sha256
+
+    model.restore_state(checkpoint)
+    restored = model.snapshot_state()
+    assert restored.state_sha256 == checkpoint.state_sha256
+    assert restored.weights_sha256 == checkpoint.weights_sha256
+    assert restored.optimizer_sha256 == checkpoint.optimizer_sha256
+    assert np.array_equal(restored.weights, checkpoint.weights)
+
+    replay = model.adapt(samples[:2], sample_rate_hz=250.0, epochs=2)
+    reference_replay = reference.adapt(samples[:2], sample_rate_hz=250.0, epochs=2)
+    assert replay.state_after.state_sha256 == first_adaptation.state_after.state_sha256
+    assert replay.state_after.state_sha256 == reference_replay.state_after.state_sha256
+    assert replay.evidence.evidence_sha256 == reference_replay.evidence.evidence_sha256
+
+
+def test_corrupt_checkpoint_fails_before_live_state_is_modified():
+    pytest.importorskip("ngclearn")
+    model = _model(optimizer="adam")
+    samples = _samples()
+    model.adapt(samples[:2], sample_rate_hz=250.0, epochs=1)
+    live_before = model.snapshot_state()
+
+    corrupted_weights = np.array(live_before.weights, copy=True)
+    corrupted_weights[0, 0] += np.asarray(0.125, dtype=corrupted_weights.dtype)
+    corrupted = NgcLearnHebbianState(
+        weights=corrupted_weights,
+        optimizer_state=live_before.optimizer_state,
+        weights_sha256=live_before.weights_sha256,
+        optimizer_sha256=live_before.optimizer_sha256,
+        state_sha256=live_before.state_sha256,
+    )
+
+    with pytest.raises(ValueError, match="weight SHA-256"):
+        model.restore_state(corrupted)
+
+    live_after = model.snapshot_state()
+    assert live_after.state_sha256 == live_before.state_sha256
+    assert np.array_equal(live_after.weights, live_before.weights)
+
+
+def test_bad_samples_geometry_and_epochs_fail_closed():
+    pytest.importorskip("ngclearn")
+    model = _model()
+    with pytest.raises(ValueError, match="2D time x channel"):
+        model.adapt(np.ones(4), sample_rate_hz=250.0)
+    with pytest.raises(ValueError, match="NaN or infinite"):
+        model.adapt(np.asarray([[0.0, np.nan]]), sample_rate_hz=250.0)
+    with pytest.raises(ValueError, match="epochs"):
+        model.adapt(_samples(), sample_rate_hz=250.0, epochs=0)
+    with pytest.raises(ValueError, match="sample_rate_hz"):
+        model.infer(_samples(), sample_rate_hz=0.0)

--- a/packages/neuros/src/neuros/compatibility.py
+++ b/packages/neuros/src/neuros/compatibility.py
@@ -213,6 +213,10 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
             "rate-cell-transform",
             "predictive-reconstruction",
             "iterative-error-feedback",
+            "hebbian-predictive-adaptation",
+            "adaptation-authority-binding",
+            "exact-learning-state-rollback",
+            "canonical-adaptation-input-identity",
             "jax-identity",
             "biological-dynamics-bridge",
         ),
@@ -220,18 +224,23 @@ _REGISTRY: tuple[IntegrationRecord, ...] = (
         evidence_paths=(
             "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_bridge.py",
             "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_predictive_coding.py",
+            "packages/neuros-foundation/src/neuros/foundation_models/ngclearn_hebbian.py",
             "packages/neuros-foundation/tests/test_ngclearn_bridge.py",
             "packages/neuros-foundation/tests/test_ngclearn_predictive_coding.py",
-            ".github/workflows/neuroai-ecosystem-ci.yml",
+            "packages/neuros-foundation/tests/test_ngclearn_hebbian.py",
+            "scripts/evidence/run_ngclearn_hebbian_authority.py",
+            "tests/test_ngclearn_hebbian_authority.py",
+            ".github/workflows/ngclearn-hebbian-ci.yml",
         ),
         notes=(
-            "Qualified upstream ngc-learn 3.2.x surfaces include RateCell execution and a "
-            "fixed-weight predictive reconstruction circuit using real RateCell, "
-            "GaussianErrorCell, and StaticSynapse residual-feedback dynamics. The circuit "
-            "resets per observation, ties feedback to the generative-weight transpose, and "
-            "records reconstruction-error trajectories and artifact identities. Hebbian/STDP "
-            "learning, online adaptation, spiking networks, real-data utility, hardware, and "
-            "closed-loop behavior remain unqualified until separate evidence lands."
+            "Qualified upstream ngc-learn 3.2.x surfaces include RateCell execution, fixed-weight "
+            "predictive reconstruction, and a governed predictive-reconstruction M-step through "
+            "the real HebbianSynapse. Adaptive evidence binds exact canonical calibration rows to "
+            "ORION AdaptationAuthority, records weight plus optimizer-state identity, keeps held-out "
+            "qualification inference read-only, and supports exact retain-or-rollback state. The "
+            "qualification partition may influence retention and is therefore not an untouched final "
+            "assessment set. STDP, spiking-network adaptation, real-neural-data efficacy, calibration "
+            "reduction, online/closed-loop adaptation, hardware, and clinical behavior remain unqualified."
         ),
         install_hint='pip install "neuros-foundation[ngclearn]"',
     ),

--- a/scripts/evidence/run_ngclearn_hebbian_authority.py
+++ b/scripts/evidence/run_ngclearn_hebbian_authority.py
@@ -1,0 +1,325 @@
+"""Compose ngc-learn Hebbian learning with ORION adaptation authority.
+
+This evidence worker deliberately lives outside both packages. ``neuros-foundation``
+owns the optional ngc-learn mechanism while ORION owns mutation authority. The worker
+is the seam where the two independent contracts are bound and audited.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+import numpy as np
+
+from orion import (
+    AdaptationApplication,
+    AdaptationAuthority,
+    AdaptationDecision,
+    AdaptationEvaluation,
+    AdaptationOutcome,
+    AdaptationPhase,
+    AdaptationProposal,
+    ArtifactIdentity,
+    GovernedAdaptationProposal,
+)
+from neuros.foundation_models.ngclearn_bridge import _array_sha256, _matrix
+from neuros.foundation_models.ngclearn_hebbian import NgcLearnHebbianPredictiveCoding
+
+
+def _canonical_sha256(payload: dict[str, Any]) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _artifact(
+    *,
+    authority: AdaptationAuthority,
+    phase: str,
+    state: Any,
+    model: NgcLearnHebbianPredictiveCoding,
+) -> ArtifactIdentity:
+    return ArtifactIdentity(
+        artifact_id=f"ngclearn-hebbian/{authority.authority_id}/{phase}",
+        artifact_type="ngclearn-hebbian-learning-state",
+        sha256=state.state_sha256,
+        version="1",
+        metadata={
+            "method_id": "neuros-ngclearn-hebbian-predictive-reconstruction-v1",
+            "weights_sha256": state.weights_sha256,
+            "optimizer_sha256": state.optimizer_sha256,
+            "optimizer": model.optimizer,
+            "latent_dim": model.latent_dim,
+        },
+    )
+
+
+def run_governed_hebbian_adaptation(
+    samples: Any,
+    *,
+    authority: AdaptationAuthority,
+    loaded_processed_data_sha256: str,
+    model: NgcLearnHebbianPredictiveCoding,
+    sample_rate_hz: float,
+    epochs: int = 1,
+    minimum_mse_improvement: float = 0.0,
+) -> dict[str, Any]:
+    """Run one authority-bound Hebbian adaptation and held-out decision.
+
+    ``loaded_processed_data_sha256`` is supplied by the data-authority layer. It
+    can therefore carry the richer ``LongitudinalCaseAuthority`` hash semantics
+    rather than forcing this worker to redefine processed-dataset identity.
+
+    The learner sees only ``authority.adaptation_indices``. Held-out rows are
+    used for read-only before/after evaluation and may determine retain versus
+    rollback only after mutation has finished.
+    """
+
+    matrix = _matrix(samples)
+    if matrix.shape[0] != authority.n_samples:
+        raise ValueError(
+            "sample count differs from adaptation authority: "
+            f"authority={authority.n_samples}, loaded={matrix.shape[0]}"
+        )
+    if loaded_processed_data_sha256 != authority.processed_data_sha256:
+        raise ValueError("loaded processed-data SHA-256 differs from adaptation authority")
+    if isinstance(epochs, bool) or not isinstance(epochs, int) or epochs < 1:
+        raise ValueError("epochs must be a positive integer")
+    if isinstance(minimum_mse_improvement, bool) or not isinstance(
+        minimum_mse_improvement, (int, float)
+    ):
+        raise ValueError("minimum_mse_improvement must be numeric")
+    minimum_mse_improvement = float(minimum_mse_improvement)
+    if not math.isfinite(minimum_mse_improvement) or minimum_mse_improvement < 0.0:
+        raise ValueError("minimum_mse_improvement must be finite and non-negative")
+
+    adaptation_indices = authority.require_adaptation_indices(authority.adaptation_indices)
+    evaluation_indices = authority.require_evaluation_indices(authority.evaluation_indices)
+    adaptation_matrix = np.ascontiguousarray(
+        matrix[np.asarray(adaptation_indices, dtype=np.int64)]
+    )
+    evaluation_matrix = np.ascontiguousarray(
+        matrix[np.asarray(evaluation_indices, dtype=np.int64)]
+    )
+    adaptation_input_sha256 = _array_sha256(adaptation_matrix)
+    evaluation_input_sha256 = _array_sha256(evaluation_matrix)
+
+    # Calibration evidence may authorize a proposal. Held-out evidence is kept
+    # out of proposal/approval semantics and is used only for final evaluation.
+    calibration_before = model.infer(adaptation_matrix, sample_rate_hz=sample_rate_hz)
+    evaluation_before = model.infer(evaluation_matrix, sample_rate_hz=sample_rate_hz)
+    before_state = model.snapshot_state()
+    if calibration_before.state_sha256 != before_state.state_sha256:
+        raise RuntimeError("calibration inference mutated learning state")
+    if evaluation_before.state_sha256 != before_state.state_sha256:
+        raise RuntimeError("held-out baseline inference mutated learning state")
+
+    before_artifact = _artifact(
+        authority=authority,
+        phase="before",
+        state=before_state,
+        model=model,
+    )
+    proposal = AdaptationProposal(
+        reason="authorized Hebbian calibration under frozen adaptation authority",
+        changes={
+            "method": "ngclearn-hebbian-predictive-reconstruction-v1",
+            "epochs": epochs,
+            "learning_rate": model.learning_rate,
+            "optimizer": model.optimizer,
+            "settling_steps": model.settling_steps,
+        },
+        evidence={"calibration_reconstruction_mse": calibration_before.mean_squared_error},
+        requires_approval=True,
+    )
+    governed = GovernedAdaptationProposal.bind(
+        proposal,
+        authority=authority,
+        before_artifact=before_artifact,
+        adaptation_indices=adaptation_indices,
+    )
+    decision = AdaptationDecision.approve(
+        governed,
+        actor="evidence-worker/frozen-authority",
+        reason="proposal is restricted to the complete frozen calibration partition",
+    )
+
+    adaptation = model.adapt(
+        adaptation_matrix,
+        sample_rate_hz=sample_rate_hz,
+        epochs=epochs,
+    )
+    if adaptation.evidence.adaptation_input_sha256 != adaptation_input_sha256:
+        raise RuntimeError(
+            "learner adaptation-input SHA-256 differs from authority-selected calibration rows"
+        )
+    if adaptation.evidence.state_before_sha256 != before_state.state_sha256:
+        raise RuntimeError("learner pre-update state differs from governed proposal artifact")
+
+    after_artifact = _artifact(
+        authority=authority,
+        phase="after",
+        state=adaptation.state_after,
+        model=model,
+    )
+    application = AdaptationApplication.record(
+        governed,
+        decision,
+        authority=authority,
+        after_artifact=after_artifact,
+        adaptation_indices=adaptation_indices,
+        update_evidence={
+            "update_count": float(adaptation.evidence.update_count),
+            "weight_delta_l2": adaptation.evidence.weight_delta_l2,
+        },
+    )
+
+    evaluation_after = model.infer(evaluation_matrix, sample_rate_hz=sample_rate_hz)
+    if evaluation_after.state_sha256 != adaptation.state_after.state_sha256:
+        raise RuntimeError("held-out evaluation mutated the post-adaptation learning state")
+    evaluation = AdaptationEvaluation.record(
+        application,
+        authority=authority,
+        evaluation_indices=evaluation_indices,
+        metrics_before={"reconstruction_mse": evaluation_before.mean_squared_error},
+        metrics_after={"reconstruction_mse": evaluation_after.mean_squared_error},
+    )
+
+    improvement = evaluation_before.mean_squared_error - evaluation_after.mean_squared_error
+    if improvement >= minimum_mse_improvement:
+        outcome = AdaptationOutcome.retain(
+            application,
+            evaluation,
+            actor="policy/held-out-reconstruction",
+            reason=(
+                "held-out reconstruction MSE met the predeclared minimum improvement "
+                f"threshold ({minimum_mse_improvement:.12g})"
+            ),
+        )
+    else:
+        model.restore_state(adaptation.state_before)
+        restored_state = model.snapshot_state()
+        if restored_state.state_sha256 != before_state.state_sha256:
+            raise RuntimeError("rollback did not restore the exact governed pre-update state")
+        restored_artifact = _artifact(
+            authority=authority,
+            phase="rollback",
+            state=restored_state,
+            model=model,
+        )
+        outcome = AdaptationOutcome.rollback(
+            application,
+            evaluation,
+            restored_artifact=restored_artifact,
+            actor="policy/held-out-reconstruction",
+            reason=(
+                "held-out reconstruction MSE failed the predeclared minimum improvement "
+                f"threshold ({minimum_mse_improvement:.12g})"
+            ),
+        )
+
+    active_state = model.snapshot_state()
+    if active_state.state_sha256 != outcome.active_artifact.sha256:
+        raise RuntimeError("live learner state differs from finalized adaptation outcome")
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "authority": authority.to_dict(),
+        "inputs": {
+            "loaded_matrix_sha256": _array_sha256(matrix),
+            "loaded_processed_data_sha256": loaded_processed_data_sha256,
+            "adaptation_input_sha256": adaptation_input_sha256,
+            "evaluation_input_sha256": evaluation_input_sha256,
+            "adaptation_indices": list(adaptation_indices),
+            "evaluation_indices": list(evaluation_indices),
+        },
+        "proposal": governed.to_dict(),
+        "decision": decision.to_dict(),
+        "learner_adaptation": adaptation.evidence.to_dict(),
+        "application": application.to_dict(),
+        "evaluation": evaluation.to_dict(),
+        "held_out_mse_improvement": improvement,
+        "minimum_mse_improvement": minimum_mse_improvement,
+        "outcome": outcome.to_dict(),
+        "claim_boundary": {
+            "orion_adaptation_authority_enforced": True,
+            "exact_adaptation_rows_verified": True,
+            "exact_evaluation_rows_verified": True,
+            "held_out_evaluation_read_only": True,
+            "retain_or_exact_rollback_exercised": True,
+            "real_dataset_qualified": False,
+            "calibration_reduction_qualified": False,
+            "cross_subject_transfer_qualified": False,
+            "online_adaptation_qualified": False,
+            "stdp_learning_qualified": False,
+            "hardware_qualified": False,
+            "closed_loop_qualified": False,
+            "clinical_qualified": False,
+        },
+    }
+    payload["evidence_sha256"] = _canonical_sha256(payload)
+    return payload
+
+
+def _fixture() -> tuple[np.ndarray, AdaptationAuthority, NgcLearnHebbianPredictiveCoding]:
+    samples = np.asarray(
+        [
+            [0.40, -0.20],
+            [0.15, 0.35],
+            [-0.30, 0.10],
+            [0.38, -0.18],
+            [0.18, 0.32],
+            [-0.28, 0.12],
+        ],
+        dtype=np.float32,
+    )
+    authority = AdaptationAuthority(
+        authority_id="fixture/session-02/budget-3",
+        dataset_id="ngclearn-hebbian-authority-fixture",
+        split_unit="session",
+        adaptation_indices=(0, 1, 2),
+        evaluation_indices=(3, 4, 5),
+        processed_data_sha256=_array_sha256(samples),
+        n_samples=len(samples),
+        protocol_fingerprint="fixture-protocol-v1",
+        source_authority_fingerprint="fixture-longitudinal-authority-v1",
+        seed=17,
+    )
+    model = NgcLearnHebbianPredictiveCoding(
+        latent_dim=2,
+        settling_steps=16,
+        settling_dt_ms=1.0,
+        tau_m_ms=12.0,
+        learning_rate=0.005,
+        optimizer="adam",
+        sign_value=-1.0,
+        weight_bound=0.0,
+        seed=17,
+        weights=np.asarray([[0.30, 0.00], [0.00, 0.30]], dtype=np.float32),
+    )
+    return samples, authority, model
+
+
+def main() -> None:
+    samples, authority, model = _fixture()
+    payload = run_governed_hebbian_adaptation(
+        samples,
+        authority=authority,
+        loaded_processed_data_sha256=authority.processed_data_sha256,
+        model=model,
+        sample_rate_hz=250.0,
+        epochs=2,
+        minimum_mse_improvement=0.0,
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evidence/run_ngclearn_hebbian_authority.py
+++ b/scripts/evidence/run_ngclearn_hebbian_authority.py
@@ -286,7 +286,10 @@ def _fixture() -> tuple[np.ndarray, AdaptationAuthority, NgcLearnHebbianPredicti
         split_unit="session",
         adaptation_indices=(0, 1, 2),
         evaluation_indices=(3, 4, 5),
-        processed_data_sha256=_array_sha256(samples),
+        # The fixture treats the canonical float64 bridge matrix as its processed
+        # data authority. Real longitudinal studies may carry a richer hash that
+        # also includes labels/group identities and pass that verified identity in.
+        processed_data_sha256=_array_sha256(_matrix(samples)),
         n_samples=len(samples),
         protocol_fingerprint="fixture-protocol-v1",
         source_authority_fingerprint="fixture-longitudinal-authority-v1",

--- a/tests/test_compatibility_registry.py
+++ b/tests/test_compatibility_registry.py
@@ -98,7 +98,7 @@ def test_snap_is_a_numerical_evidence_contract_not_a_biological_claim():
     assert "spectral_alignment.py" in " ".join(record.evidence_paths)
 
 
-def test_ngclearn_predictive_coding_is_integration_qualified_but_learning_is_not():
+def test_ngclearn_governed_hebbian_adaptation_is_integration_qualified_only():
     record = get_integration("ngclearn")
 
     assert record.status is IntegrationStatus.EXPERIMENTAL
@@ -106,17 +106,30 @@ def test_ngclearn_predictive_coding_is_integration_qualified_but_learning_is_not
     assert "rate-cell-transform" in record.capabilities
     assert "predictive-reconstruction" in record.capabilities
     assert "iterative-error-feedback" in record.capabilities
+    assert "hebbian-predictive-adaptation" in record.capabilities
+    assert "adaptation-authority-binding" in record.capabilities
+    assert "exact-learning-state-rollback" in record.capabilities
+    assert "canonical-adaptation-input-identity" in record.capabilities
     assert "spiking-network" not in record.capabilities
-    assert "hebbian-learning" not in record.capabilities
     assert "stdp-learning" not in record.capabilities
     assert "online-adaptation" not in record.capabilities
+    assert "real-dataset-utility" not in record.capabilities
+    assert "calibration-reduction" not in record.capabilities
     assert record.install_hint == 'pip install "neuros-foundation[ngclearn]"'
+
     evidence = " ".join(record.evidence_paths)
     assert "ngclearn_predictive_coding.py" in evidence
     assert "test_ngclearn_predictive_coding.py" in evidence
+    assert "ngclearn_hebbian.py" in evidence
+    assert "test_ngclearn_hebbian.py" in evidence
+    assert "run_ngclearn_hebbian_authority.py" in evidence
+    assert "test_ngclearn_hebbian_authority.py" in evidence
+    assert "ngclearn-hebbian-ci.yml" in evidence
+
     assert "3.2.x" in record.notes
-    assert "fixed-weight predictive reconstruction" in record.notes
-    assert "Hebbian/STDP" in record.notes
+    assert "HebbianSynapse" in record.notes
+    assert "optimizer-state" in record.notes
+    assert "not an untouched final assessment set" in record.notes
     assert "remain unqualified" in record.notes
 
 

--- a/tests/test_ngclearn_hebbian_authority.py
+++ b/tests/test_ngclearn_hebbian_authority.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from neuros.foundation_models.ngclearn_bridge import _array_sha256
+from neuros.foundation_models.ngclearn_bridge import _array_sha256, _matrix
 from scripts.evidence.run_ngclearn_hebbian_authority import (
     _fixture,
     run_governed_hebbian_adaptation,
@@ -27,8 +27,11 @@ def test_real_upstream_authority_worker_binds_exact_calibration_and_evaluation_r
     pytest.importorskip("ngclearn")
     samples, authority, model, payload = _run()
 
-    adaptation = samples[list(authority.adaptation_indices)]
-    evaluation = samples[list(authority.evaluation_indices)]
+    # Match the exact canonical matrix representation consumed by the bridge and
+    # sliced by the authority worker rather than the caller's source dtype.
+    canonical = _matrix(samples)
+    adaptation = canonical[list(authority.adaptation_indices)]
+    evaluation = canonical[list(authority.evaluation_indices)]
     assert payload["inputs"]["adaptation_input_sha256"] == _array_sha256(adaptation)
     assert payload["inputs"]["evaluation_input_sha256"] == _array_sha256(evaluation)
     assert (
@@ -70,8 +73,14 @@ def test_authority_worker_is_deterministic_across_independent_real_upstream_runs
 
     assert first_authority.authority_fingerprint == second_authority.authority_fingerprint
     assert first["evidence_sha256"] == second["evidence_sha256"]
-    assert first["learner_adaptation"]["evidence_sha256"] == second["learner_adaptation"]["evidence_sha256"]
-    assert first["outcome"]["outcome_fingerprint"] == second["outcome"]["outcome_fingerprint"]
+    assert (
+        first["learner_adaptation"]["evidence_sha256"]
+        == second["learner_adaptation"]["evidence_sha256"]
+    )
+    assert (
+        first["outcome"]["outcome_fingerprint"]
+        == second["outcome"]["outcome_fingerprint"]
+    )
     assert first == second
 
 
@@ -88,7 +97,10 @@ def test_predeclared_failed_held_out_gate_rolls_back_exact_complete_learning_sta
         payload["outcome"]["active_artifact"]["sha256"]
         != payload["application"]["after_artifact"]["sha256"]
     )
-    assert model.snapshot_state().state_sha256 == payload["outcome"]["active_artifact"]["sha256"]
+    assert (
+        model.snapshot_state().state_sha256
+        == payload["outcome"]["active_artifact"]["sha256"]
+    )
 
 
 def test_processed_data_identity_mismatch_fails_before_learner_runtime_is_initialized():

--- a/tests/test_ngclearn_hebbian_authority.py
+++ b/tests/test_ngclearn_hebbian_authority.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+from neuros.foundation_models.ngclearn_bridge import _array_sha256
+from scripts.evidence.run_ngclearn_hebbian_authority import (
+    _fixture,
+    run_governed_hebbian_adaptation,
+)
+
+
+def _run(*, minimum_mse_improvement: float = 0.0):
+    samples, authority, model = _fixture()
+    payload = run_governed_hebbian_adaptation(
+        samples,
+        authority=authority,
+        loaded_processed_data_sha256=authority.processed_data_sha256,
+        model=model,
+        sample_rate_hz=250.0,
+        epochs=2,
+        minimum_mse_improvement=minimum_mse_improvement,
+    )
+    return samples, authority, model, payload
+
+
+def test_real_upstream_authority_worker_binds_exact_calibration_and_evaluation_rows():
+    pytest.importorskip("ngclearn")
+    samples, authority, model, payload = _run()
+
+    adaptation = samples[list(authority.adaptation_indices)]
+    evaluation = samples[list(authority.evaluation_indices)]
+    assert payload["inputs"]["adaptation_input_sha256"] == _array_sha256(adaptation)
+    assert payload["inputs"]["evaluation_input_sha256"] == _array_sha256(evaluation)
+    assert (
+        payload["learner_adaptation"]["adaptation_input_sha256"]
+        == payload["inputs"]["adaptation_input_sha256"]
+    )
+    assert payload["application"]["adaptation_indices"] == list(authority.adaptation_indices)
+    assert payload["evaluation"]["evaluation_indices"] == list(authority.evaluation_indices)
+    assert payload["learner_adaptation"]["update_count"] == 6
+
+    fingerprint = authority.authority_fingerprint
+    assert payload["proposal"]["authority_fingerprint"] == fingerprint
+    assert payload["decision"]["authority_fingerprint"] == fingerprint
+    assert payload["application"]["authority_fingerprint"] == fingerprint
+    assert payload["evaluation"]["authority_fingerprint"] == fingerprint
+    assert payload["outcome"]["authority_fingerprint"] == fingerprint
+
+    boundary = payload["claim_boundary"]
+    assert boundary["orion_adaptation_authority_enforced"] is True
+    assert boundary["exact_adaptation_rows_verified"] is True
+    assert boundary["exact_evaluation_rows_verified"] is True
+    assert boundary["held_out_evaluation_read_only"] is True
+    assert boundary["real_dataset_qualified"] is False
+    assert boundary["calibration_reduction_qualified"] is False
+
+    # Approval evidence is calibration-only. Held-out performance cannot silently
+    # become an input to the pre-adaptation approval decision.
+    proposal_evidence = payload["proposal"]["proposal"]["evidence"]
+    assert set(proposal_evidence) == {"calibration_reconstruction_mse"}
+
+    active = model.snapshot_state()
+    assert active.state_sha256 == payload["outcome"]["active_artifact"]["sha256"]
+
+
+def test_authority_worker_is_deterministic_across_independent_real_upstream_runs():
+    pytest.importorskip("ngclearn")
+    _, first_authority, _, first = _run()
+    _, second_authority, _, second = _run()
+
+    assert first_authority.authority_fingerprint == second_authority.authority_fingerprint
+    assert first["evidence_sha256"] == second["evidence_sha256"]
+    assert first["learner_adaptation"]["evidence_sha256"] == second["learner_adaptation"]["evidence_sha256"]
+    assert first["outcome"]["outcome_fingerprint"] == second["outcome"]["outcome_fingerprint"]
+    assert first == second
+
+
+def test_predeclared_failed_held_out_gate_rolls_back_exact_complete_learning_state():
+    pytest.importorskip("ngclearn")
+    _, _, model, payload = _run(minimum_mse_improvement=1_000_000.0)
+
+    assert payload["outcome"]["phase"] == "rolled-back"
+    assert (
+        payload["outcome"]["active_artifact"]["sha256"]
+        == payload["application"]["before_artifact"]["sha256"]
+    )
+    assert (
+        payload["outcome"]["active_artifact"]["sha256"]
+        != payload["application"]["after_artifact"]["sha256"]
+    )
+    assert model.snapshot_state().state_sha256 == payload["outcome"]["active_artifact"]["sha256"]
+
+
+def test_processed_data_identity_mismatch_fails_before_learner_runtime_is_initialized():
+    pytest.importorskip("ngclearn")
+    samples, authority, model = _fixture()
+
+    with pytest.raises(ValueError, match="processed-data SHA-256"):
+        run_governed_hebbian_adaptation(
+            samples,
+            authority=authority,
+            loaded_processed_data_sha256="0" * 64,
+            model=model,
+            sample_rate_hz=250.0,
+            epochs=1,
+        )
+
+    with pytest.raises(RuntimeError, match="before the first infer/adapt"):
+        model.snapshot_state()
+
+
+def test_invalid_retention_threshold_fails_closed():
+    pytest.importorskip("ngclearn")
+    samples, authority, model = _fixture()
+    with pytest.raises(ValueError, match="minimum_mse_improvement"):
+        run_governed_hebbian_adaptation(
+            samples,
+            authority=authority,
+            loaded_processed_data_sha256=authority.processed_data_sha256,
+            model=model,
+            sample_rate_hz=250.0,
+            minimum_mse_improvement=-1.0,
+        )


### PR DESCRIPTION
## Why

PR #42 qualified fixed-weight predictive reconstruction. PR #43 added a generic ORION adaptation authority. This PR closes the next rung: a real upstream ngc-learn 3.2 predictive-reconstruction learner whose Hebbian state mutation is bound to frozen ORION calibration/qualification authority and exact rollback identity.

## What is qualified

`NgcLearnHebbianPredictiveCoding`:

- runs predictive inference before every M-step;
- executes the real upstream `HebbianSynapse.evolve()` update;
- uses latent activity as the Hebbian pre statistic and `GaussianErrorCell.dmu` as the post statistic;
- ties feedback to the current generative transpose;
- supports SGD and Adam;
- performs no hidden filtering, resampling, normalization, padding, channel reordering, or post-update row normalization;
- records weight, optimizer-state, and combined mutable-state SHA-256 identities;
- guarantees `infer()` is read-only with respect to learned state;
- supports exact rollback of weights and optimizer state;
- validates checkpoint hashes, weight dtype/shape, optimizer pytree structure, leaf shapes, and leaf dtypes transactionally before live mutation.

## Governed adaptation evidence

`scripts/evidence/run_ngclearn_hebbian_authority.py` composes the optional foundation learner with ORION at the evidence layer without reversing package dependencies.

The worker verifies that:

- exact ordered calibration rows are frozen by `AdaptationAuthority`;
- the learner's canonical `adaptation_input_sha256` matches the exact authorized matrix;
- qualification rows are disjoint from calibration rows;
- proposal/approval evidence contains calibration evidence only;
- qualification inference is read-only;
- retain uses the exact post-update artifact identity;
- rollback restores the exact pre-update complete learning state;
- the final active learner state equals the recorded `AdaptationOutcome` artifact;
- complete public evidence output is byte-identical across repeated executions.

A forced qualification-gate failure is tested to prove exact rollback.

## Statistical authority boundary

This PR also makes an important distinction explicit: if `evaluation_indices` influence retain-versus-rollback, they are scientifically a **qualification/state-selection partition**, not an untouched final test set.

Future efficacy or calibration-reduction studies must therefore use three disjoint roles:

1. calibration/adaptation rows;
2. held-out qualification rows that may select retain/rollback;
3. an independent final-assessment partition scored only after state and policy are frozen.

The API field remains named `evaluation_indices` for backward compatibility, but the documentation now defines this stronger interpretation.

## Public compatibility promotion

The `ngclearn` compatibility record is promoted at the **integration** evidence tier with capabilities for:

- Hebbian predictive adaptation;
- ORION adaptation-authority binding;
- exact learning-state rollback;
- canonical adaptation-input identity;
- existing RateCell, fixed predictive-reconstruction, and JAX identity surfaces.

The dedicated CI lane installs the exact local monorepo dependency graph, runs `pip check`, exercises the real upstream learner and authority tests, replays the public evidence worker twice, runs compatibility registry regressions, and verifies the installed `neuros compatibility ngclearn --json` claim.

## Adversarial coverage

The real-upstream suite checks:

- installed ngc-learn 3.2 identity;
- real weight and optimizer-state mutation;
- exact update counts;
- canonical consumed-data identity;
- deterministic independent Adam learners;
- read-only inference after adaptation;
- exact Adam rollback including optimizer moments/timestep and future trajectory;
- corrupt checkpoint hashes failing before mutation;
- self-consistent but structurally incompatible optimizer checkpoints failing before mutation;
- dtype/shape preservation;
- conservative claim boundaries.

## Exact-head qualification

Final head: `9e12c266b7e9115c76d92a0f175d8ed7030712c5`

All exact-head workflows are green:

- ngc-learn Hebbian Adaptation
- ORION Adaptation Authority
- neurOS CI
- Ecosystem Compatibility
- NeuroAI Ecosystem Evidence
- Public Trust Contracts
- neurOS real-world evidence
- Braindecode Compatibility
- Braindecode Longitudinal Evidence

The branch is behind `main` by 0 at qualification time.

## Claim boundary

This PR does **not** claim:

- real neural-dataset adaptation efficacy;
- reduced calibration burden;
- ORION superiority;
- STDP learning;
- spiking-network adaptation;
- online/closed-loop adaptation safety;
- hardware qualification;
- clinical qualification.

Those remain separate evidence rungs.