### PR TITLE
evidence: add three-way longitudinal adaptation authority

### DIFF
--- a/.github/workflows/evidence-ci.yml
+++ b/.github/workflows/evidence-ci.yml
@@ -55,7 +55,35 @@ jobs:
           pytest -q \
             packages/neuros-foundation/tests/test_real_world.py \
             packages/neuros-foundation/tests/test_longitudinal.py \
-            packages/neuros-foundation/tests/test_longitudinal_authority.py
+            packages/neuros-foundation/tests/test_longitudinal_authority.py \
+            packages/neuros-foundation/tests/test_longitudinal_three_way.py \
+            packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
+      - name: Replay three-way authority evidence twice
+        run: |
+          python scripts/evidence/verify_longitudinal_three_way_authority.py > "${RUNNER_TEMP}/three-way-first.json"
+          python scripts/evidence/verify_longitudinal_three_way_authority.py > "${RUNNER_TEMP}/three-way-second.json"
+          diff -u "${RUNNER_TEMP}/three-way-first.json" "${RUNNER_TEMP}/three-way-second.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads((Path(os.environ["RUNNER_TEMP"]) / "three-way-first.json").read_text())
+          boundary = payload["claim_boundary"]
+          assert boundary["chronological_source_history_enforced"] is True
+          assert boundary["nested_balanced_calibration_enforced"] is True
+          assert boundary["final_assessment_separate_from_state_selection"] is True
+          assert boundary["real_dataset_qualified"] is False
+          assert boundary["calibration_reduction_qualified"] is False
+
+          budgets = payload["calibration_budgets"]
+          assert budgets
+          assert len({item["calibration_budget_sha256"] for item in budgets}) == len(budgets)
+          assert len({item["qualification_set_sha256"] for item in budgets}) == 1
+          assert len({item["final_assessment_set_sha256"] for item in budgets}) == 1
+          assert payload["authority"]["qualification_set_sha256"] == budgets[0]["qualification_set_sha256"]
+          assert payload["authority"]["final_assessment_set_sha256"] == budgets[0]["final_assessment_set_sha256"]
+          PY
       - name: Exercise evidence discovery and runner CLIs
         run: |
           neuros-foundation evidence
@@ -64,6 +92,12 @@ jobs:
           python packages/neuros-foundation/examples/05_real_world_evidence.py
           python scripts/evidence/run_moabb_longitudinal.py --help
           python scripts/evidence/run_moabb_model_ladder.py --help
+      - name: Compile three-way authority modules
+        run: |
+          python -m compileall -q \
+            packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way.py \
+            packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py \
+            scripts/evidence/verify_longitudinal_three_way_authority.py
 
   moabb-profile:
     name: MOABB evidence profile
@@ -108,6 +142,7 @@ jobs:
           pytest -q \
             packages/neuros-foundation/tests/test_real_world.py \
             packages/neuros-foundation/tests/test_longitudinal.py \
+            packages/neuros-foundation/tests/test_longitudinal_three_way.py \
             packages/neuros-foundation/tests/test_longitudinal_runner.py
           python scripts/evidence/run_moabb_longitudinal.py --help
 
@@ -131,6 +166,7 @@ jobs:
         run: |
           pytest -q \
             packages/neuros-foundation/tests/test_longitudinal_authority.py \
+            packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py \
             packages/neuros-foundation/tests/test_longitudinal_methods.py \
             packages/neuros-foundation/tests/test_longitudinal_transfer.py \
             packages/neuros-foundation/tests/test_longitudinal_zero_calibration.py \

--- a/docs/ADAPTATION_AUTHORITY.md
+++ b/docs/ADAPTATION_AUTHORITY.md
@@ -40,7 +40,7 @@ GovernedAdaptationProposal
 
 The evidence records are immutable and deterministically fingerprinted. They do not contain wall-clock time in their semantic identity, so replaying the same authority, proposal, decision, application, and evaluation yields the same fingerprints.
 
-The API field remains named `evaluation_indices` for compatibility, but when those rows are used to choose `RETAINED` versus `ROLLED_BACK`, they are scientifically a **qualification/state-selection partition**. They are not an untouched final test set.
+The ORION API field remains named `evaluation_indices` for compatibility, but when those rows are used to choose `RETAINED` versus `ROLLED_BACK`, they are scientifically a **qualification/state-selection partition**. They are not an untouched final test set.
 
 ## Why this exists
 
@@ -58,7 +58,7 @@ Adaptive neural systems can accidentally produce optimistic results when:
 
 The authority contract makes these failure modes explicit and testable.
 
-## Core types
+## Core ORION types
 
 ### `ArtifactIdentity`
 
@@ -131,7 +131,7 @@ Finalizes the evidence as either:
 
 This record says what happened. It does not prescribe a universal policy for whether accuracy, calibration, latency, reconstruction error, or another metric should dominate the retain/rollback decision.
 
-## Example
+## ORION example
 
 ```python
 from orion import (
@@ -211,30 +211,132 @@ The worker runs against installed ngc-learn 3.2 on Python 3.10 and 3.11 and its 
 
 This qualifies **process integrity** for that integration. It does not establish real neural-data efficacy.
 
-## Relationship to longitudinal evidence
+## Longitudinal authority versions
 
-The foundation evidence layer already owns stronger dataset-specific authorities such as `LongitudinalCaseAuthority`. ORION does **not** import `neuros-foundation` to reuse them, because that would reverse the stable dependency direction.
+neurOS now has two complementary longitudinal evidence contracts.
 
-Instead, a real experiment should derive adaptation authority from an already-frozen case and carry identity forward:
+### v1: `LongitudinalCaseAuthority`
+
+The v1 authority freezes source history, nested target calibration, and one immutable evaluation set. Existing v1 artifacts remain valid and replayable.
+
+V1 is appropriate when the held-out evaluation set is never used to select model state, hyperparameters, thresholds, metrics, or policy. For example, a predetermined model may be fit at a declared calibration budget and scored once on the same frozen evaluation set across methods.
+
+V1 must **not** be reinterpreted as untouched final-assessment evidence if its evaluation rows were used to choose retain versus rollback or otherwise select the reported model state.
+
+### v2: `ThreeWayLongitudinalCaseAuthority`
+
+Adaptive efficacy studies should use the additive v2 contract:
+
+```python
+from neuros.foundation_models import (
+    ThreeWayLongitudinalCaseAuthority,
+    make_three_way_calibration_split,
+)
+
+split = make_three_way_calibration_split(
+    prospective_partition,
+    qualification_fraction=0.25,
+    final_assessment_fraction=0.25,
+    seed=23,
+)
+
+authority = ThreeWayLongitudinalCaseAuthority.from_split(
+    split,
+    case_id="subject-07/session-02/three-way-v2",
+    history_policy="prior",
+)
+```
+
+The v2 authority freezes four roles:
 
 ```text
-LongitudinalCaseAuthority
+historical/source rows
+        |
+        v
+CALIBRATION
+state may change
+        |
+        v
+QUALIFICATION
+read-only; may choose retain/rollback
+        |
+        v
+frozen selected state + frozen policy
+        |
+        v
+FINAL ASSESSMENT
+read-only; cannot select state or policy
+        |
+        v
+scientific result
+```
+
+The contract enforces:
+
+- source history remains separate from the held-out deployment unit;
+- calibration, qualification, and final-assessment rows are pairwise disjoint;
+- those three target roles cover the held-out partition exactly;
+- qualification and final assessment preserve complete held-out class support;
+- calibration membership is balanced and nested per class;
+- selected calibration rows are returned in canonical source-row order so order-sensitive adaptive methods receive the same execution order;
+- qualification and final-assessment identities remain invariant across every calibration budget;
+- exact SHA-256 identities bind qualification, final assessment, and each calibration budget to the processed-data identity;
+- serialization rejects malformed numeric fields rather than truncating/coercing them;
+- non-finite or opaque semantic metadata is rejected;
+- declared chronology is checked when the authority is constructed;
+- `restore(processed_data)` independently verifies processed neural bytes, labels/groups, chronology, partition identity, class support, and split identity.
+
+The returned qualification/final arrays and calibration-order arrays are read-only. Exact-set guards reject subsets, supersets, or reordered qualification/final-assessment rows.
+
+### Construction is not dataset qualification
+
+A serialized v2 authority is an **identity declaration** until it has successfully restored against the processed dataset.
+
+A SHA-256 over declared indices does not prove that those rows truly belong to the claimed subject/session/classes. `restore(data)` is the operation that reconnects the declaration to processed neural bytes and re-runs dataset-dependent invariants.
+
+The deterministic software evidence worker therefore serializes the authority and restores it against the processed fixture before emitting evidence:
+
+```bash
+python scripts/evidence/verify_longitudinal_three_way_authority.py
+```
+
+CI executes that worker twice and requires byte-identical JSON.
+
+## Relationship between v2 and ORION authority
+
+The foundation evidence layer owns dataset-specific chronology and three-way partitioning. ORION does **not** import `neuros-foundation`, because that would reverse the stable dependency direction.
+
+Instead, each positive calibration budget derives a method-specific `AdaptationAuthority` from the already-restored v2 longitudinal authority:
+
+```text
+ThreeWayLongitudinalCaseAuthority
   processed data SHA-256
-  calibration ordering
-  qualification ordering
-  source authority fingerprint
+  source chronology
+  exact calibration budget SHA-256
+  immutable qualification SHA-256
+  immutable final-assessment SHA-256
+  authority fingerprint
             |
             v
 AdaptationAuthority
-  exact selected calibration budget
+  exact selected calibration indices
   exact qualification indices
   source_authority_fingerprint
             |
             v
 state-changing algorithm
+            |
+            v
+retain / exact rollback
+            |
+            v
+frozen state
+            |
+            v
+ThreeWayLongitudinalCaseAuthority.final_assessment_indices
 ```
 
-The selected state must then be frozen before an independent final assessment.
+Budget 0 is a **frozen no-update baseline**. The current ORION `AdaptationAuthority` requires non-empty adaptation indices, so a zero-calibration point must not fabricate an empty adaptation event merely to fit the state-changing API.
 
 ## Three-way authority for efficacy studies
 
@@ -245,45 +347,24 @@ Two partitions are sufficient to qualify **adaptation process integrity**:
 
 They are not sufficient for an unbiased final efficacy claim if the second partition influences model-state selection.
 
-Real adaptation studies should therefore use:
-
-```text
-source / historical data
-        |
-        v
-CALIBRATION AUTHORITY
-state may change
-        |
-        v
-QUALIFICATION AUTHORITY
-state is read-only; may choose retain/rollback
-        |
-        v
-frozen selected state
-        |
-        v
-FINAL-ASSESSMENT AUTHORITY
-state and policy are immutable
-        |
-        v
-scientific result
-```
-
 The final-assessment partition must not influence:
 
 - whether adaptation occurs;
 - learning rate, epoch count, calibration budget, or other hyperparameters;
 - retain/rollback decisions;
 - metric selection;
-- threshold selection.
+- threshold selection;
+- early stopping;
+- architecture/model selection;
+- the definition of the reported operating point.
 
 This is the authority neurOS should use for claims such as “X requires fewer calibration examples than Y” or “X transfers better across sessions.”
 
 ## What this does not claim
 
-A valid adaptation ledger proves **process integrity**, not adaptation benefit.
+A valid adaptation ledger and v2 longitudinal authority prove **process/evaluation integrity**, not adaptation benefit.
 
-It does not prove that:
+They do not prove that:
 
 - the update improves real neural decoding;
 - personalization reduces calibration cost;
@@ -295,16 +376,16 @@ Those require their own evidence under the project-wide scientific claim ladder.
 
 ## Next qualification rung
 
-The next use should be a real longitudinal governed-adaptation study in which:
+After this software authority is qualified, the next study should use one restored v2 longitudinal case for all competing methods:
 
-1. a real `LongitudinalCaseAuthority` freezes target-session chronology and processed-data identity;
-2. one explicit calibration budget becomes the adaptation partition;
-3. a second held-out target partition becomes the retention/rollback qualification partition;
-4. real upstream Hebbian synapses update only calibration rows;
-5. before/after complete learning states receive immutable identities;
-6. the state is retained or exactly rolled back under a predeclared policy;
-7. the selected state is frozen;
-8. a third independent final-assessment partition is scored once;
-9. the identical three-way authority is given to ORION and frozen baselines for matched comparison.
+1. freeze source chronology and processed-data identity;
+2. freeze calibration membership, qualification rows, and final-assessment rows once;
+3. instantiate one explicit positive calibration budget per experiment;
+4. adapt only on those calibration rows;
+5. use qualification rows only under a predeclared state-selection policy;
+6. retain or exactly roll back complete mutable state;
+7. freeze the selected state and every policy/hyperparameter;
+8. score the final-assessment set once;
+9. give the same v2 authority to frozen baselines, governed Hebbian predictive coding, and ORION adaptation.
 
 That sequence lets neurOS compare biologically local learning and ORION personalization without allowing either method to move the goalposts.

--- a/docs/LONGITUDINAL_MODEL_LADDER.md
+++ b/docs/LONGITUDINAL_MODEL_LADDER.md
@@ -6,7 +6,9 @@ The governing rule is simple:
 
 > One frozen data authority, many methods.
 
-Every method must consume the same serialized source-history, target-calibration and final-evaluation identity. Method-specific convenience is never allowed to silently redefine the scientific question.
+Every method must consume the same serialized source-history and target-partition identity. Method-specific convenience is never allowed to silently redefine the scientific question.
+
+For predetermined, non-state-selecting model comparisons, the existing v1 `LongitudinalCaseAuthority` remains the authoritative contract. Adaptive efficacy studies in which held-out data influence retain/rollback or other state selection must use the additive v2 `ThreeWayLongitudinalCaseAuthority` described below.
 
 ## Why this exists
 
@@ -14,9 +16,9 @@ A longitudinal BCI benchmark becomes misleading quickly if each model is allowed
 
 The ladder therefore separates three identities:
 
-1. **data identity**: processed-data SHA-256 plus exact source/calibration/evaluation indices;
+1. **data identity**: processed-data SHA-256 plus exact source and target partition indices;
 2. **learned-state identity**: SHA-256 of the complete trained model state, including registered buffers;
-3. **representation identity**: SHA-256 over the exact frozen source/calibration/evaluation embedding tensors used by a downstream method.
+3. **representation identity**: SHA-256 over the exact frozen source/target embedding tensors used by a downstream method.
 
 Configuration and seed are provenance. They are not substitutes for learned-state identity.
 
@@ -66,18 +68,18 @@ Only the transfer strategy changes.
 
 Target-dependent source weights may be estimated from declared target calibration embeddings. Final evaluation embeddings are forbidden from target-moment estimation.
 
-## LongitudinalCaseAuthority
+## V1 longitudinal authority
 
-Each subject / target-session case is serialized as a `LongitudinalCaseAuthority` before model fitting.
+Each subject / target-session case in the current ladder is serialized as a `LongitudinalCaseAuthority` before model fitting.
 
-The authority binds:
+The v1 authority binds:
 
 - subject identity;
 - target session;
 - observed chronology;
 - source-history indices;
 - ordered target calibration indices;
-- immutable final evaluation indices;
+- immutable evaluation indices;
 - processed-data SHA-256;
 - partition fingerprint;
 - calibration fingerprint;
@@ -85,6 +87,8 @@ The authority binds:
 - dataset-specific metadata such as original protocol/cohort.
 
 A method restores and validates that authority before fitting. Changed processed EEG bytes, sample order, labels, grouping metadata or case identity fail before a model is trained.
+
+Existing v1 evidence bundles remain valid and replayable. V1 is suitable when the evaluation rows never influence model-state selection, threshold selection, hyperparameters, or the definition of the reported operating point.
 
 ## Prospective history semantics
 
@@ -94,13 +98,15 @@ For held-out target session `S_k`, only sessions observed before `S_k` may enter
 
 A conventional all-other-session analysis may still be useful as a secondary symmetric benchmark, but it must not be narrated as prospective evidence.
 
-## Fixed target evaluation identity
+## Fixed target evaluation identity in v1
 
-For each target session, neurOS creates one deterministic balanced calibration pool and one immutable final evaluation set.
+For each target session, the v1 ladder creates one deterministic balanced calibration pool and one immutable evaluation set.
 
-Increasing the calibration budget changes only how much of the calibration pool a method may use. The final evaluation indices never move.
+Increasing the calibration budget changes only how much of the calibration pool a method may use. The evaluation indices never move.
 
 This avoids an especially common source of false calibration gains: testing larger-budget models on a smaller or easier remainder of the same held-out session.
+
+The v1 evaluation set is a valid final evaluation only when it does not influence model or policy selection. If those rows are used to decide retain versus rollback, choose thresholds, stop training, or select a model, they become qualification/state-selection data and cannot later be described as untouched final-assessment evidence.
 
 ## Nested calibration budgets
 
@@ -114,13 +120,13 @@ If the budgets are:
 
 the budget-2 set must contain the budget-1 examples, the budget-5 set must contain budget 2, and so on.
 
-The resulting frontier measures the marginal value of additional labeled target calibration under a fixed final evaluation identity.
+The resulting frontier measures the marginal value of additional labeled target calibration under a fixed held-out identity.
 
 ## Zero-calibration semantics
 
 Target-independent methods can report budget 0.
 
-A target-dependent SourceWeigher lane is explicitly unavailable at budget 0 because no legal target calibration observations exist. neurOS does not substitute final evaluation examples as unlabeled target observations.
+A target-dependent SourceWeigher lane is explicitly unavailable at budget 0 because no legal target calibration observations exist. neurOS does not substitute held-out evaluation examples as unlabeled target observations.
 
 This produces two frontier summaries:
 
@@ -128,6 +134,78 @@ This produces two frontier summaries:
 - **positive-budget adaptation AUC**, for methods whose adaptation begins only after target calibration becomes available.
 
 An unavailable zero-calibration point is not a failure.
+
+For future state-changing v2 studies, budget 0 is a frozen no-update baseline. It must not be represented as a fake adaptation event with an empty adaptation set.
+
+## Adaptive efficacy extension: v2 three-way authority
+
+State-changing methods require a stronger contract when qualification evidence can determine which state is ultimately reported.
+
+The additive v2 `ThreeWayLongitudinalCaseAuthority` freezes:
+
+```text
+prior source history
+        |
+        +--> calibration pool
+        |      nested balanced budgets
+        |      state may change
+        |
+        +--> qualification set
+        |      state read-only
+        |      may choose retain/rollback
+        |
+        +--> final-assessment set
+               state/policy immutable
+               scientific score only
+```
+
+The corresponding `ThreeWayCalibrationSplit` preserves the original chronological source partition while dividing the held-out target deployment unit into calibration, qualification, and final-assessment roles exactly once.
+
+V2 enforces:
+
+- calibration, qualification, and final-assessment rows are pairwise disjoint;
+- the three roles cover the target partition exactly;
+- qualification and final assessment preserve complete target class support;
+- calibration pools are class-consistent;
+- calibration budgets remain balanced and nested;
+- selected calibration rows use canonical source-row execution order;
+- qualification and final-assessment sets are fixed across every calibration budget;
+- each calibration budget, qualification set, and final-assessment set has a SHA-256 identity bound to the processed-data SHA-256;
+- malformed serialized numeric fields are rejected rather than coerced;
+- semantic metadata must be deterministic and finite;
+- declared prospective history is checked before use;
+- `restore(data)` revalidates processed neural bytes, group/label support, chronology, partition identity, and three-way split identity.
+
+A serialized authority by itself is an identity declaration. It becomes dataset-backed evidence only after successful restore against the processed dataset.
+
+### Matched adaptive comparison protocol
+
+A future governed adaptive ladder should give the same restored v2 case to every method:
+
+```text
+same processed EEG
+same source chronology
+same calibration membership
+same qualification rows
+same final-assessment rows
+        |
+        +--> conventional adaptation baseline
+        +--> governed Hebbian predictive coding
+        +--> ORION personalization
+        +--> any frozen/no-update control
+```
+
+For each positive calibration budget:
+
+1. adapt only on the exact authorized calibration indices;
+2. freeze learning before qualification;
+3. apply one predeclared retain/rollback policy on the full qualification set;
+4. freeze the selected state, policy, thresholds, and hyperparameters;
+5. score the complete final-assessment set once.
+
+The final-assessment partition must not influence architecture choice, learning rate, epoch count, calibration budget, early stopping, retain/rollback, threshold selection, metric selection, or operating-point definition.
+
+Only this final stage can support an adaptive efficacy or calibration-saved claim after state selection has occurred.
 
 ## PreparedFrozenEncoderCase
 
@@ -139,7 +217,7 @@ The prepared state contains:
 - complete model-state SHA-256;
 - exact source embeddings;
 - exact ordered target-calibration embeddings;
-- exact final-evaluation embeddings;
+- exact held-out evaluation embeddings;
 - representation SHA-256;
 - encoder configuration and parameter count;
 - training history;
@@ -149,6 +227,8 @@ The prepared state contains:
 Downstream frozen and SourceWeigher methods reuse that object rather than independently retraining nominally identical encoders.
 
 This is what makes weighted-vs-unweighted transfer a clean intervention on the transfer policy rather than an uncontrolled comparison between two separately trained networks.
+
+The current `PreparedFrozenEncoderCase` belongs to the v1 ladder. A future adaptive-v2 extension must materialize qualification and final-assessment representations separately rather than relabeling one v1 evaluation tensor after state selection.
 
 ## Failure preservation
 
@@ -174,7 +254,9 @@ A descriptive bundle is promotion-ready only if:
 
 SourceWeigher budget 0 is the only expected unavailable point in the initial ladder.
 
-This prevents an apparently stronger high-budget curve from being produced by silently losing difficult cases.
+For a future v2 adaptive bundle, promotion must additionally require identical qualification and final-assessment identities across all compared methods and calibration budgets.
+
+This prevents an apparently stronger high-budget curve from being produced by silently losing difficult cases or moving the test set.
 
 ## Metrics
 
@@ -198,9 +280,11 @@ Per-method evidence should include, where applicable:
 - representation geometry;
 - exact authority/partition/calibration fingerprints.
 
+For v2 adaptive studies, evidence should additionally carry qualification-set SHA-256, final-assessment-set SHA-256, calibration-budget SHA-256, pre/post mutable-state identities, and the retain/rollback outcome identity.
+
 No single metric is the product claim.
 
-For BCI productization, one of the most economically legible summaries is **calibration saved**: how many labeled target trials are required to reach a declared performance/reliability operating point.
+For BCI productization, one of the most economically legible summaries is **calibration saved**: how many labeled target trials are required to reach a declared performance/reliability operating point on untouched final assessment.
 
 ## Kumar2024 preregistration
 
@@ -218,7 +302,7 @@ Repeated sessions from one participant are not independent biological replicates
 
 ## Artifact bundle
 
-A complete ladder execution emits:
+A complete current ladder execution emits:
 
 ```text
 study_manifest.json
@@ -231,6 +315,8 @@ artifact_hashes.json
 ```
 
 `artifact_hashes.json` binds the machine-readable result surfaces. The human report is rendered from those same rows rather than maintained as an independent narrative source of truth.
+
+A future v2 adaptive bundle should preserve the v2 authority itself plus explicit state-selection and final-assessment records rather than overwriting the existing v1 artifact schema.
 
 ## Public API boundary
 
@@ -245,7 +331,8 @@ The CLI should remain primarily responsible for:
 
 Core public contracts include:
 
-- `LongitudinalCaseAuthority`;
+- `LongitudinalCaseAuthority` for the current v1 ladder;
+- `ThreeWayCalibrationSplit` and `ThreeWayLongitudinalCaseAuthority` for adaptive v2 studies;
 - `PreparedFrozenEncoderCase`;
 - method specifications;
 - `LadderRuntimeConfig`;
@@ -258,7 +345,7 @@ This keeps the scientific comparison reusable outside one script.
 
 ## Execution
 
-The public study runner is:
+The current public v1 study runner is:
 
 ```bash
 python scripts/evidence/run_moabb_model_ladder.py \
@@ -271,9 +358,13 @@ python scripts/evidence/run_moabb_model_ladder.py \
 
 The corresponding GitHub Actions study workflow is manual only. Large public datasets are never downloaded as a normal push/PR side effect.
 
+The v2 authority is currently qualified as a software/evaluation contract. It is not yet wired into this public real-dataset runner, and its existence must not be narrated as a real adaptive result.
+
 ## External research extensions
 
-External research packages, including the documented QuantumBCI extension, must reuse the same frozen `LongitudinalCaseAuthority` and evidence identities if they join this comparison. An extension may add a method lane, mechanism analysis, or resource accounting, but it may not create a second hidden split/calibration authority and still claim a matched comparison.
+External research packages, including the documented QuantumBCI extension, must reuse the same frozen authority and evidence identities if they join a comparison. An extension may add a method lane, mechanism analysis, or resource accounting, but it may not create a second hidden split/calibration authority and still claim a matched comparison.
+
+For adaptive comparisons that perform state selection, this means reusing the same restored v2 authority, not merely the same v1 target session.
 
 This keeps external experiments interoperable with neurOS Evidence without making those projects dependencies of the core runtime.
 
@@ -289,21 +380,25 @@ model seed
 processed-data SHA-256
 authority fingerprint
 partition fingerprint
-calibration fingerprint
+calibration fingerprint / budget SHA-256
+qualification-set SHA-256 when applicable
+final-assessment-set SHA-256 when applicable
 artifact verification
 ```
 
 ## Claim boundary
 
-This ladder can establish controlled **offline real-dataset evidence** for longitudinal transfer and labeled recalibration burden.
+The current v1 ladder can establish controlled **offline real-dataset evidence** for longitudinal transfer and labeled recalibration burden when its frozen evaluation set is not used for state selection.
 
-It does not establish:
+The v2 authority can establish the **evaluation/process integrity** needed for future adaptive efficacy studies. By itself it does not establish that adaptation works.
+
+Neither establishes:
 
 - live hardware reliability;
 - online closed-loop improvement;
 - clinical benefit;
 - causal biological interpretation;
 - foundation-model superiority without a verified executable foundation encoder;
-- ORION superiority until an actual ORION EEG representation is evaluated under this same authority.
+- ORION superiority until an actual ORION EEG representation/adaptation method is evaluated under a restored matched authority and untouched final assessment.
 
 The long-term neurOS/ORION claim should be earned by moving the calibration frontier under increasingly difficult real-world shifts while preserving this evidence discipline.

--- a/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/__init__.py
@@ -26,6 +26,13 @@ from neuros.foundation_models.longitudinal_authority import (
     LongitudinalCaseAuthority,
     processed_data_sha256,
 )
+from neuros.foundation_models.longitudinal_three_way import (
+    ThreeWayCalibrationSplit,
+    make_three_way_calibration_split,
+)
+from neuros.foundation_models.longitudinal_three_way_authority import (
+    ThreeWayLongitudinalCaseAuthority,
+)
 from neuros.foundation_models.longitudinal_baseline import CSPCaseResult, run_csp_case
 from neuros.foundation_models.longitudinal_external import (
     ExternalTaskDecoderCaseResult,
@@ -235,6 +242,9 @@ __all__ = [
     "NestedCalibrationSplit",
     "make_nested_calibration_split",
     "LongitudinalCaseAuthority",
+    "ThreeWayCalibrationSplit",
+    "make_three_way_calibration_split",
+    "ThreeWayLongitudinalCaseAuthority",
     "processed_data_sha256",
     "CSPCaseResult",
     "run_csp_case",

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way.py
@@ -1,0 +1,380 @@
+"""Three-way target-session authority for unbiased adaptive longitudinal studies.
+
+This module is additive to the v1 ``NestedCalibrationSplit`` contract. It keeps
+calibration budgets nested while separating two held-out roles:
+
+* ``qualification_indices`` may be used for retain/rollback or other frozen
+  state-selection policy;
+* ``final_assessment_indices`` must remain untouched until model state and
+  selection policy are frozen.
+
+The distinction prevents state-selection data from being reported later as an
+untouched final test set.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import numpy as np
+
+from .real_world import EvaluationPartition
+
+
+def _fraction(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 < result < 1.0:
+        raise ValueError(f"{name} must lie strictly between 0 and 1")
+    return result
+
+
+def _seed(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError("seed must be a non-negative integer")
+    result = int(value)
+    if result < 0:
+        raise ValueError("seed must be a non-negative integer")
+    return result
+
+
+def _readonly_indices(name: str, values: Any, *, allow_empty: bool) -> np.ndarray:
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if array.dtype == np.bool_:
+        raise ValueError(f"{name} must contain integer sample indices, not booleans")
+    try:
+        integer = array.astype(np.int64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain integer sample indices") from exc
+    if not np.array_equal(array, integer):
+        raise ValueError(f"{name} must contain integer sample indices")
+    if not allow_empty and integer.size == 0:
+        raise ValueError(f"{name} must be non-empty")
+    if np.any(integer < 0):
+        raise ValueError(f"{name} cannot contain negative indices")
+    if len(set(int(v) for v in integer.tolist())) != integer.size:
+        raise ValueError(f"{name} cannot contain duplicate indices")
+    result = np.ascontiguousarray(integer.copy())
+    result.setflags(write=False)
+    return result
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ThreeWayCalibrationSplit:
+    """Frozen source/calibration/qualification/final-assessment partition.
+
+    Calibration order remains randomized per class so balanced budgets are
+    nested. Qualification and final-assessment rows are immutable across every
+    calibration budget.
+    """
+
+    partition: EvaluationPartition
+    qualification_indices: np.ndarray
+    final_assessment_indices: np.ndarray
+    calibration_order_by_class: Mapping[str, np.ndarray]
+    qualification_fraction: float
+    final_assessment_fraction: float
+    seed: int
+    schema_version: int = 2
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 2:
+            raise ValueError("ThreeWayCalibrationSplit schema_version must be 2")
+        qualification_fraction = _fraction(
+            "qualification_fraction", self.qualification_fraction
+        )
+        final_fraction = _fraction(
+            "final_assessment_fraction", self.final_assessment_fraction
+        )
+        if qualification_fraction + final_fraction >= 1.0:
+            raise ValueError(
+                "qualification_fraction + final_assessment_fraction must be strictly less than 1"
+            )
+        seed = _seed(self.seed)
+
+        qualification = _readonly_indices(
+            "qualification_indices", self.qualification_indices, allow_empty=False
+        )
+        final_assessment = _readonly_indices(
+            "final_assessment_indices", self.final_assessment_indices, allow_empty=False
+        )
+        source = _readonly_indices(
+            "source_train_indices", self.partition.train_indices, allow_empty=False
+        )
+        held_out = _readonly_indices(
+            "held_out_indices", self.partition.test_indices, allow_empty=False
+        )
+
+        test_set = set(int(v) for v in held_out.tolist())
+        source_set = set(int(v) for v in source.tolist())
+        qualification_set = set(int(v) for v in qualification.tolist())
+        final_set = set(int(v) for v in final_assessment.tolist())
+
+        if not qualification_set.issubset(test_set):
+            raise ValueError("qualification indices must come from the held-out partition")
+        if not final_set.issubset(test_set):
+            raise ValueError("final-assessment indices must come from the held-out partition")
+        if qualification_set & final_set:
+            raise ValueError("qualification and final-assessment indices must be disjoint")
+        if qualification_set & source_set or final_set & source_set:
+            raise ValueError("held-out authority overlaps source training data")
+
+        y = np.asarray(self.partition.data.y).astype(str)
+        held_labels = tuple(sorted(np.unique(y[held_out]).tolist()))
+        if len(held_labels) < 2:
+            raise ValueError("three-way calibration split requires at least two held-out classes")
+
+        qualification_labels = set(y[qualification].tolist())
+        final_labels = set(y[final_assessment].tolist())
+        if qualification_labels != set(held_labels):
+            raise ValueError(
+                "qualification set must preserve complete held-out class support"
+            )
+        if final_labels != set(held_labels):
+            raise ValueError(
+                "final-assessment set must preserve complete held-out class support"
+            )
+
+        raw_mapping = {str(label): values for label, values in self.calibration_order_by_class.items()}
+        if set(raw_mapping) != set(held_labels):
+            missing = sorted(set(held_labels) - set(raw_mapping))
+            extra = sorted(set(raw_mapping) - set(held_labels))
+            raise ValueError(
+                "calibration pools must contain every held-out class exactly once; "
+                f"missing={missing}, extra={extra}"
+            )
+
+        normalized: dict[str, np.ndarray] = {}
+        seen_calibration: set[int] = set()
+        for label in held_labels:
+            array = _readonly_indices(
+                f"calibration_order_by_class[{label!r}]",
+                raw_mapping[label],
+                allow_empty=True,
+            )
+            array_set = set(int(v) for v in array.tolist())
+            if not array_set.issubset(test_set):
+                raise ValueError(f"calibration pool for {label!r} leaves held-out partition")
+            if array_set & source_set:
+                raise ValueError(f"calibration pool for {label!r} overlaps source training")
+            if array_set & qualification_set:
+                raise ValueError(f"calibration pool for {label!r} overlaps qualification")
+            if array_set & final_set:
+                raise ValueError(f"calibration pool for {label!r} overlaps final assessment")
+            duplicate = seen_calibration & array_set
+            if duplicate:
+                raise ValueError(f"calibration pools overlap at indices {sorted(duplicate)}")
+            if array.size and not np.all(y[array] == label):
+                raise ValueError(
+                    f"calibration pool for {label!r} contains samples from another class"
+                )
+            seen_calibration.update(array_set)
+            normalized[label] = array
+
+        covered = qualification_set | final_set | seen_calibration
+        if covered != test_set:
+            missing = sorted(test_set - covered)
+            extra = sorted(covered - test_set)
+            raise ValueError(
+                "calibration/qualification/final split must cover held-out partition exactly; "
+                f"missing={missing}, extra={extra}"
+            )
+
+        object.__setattr__(self, "qualification_indices", qualification)
+        object.__setattr__(self, "final_assessment_indices", final_assessment)
+        object.__setattr__(self, "calibration_order_by_class", MappingProxyType(normalized))
+        object.__setattr__(self, "qualification_fraction", qualification_fraction)
+        object.__setattr__(self, "final_assessment_fraction", final_fraction)
+        object.__setattr__(self, "seed", seed)
+
+    @property
+    def labels(self) -> tuple[str, ...]:
+        return tuple(sorted(self.calibration_order_by_class))
+
+    @property
+    def source_train_indices(self) -> np.ndarray:
+        values = np.ascontiguousarray(np.asarray(self.partition.train_indices, dtype=np.int64)).copy()
+        values.setflags(write=False)
+        return values
+
+    @property
+    def max_budget_per_class(self) -> int:
+        """Largest balanced calibration budget supported by every held-out class."""
+        return min(len(values) for values in self.calibration_order_by_class.values())
+
+    def calibration_indices(self, per_class: int) -> np.ndarray:
+        if isinstance(per_class, bool) or not isinstance(per_class, (int, np.integer)):
+            raise ValueError("calibration budget must be a non-negative integer")
+        budget = int(per_class)
+        if budget < 0:
+            raise ValueError("calibration budget must be non-negative")
+        if budget > self.max_budget_per_class:
+            raise ValueError(
+                f"budget {budget} exceeds balanced maximum {self.max_budget_per_class}"
+            )
+        if budget == 0:
+            result = np.asarray([], dtype=np.int64)
+        else:
+            selected = [
+                values[:budget]
+                for _, values in sorted(self.calibration_order_by_class.items())
+            ]
+            result = np.sort(np.concatenate(selected).astype(np.int64, copy=False))
+        result = np.ascontiguousarray(result)
+        result.setflags(write=False)
+        return result
+
+    def train_indices_for_budget(self, per_class: int) -> np.ndarray:
+        calibration = self.calibration_indices(per_class)
+        if len(calibration) == 0:
+            result = self.source_train_indices.copy()
+        else:
+            result = np.sort(
+                np.concatenate([self.source_train_indices, calibration]).astype(
+                    np.int64, copy=False
+                )
+            )
+        result = np.ascontiguousarray(result)
+        result.setflags(write=False)
+        return result
+
+    @property
+    def fingerprint(self) -> str:
+        payload = {
+            "schema_version": self.schema_version,
+            "partition_fingerprint": self.partition.fingerprint,
+            "qualification_indices": self.qualification_indices.tolist(),
+            "final_assessment_indices": self.final_assessment_indices.tolist(),
+            "calibration_order_by_class": {
+                label: values.tolist()
+                for label, values in sorted(self.calibration_order_by_class.items())
+            },
+            "qualification_fraction": self.qualification_fraction,
+            "final_assessment_fraction": self.final_assessment_fraction,
+            "seed": self.seed,
+        }
+        return _canonical_sha256(payload)
+
+    def manifest(self) -> dict[str, Any]:
+        y = np.asarray(self.partition.data.y).astype(str)
+        return {
+            "schema_version": self.schema_version,
+            "kind": "three_way_calibration_split",
+            "dataset_id": self.partition.data.dataset_id,
+            "split_unit": self.partition.split_unit,
+            "held_out_values": list(self.partition.held_out_values),
+            "source_train_samples": int(len(self.source_train_indices)),
+            "calibration_pool_samples": int(
+                sum(len(values) for values in self.calibration_order_by_class.values())
+            ),
+            "qualification_samples": int(len(self.qualification_indices)),
+            "final_assessment_samples": int(len(self.final_assessment_indices)),
+            "qualification_fraction_requested": self.qualification_fraction,
+            "final_assessment_fraction_requested": self.final_assessment_fraction,
+            "max_balanced_budget_per_class": self.max_budget_per_class,
+            "calibration_pool_by_class": {
+                label: int(len(values))
+                for label, values in sorted(self.calibration_order_by_class.items())
+            },
+            "qualification_by_class": {
+                label: int(np.sum(y[self.qualification_indices] == label))
+                for label in self.labels
+            },
+            "final_assessment_by_class": {
+                label: int(np.sum(y[self.final_assessment_indices] == label))
+                for label in self.labels
+            },
+            "seed": self.seed,
+            "partition_fingerprint": self.partition.fingerprint,
+            "three_way_split_fingerprint": self.fingerprint,
+            "invariants": [
+                "source training contains no held-out deployment unit",
+                "calibration budgets are balanced and nested within each class",
+                "qualification indices are fixed across calibration budgets",
+                "final-assessment indices are fixed across calibration budgets",
+                "calibration, qualification, and final-assessment indices are pairwise disjoint",
+                "qualification and final-assessment sets preserve complete held-out class support",
+                "final-assessment rows are not part of state-selection authority",
+            ],
+        }
+
+
+def make_three_way_calibration_split(
+    partition: EvaluationPartition,
+    *,
+    qualification_fraction: float = 0.25,
+    final_assessment_fraction: float = 0.25,
+    seed: int = 0,
+) -> ThreeWayCalibrationSplit:
+    """Freeze calibration, qualification, and untouched final-assessment rows.
+
+    Fractions are interpreted against each held-out class independently. At
+    least one row per class is reserved for qualification and one for final
+    assessment. Small classes may therefore leave a zero-sized calibration
+    pool; the balanced maximum budget then becomes zero rather than silently
+    changing class support.
+    """
+
+    q_fraction = _fraction("qualification_fraction", qualification_fraction)
+    f_fraction = _fraction("final_assessment_fraction", final_assessment_fraction)
+    if q_fraction + f_fraction >= 1.0:
+        raise ValueError(
+            "qualification_fraction + final_assessment_fraction must be strictly less than 1"
+        )
+    normalized_seed = _seed(seed)
+
+    y = np.asarray(partition.data.y).astype(str)
+    held_out = np.asarray(partition.test_indices, dtype=np.int64)
+    held_labels = y[held_out]
+    labels = tuple(sorted(np.unique(held_labels).tolist()))
+    if len(labels) < 2:
+        raise ValueError("three-way calibration split requires at least two held-out classes")
+
+    rng = np.random.default_rng(normalized_seed)
+    qualification: list[np.ndarray] = []
+    final_assessment: list[np.ndarray] = []
+    calibration: dict[str, np.ndarray] = {}
+
+    for label in labels:
+        class_indices = held_out[held_labels == label].copy()
+        rng.shuffle(class_indices)
+        n_class = int(len(class_indices))
+        n_qualification = max(1, int(np.ceil(n_class * q_fraction)))
+        n_final = max(1, int(np.ceil(n_class * f_fraction)))
+        if n_qualification + n_final > n_class:
+            raise ValueError(
+                "held-out class does not contain enough rows for separate qualification "
+                f"and final assessment: label={label!r}, n={n_class}, "
+                f"qualification={n_qualification}, final={n_final}"
+            )
+
+        # Reserve the final-assessment subset first. It never becomes eligible
+        # for calibration or retain/rollback qualification.
+        final_assessment.append(class_indices[:n_final])
+        qualification.append(class_indices[n_final : n_final + n_qualification])
+        calibration[label] = class_indices[n_final + n_qualification :]
+
+    return ThreeWayCalibrationSplit(
+        partition=partition,
+        qualification_indices=np.sort(np.concatenate(qualification)),
+        final_assessment_indices=np.sort(np.concatenate(final_assessment)),
+        calibration_order_by_class=calibration,
+        qualification_fraction=q_fraction,
+        final_assessment_fraction=f_fraction,
+        seed=normalized_seed,
+    )

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
@@ -1,0 +1,484 @@
+"""Serializable v2 authority for three-way longitudinal adaptation studies.
+
+The v1 ``LongitudinalCaseAuthority`` remains unchanged and replayable. This v2
+contract freezes a distinct qualification/state-selection set and an untouched
+final-assessment set so adaptive methods cannot reuse state-selection evidence
+as final efficacy evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
+
+import numpy as np
+
+from .benchmark import SplitUnit
+from .longitudinal import ordered_group_values
+from .longitudinal_authority import processed_data_sha256
+from .longitudinal_three_way import ThreeWayCalibrationSplit
+from .real_world import EvaluationPartition, GroupedEvaluationData
+
+HistoryPolicy = Literal["prior", "all-other", "custom"]
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _indices_tuple(name: str, values: Any, *, allow_empty: bool = False) -> tuple[int, ...]:
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    if array.dtype == np.bool_:
+        raise ValueError(f"{name} must contain integer sample indices, not booleans")
+    try:
+        integer = array.astype(np.int64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain integer sample indices") from exc
+    if not np.array_equal(array, integer):
+        raise ValueError(f"{name} must contain integer sample indices")
+    result = tuple(int(value) for value in integer.tolist())
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must be non-empty")
+    if any(value < 0 for value in result):
+        raise ValueError(f"{name} cannot contain negative indices")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} cannot contain duplicate indices")
+    return result
+
+
+def _fraction(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+        raise ValueError(f"{name} must be numeric")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 < result < 1.0:
+        raise ValueError(f"{name} must lie strictly between 0 and 1")
+    return result
+
+
+def _sha256(name: str, value: str) -> str:
+    normalized = str(value).strip().lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError(f"{name} must be a 64-character lowercase SHA-256 hex digest")
+    return normalized
+
+
+def _ordered_values(values: np.ndarray) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(np.asarray(values).astype(str).tolist()))
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _index_set_sha256(kind: str, processed_sha256: str, indices: tuple[int, ...]) -> str:
+    return _canonical_sha256(
+        {
+            "kind": kind,
+            "processed_data_sha256": processed_sha256,
+            "indices": list(indices),
+        }
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ThreeWayLongitudinalCaseAuthority:
+    """Frozen v2 sample authority for one target deployment unit.
+
+    ``qualification_indices`` may influence state selection, such as a
+    retain/rollback decision. ``final_assessment_indices`` must not influence
+    adaptation, hyperparameters, thresholds, or retain/rollback policy.
+    """
+
+    dataset_id: str
+    case_id: str
+    split_unit: SplitUnit
+    held_out_values: tuple[str, ...]
+    history_policy: HistoryPolicy
+    observed_group_order: tuple[str, ...]
+    source_group_values: tuple[str, ...]
+    source_train_indices: tuple[int, ...]
+    qualification_indices: tuple[int, ...]
+    final_assessment_indices: tuple[int, ...]
+    calibration_order_by_class: Mapping[str, tuple[int, ...]]
+    qualification_fraction: float
+    final_assessment_fraction: float
+    seed: int
+    partition_fingerprint: str
+    three_way_split_fingerprint: str
+    processed_data_sha256: str
+    n_samples: int
+    input_shape: tuple[int, ...]
+    case_metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 2
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 2:
+            raise ValueError("ThreeWayLongitudinalCaseAuthority schema_version must be 2")
+        if not self.dataset_id.strip() or not self.case_id.strip():
+            raise ValueError("dataset_id and case_id must be non-empty")
+        if self.split_unit == "sample":
+            raise ValueError("three-way longitudinal authority requires a deployment-unit split")
+        if not self.held_out_values:
+            raise ValueError("held_out_values must be non-empty")
+        if self.history_policy not in {"prior", "all-other", "custom"}:
+            raise ValueError(f"unsupported history_policy={self.history_policy!r}")
+        if isinstance(self.n_samples, bool) or not isinstance(self.n_samples, int) or self.n_samples <= 0:
+            raise ValueError("n_samples must be a positive integer")
+        if not self.input_shape or self.input_shape[0] != self.n_samples:
+            raise ValueError("input_shape must begin with n_samples")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int) or self.seed < 0:
+            raise ValueError("seed must be a non-negative integer")
+
+        processed_sha = _sha256("processed_data_sha256", self.processed_data_sha256)
+        qualification_fraction = _fraction(
+            "qualification_fraction", self.qualification_fraction
+        )
+        final_fraction = _fraction(
+            "final_assessment_fraction", self.final_assessment_fraction
+        )
+        if qualification_fraction + final_fraction >= 1.0:
+            raise ValueError(
+                "qualification_fraction + final_assessment_fraction must be strictly less than 1"
+            )
+
+        source = _indices_tuple("source_train_indices", self.source_train_indices)
+        qualification = _indices_tuple("qualification_indices", self.qualification_indices)
+        final_assessment = _indices_tuple(
+            "final_assessment_indices", self.final_assessment_indices
+        )
+        calibration = {
+            str(label): _indices_tuple(
+                f"calibration_order_by_class[{label!r}]", values, allow_empty=True
+            )
+            for label, values in self.calibration_order_by_class.items()
+        }
+        if not calibration:
+            raise ValueError("calibration_order_by_class must be non-empty")
+
+        all_sets: list[tuple[str, set[int]]] = [
+            ("source", set(source)),
+            ("qualification", set(qualification)),
+            ("final_assessment", set(final_assessment)),
+        ] + [
+            (f"calibration[{label}]", set(values))
+            for label, values in sorted(calibration.items())
+        ]
+        for index, (left_name, left) in enumerate(all_sets):
+            if left and max(left) >= self.n_samples:
+                raise ValueError(f"{left_name} contains out-of-range sample indices")
+            for right_name, right in all_sets[index + 1 :]:
+                overlap = left & right
+                if overlap:
+                    raise ValueError(
+                        f"authority index sets must be pairwise disjoint: {left_name} vs "
+                        f"{right_name}, overlap={sorted(overlap)[:8]}"
+                    )
+
+        object.__setattr__(self, "source_train_indices", source)
+        object.__setattr__(self, "qualification_indices", qualification)
+        object.__setattr__(self, "final_assessment_indices", final_assessment)
+        object.__setattr__(self, "calibration_order_by_class", MappingProxyType(calibration))
+        object.__setattr__(self, "processed_data_sha256", processed_sha)
+        object.__setattr__(self, "qualification_fraction", qualification_fraction)
+        object.__setattr__(self, "final_assessment_fraction", final_fraction)
+        object.__setattr__(self, "case_metadata", MappingProxyType(dict(self.case_metadata)))
+
+    @classmethod
+    def from_split(
+        cls,
+        split: ThreeWayCalibrationSplit,
+        *,
+        case_id: str,
+        history_policy: HistoryPolicy,
+        observed_group_order: tuple[str, ...] | None = None,
+        case_metadata: Mapping[str, Any] | None = None,
+    ) -> "ThreeWayLongitudinalCaseAuthority":
+        data = split.partition.data
+        unit = split.partition.split_unit
+        if unit == "sample":
+            raise ValueError("three-way longitudinal authority requires a deployment-unit split")
+        group = np.asarray(data.groups[unit]).astype(str)
+        observed = observed_group_order or ordered_group_values(data, split_unit=unit)
+        source_values = _ordered_values(group[split.source_train_indices])
+        return cls(
+            dataset_id=data.dataset_id,
+            case_id=case_id,
+            split_unit=unit,
+            held_out_values=tuple(str(v) for v in split.partition.held_out_values),
+            history_policy=history_policy,
+            observed_group_order=tuple(str(v) for v in observed),
+            source_group_values=source_values,
+            source_train_indices=_indices_tuple(
+                "source_train_indices", split.source_train_indices
+            ),
+            qualification_indices=_indices_tuple(
+                "qualification_indices", split.qualification_indices
+            ),
+            final_assessment_indices=_indices_tuple(
+                "final_assessment_indices", split.final_assessment_indices
+            ),
+            calibration_order_by_class={
+                label: _indices_tuple(
+                    f"calibration_order_by_class[{label!r}]", values, allow_empty=True
+                )
+                for label, values in split.calibration_order_by_class.items()
+            },
+            qualification_fraction=float(split.qualification_fraction),
+            final_assessment_fraction=float(split.final_assessment_fraction),
+            seed=int(split.seed),
+            partition_fingerprint=split.partition.fingerprint,
+            three_way_split_fingerprint=split.fingerprint,
+            processed_data_sha256=processed_data_sha256(data),
+            n_samples=int(len(data.X)),
+            input_shape=tuple(int(v) for v in np.asarray(data.X).shape),
+            case_metadata={} if case_metadata is None else case_metadata,
+        )
+
+    @property
+    def authority_fingerprint(self) -> str:
+        return _canonical_sha256(self.to_dict(include_fingerprint=False))
+
+    @property
+    def qualification_set_sha256(self) -> str:
+        return _index_set_sha256(
+            "qualification", self.processed_data_sha256, self.qualification_indices
+        )
+
+    @property
+    def final_assessment_set_sha256(self) -> str:
+        return _index_set_sha256(
+            "final-assessment", self.processed_data_sha256, self.final_assessment_indices
+        )
+
+    @property
+    def max_budget_per_class(self) -> int:
+        return min(len(values) for values in self.calibration_order_by_class.values())
+
+    def calibration_indices(self, per_class: int) -> tuple[int, ...]:
+        if isinstance(per_class, bool) or not isinstance(per_class, (int, np.integer)):
+            raise ValueError("calibration budget must be a non-negative integer")
+        budget = int(per_class)
+        if budget < 0:
+            raise ValueError("calibration budget must be non-negative")
+        if budget > self.max_budget_per_class:
+            raise ValueError(
+                f"budget {budget} exceeds balanced maximum {self.max_budget_per_class}"
+            )
+        if budget == 0:
+            return ()
+        selected: list[int] = []
+        for _, values in sorted(self.calibration_order_by_class.items()):
+            selected.extend(values[:budget])
+        return tuple(sorted(selected))
+
+    def calibration_budget_sha256(self, per_class: int) -> str:
+        return _index_set_sha256(
+            f"calibration-budget-{int(per_class)}",
+            self.processed_data_sha256,
+            self.calibration_indices(per_class),
+        )
+
+    def require_calibration_indices(self, per_class: int, values: Any) -> tuple[int, ...]:
+        actual = _indices_tuple("calibration indices", values, allow_empty=per_class == 0)
+        expected = self.calibration_indices(per_class)
+        if actual != expected:
+            raise ValueError(
+                "calibration must use the exact frozen budget indices in canonical order"
+            )
+        return actual
+
+    def require_qualification_indices(self, values: Any) -> tuple[int, ...]:
+        actual = _indices_tuple("qualification indices", values)
+        if actual != self.qualification_indices:
+            raise ValueError(
+                "qualification must use the complete frozen qualification set in exact order"
+            )
+        return actual
+
+    def require_final_assessment_indices(self, values: Any) -> tuple[int, ...]:
+        actual = _indices_tuple("final-assessment indices", values)
+        if actual != self.final_assessment_indices:
+            raise ValueError(
+                "final assessment must use the complete frozen final-assessment set in exact order"
+            )
+        return actual
+
+    def to_dict(self, *, include_fingerprint: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "kind": "three_way_longitudinal_case_authority",
+            "dataset_id": self.dataset_id,
+            "case_id": self.case_id,
+            "split_unit": self.split_unit,
+            "held_out_values": list(self.held_out_values),
+            "history_policy": self.history_policy,
+            "observed_group_order": list(self.observed_group_order),
+            "source_group_values": list(self.source_group_values),
+            "source_train_indices": list(self.source_train_indices),
+            "qualification_indices": list(self.qualification_indices),
+            "final_assessment_indices": list(self.final_assessment_indices),
+            "calibration_order_by_class": {
+                key: list(values)
+                for key, values in sorted(self.calibration_order_by_class.items())
+            },
+            "qualification_fraction": self.qualification_fraction,
+            "final_assessment_fraction": self.final_assessment_fraction,
+            "seed": self.seed,
+            "partition_fingerprint": self.partition_fingerprint,
+            "three_way_split_fingerprint": self.three_way_split_fingerprint,
+            "processed_data_sha256": self.processed_data_sha256,
+            "qualification_set_sha256": self.qualification_set_sha256,
+            "final_assessment_set_sha256": self.final_assessment_set_sha256,
+            "n_samples": self.n_samples,
+            "input_shape": list(self.input_shape),
+            "case_metadata": dict(self.case_metadata),
+        }
+        if include_fingerprint:
+            payload["authority_fingerprint"] = self.authority_fingerprint
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ThreeWayLongitudinalCaseAuthority":
+        if int(payload.get("schema_version", 0)) != 2:
+            raise ValueError("three-way longitudinal authority requires schema_version=2")
+        value = cls(
+            dataset_id=str(payload["dataset_id"]),
+            case_id=str(payload["case_id"]),
+            split_unit=str(payload["split_unit"]),  # type: ignore[arg-type]
+            held_out_values=tuple(str(v) for v in payload["held_out_values"]),
+            history_policy=str(payload["history_policy"]),  # type: ignore[arg-type]
+            observed_group_order=tuple(str(v) for v in payload["observed_group_order"]),
+            source_group_values=tuple(str(v) for v in payload["source_group_values"]),
+            source_train_indices=tuple(int(v) for v in payload["source_train_indices"]),
+            qualification_indices=tuple(int(v) for v in payload["qualification_indices"]),
+            final_assessment_indices=tuple(
+                int(v) for v in payload["final_assessment_indices"]
+            ),
+            calibration_order_by_class={
+                str(key): tuple(int(v) for v in values)
+                for key, values in dict(payload["calibration_order_by_class"]).items()
+            },
+            qualification_fraction=float(payload["qualification_fraction"]),
+            final_assessment_fraction=float(payload["final_assessment_fraction"]),
+            seed=int(payload["seed"]),
+            partition_fingerprint=str(payload["partition_fingerprint"]),
+            three_way_split_fingerprint=str(payload["three_way_split_fingerprint"]),
+            processed_data_sha256=str(payload["processed_data_sha256"]),
+            n_samples=int(payload["n_samples"]),
+            input_shape=tuple(int(v) for v in payload["input_shape"]),
+            case_metadata=dict(payload.get("case_metadata", {})),
+            schema_version=2,
+        )
+        expected_authority = payload.get("authority_fingerprint")
+        if expected_authority is not None and str(expected_authority) != value.authority_fingerprint:
+            raise ValueError("authority_fingerprint does not match serialized content")
+        expected_qualification = payload.get("qualification_set_sha256")
+        if expected_qualification is not None and str(expected_qualification) != value.qualification_set_sha256:
+            raise ValueError("qualification_set_sha256 does not match serialized content")
+        expected_final = payload.get("final_assessment_set_sha256")
+        if expected_final is not None and str(expected_final) != value.final_assessment_set_sha256:
+            raise ValueError("final_assessment_set_sha256 does not match serialized content")
+        return value
+
+    def restore(self, data: GroupedEvaluationData) -> ThreeWayCalibrationSplit:
+        """Validate loaded processed data and reconstruct the exact v2 split."""
+        if data.dataset_id != self.dataset_id:
+            raise ValueError(
+                f"dataset mismatch: authority={self.dataset_id!r}, loaded={data.dataset_id!r}"
+            )
+        if len(data.X) != self.n_samples or tuple(np.asarray(data.X).shape) != self.input_shape:
+            raise ValueError("processed dataset sample count/shape differs from authority")
+        actual_sha = processed_data_sha256(data)
+        if actual_sha != self.processed_data_sha256:
+            raise ValueError("processed neural data SHA-256 differs from authority")
+        if self.split_unit not in data.groups:
+            raise ValueError(f"loaded dataset has no {self.split_unit!r} group")
+
+        n = len(data.X)
+        source = np.asarray(self.source_train_indices, dtype=np.int64)
+        qualification = np.asarray(self.qualification_indices, dtype=np.int64)
+        final_assessment = np.asarray(self.final_assessment_indices, dtype=np.int64)
+        calibration = {
+            label: np.asarray(values, dtype=np.int64)
+            for label, values in self.calibration_order_by_class.items()
+        }
+        all_indices = [source, qualification, final_assessment, *calibration.values()]
+        if any(np.any(values < 0) or np.any(values >= n) for values in all_indices):
+            raise ValueError("authority contains out-of-range sample indices")
+
+        calibration_flat = (
+            np.concatenate(list(calibration.values()))
+            if calibration
+            else np.asarray([], dtype=np.int64)
+        )
+        test = np.sort(
+            np.concatenate([qualification, final_assessment, calibration_flat]).astype(
+                np.int64, copy=False
+            )
+        )
+        partition = EvaluationPartition(
+            data=data,
+            split_unit=self.split_unit,
+            train_indices=source,
+            test_indices=test,
+            held_out_values=self.held_out_values,
+        )
+        if partition.fingerprint != self.partition_fingerprint:
+            raise ValueError("partition fingerprint differs from authority")
+
+        split = ThreeWayCalibrationSplit(
+            partition=partition,
+            qualification_indices=qualification,
+            final_assessment_indices=final_assessment,
+            calibration_order_by_class=calibration,
+            qualification_fraction=self.qualification_fraction,
+            final_assessment_fraction=self.final_assessment_fraction,
+            seed=self.seed,
+        )
+        if split.fingerprint != self.three_way_split_fingerprint:
+            raise ValueError("three-way split fingerprint differs from authority")
+
+        group = np.asarray(data.groups[self.split_unit]).astype(str)
+        observed = ordered_group_values(data, split_unit=self.split_unit)
+        if observed != self.observed_group_order:
+            raise ValueError(
+                "deployment-unit order differs from authority; "
+                f"authority={self.observed_group_order}, loaded={observed}"
+            )
+        if set(group[test].tolist()) != set(self.held_out_values):
+            raise ValueError("held-out indices do not match authority held_out_values")
+        actual_source_values = _ordered_values(group[source])
+        if actual_source_values != self.source_group_values:
+            raise ValueError("source deployment-unit identities differ from authority")
+
+        source_set = set(source.tolist())
+        expected_source = set(
+            np.flatnonzero(np.isin(group, np.asarray(self.source_group_values, dtype=str))).tolist()
+        )
+        if source_set != expected_source:
+            raise ValueError("authority source indices do not cover source groups exactly")
+
+        if self.history_policy == "prior":
+            if len(self.held_out_values) != 1:
+                raise ValueError("prior authority requires exactly one held-out group")
+            held = self.held_out_values[0]
+            if held not in observed:
+                raise ValueError("held-out group missing from observed chronology")
+            expected_values = observed[: observed.index(held)]
+            if self.source_group_values != expected_values:
+                raise ValueError(
+                    "prior authority source groups are not the complete chronological prefix"
+                )
+        elif self.history_policy == "all-other":
+            expected_values = tuple(v for v in observed if v not in self.held_out_values)
+            if self.source_group_values != expected_values:
+                raise ValueError("all-other authority does not contain every non-held-out group")
+
+        return split

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
@@ -54,6 +54,16 @@ def _jsonable(value: Any) -> Any:
     )
 
 
+def _freeze_json(value: Any) -> Any:
+    """Deep-freeze already-normalized JSON evidence values."""
+
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
 def _indices_tuple(name: str, values: Any, *, allow_empty: bool = False) -> tuple[int, ...]:
     array = np.asarray(values)
     if array.ndim != 1:
@@ -285,9 +295,10 @@ class ThreeWayLongitudinalCaseAuthority:
                         f"{right_name}, overlap={sorted(overlap)[:8]}"
                     )
 
-        metadata = _jsonable(self.case_metadata)
-        if not isinstance(metadata, dict):
+        metadata_json = _jsonable(self.case_metadata)
+        if not isinstance(metadata_json, dict):
             raise TypeError("case_metadata must be a mapping")
+        metadata = _freeze_json(metadata_json)
 
         object.__setattr__(self, "dataset_id", dataset_id)
         object.__setattr__(self, "case_id", case_id)
@@ -307,7 +318,7 @@ class ThreeWayLongitudinalCaseAuthority:
         object.__setattr__(self, "n_samples", n_samples)
         object.__setattr__(self, "input_shape", input_shape)
         object.__setattr__(self, "partition_fingerprint", partition_fingerprint)
-        object.__setattr__(self, "case_metadata", MappingProxyType(metadata))
+        object.__setattr__(self, "case_metadata", metadata)
 
     @classmethod
     def from_split(
@@ -465,7 +476,7 @@ class ThreeWayLongitudinalCaseAuthority:
             "final_assessment_set_sha256": self.final_assessment_set_sha256,
             "n_samples": self.n_samples,
             "input_shape": list(self.input_shape),
-            "case_metadata": dict(self.case_metadata),
+            "case_metadata": _jsonable(self.case_metadata),
         }
         if include_fingerprint:
             payload["authority_fingerprint"] = self.authority_fingerprint
@@ -487,11 +498,14 @@ class ThreeWayLongitudinalCaseAuthority:
         final_assessment_indices = _indices_tuple(
             "final_assessment_indices", payload["final_assessment_indices"]
         )
+        raw_calibration = payload["calibration_order_by_class"]
+        if not isinstance(raw_calibration, Mapping):
+            raise TypeError("calibration_order_by_class must be a mapping")
         calibration = {
             str(key): _indices_tuple(
                 f"calibration_order_by_class[{str(key)!r}]", values, allow_empty=True
             )
-            for key, values in dict(payload["calibration_order_by_class"]).items()
+            for key, values in raw_calibration.items()
         }
         seed = _strict_int("seed", payload["seed"], minimum=0)
         n_samples = _strict_int("n_samples", payload["n_samples"], minimum=1)

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
@@ -87,6 +87,33 @@ def _string_tuple(name: str, values: Any, *, allow_empty: bool = False) -> tuple
     return result
 
 
+def _strict_int(name: str, value: Any, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        qualifier = "positive" if minimum == 1 else "non-negative"
+        raise ValueError(f"{name} must be {qualifier}")
+    return result
+
+
+def _shape_tuple(name: str, values: Any) -> tuple[int, ...]:
+    array = np.asarray(values)
+    if array.ndim != 1 or array.size == 0:
+        raise ValueError(f"{name} must be a non-empty one-dimensional integer shape")
+    if array.dtype == np.bool_:
+        raise ValueError(f"{name} must contain integer dimensions, not booleans")
+    try:
+        integer = array.astype(np.int64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain integer dimensions") from exc
+    if not np.array_equal(array, integer):
+        raise ValueError(f"{name} must contain integer dimensions")
+    if np.any(integer < 1):
+        raise ValueError(f"{name} dimensions must be positive")
+    return tuple(int(value) for value in integer.tolist())
+
+
 def _fraction(name: str, value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
         raise ValueError(f"{name} must be numeric")
@@ -172,13 +199,13 @@ class ThreeWayLongitudinalCaseAuthority:
             raise ValueError("three-way longitudinal authority requires a deployment-unit split")
         if self.history_policy not in {"prior", "all-other", "custom"}:
             raise ValueError(f"unsupported history_policy={self.history_policy!r}")
-        if isinstance(self.n_samples, bool) or not isinstance(self.n_samples, int) or self.n_samples <= 0:
-            raise ValueError("n_samples must be a positive integer")
-        if not self.input_shape or self.input_shape[0] != self.n_samples:
+        n_samples = _strict_int("n_samples", self.n_samples, minimum=1)
+        seed = _strict_int("seed", self.seed, minimum=0)
+        input_shape = _shape_tuple("input_shape", self.input_shape)
+        if input_shape[0] != n_samples:
             raise ValueError("input_shape must begin with n_samples")
-        if isinstance(self.seed, bool) or not isinstance(self.seed, int) or self.seed < 0:
-            raise ValueError("seed must be a non-negative integer")
-        if not str(self.partition_fingerprint).strip():
+        partition_fingerprint = str(self.partition_fingerprint).strip()
+        if not partition_fingerprint:
             raise ValueError("partition_fingerprint must be non-empty")
 
         held_out = _string_tuple("held_out_values", self.held_out_values)
@@ -248,7 +275,7 @@ class ThreeWayLongitudinalCaseAuthority:
             for label, values in sorted(calibration.items())
         ]
         for index, (left_name, left) in enumerate(all_sets):
-            if left and max(left) >= self.n_samples:
+            if left and max(left) >= n_samples:
                 raise ValueError(f"{left_name} contains out-of-range sample indices")
             for right_name, right in all_sets[index + 1 :]:
                 overlap = left & right
@@ -276,6 +303,10 @@ class ThreeWayLongitudinalCaseAuthority:
         object.__setattr__(self, "three_way_split_fingerprint", split_fingerprint)
         object.__setattr__(self, "qualification_fraction", qualification_fraction)
         object.__setattr__(self, "final_assessment_fraction", final_fraction)
+        object.__setattr__(self, "seed", seed)
+        object.__setattr__(self, "n_samples", n_samples)
+        object.__setattr__(self, "input_shape", input_shape)
+        object.__setattr__(self, "partition_fingerprint", partition_fingerprint)
         object.__setattr__(self, "case_metadata", MappingProxyType(metadata))
 
     @classmethod
@@ -442,35 +473,55 @@ class ThreeWayLongitudinalCaseAuthority:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "ThreeWayLongitudinalCaseAuthority":
-        if int(payload.get("schema_version", 0)) != 2:
+        schema_version = _strict_int(
+            "schema_version", payload.get("schema_version", 0), minimum=0
+        )
+        if schema_version != 2:
             raise ValueError("three-way longitudinal authority requires schema_version=2")
+        source_indices = _indices_tuple(
+            "source_train_indices", payload["source_train_indices"]
+        )
+        qualification_indices = _indices_tuple(
+            "qualification_indices", payload["qualification_indices"]
+        )
+        final_assessment_indices = _indices_tuple(
+            "final_assessment_indices", payload["final_assessment_indices"]
+        )
+        calibration = {
+            str(key): _indices_tuple(
+                f"calibration_order_by_class[{str(key)!r}]", values, allow_empty=True
+            )
+            for key, values in dict(payload["calibration_order_by_class"]).items()
+        }
+        seed = _strict_int("seed", payload["seed"], minimum=0)
+        n_samples = _strict_int("n_samples", payload["n_samples"], minimum=1)
+        input_shape = _shape_tuple("input_shape", payload["input_shape"])
+        metadata = payload.get("case_metadata", {})
+        if not isinstance(metadata, Mapping):
+            raise TypeError("case_metadata must be a mapping")
+
         value = cls(
-            dataset_id=str(payload["dataset_id"]),
-            case_id=str(payload["case_id"]),
-            split_unit=str(payload["split_unit"]),  # type: ignore[arg-type]
-            held_out_values=tuple(str(item) for item in payload["held_out_values"]),
-            history_policy=str(payload["history_policy"]),  # type: ignore[arg-type]
-            observed_group_order=tuple(str(item) for item in payload["observed_group_order"]),
-            source_group_values=tuple(str(item) for item in payload["source_group_values"]),
-            source_train_indices=tuple(int(item) for item in payload["source_train_indices"]),
-            qualification_indices=tuple(int(item) for item in payload["qualification_indices"]),
-            final_assessment_indices=tuple(
-                int(item) for item in payload["final_assessment_indices"]
-            ),
-            calibration_order_by_class={
-                str(key): tuple(int(item) for item in values)
-                for key, values in dict(payload["calibration_order_by_class"]).items()
-            },
-            qualification_fraction=float(payload["qualification_fraction"]),
-            final_assessment_fraction=float(payload["final_assessment_fraction"]),
-            seed=int(payload["seed"]),
-            partition_fingerprint=str(payload["partition_fingerprint"]),
-            three_way_split_fingerprint=str(payload["three_way_split_fingerprint"]),
-            processed_data_sha256=str(payload["processed_data_sha256"]),
-            n_samples=int(payload["n_samples"]),
-            input_shape=tuple(int(item) for item in payload["input_shape"]),
-            case_metadata=dict(payload.get("case_metadata", {})),
-            schema_version=2,
+            dataset_id=payload["dataset_id"],
+            case_id=payload["case_id"],
+            split_unit=payload["split_unit"],  # type: ignore[arg-type]
+            held_out_values=tuple(payload["held_out_values"]),
+            history_policy=payload["history_policy"],  # type: ignore[arg-type]
+            observed_group_order=tuple(payload["observed_group_order"]),
+            source_group_values=tuple(payload["source_group_values"]),
+            source_train_indices=source_indices,
+            qualification_indices=qualification_indices,
+            final_assessment_indices=final_assessment_indices,
+            calibration_order_by_class=calibration,
+            qualification_fraction=payload["qualification_fraction"],
+            final_assessment_fraction=payload["final_assessment_fraction"],
+            seed=seed,
+            partition_fingerprint=payload["partition_fingerprint"],
+            three_way_split_fingerprint=payload["three_way_split_fingerprint"],
+            processed_data_sha256=payload["processed_data_sha256"],
+            n_samples=n_samples,
+            input_shape=input_shape,
+            case_metadata=metadata,
+            schema_version=schema_version,
         )
         expected_authority = payload.get("authority_fingerprint")
         if expected_authority is not None and str(expected_authority) != value.authority_fingerprint:

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
@@ -28,6 +28,32 @@ HistoryPolicy = Literal["prior", "all-other", "custom"]
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
+def _jsonable(value: Any) -> Any:
+    """Normalize deterministic evidence metadata or fail closed."""
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("authority metadata cannot contain NaN or infinity")
+        return value
+    if isinstance(value, np.generic):
+        return _jsonable(value.item())
+    if isinstance(value, np.ndarray):
+        return _jsonable(value.tolist())
+    if isinstance(value, Mapping):
+        return {
+            str(key): _jsonable(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    raise TypeError(
+        "authority metadata must contain JSON-compatible primitives, NumPy scalars/arrays, "
+        f"mappings, lists, or tuples; got {type(value).__name__}"
+    )
+
+
 def _indices_tuple(name: str, values: Any, *, allow_empty: bool = False) -> tuple[int, ...]:
     array = np.asarray(values)
     if array.ndim != 1:
@@ -47,6 +73,17 @@ def _indices_tuple(name: str, values: Any, *, allow_empty: bool = False) -> tupl
         raise ValueError(f"{name} cannot contain negative indices")
     if len(set(result)) != len(result):
         raise ValueError(f"{name} cannot contain duplicate indices")
+    return result
+
+
+def _string_tuple(name: str, values: Any, *, allow_empty: bool = False) -> tuple[str, ...]:
+    result = tuple(str(value) for value in values)
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must be non-empty")
+    if any(not value.strip() for value in result):
+        raise ValueError(f"{name} cannot contain empty values")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} cannot contain duplicate values")
     return result
 
 
@@ -71,9 +108,12 @@ def _ordered_values(values: np.ndarray) -> tuple[str, ...]:
 
 
 def _canonical_sha256(payload: Mapping[str, Any]) -> str:
-    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode(
-        "utf-8"
-    )
+    raw = json.dumps(
+        _jsonable(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
     return hashlib.sha256(raw).hexdigest()
 
 
@@ -121,12 +161,15 @@ class ThreeWayLongitudinalCaseAuthority:
     def __post_init__(self) -> None:
         if self.schema_version != 2:
             raise ValueError("ThreeWayLongitudinalCaseAuthority schema_version must be 2")
-        if not self.dataset_id.strip() or not self.case_id.strip():
+        dataset_id = str(self.dataset_id).strip()
+        case_id = str(self.case_id).strip()
+        split_unit = str(self.split_unit).strip()
+        if not dataset_id or not case_id:
             raise ValueError("dataset_id and case_id must be non-empty")
-        if self.split_unit == "sample":
+        if not split_unit:
+            raise ValueError("split_unit must be non-empty")
+        if split_unit == "sample":
             raise ValueError("three-way longitudinal authority requires a deployment-unit split")
-        if not self.held_out_values:
-            raise ValueError("held_out_values must be non-empty")
         if self.history_policy not in {"prior", "all-other", "custom"}:
             raise ValueError(f"unsupported history_policy={self.history_policy!r}")
         if isinstance(self.n_samples, bool) or not isinstance(self.n_samples, int) or self.n_samples <= 0:
@@ -135,8 +178,38 @@ class ThreeWayLongitudinalCaseAuthority:
             raise ValueError("input_shape must begin with n_samples")
         if isinstance(self.seed, bool) or not isinstance(self.seed, int) or self.seed < 0:
             raise ValueError("seed must be a non-negative integer")
+        if not str(self.partition_fingerprint).strip():
+            raise ValueError("partition_fingerprint must be non-empty")
+
+        held_out = _string_tuple("held_out_values", self.held_out_values)
+        observed = _string_tuple("observed_group_order", self.observed_group_order)
+        source_groups = _string_tuple("source_group_values", self.source_group_values)
+        observed_set = set(observed)
+        if not set(held_out).issubset(observed_set):
+            raise ValueError("held_out_values must be contained in observed_group_order")
+        if not set(source_groups).issubset(observed_set):
+            raise ValueError("source_group_values must be contained in observed_group_order")
+        if set(source_groups) & set(held_out):
+            raise ValueError("source_group_values and held_out_values must be disjoint")
+
+        if self.history_policy == "prior":
+            if len(held_out) != 1:
+                raise ValueError("prior authority requires exactly one held-out group")
+            held = held_out[0]
+            expected_source = observed[: observed.index(held)]
+            if source_groups != expected_source:
+                raise ValueError(
+                    "prior authority source groups are not the complete chronological prefix"
+                )
+        elif self.history_policy == "all-other":
+            expected_source = tuple(value for value in observed if value not in held_out)
+            if source_groups != expected_source:
+                raise ValueError("all-other authority does not contain every non-held-out group")
 
         processed_sha = _sha256("processed_data_sha256", self.processed_data_sha256)
+        split_fingerprint = _sha256(
+            "three_way_split_fingerprint", self.three_way_split_fingerprint
+        )
         qualification_fraction = _fraction(
             "qualification_fraction", self.qualification_fraction
         )
@@ -153,12 +226,16 @@ class ThreeWayLongitudinalCaseAuthority:
         final_assessment = _indices_tuple(
             "final_assessment_indices", self.final_assessment_indices
         )
-        calibration = {
-            str(label): _indices_tuple(
+        calibration: dict[str, tuple[int, ...]] = {}
+        for raw_label, values in self.calibration_order_by_class.items():
+            label = str(raw_label)
+            if not label.strip():
+                raise ValueError("calibration class labels must be non-empty")
+            if label in calibration:
+                raise ValueError(f"duplicate normalized calibration class label: {label!r}")
+            calibration[label] = _indices_tuple(
                 f"calibration_order_by_class[{label!r}]", values, allow_empty=True
             )
-            for label, values in self.calibration_order_by_class.items()
-        }
         if not calibration:
             raise ValueError("calibration_order_by_class must be non-empty")
 
@@ -181,14 +258,25 @@ class ThreeWayLongitudinalCaseAuthority:
                         f"{right_name}, overlap={sorted(overlap)[:8]}"
                     )
 
+        metadata = _jsonable(self.case_metadata)
+        if not isinstance(metadata, dict):
+            raise TypeError("case_metadata must be a mapping")
+
+        object.__setattr__(self, "dataset_id", dataset_id)
+        object.__setattr__(self, "case_id", case_id)
+        object.__setattr__(self, "split_unit", split_unit)
+        object.__setattr__(self, "held_out_values", held_out)
+        object.__setattr__(self, "observed_group_order", observed)
+        object.__setattr__(self, "source_group_values", source_groups)
         object.__setattr__(self, "source_train_indices", source)
         object.__setattr__(self, "qualification_indices", qualification)
         object.__setattr__(self, "final_assessment_indices", final_assessment)
         object.__setattr__(self, "calibration_order_by_class", MappingProxyType(calibration))
         object.__setattr__(self, "processed_data_sha256", processed_sha)
+        object.__setattr__(self, "three_way_split_fingerprint", split_fingerprint)
         object.__setattr__(self, "qualification_fraction", qualification_fraction)
         object.__setattr__(self, "final_assessment_fraction", final_fraction)
-        object.__setattr__(self, "case_metadata", MappingProxyType(dict(self.case_metadata)))
+        object.__setattr__(self, "case_metadata", MappingProxyType(metadata))
 
     @classmethod
     def from_split(
@@ -215,9 +303,9 @@ class ThreeWayLongitudinalCaseAuthority:
             dataset_id=data.dataset_id,
             case_id=case_id,
             split_unit=unit,
-            held_out_values=tuple(str(v) for v in split.partition.held_out_values),
+            held_out_values=tuple(str(value) for value in split.partition.held_out_values),
             history_policy=history_policy,
-            observed_group_order=tuple(str(v) for v in observed),
+            observed_group_order=tuple(str(value) for value in observed),
             source_group_values=source_values,
             source_train_indices=_indices_tuple(
                 "source_train_indices", split.source_train_indices
@@ -241,7 +329,7 @@ class ThreeWayLongitudinalCaseAuthority:
             three_way_split_fingerprint=split.fingerprint,
             processed_data_sha256=processed_data_sha256(data),
             n_samples=int(len(data.X)),
-            input_shape=tuple(int(v) for v in np.asarray(data.X).shape),
+            input_shape=tuple(int(value) for value in np.asarray(data.X).shape),
             case_metadata={} if case_metadata is None else case_metadata,
         )
 
@@ -360,17 +448,17 @@ class ThreeWayLongitudinalCaseAuthority:
             dataset_id=str(payload["dataset_id"]),
             case_id=str(payload["case_id"]),
             split_unit=str(payload["split_unit"]),  # type: ignore[arg-type]
-            held_out_values=tuple(str(v) for v in payload["held_out_values"]),
+            held_out_values=tuple(str(item) for item in payload["held_out_values"]),
             history_policy=str(payload["history_policy"]),  # type: ignore[arg-type]
-            observed_group_order=tuple(str(v) for v in payload["observed_group_order"]),
-            source_group_values=tuple(str(v) for v in payload["source_group_values"]),
-            source_train_indices=tuple(int(v) for v in payload["source_train_indices"]),
-            qualification_indices=tuple(int(v) for v in payload["qualification_indices"]),
+            observed_group_order=tuple(str(item) for item in payload["observed_group_order"]),
+            source_group_values=tuple(str(item) for item in payload["source_group_values"]),
+            source_train_indices=tuple(int(item) for item in payload["source_train_indices"]),
+            qualification_indices=tuple(int(item) for item in payload["qualification_indices"]),
             final_assessment_indices=tuple(
-                int(v) for v in payload["final_assessment_indices"]
+                int(item) for item in payload["final_assessment_indices"]
             ),
             calibration_order_by_class={
-                str(key): tuple(int(v) for v in values)
+                str(key): tuple(int(item) for item in values)
                 for key, values in dict(payload["calibration_order_by_class"]).items()
             },
             qualification_fraction=float(payload["qualification_fraction"]),
@@ -380,7 +468,7 @@ class ThreeWayLongitudinalCaseAuthority:
             three_way_split_fingerprint=str(payload["three_way_split_fingerprint"]),
             processed_data_sha256=str(payload["processed_data_sha256"]),
             n_samples=int(payload["n_samples"]),
-            input_shape=tuple(int(v) for v in payload["input_shape"]),
+            input_shape=tuple(int(item) for item in payload["input_shape"]),
             case_metadata=dict(payload.get("case_metadata", {})),
             schema_version=2,
         )
@@ -473,19 +561,17 @@ class ThreeWayLongitudinalCaseAuthority:
         if source_set != expected_source:
             raise ValueError("authority source indices do not cover source groups exactly")
 
+        # Construction already validates policy against the declared chronology.
+        # This second check validates that declaration against the loaded dataset.
         if self.history_policy == "prior":
-            if len(self.held_out_values) != 1:
-                raise ValueError("prior authority requires exactly one held-out group")
             held = self.held_out_values[0]
-            if held not in observed:
-                raise ValueError("held-out group missing from observed chronology")
             expected_values = observed[: observed.index(held)]
             if self.source_group_values != expected_values:
                 raise ValueError(
                     "prior authority source groups are not the complete chronological prefix"
                 )
         elif self.history_policy == "all-other":
-            expected_values = tuple(v for v in observed if v not in self.held_out_values)
+            expected_values = tuple(value for value in observed if value not in self.held_out_values)
             if self.source_group_values != expected_values:
                 raise ValueError("all-other authority does not contain every non-held-out group")
 

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
@@ -205,7 +205,11 @@ class ThreeWayLongitudinalCaseAuthority:
         if unit == "sample":
             raise ValueError("three-way longitudinal authority requires a deployment-unit split")
         group = np.asarray(data.groups[unit]).astype(str)
-        observed = observed_group_order or ordered_group_values(data, split_unit=unit)
+        observed = (
+            ordered_group_values(data, split_unit=unit)
+            if observed_group_order is None
+            else observed_group_order
+        )
         source_values = _ordered_values(group[split.source_train_indices])
         return cls(
             dataset_id=data.dataset_id,
@@ -279,15 +283,19 @@ class ThreeWayLongitudinalCaseAuthority:
         return tuple(sorted(selected))
 
     def calibration_budget_sha256(self, per_class: int) -> str:
+        indices = self.calibration_indices(per_class)
+        budget = int(per_class)
         return _index_set_sha256(
-            f"calibration-budget-{int(per_class)}",
+            f"calibration-budget-{budget}",
             self.processed_data_sha256,
-            self.calibration_indices(per_class),
+            indices,
         )
 
     def require_calibration_indices(self, per_class: int, values: Any) -> tuple[int, ...]:
-        actual = _indices_tuple("calibration indices", values, allow_empty=per_class == 0)
         expected = self.calibration_indices(per_class)
+        actual = _indices_tuple(
+            "calibration indices", values, allow_empty=len(expected) == 0
+        )
         if actual != expected:
             raise ValueError(
                 "calibration must use the exact frozen budget indices in canonical order"

--- a/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/longitudinal_three_way_authority.py
@@ -42,10 +42,16 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return _jsonable(value.tolist())
     if isinstance(value, Mapping):
-        return {
-            str(key): _jsonable(item)
-            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
-        }
+        normalized: dict[str, Any] = {}
+        for key, item in sorted(value.items(), key=lambda pair: str(pair[0])):
+            normalized_key = str(key)
+            if normalized_key in normalized:
+                raise ValueError(
+                    "authority metadata contains keys that collide after string normalization: "
+                    f"{normalized_key!r}"
+                )
+            normalized[normalized_key] = _jsonable(item)
+        return normalized
     if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
     raise TypeError(
@@ -162,6 +168,22 @@ def _index_set_sha256(kind: str, processed_sha256: str, indices: tuple[int, ...]
             "indices": list(indices),
         }
     )
+
+
+def _serialized_string(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"serialized {name} must be a string")
+    if not value.strip():
+        raise ValueError(f"serialized {name} must be non-empty")
+    return value
+
+
+def _serialized_string_sequence(name: str, value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(f"serialized {name} must be an array of strings")
+    if any(not isinstance(item, str) for item in value):
+        raise ValueError(f"serialized {name} must contain only strings")
+    return tuple(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -489,6 +511,21 @@ class ThreeWayLongitudinalCaseAuthority:
         )
         if schema_version != 2:
             raise ValueError("three-way longitudinal authority requires schema_version=2")
+
+        dataset_id = _serialized_string("dataset_id", payload["dataset_id"])
+        case_id = _serialized_string("case_id", payload["case_id"])
+        split_unit = _serialized_string("split_unit", payload["split_unit"])
+        history_policy = _serialized_string("history_policy", payload["history_policy"])
+        held_out_values = _serialized_string_sequence(
+            "held_out_values", payload["held_out_values"]
+        )
+        observed_group_order = _serialized_string_sequence(
+            "observed_group_order", payload["observed_group_order"]
+        )
+        source_group_values = _serialized_string_sequence(
+            "source_group_values", payload["source_group_values"]
+        )
+
         source_indices = _indices_tuple(
             "source_train_indices", payload["source_train_indices"]
         )
@@ -501,9 +538,11 @@ class ThreeWayLongitudinalCaseAuthority:
         raw_calibration = payload["calibration_order_by_class"]
         if not isinstance(raw_calibration, Mapping):
             raise TypeError("calibration_order_by_class must be a mapping")
+        if any(not isinstance(key, str) for key in raw_calibration):
+            raise ValueError("serialized calibration class labels must be strings")
         calibration = {
-            str(key): _indices_tuple(
-                f"calibration_order_by_class[{str(key)!r}]", values, allow_empty=True
+            key: _indices_tuple(
+                f"calibration_order_by_class[{key!r}]", values, allow_empty=True
             )
             for key, values in raw_calibration.items()
         }
@@ -515,13 +554,13 @@ class ThreeWayLongitudinalCaseAuthority:
             raise TypeError("case_metadata must be a mapping")
 
         value = cls(
-            dataset_id=payload["dataset_id"],
-            case_id=payload["case_id"],
-            split_unit=payload["split_unit"],  # type: ignore[arg-type]
-            held_out_values=tuple(payload["held_out_values"]),
-            history_policy=payload["history_policy"],  # type: ignore[arg-type]
-            observed_group_order=tuple(payload["observed_group_order"]),
-            source_group_values=tuple(payload["source_group_values"]),
+            dataset_id=dataset_id,
+            case_id=case_id,
+            split_unit=split_unit,  # type: ignore[arg-type]
+            held_out_values=held_out_values,
+            history_policy=history_policy,  # type: ignore[arg-type]
+            observed_group_order=observed_group_order,
+            source_group_values=source_group_values,
             source_train_indices=source_indices,
             qualification_indices=qualification_indices,
             final_assessment_indices=final_assessment_indices,

--- a/packages/neuros-foundation/tests/test_longitudinal_three_way.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_three_way.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.longitudinal_three_way import (
+    ThreeWayCalibrationSplit,
+    make_three_way_calibration_split,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData, hold_out_groups
+
+
+def _fixture_data() -> GroupedEvaluationData:
+    rng = np.random.default_rng(71)
+    X = []
+    y = []
+    metadata = []
+    for session in ("0", "1", "2"):
+        for label in ("left", "right"):
+            for trial in range(12):
+                X.append(rng.normal(size=(4, 16)))
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"run-{trial // 6}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata), dataset_id="three-way-fixture"
+    )
+
+
+def _partition():
+    return hold_out_groups(_fixture_data(), split_unit="session", held_out_values=["2"])
+
+
+def test_three_way_split_freezes_distinct_qualification_and_final_sets():
+    split = make_three_way_calibration_split(
+        _partition(),
+        qualification_fraction=0.25,
+        final_assessment_fraction=0.25,
+        seed=7,
+    )
+
+    assert len(split.source_train_indices) == 48
+    assert len(split.qualification_indices) == 6
+    assert len(split.final_assessment_indices) == 6
+    assert split.max_budget_per_class == 6
+
+    assert split.qualification_indices.flags.writeable is False
+    assert split.final_assessment_indices.flags.writeable is False
+    for values in split.calibration_order_by_class.values():
+        assert values.flags.writeable is False
+
+    q = set(split.qualification_indices.tolist())
+    final = set(split.final_assessment_indices.tolist())
+    calibration_pool = set(
+        np.concatenate(list(split.calibration_order_by_class.values())).tolist()
+    )
+    source = set(split.source_train_indices.tolist())
+    held = set(split.partition.test_indices.tolist())
+
+    assert q.isdisjoint(final)
+    assert q.isdisjoint(calibration_pool)
+    assert final.isdisjoint(calibration_pool)
+    assert source.isdisjoint(q | final | calibration_pool)
+    assert q | final | calibration_pool == held
+
+    y = split.partition.data.y.astype(str)
+    assert set(y[split.qualification_indices]) == {"left", "right"}
+    assert set(y[split.final_assessment_indices]) == {"left", "right"}
+    assert np.sum(y[split.qualification_indices] == "left") == 3
+    assert np.sum(y[split.final_assessment_indices] == "left") == 3
+
+
+def test_calibration_budgets_remain_nested_without_touching_held_out_sets():
+    split = make_three_way_calibration_split(_partition(), seed=11)
+    qualification_identity = split.qualification_indices.copy()
+    final_identity = split.final_assessment_indices.copy()
+
+    zero = set(split.calibration_indices(0).tolist())
+    one = set(split.calibration_indices(1).tolist())
+    three = set(split.calibration_indices(3).tolist())
+    six = set(split.calibration_indices(6).tolist())
+
+    assert zero == set()
+    assert one < three < six
+    assert len(one) == 2
+    assert len(three) == 6
+    assert len(six) == 12
+
+    for budget in (0, 1, 3, 6):
+        calibration = split.calibration_indices(budget)
+        training = split.train_indices_for_budget(budget)
+        assert np.array_equal(split.qualification_indices, qualification_identity)
+        assert np.array_equal(split.final_assessment_indices, final_identity)
+        assert np.intersect1d(calibration, split.qualification_indices).size == 0
+        assert np.intersect1d(calibration, split.final_assessment_indices).size == 0
+        assert np.intersect1d(training, split.qualification_indices).size == 0
+        assert np.intersect1d(training, split.final_assessment_indices).size == 0
+
+
+def test_three_way_fingerprint_and_manifest_are_deterministic():
+    partition = _partition()
+    first = make_three_way_calibration_split(partition, seed=13)
+    second = make_three_way_calibration_split(partition, seed=13)
+    changed = make_three_way_calibration_split(partition, seed=14)
+
+    assert first.fingerprint == second.fingerprint
+    assert len(first.fingerprint) == 64
+    assert first.fingerprint != changed.fingerprint
+    assert np.array_equal(first.qualification_indices, second.qualification_indices)
+    assert np.array_equal(first.final_assessment_indices, second.final_assessment_indices)
+
+    manifest = first.manifest()
+    assert manifest["schema_version"] == 2
+    assert manifest["kind"] == "three_way_calibration_split"
+    assert manifest["source_train_samples"] == 48
+    assert manifest["calibration_pool_samples"] == 12
+    assert manifest["qualification_samples"] == 6
+    assert manifest["final_assessment_samples"] == 6
+    assert manifest["calibration_pool_by_class"] == {"left": 6, "right": 6}
+    assert manifest["qualification_by_class"] == {"left": 3, "right": 3}
+    assert manifest["final_assessment_by_class"] == {"left": 3, "right": 3}
+    assert manifest["three_way_split_fingerprint"] == first.fingerprint
+    assert "final-assessment rows are not part of state-selection authority" in manifest[
+        "invariants"
+    ]
+
+
+def test_small_classes_fail_closed_or_produce_zero_calibration_budget():
+    rng = np.random.default_rng(2)
+    X = rng.normal(size=(8, 2, 4))
+    y = np.asarray(["left", "right"] * 2 + ["left", "left", "right", "right"])
+    metadata = [
+        {"subject": "1", "session": "source", "run": f"s-{i}"}
+        for i in range(4)
+    ] + [
+        {"subject": "1", "session": "held", "run": f"h-{i}"}
+        for i in range(4)
+    ]
+    data = GroupedEvaluationData.from_moabb_result((X, y, metadata), dataset_id="tiny")
+    partition = hold_out_groups(data, split_unit="session", held_out_values=["held"])
+    split = make_three_way_calibration_split(partition, seed=1)
+    assert split.max_budget_per_class == 0
+    assert split.calibration_indices(0).size == 0
+    with pytest.raises(ValueError, match="balanced maximum"):
+        split.calibration_indices(1)
+
+    X_single = rng.normal(size=(6, 2, 4))
+    y_single = np.asarray(["left", "right", "left", "right", "left", "right"])
+    metadata_single = [
+        {"subject": "1", "session": "source", "run": "s0"},
+        {"subject": "1", "session": "source", "run": "s1"},
+        {"subject": "1", "session": "source", "run": "s2"},
+        {"subject": "1", "session": "source", "run": "s3"},
+        {"subject": "1", "session": "held", "run": "h0"},
+        {"subject": "1", "session": "held", "run": "h1"},
+    ]
+    data_single = GroupedEvaluationData.from_moabb_result(
+        (X_single, y_single, metadata_single), dataset_id="one-per-class"
+    )
+    held_single = hold_out_groups(
+        data_single, split_unit="session", held_out_values=["held"]
+    )
+    with pytest.raises(ValueError, match="enough rows"):
+        make_three_way_calibration_split(held_single, seed=1)
+
+
+def test_invalid_fractions_and_budgets_fail_closed():
+    partition = _partition()
+    for invalid in (0.0, 1.0, -0.1, 1.1, np.nan):
+        with pytest.raises(ValueError, match="strictly between"):
+            make_three_way_calibration_split(
+                partition,
+                qualification_fraction=invalid,
+            )
+    with pytest.raises(ValueError, match="strictly less than 1"):
+        make_three_way_calibration_split(
+            partition,
+            qualification_fraction=0.5,
+            final_assessment_fraction=0.5,
+        )
+
+    split = make_three_way_calibration_split(partition)
+    with pytest.raises(ValueError, match="non-negative"):
+        split.calibration_indices(-1)
+    with pytest.raises(ValueError, match="integer"):
+        split.calibration_indices(1.5)  # type: ignore[arg-type]
+
+
+def test_manual_overlap_and_wrong_class_calibration_fail_before_use():
+    split = make_three_way_calibration_split(_partition(), seed=5)
+    calibration = {
+        label: np.array(values, copy=True)
+        for label, values in split.calibration_order_by_class.items()
+    }
+
+    with pytest.raises(ValueError, match="disjoint"):
+        ThreeWayCalibrationSplit(
+            partition=split.partition,
+            qualification_indices=split.qualification_indices,
+            final_assessment_indices=split.qualification_indices,
+            calibration_order_by_class=calibration,
+            qualification_fraction=split.qualification_fraction,
+            final_assessment_fraction=split.final_assessment_fraction,
+            seed=split.seed,
+        )
+
+    left = calibration["left"].copy()
+    right = calibration["right"].copy()
+    left[0], right[0] = right[0], left[0]
+    with pytest.raises(ValueError, match="another class"):
+        ThreeWayCalibrationSplit(
+            partition=split.partition,
+            qualification_indices=split.qualification_indices,
+            final_assessment_indices=split.final_assessment_indices,
+            calibration_order_by_class={"left": left, "right": right},
+            qualification_fraction=split.qualification_fraction,
+            final_assessment_fraction=split.final_assessment_fraction,
+            seed=split.seed,
+        )

--- a/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.longitudinal import chronological_partition
+from neuros.foundation_models.longitudinal_three_way import make_three_way_calibration_split
+from neuros.foundation_models.longitudinal_three_way_authority import (
+    ThreeWayLongitudinalCaseAuthority,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+
+def _fixture_data() -> GroupedEvaluationData:
+    rng = np.random.default_rng(83)
+    X = []
+    y = []
+    metadata = []
+    for session in ("0", "1", "2"):
+        for label in ("left", "right"):
+            for trial in range(12):
+                X.append(rng.normal(size=(4, 16)))
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "1",
+                        "session": session,
+                        "run": f"run-{trial // 6}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata), dataset_id="three-way-authority-fixture"
+    )
+
+
+def _authority():
+    data = _fixture_data()
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+    )
+    split = make_three_way_calibration_split(
+        partition,
+        qualification_fraction=0.25,
+        final_assessment_fraction=0.25,
+        seed=19,
+    )
+    authority = ThreeWayLongitudinalCaseAuthority.from_split(
+        split,
+        case_id="subject-1/session-2/v2",
+        history_policy="prior",
+        case_metadata={"protocol": "synthetic-contract"},
+    )
+    return data, split, authority
+
+
+def test_v2_authority_freezes_chronology_and_three_distinct_target_roles():
+    data, split, authority = _authority()
+
+    assert authority.schema_version == 2
+    assert authority.dataset_id == data.dataset_id
+    assert authority.split_unit == "session"
+    assert authority.held_out_values == ("2",)
+    assert authority.observed_group_order == ("0", "1", "2")
+    assert authority.source_group_values == ("0", "1")
+    assert len(authority.source_train_indices) == 48
+    assert len(authority.qualification_indices) == 6
+    assert len(authority.final_assessment_indices) == 6
+    assert authority.max_budget_per_class == 6
+    assert len(authority.authority_fingerprint) == 64
+    assert len(authority.qualification_set_sha256) == 64
+    assert len(authority.final_assessment_set_sha256) == 64
+    assert authority.qualification_set_sha256 != authority.final_assessment_set_sha256
+    assert authority.three_way_split_fingerprint == split.fingerprint
+
+    calibration = set(authority.calibration_indices(6))
+    qualification = set(authority.qualification_indices)
+    final_assessment = set(authority.final_assessment_indices)
+    source = set(authority.source_train_indices)
+    assert calibration.isdisjoint(qualification)
+    assert calibration.isdisjoint(final_assessment)
+    assert qualification.isdisjoint(final_assessment)
+    assert source.isdisjoint(calibration | qualification | final_assessment)
+
+
+def test_budget_identities_are_nested_and_final_authority_is_budget_invariant():
+    _, _, authority = _authority()
+    final_identity = authority.final_assessment_set_sha256
+    qualification_identity = authority.qualification_set_sha256
+
+    one = set(authority.calibration_indices(1))
+    three = set(authority.calibration_indices(3))
+    six = set(authority.calibration_indices(6))
+    assert one < three < six
+    assert authority.calibration_indices(0) == ()
+
+    hashes = [authority.calibration_budget_sha256(budget) for budget in (0, 1, 3, 6)]
+    assert len(set(hashes)) == 4
+    assert all(len(value) == 64 for value in hashes)
+    assert authority.final_assessment_set_sha256 == final_identity
+    assert authority.qualification_set_sha256 == qualification_identity
+
+
+def test_exact_set_guards_reject_subsets_supersets_and_reordering():
+    _, _, authority = _authority()
+    qualification = authority.qualification_indices
+    final_assessment = authority.final_assessment_indices
+    calibration = authority.calibration_indices(3)
+
+    assert authority.require_qualification_indices(qualification) == qualification
+    assert authority.require_final_assessment_indices(final_assessment) == final_assessment
+    assert authority.require_calibration_indices(3, calibration) == calibration
+    assert authority.require_calibration_indices(0, ()) == ()
+
+    with pytest.raises(ValueError, match="complete frozen qualification"):
+        authority.require_qualification_indices(qualification[:-1])
+    with pytest.raises(ValueError, match="exact order"):
+        authority.require_qualification_indices(tuple(reversed(qualification)))
+    with pytest.raises(ValueError, match="complete frozen final-assessment"):
+        authority.require_final_assessment_indices(final_assessment[:-1])
+    with pytest.raises(ValueError, match="canonical order"):
+        authority.require_calibration_indices(3, tuple(reversed(calibration)))
+
+
+def test_serialization_roundtrip_and_restore_are_exact_and_deterministic():
+    data, split, authority = _authority()
+    payload = authority.to_dict()
+    restored_authority = ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+    restored_split = restored_authority.restore(data)
+
+    assert restored_authority.authority_fingerprint == authority.authority_fingerprint
+    assert restored_authority.to_dict() == payload
+    assert restored_split.fingerprint == split.fingerprint
+    assert np.array_equal(restored_split.qualification_indices, split.qualification_indices)
+    assert np.array_equal(
+        restored_split.final_assessment_indices, split.final_assessment_indices
+    )
+    for budget in (0, 1, 3, 6):
+        assert np.array_equal(
+            restored_split.calibration_indices(budget), split.calibration_indices(budget)
+        )
+
+
+def test_tampered_serialized_final_set_fails_its_independent_sha_identity():
+    _, _, authority = _authority()
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    values = list(payload["final_assessment_indices"])
+    values[0], values[1] = values[1], values[0]
+    payload["final_assessment_indices"] = values
+
+    with pytest.raises(ValueError, match="final_assessment_set_sha256"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+
+def test_pairwise_overlap_fails_before_dataset_restore():
+    _, _, authority = _authority()
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload.pop("qualification_set_sha256")
+    payload.pop("final_assessment_set_sha256")
+    payload["final_assessment_indices"][0] = payload["qualification_indices"][0]
+
+    with pytest.raises(ValueError, match="pairwise disjoint"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+
+def test_processed_data_change_fails_before_reconstructed_split_is_trusted():
+    data, _, authority = _authority()
+    changed_x = np.array(data.X, copy=True)
+    changed_x[0, 0, 0] += 0.125
+    changed = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=changed_x,
+        y=np.array(data.y, copy=True),
+        groups={key: np.array(values, copy=True) for key, values in data.groups.items()},
+        metadata=data.metadata,
+    )
+
+    with pytest.raises(ValueError, match="processed neural data SHA-256"):
+        authority.restore(changed)
+
+
+def test_chronology_tampering_fails_even_with_self_consistent_new_authority_hash():
+    data, _, authority = _authority()
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["observed_group_order"] = ["0", "2", "1"]
+    tampered = ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    with pytest.raises(ValueError, match="deployment-unit order"):
+        tampered.restore(data)
+
+
+def test_schema_and_history_policy_fail_closed():
+    _, _, authority = _authority()
+    payload = copy.deepcopy(authority.to_dict())
+    payload["schema_version"] = 1
+    with pytest.raises(ValueError, match="schema_version=2"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["history_policy"] = "future-data"
+    with pytest.raises(ValueError, match="unsupported history_policy"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)

--- a/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
@@ -171,6 +171,34 @@ def test_pairwise_overlap_fails_before_dataset_restore():
         ThreeWayLongitudinalCaseAuthority.from_dict(payload)
 
 
+def test_serialized_numeric_fields_are_validated_not_coerced():
+    _, _, authority = _authority()
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["qualification_indices"][0] = 3.5
+    with pytest.raises(ValueError, match="integer sample indices"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["n_samples"] = float(payload["n_samples"])
+    with pytest.raises(ValueError, match="n_samples must be an integer"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["seed"] = True
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["input_shape"][1] = 4.5
+    with pytest.raises(ValueError, match="integer dimensions"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+
 def test_processed_data_change_fails_before_reconstructed_split_is_trusted():
     data, _, authority = _authority()
     changed_x = np.array(data.X, copy=True)

--- a/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
@@ -225,7 +225,7 @@ def test_prior_chronology_tampering_fails_at_authority_construction():
         ThreeWayLongitudinalCaseAuthority.from_dict(payload)
 
 
-def test_metadata_must_be_deterministic_and_finite():
+def test_metadata_must_be_deterministic_finite_and_deeply_immutable():
     _, split, _ = _authority()
 
     with pytest.raises(ValueError, match="NaN or infinity"):
@@ -243,6 +243,30 @@ def test_metadata_must_be_deterministic_and_finite():
             history_policy="prior",
             case_metadata={"opaque": object()},
         )
+
+    source_metadata = {
+        "protocol": {"name": "three-way", "thresholds": [0.1, 0.2]},
+        "flags": ["frozen", "prospective"],
+    }
+    authority = ThreeWayLongitudinalCaseAuthority.from_split(
+        split,
+        case_id="immutable-metadata",
+        history_policy="prior",
+        case_metadata=source_metadata,
+    )
+    fingerprint = authority.authority_fingerprint
+    serialized = authority.to_dict()
+
+    source_metadata["protocol"]["name"] = "mutated-outside"
+    source_metadata["flags"].append("mutated-outside")
+    assert authority.authority_fingerprint == fingerprint
+    assert authority.to_dict() == serialized
+
+    with pytest.raises(TypeError):
+        authority.case_metadata["protocol"]["name"] = "mutated-inside"  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        authority.case_metadata["flags"].append("mutated-inside")  # type: ignore[union-attr]
+    assert authority.authority_fingerprint == fingerprint
 
 
 def test_declared_group_identity_invariants_fail_before_restore():

--- a/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
@@ -199,6 +199,32 @@ def test_serialized_numeric_fields_are_validated_not_coerced():
         ThreeWayLongitudinalCaseAuthority.from_dict(payload)
 
 
+def test_serialized_identity_fields_are_not_repaired():
+    _, _, authority = _authority()
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["dataset_id"] = 123
+    with pytest.raises(ValueError, match="serialized dataset_id must be a string"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["held_out_values"] = "2"
+    with pytest.raises(TypeError, match="array of strings"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    calibration = dict(payload["calibration_order_by_class"])
+    first_key = next(iter(calibration))
+    values = calibration.pop(first_key)
+    calibration[7] = values
+    payload["calibration_order_by_class"] = calibration
+    with pytest.raises(ValueError, match="class labels must be strings"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+
 def test_processed_data_change_fails_before_reconstructed_split_is_trusted():
     data, _, authority = _authority()
     changed_x = np.array(data.X, copy=True)
@@ -242,6 +268,14 @@ def test_metadata_must_be_deterministic_finite_and_deeply_immutable():
             case_id="object-metadata",
             history_policy="prior",
             case_metadata={"opaque": object()},
+        )
+
+    with pytest.raises(ValueError, match="collide after string normalization"):
+        ThreeWayLongitudinalCaseAuthority.from_split(
+            split,
+            case_id="colliding-metadata-keys",
+            history_policy="prior",
+            case_metadata={1: "integer-key", "1": "string-key"},
         )
 
     source_metadata = {

--- a/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
+++ b/packages/neuros-foundation/tests/test_longitudinal_three_way_authority.py
@@ -103,6 +103,9 @@ def test_budget_identities_are_nested_and_final_authority_is_budget_invariant():
     assert authority.final_assessment_set_sha256 == final_identity
     assert authority.qualification_set_sha256 == qualification_identity
 
+    with pytest.raises(ValueError, match="integer"):
+        authority.calibration_budget_sha256(1.5)  # type: ignore[arg-type]
+
 
 def test_exact_set_guards_reject_subsets_supersets_and_reordering():
     _, _, authority = _authority()
@@ -184,15 +187,50 @@ def test_processed_data_change_fails_before_reconstructed_split_is_trusted():
         authority.restore(changed)
 
 
-def test_chronology_tampering_fails_even_with_self_consistent_new_authority_hash():
-    data, _, authority = _authority()
+def test_prior_chronology_tampering_fails_at_authority_construction():
+    _, _, authority = _authority()
     payload = copy.deepcopy(authority.to_dict())
     payload.pop("authority_fingerprint")
     payload["observed_group_order"] = ["0", "2", "1"]
-    tampered = ThreeWayLongitudinalCaseAuthority.from_dict(payload)
 
-    with pytest.raises(ValueError, match="deployment-unit order"):
-        tampered.restore(data)
+    with pytest.raises(ValueError, match="complete chronological prefix"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+
+def test_metadata_must_be_deterministic_and_finite():
+    _, split, _ = _authority()
+
+    with pytest.raises(ValueError, match="NaN or infinity"):
+        ThreeWayLongitudinalCaseAuthority.from_split(
+            split,
+            case_id="nan-metadata",
+            history_policy="prior",
+            case_metadata={"score": float("nan")},
+        )
+
+    with pytest.raises(TypeError, match="JSON-compatible"):
+        ThreeWayLongitudinalCaseAuthority.from_split(
+            split,
+            case_id="object-metadata",
+            history_policy="prior",
+            case_metadata={"opaque": object()},
+        )
+
+
+def test_declared_group_identity_invariants_fail_before_restore():
+    _, _, authority = _authority()
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["observed_group_order"] = ["0", "1", "1", "2"]
+    with pytest.raises(ValueError, match="duplicate"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
+
+    payload = copy.deepcopy(authority.to_dict())
+    payload.pop("authority_fingerprint")
+    payload["source_group_values"] = ["0", "2"]
+    with pytest.raises(ValueError, match="disjoint"):
+        ThreeWayLongitudinalCaseAuthority.from_dict(payload)
 
 
 def test_schema_and_history_policy_fail_closed():

--- a/scripts/evidence/verify_longitudinal_three_way_authority.py
+++ b/scripts/evidence/verify_longitudinal_three_way_authority.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Emit deterministic evidence for the v2 three-way longitudinal authority."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+import numpy as np
+
+from neuros.foundation_models.longitudinal import chronological_partition
+from neuros.foundation_models.longitudinal_three_way import make_three_way_calibration_split
+from neuros.foundation_models.longitudinal_three_way_authority import (
+    ThreeWayLongitudinalCaseAuthority,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+
+def _canonical_sha256(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _fixture() -> GroupedEvaluationData:
+    rng = np.random.default_rng(20260826)
+    X = []
+    y = []
+    metadata = []
+    for session in ("0", "1", "2"):
+        for label in ("left", "right"):
+            for trial in range(12):
+                X.append(rng.normal(size=(4, 16)))
+                y.append(label)
+                metadata.append(
+                    {
+                        "subject": "synthetic-1",
+                        "session": session,
+                        "run": f"run-{trial // 6}",
+                    }
+                )
+    return GroupedEvaluationData.from_moabb_result(
+        (np.asarray(X), np.asarray(y), metadata),
+        dataset_id="synthetic-three-way-authority-v1",
+    )
+
+
+def build_evidence() -> dict[str, Any]:
+    data = _fixture()
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="2",
+    )
+    split = make_three_way_calibration_split(
+        partition,
+        qualification_fraction=0.25,
+        final_assessment_fraction=0.25,
+        seed=23,
+    )
+    authority = ThreeWayLongitudinalCaseAuthority.from_split(
+        split,
+        case_id="synthetic-1/session-2/three-way-v2",
+        history_policy="prior",
+        case_metadata={
+            "purpose": "software-contract-evidence",
+            "final_assessment_policy": "untouched until state and policy freeze",
+        },
+    )
+
+    # Round-trip the serialized authority before emitting evidence. The public
+    # record is therefore evidence of the replayable contract, not only the
+    # in-memory constructor.
+    serialized = authority.to_dict()
+    restored_authority = ThreeWayLongitudinalCaseAuthority.from_dict(serialized)
+    restored_split = restored_authority.restore(data)
+    if restored_split.fingerprint != split.fingerprint:
+        raise RuntimeError("three-way authority replay changed split identity")
+
+    qualification_set = set(restored_authority.qualification_indices)
+    final_set = set(restored_authority.final_assessment_indices)
+    budgets = []
+    for budget in (0, 1, 3, restored_authority.max_budget_per_class):
+        calibration = restored_authority.calibration_indices(budget)
+        calibration_set = set(calibration)
+        if calibration_set & qualification_set:
+            raise RuntimeError("calibration overlaps qualification")
+        if calibration_set & final_set:
+            raise RuntimeError("calibration overlaps final assessment")
+        budgets.append(
+            {
+                "per_class": budget,
+                "n_calibration_samples": len(calibration),
+                "calibration_indices": list(calibration),
+                "calibration_budget_sha256": restored_authority.calibration_budget_sha256(
+                    budget
+                ),
+                "qualification_set_sha256": restored_authority.qualification_set_sha256,
+                "final_assessment_set_sha256": restored_authority.final_assessment_set_sha256,
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "kind": "neuros-longitudinal-three-way-authority-evidence",
+        "authority": restored_authority.to_dict(),
+        "split_manifest": restored_split.manifest(),
+        "calibration_budgets": budgets,
+        "claim_boundary": {
+            "chronological_source_history_enforced": True,
+            "nested_balanced_calibration_enforced": True,
+            "qualification_separate_from_calibration": True,
+            "final_assessment_separate_from_calibration": True,
+            "final_assessment_separate_from_state_selection": True,
+            "processed_data_identity_enforced": True,
+            "serialization_replay_verified": True,
+            "real_dataset_qualified": False,
+            "adaptation_efficacy_qualified": False,
+            "calibration_reduction_qualified": False,
+            "orion_superiority_qualified": False,
+            "hardware_qualified": False,
+            "closed_loop_qualified": False,
+            "clinical_qualified": False,
+        },
+    }
+    payload["evidence_sha256"] = _canonical_sha256(payload)
+    return payload
+
+
+def main() -> None:
+    print(json.dumps(build_evidence(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

PR #44 qualified state-changing ngc-learn Hebbian adaptation under ORION authority and made one statistical boundary explicit: if held-out rows influence retain-versus-rollback, they are a qualification/state-selection set rather than an untouched final test set.

This PR adds the missing longitudinal authority needed to enforce that distinction in adaptive efficacy studies without modifying or invalidating the existing v1 evidence schema.

## Additive v2 contract

The existing `NestedCalibrationSplit` and `LongitudinalCaseAuthority` remain unchanged and replayable.

This PR adds:

- `ThreeWayCalibrationSplit`
- `make_three_way_calibration_split(...)`
- `ThreeWayLongitudinalCaseAuthority`

The held-out deployment unit is frozen into three distinct target roles:

1. calibration rows, with balanced nested per-class budgets;
2. qualification rows, which may be used for retain/rollback or other state selection;
3. final-assessment rows, which must remain untouched until state and policy are frozen.

## Qualified invariants

The v2 split/authority enforce:

- source/history remains separate from the held-out deployment unit;
- calibration, qualification, and final-assessment indices are pairwise disjoint;
- the three target roles cover the held-out partition exactly;
- qualification and final assessment preserve complete held-out class support;
- calibration pools are label-consistent and balanced budgets remain nested;
- selected calibration rows are returned in canonical sample order for order-sensitive method parity;
- qualification/final arrays and calibration orders are immutable;
- qualification and final-assessment sets remain identical across every calibration budget;
- exact set SHA-256 identities bind each target role to the processed-data identity;
- serialization/replay revalidates processed neural SHA, chronology, partition fingerprint, and three-way split fingerprint;
- subsets, supersets, reordering, overlaps, malformed serialized indices, and silent type coercions fail closed;
- nested semantic metadata is deeply frozen and deterministically fingerprinted;
- metadata key normalization collisions, NaN/infinity, and opaque non-JSON values fail closed;
- zero calibration is represented as a true no-update control rather than a synthetic adaptation event.

## Compatibility and migration rule

V1 remains authoritative for predetermined models when its held-out evaluation set does not influence state, thresholds, hyperparameters, or policy.

V2 is required when held-out evidence participates in retain/rollback, early stopping, threshold selection, hyperparameter selection, model/state selection, or any other adaptive decision that would make that evidence scientifically ineligible as an untouched final assessment.

This preserves replayability of existing v1 bundles while preventing qualification evidence from being relabeled as final test evidence.

## Deterministic evidence worker

`scripts/evidence/verify_longitudinal_three_way_authority.py` constructs a deterministic synthetic longitudinal case, serializes/restores the v2 authority, and emits per-budget identities. CI executes it twice and requires byte-identical JSON.

Each calibration budget receives its own calibration identity while sharing exactly one qualification-set identity and one final-assessment identity.

## Adversarial coverage

The tests cover:

- pairwise role overlap;
- wrong-class calibration rows;
- insufficient held-out class support;
- invalid fractions and calibration budgets;
- subsets, supersets, and reordering;
- tampered serialized final-assessment identity;
- malformed fractional/bool indices and malformed scalar types;
- processed-data mutation;
- declared and observed chronology tampering;
- history-policy violations;
- metadata mutability and caller aliasing;
- non-finite/opaque metadata;
- normalized metadata-key collisions;
- schema-version violations.

## Exact-head qualification

Final head: `ff811a872dfcd2534e93a66f890296eef26b00d2`

All exact-head workflows are green:

- neurOS real-world evidence
- neurOS CI
- ORION Adaptation Authority
- ngc-learn Hebbian Adaptation
- Braindecode Longitudinal Evidence
- NeuroAI Ecosystem Evidence
- Ecosystem Compatibility
- Public Trust Contracts

The branch is behind `main` by 0 at final qualification time.

## Claim boundary

This PR qualifies a software/evaluation-authority contract. It does **not** claim:

- real-dataset adaptive efficacy;
- reduced calibration burden;
- ORION superiority;
- Hebbian superiority;
- online adaptation safety;
- hardware or closed-loop performance;
- clinical validity.

The next evidence rung should compose this exact v2 authority with real longitudinal neural data and multiple matched adaptive/frozen methods, then score the selected states once on the untouched final-assessment partition.