### PR TITLE
Synthetic BCI Arena: causal EEG world models, populations, and hardware-free conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,15 @@ jobs:
           python -m pip install build
       - name: Build every workspace distribution
         run: |
+          set -euo pipefail
           DIST="${RUNNER_TEMP}/neuros-wheels"
           mkdir -p "${DIST}"
-          for package in \
-            packages/neuros-core \
-            packages/neuros-drivers \
-            packages/neuros-models \
-            packages/neuros-foundation \
-            packages/neuros-ui \
-            packages/neuros-cloud \
-            packages/neuros \
-            packages/neuros-mechint \
-            packages/neuros-neurofm \
-            packages/neuros-sourceweigher \
-            packages/orion
+          mapfile -t PACKAGES < <(python scripts/list_workspace_packages.py)
+          for package in "${PACKAGES[@]}"
           do
             python -m build --wheel --outdir "${DIST}" "${package}"
           done
-          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 11
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq "${#PACKAGES[@]}"
 
   kernel-contracts:
     name: Kernel contracts / Python ${{ matrix.python-version }}
@@ -74,6 +65,7 @@ jobs:
           python -m pip install -e "packages/neuros-core[test]"
       - name: Run kernel contract tests
         run: |
+          python scripts/list_workspace_packages.py --json
           pytest -q \
             tests/test_kernel_contracts.py \
             tests/test_runtime_queues.py \

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -9,6 +9,7 @@ on:
       - "docs/RELEASE_POLICY.md"
       - "docs/SCIENTIFIC_CLAIMS.md"
       - "scripts/check_public_contracts.py"
+      - "scripts/list_workspace_packages.py"
       - "mkdocs.yml"
   workflow_dispatch:
   push:
@@ -48,22 +49,12 @@ jobs:
           set -euo pipefail
           DIST="${RUNNER_TEMP}/neuros-release"
           mkdir -p "${DIST}"
-          for package in \
-            packages/neuros-core \
-            packages/neuros-drivers \
-            packages/neuros-models \
-            packages/neuros-foundation \
-            packages/neuros-ui \
-            packages/neuros-cloud \
-            packages/neuros \
-            packages/neuros-mechint \
-            packages/neuros-neurofm \
-            packages/neuros-sourceweigher \
-            packages/orion
+          mapfile -t PACKAGES < <(python scripts/list_workspace_packages.py)
+          for package in "${PACKAGES[@]}"
           do
             python -m build --wheel --outdir "${DIST}" "${package}"
           done
-          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 11
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq "${#PACKAGES[@]}"
           python -m twine check "${DIST}"/*.whl
       - name: Generate component and checksum manifests
         run: |
@@ -73,9 +64,17 @@ jobs:
           import hashlib
           import json
           import os
+          import subprocess
+          import sys
           from pathlib import Path
           from zipfile import ZipFile
 
+          expected_count = int(
+              subprocess.check_output(
+                  [sys.executable, "scripts/list_workspace_packages.py", "--count"],
+                  text=True,
+              ).strip()
+          )
           dist = Path(os.environ["RUNNER_TEMP"]) / "neuros-release"
           artifacts = []
           for wheel in sorted(dist.glob("*.whl")):
@@ -96,9 +95,9 @@ jobs:
               if set(fields) != {"name", "version"}:
                   raise SystemExit(f"missing package metadata in {wheel.name}")
               artifacts.append({"file": wheel.name, "sha256": digest, **fields})
-          if len(artifacts) != 11:
-              raise SystemExit(f"expected 11 wheels, found {len(artifacts)}")
-          if len({item["name"] for item in artifacts}) != 11:
+          if len(artifacts) != expected_count:
+              raise SystemExit(f"expected {expected_count} wheels, found {len(artifacts)}")
+          if len({item["name"] for item in artifacts}) != expected_count:
               raise SystemExit("release contains duplicate distribution names")
           manifest = {
               "schema_version": 1,
@@ -121,36 +120,42 @@ jobs:
           set -euo pipefail
           cd "${RUNNER_TEMP}/neuros-release"
           sha256sum --check SHA256SUMS
-      - name: Smoke-install the public SDK from this exact wheel set
+      - name: Smoke-install the public SDK and Arena from this exact wheel set
         run: |
           set -euo pipefail
           DIST="${RUNNER_TEMP}/neuros-release"
           python -m venv "${RUNNER_TEMP}/release-smoke"
           PY="${RUNNER_TEMP}/release-smoke/bin/python"
           NEUROS="${RUNNER_TEMP}/release-smoke/bin/neuros"
+          ARENA="${RUNNER_TEMP}/release-smoke/bin/neuros-arena"
           "${PY}" -m pip install --upgrade pip
 
           CORE_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_core-*.whl' -print -quit)"
           DRIVERS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_drivers-*.whl' -print -quit)"
+          ARENA_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_arena-*.whl' -print -quit)"
           MODELS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_models-*.whl' -print -quit)"
           SDK_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros-[0-9]*.whl' -print -quit)"
           test -n "${CORE_WHEEL}"
           test -n "${DRIVERS_WHEEL}"
+          test -n "${ARENA_WHEEL}"
           test -n "${MODELS_WHEEL}"
           test -n "${SDK_WHEEL}"
 
-          # Install all internal SDK dependencies explicitly from the artifacts
-          # produced by this exact source revision. External third-party
-          # dependencies may resolve normally, but neurOS components cannot be
-          # substituted by a stale or unrelated package index artifact.
+          # Install internal public-runtime dependencies explicitly from the
+          # artifacts produced by this exact source revision. External
+          # third-party dependencies may resolve normally, but neurOS
+          # components cannot be substituted by stale package-index artifacts.
           "${PY}" -m pip install \
             "${CORE_WHEEL}" \
             "${DRIVERS_WHEEL}" \
             "${MODELS_WHEEL}" \
-            "${SDK_WHEEL}"
+            "${SDK_WHEEL}" \
+            "${ARENA_WHEEL}"
           "${PY}" -m pip check
           "${NEUROS}" doctor --json
           "${NEUROS}" compatibility --json
+          "${ARENA}" --preset dual-target-smoke --output "${RUNNER_TEMP}/arena-wheel-smoke.json"
+          test -s "${RUNNER_TEMP}/arena-wheel-smoke.json"
       - name: Upload immutable release-candidate bundle
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/synthetic-arena.yml
+++ b/.github/workflows/synthetic-arena.yml
@@ -1,0 +1,100 @@
+name: Synthetic BCI Arena
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-arena/**"
+      - "packages/neuros-core/src/neuros/plugins/**"
+      - "packages/neuros-drivers/**"
+      - "packages/neuros-sourceweigher/**"
+      - "tests/test_synthetic_bci_arena.py"
+      - "tests/test_arena_*.py"
+      - "tests/test_plugin_registry.py"
+      - "examples/arena/**"
+      - ".github/workflows/synthetic-arena.yml"
+      - "pyproject.toml"
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  arena-contracts:
+    name: Arena contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install local Arena stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-drivers
+          python -m pip install -e "packages/neuros-arena[test]"
+      - name: Run deterministic Arena contracts
+        run: |
+          pytest -q \
+            tests/test_synthetic_bci_arena.py \
+            tests/test_arena_world_models.py \
+            tests/test_arena_leadfield.py \
+            tests/test_arena_population.py \
+            tests/test_arena_conformance.py \
+            tests/test_arena_timing.py \
+            tests/test_arena_benchmark.py \
+            tests/test_arena_recording_metadata.py \
+            tests/test_plugin_registry.py
+      - name: Exercise preset, manifest, and benchmark CLI
+        run: |
+          OUT="${RUNNER_TEMP}/arena"
+          mkdir -p "${OUT}"
+          neuros-arena --preset dual-target-smoke --output "${OUT}/smoke.json" --write-manifest "${OUT}/world.json"
+          neuros-arena --manifest examples/arena/dual_target_custom.json --output "${OUT}/custom.json" --npz "${OUT}/custom.npz"
+          neuros-arena --benchmark-pack examples/arena/benchmark_packs/eeg_game_system_v1.json --output "${OUT}/benchmark.json"
+          test -s "${OUT}/smoke.json"
+          test -s "${OUT}/world.json"
+          test -s "${OUT}/custom.json"
+          test -s "${OUT}/custom.npz"
+          test -s "${OUT}/benchmark.json"
+
+  reality-anchor:
+    name: Arena real-domain anchoring
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install local reality stack
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-drivers
+          python -m pip install -e packages/neuros-sourceweigher
+          python -m pip install -e "packages/neuros-arena[test]"
+      - name: Qualify SourceWeigher and held-out reality bridges
+        run: |
+          pytest -q \
+            tests/test_arena_reality_anchor.py \
+            tests/test_arena_scientific_validation.py \
+            tests/test_arena_cohort_study.py
+
+  arena-wheel:
+    name: Arena wheel build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip build
+      - run: python -m build --wheel packages/neuros-arena --outdir "${RUNNER_TEMP}/dist"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ pytest tests/
 python scripts/check_repo_hygiene.py
 ```
 
+The root `pyproject.toml` workspace is the canonical maintained-package inventory. CI and release tooling derive package membership from it through `scripts/list_workspace_packages.py`; do not add parallel hard-coded package lists.
+
 ## Architecture rule
 
 Dependency direction should remain:
@@ -44,11 +46,11 @@ Dependency direction should remain:
 neural contracts
       <- runtime / config / recording / quality
       <- drivers / task models / SDK
-      <- ORION / foundation / transfer / mechanism integrations
+      <- ORION / foundation / transfer / mechanism / Arena integrations
       <- experiments and studies
 ```
 
-A kernel package must not import a research implementation. New hardware, transforms, tokenizers, encoders, decoders, sinks, and monitors should normally enter through plugin interfaces. Model/research ecosystems should use narrow adapters rather than making the runtime aware of their internals.
+A kernel package must not import a research implementation. New hardware, transforms, tokenizers, encoders, decoders, sinks, monitors, and neural world models should normally enter through plugin interfaces. Model/research ecosystems should use narrow adapters rather than making the runtime aware of their internals.
 
 ## Where changes belong
 
@@ -71,6 +73,22 @@ Avoid hardware SDKs, task-specific models, cloud vendors, large deep-learning fr
 Maintained source integrations and simulated/data sources. Optional device dependencies belong in extras or external plugin distributions.
 
 A driver PR claiming hardware support should separate software contract tests from device qualification. Qualification evidence must identify the exact device, firmware, transport, OS, plugin revision, and protocol used.
+
+### `packages/neuros-arena`
+
+Deterministic closed-loop synthetic BCI systems worlds for falsification, conformance, fault injection, population coverage, and counterexample search.
+
+Arena changes should preserve explicit causal boundaries between:
+
+- requested stimulus and actually emitted display history;
+- neural-world dynamics and sensor/device effects;
+- device timing and transport behavior;
+- decoder outputs and application authority;
+- synthetic evidence and real human evidence.
+
+A new world model should normally implement the `neuros.world_models` plugin boundary rather than owning display/device/network/application semantics. More physiological complexity is not automatically stronger evidence. Promotion requires a declared model identity, deterministic/replayable behavior where applicable, metamorphic or ground-truth tests, and an explicit statement of what the model cannot establish.
+
+Public-data similarity or SourceWeigher weights must be described as similarity under the chosen geometry, not as probabilities that synthetic participants are biologically true.
 
 ### `packages/neuros-models`
 
@@ -128,9 +146,9 @@ A new adapter establishes an execution boundary, not truth about a discovered me
 
 ### `packages/orion`
 
-Neural tokenization, representation, adaptation, and neural-intelligence contracts/implementations that have a common evaluation path. New ORION methods require leakage-controlled comparative evidence.
+Neural tokenization, representation, adaptation, assessment authority, and neural-intelligence contracts/implementations that have a common evaluation path. New ORION methods require leakage-controlled comparative evidence.
 
-Fit, representation training, adaptation, and final evaluation partitions should remain explicit. New tokenizers or representations should be compared against simpler controls under matched downstream capacity and compute where practical.
+Fit, representation training, calibration, qualification/model selection, adaptation, and final evaluation partitions should remain explicit. New tokenizers or representations should be compared against simpler controls under matched downstream capacity and compute where practical. Untouched final-assessment rows must never become an implicit adaptation or model-selection pool.
 
 ### `packages/neuros-neurofm` and research packages
 
@@ -140,7 +158,7 @@ A NeuroFM implementation moves behind a promoted ORION interface only after it s
 
 ### `packages/neuros-ui` and `packages/neuros-cloud`
 
-Optional UI/API/distributed integration surfaces. These packages should consume the same config/runtime/event contracts as local execution rather than creating alternate orchestration semantics.
+Optional UI/API/distributed integration surfaces. These packages should consume the same config/runtime/event/evidence contracts as local execution rather than creating alternate orchestration semantics.
 
 Provider- or UI-specific claims require their own tests. Package version numbers alone do not imply kernel-level qualification.
 
@@ -172,6 +190,7 @@ neuros.encoders
 neuros.decoders
 neuros.sinks
 neuros.monitors
+neuros.world_models
 ```
 
 A plugin should:
@@ -181,9 +200,10 @@ A plugin should:
 3. expose deterministic configuration options;
 4. fail with a useful typed error when prerequisites are absent;
 5. include a contract test;
-6. include real-hardware qualification evidence separately if hardware support is claimed.
+6. declare compatible neurOS package ranges in package metadata rather than relying on undocumented assumptions;
+7. include real-hardware qualification evidence separately if hardware support is claimed.
 
-External plugins should not require edits to `neuros-core` unless they reveal a genuinely missing general contract.
+External plugins should not require edits to `neuros-core` unless they reveal a genuinely missing general contract. Plugin authors should depend on the narrowest stable package surface needed by their plugin rather than the entire monorepo.
 
 ## Runtime changes
 
@@ -215,7 +235,7 @@ NWB/Zarr interoperability should not weaken the canonical lossless replay contra
 
 ## Scientific and ORION changes
 
-Scientific comparisons must separate fit/train/adaptation/discovery/evaluation data where relevant. A new tokenizer, representation, transfer method, or mechanistic claim should include appropriate controls and report more than one convenient metric.
+Scientific comparisons must separate fit/train/adaptation/discovery/evaluation data where relevant. A new tokenizer, representation, transfer method, world model, or mechanistic claim should include appropriate controls and report more than one convenient metric.
 
 At minimum consider:
 
@@ -230,6 +250,7 @@ At minimum consider:
 - runtime and memory;
 - representation geometry/domain leakage;
 - mechanism intervention/faithfulness where claimed;
+- synthetic-world sensitivity/counterexamples where applicable;
 - reproducibility seed/config/data/artifact manifests.
 
 Do not describe synthetic, software-only, or public-dataset evidence as hardware or clinical validation.
@@ -248,7 +269,7 @@ Use the weakest accurate evidence label:
 8. closed-loop qualification;
 9. clinical evidence.
 
-A passing unit test is not evidence for a device latency claim. A hardware smoke test is not clinical validation. A model-level causal intervention is not automatically a biological mechanism.
+A passing unit test is not evidence for a device latency claim. A hardware smoke test is not clinical validation. A model-level causal intervention is not automatically a biological mechanism. A simulator passing its own benchmark is not proof of human BCI performance.
 
 ## Pull requests
 
@@ -291,7 +312,7 @@ Run:
 python scripts/check_repo_hygiene.py
 ```
 
-before submitting structural changes.
+before submitting structural changes. The hygiene check automatically includes every workspace package README, so a new maintained distribution must ship a current README as part of its addition.
 
 ## Security, privacy, and safety
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **neurOS is an open execution and evidence platform for neural interfaces.**
 
-The goal is not to replace the neuroscience ecosystem. neurOS provides the stable runtime, replay, interoperability, and evidence semantics needed to make neural systems reproducible across hardware, models, datasets, sessions, and people.
+The goal is not to replace the neuroscience ecosystem. neurOS provides stable runtime, replay, interoperability, synthetic systems falsification, and evidence semantics needed to make neural systems reproducible across hardware, models, datasets, sessions, and people.
 
-**ORION** is the complementary neural-intelligence plane for tokenization, learned representations, transfer, personalization, and auditable adaptation.
+**ORION** is the complementary neural-intelligence plane for tokenization, learned representations, transfer, personalization, auditable adaptation, and frozen final assessment.
 
-> **Status:** active research and engineering platform. Software maturity, package versions, and passing CI do not imply hardware qualification, clinical validation, biological correctness, or safety certification.
+> **Status:** active research and engineering platform. Software maturity, package versions, synthetic studies, and passing CI do not imply hardware qualification, clinical validation, biological correctness, or safety certification.
 
 ## Four public surfaces
 
@@ -16,10 +16,12 @@ The repository contains multiple internal distributions, but the public product 
 | --- | --- |
 | **neurOS** | acquisition contracts, timing, runtime graphs, recording/replay, plugins, configuration, deployment semantics |
 | **ORION** | neural tokenization, representations, foundation encoders, transfer, personalization, adaptation |
-| **Evidence** | protocol identity, real-dataset benchmarks, calibration, robustness, transfer, mechanistic interventions, qualification |
-| **Studio** | inspection of live/replayed runtime state, signals, representations, adaptation, latency, and evidence |
+| **Evidence** | protocol identity, real-dataset benchmarks, Arena worlds, robustness, transfer, mechanistic interventions, qualification and claim authority |
+| **Studio** | inspection of live/replayed runtime state, signals, Arena worlds, representations, adaptation, latency, and evidence |
 
-Read [`docs/PLATFORM.md`](docs/PLATFORM.md) for the governing architecture, [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) for the evidence-backed ecosystem matrix, and [`docs/getting-started/first-10-minutes.md`](docs/getting-started/first-10-minutes.md) for the shortest end-to-end newcomer path.
+`neuros-arena` belongs to **Evidence**. It is a deterministic BCI systems wind tunnel for finding failures across display, neural-world, device, transport, decoder, and application boundaries. It is not a fifth product surface and a simulator cannot self-promote a biological claim.
+
+Read [`docs/PLATFORM.md`](docs/PLATFORM.md) for the governing architecture, [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) for the evidence-backed ecosystem matrix, [`docs/SYNTHETIC_BCI_ARENA.md`](docs/SYNTHETIC_BCI_ARENA.md) for the Arena contract, and [`docs/getting-started/first-10-minutes.md`](docs/getting-started/first-10-minutes.md) for the shortest newcomer path.
 
 ## Architecture
 
@@ -43,17 +45,19 @@ hardware / LSL / datasets / replay
                             ORION           Evidence
                      representation +      benchmark +
                         adaptation         qualification
+                                                |
+                                                +-> Arena / counterexamples
                               \                /
                                +------+-------+
                                       v
                                     Studio
 ```
 
-The key boundary is intentional:
+The boundaries are intentional:
 
 - **neurOS** answers: _How should neural systems execute reliably and reproducibly?_
 - **ORION** answers: _How should neural activity be represented, transferred, and adapted?_
-- **Evidence** answers: _What exactly supports a scientific or deployment claim?_
+- **Evidence** answers: _What exactly supports a scientific or deployment claim, and how can it be falsified?_
 - **Studio** answers: _How can a developer inspect the running system without creating a second runtime?_
 
 ## Quick start
@@ -83,13 +87,7 @@ The checked-in mock runtime is deliberately training-free so an installation smo
 
 ## Config-first runtime
 
-`SignalFrame` is the stable neural interchange contract. It carries:
-
-- stream and sequence identity;
-- array payload and sample rate;
-- device, host-receive, and synchronized timing semantics;
-- explicit clock domain and quality flags;
-- immutable metadata/provenance.
+`SignalFrame` is the stable neural interchange contract. It carries stream/sequence identity, array payload and sample rate, device/host/synchronized timing, explicit clock domain, quality flags, and immutable metadata/provenance.
 
 A versioned YAML configuration resolves installed plugins into a `RuntimeGraph`:
 
@@ -121,8 +119,6 @@ neuros replay /tmp/session \
 
 The archive preserves sequence/timing/quality metadata, stream descriptors, config identity, Git/package provenance, runtime metrics, and per-frame integrity hashes. NWB and Zarr are interoperability exports rather than replacements for exact neurOS replay semantics.
 
-Replay is the bridge between research and deployment: the same recorded neural input can drive model regressions, ORION experiments, fault injection, latency analysis, representation probes, and evidence generation without requiring the original hardware.
-
 A reproducible software qualification bundle can be sealed and independently verified:
 
 ```bash
@@ -133,6 +129,34 @@ neuros reproduce /tmp/qualification
 ```
 
 Qualification bundles bind configuration, environment, compatibility, clocks/devices, model/runtime evidence, decoder outputs, the recorded session, file hashes, and a root artifact identity. Synthetic qualification cannot self-award a physical hardware claim.
+
+## Synthetic BCI Arena
+
+Arena is the systems-level adversary for hardware-free BCI development:
+
+```bash
+neuros-arena --preset dual-target-smoke --output arena-report.json
+```
+
+Its causal stack is explicit:
+
+```text
+application / task state
+        -> requested stimulus
+        -> actually emitted display history
+        -> neural world model + latent state
+        -> sensor-space EEG
+        -> device / montage / ADC / device clock
+        -> transport / loss / jitter / silence
+        -> decoder / quality authority
+        -> application behavior
+```
+
+Display-coupled world models consume the **sample-and-held emitted waveform after frame quantization, jitter, drops, and held frames**, not an ideal target-frequency oracle. Current model modes include a legacy deterministic fixture, a driven state-space model, semi-synthetic recorded-background replay, and a portable lead-field-driven model.
+
+Arena also provides population sampling, metamorphic checks, portable counterexamples, application traces, and optional SourceWeigher-based reality anchoring. Population coverage is coverage over the declared synthetic envelope, not human prevalence. Similarity weights are not probabilities that a synthetic participant is physiologically true.
+
+See [`docs/EEG_WORLD_MODELS.md`](docs/EEG_WORLD_MODELS.md), [`docs/SCIENTIFIC_VALIDATION_POLICY.md`](docs/SCIENTIFIC_VALIDATION_POLICY.md), and [`docs/PUBLIC_EEG_ANCHORING_STUDY.md`](docs/PUBLIC_EEG_ANCHORING_STUDY.md).
 
 ## Ecosystem compatibility
 
@@ -147,24 +171,11 @@ neuros compatibility ngclearn --json
 neuros compatibility --status planned --json
 ```
 
-A supported or experimental integration must state the exact surface for which executable evidence exists. A planned integration cannot claim a qualification tier.
-
-Current evidence-backed lanes include:
-
-- **BrainFlow** for board-aware live acquisition software contracts;
-- **Lab Streaming Layer** for deterministic stream discovery and explicit clock correction;
-- **MNE-Python** for scientific object interoperability;
-- **NWB / Zarr** for recording export interoperability;
-- **MOABB** for named real-dataset longitudinal EEG evidence;
-- **Braindecode** for a narrow, version-qualified real upstream model/training integration;
-- **SNAP** for backend-invariant spectral representation evidence numerically checked against the authors' pinned upstream implementation;
-- **ngc-learn** for a narrow real upstream 3.2.x RateCell/JAX execution boundary.
-
-Planned targets include Meta NeuralBench, DANDI, SpikeInterface, py_neuromodulation, Open Ephys, an isolated IBM NeuroAIKit reference worker, and selected NeuroAI Lab benchmarks. Research organizations are not treated as monolithic integrations.
+Current evidence-backed lanes include BrainFlow, Lab Streaming Layer, MNE-Python, NWB/Zarr, MOABB, Braindecode, SNAP, and a narrow ngc-learn execution boundary. Planned or exploratory targets are tracked separately and cannot claim a qualification tier.
 
 OpenBCI is currently represented through the BrainFlow device family rather than falsely marked hardware-qualified. Physical qualification requires a named board, firmware, transport, host, protocol, and measured evidence bundle.
 
-See [`docs/NEUROAI_ECOSYSTEM.md`](docs/NEUROAI_ECOSYSTEM.md) for the NeuroAI-specific boundaries.
+See [`docs/NEUROAI_ECOSYSTEM.md`](docs/NEUROAI_ECOSYSTEM.md) and [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
 
 ### MNE ↔ neurOS
 
@@ -206,16 +217,13 @@ software contract
       -> clinical
 ```
 
-The current real-world program includes subject/session/run-aware longitudinal EEG evaluation through MOABB, frozen calibration/evaluation authority, model ladders, representation transfer lanes, and SourceWeigher comparisons. See:
+The real-world program includes subject/session/run-aware longitudinal EEG evaluation through MOABB, frozen calibration/evaluation authority, model ladders, representation transfer lanes, and SourceWeigher comparisons. ORION now additionally separates calibration, qualification/model selection, selected state, and untouched final assessment.
 
-- [`docs/REAL_WORLD_EVIDENCE.md`](docs/REAL_WORLD_EVIDENCE.md)
-- [`docs/LONGITUDINAL_EEG_SHOWCASE.md`](docs/LONGITUDINAL_EEG_SHOWCASE.md)
-- [`docs/LONGITUDINAL_MODEL_LADDER.md`](docs/LONGITUDINAL_MODEL_LADDER.md)
-- [`docs/SCIENTIFIC_CLAIMS.md`](docs/SCIENTIFIC_CLAIMS.md)
+A useful neural-system result should describe the dimensions relevant to its claim, such as task utility, calibration cost, subject/session/site/device transfer, montage robustness, artifact sensitivity, representation geometry, causal/mechanistic evidence, uncertainty, runtime latency/resource use, and immutable protocol/model/data identities.
 
-The objective is broader than accuracy. A useful neural-system result should describe the dimensions relevant to its claim, such as task utility, calibration cost, subject/session/site/device transfer, montage robustness, artifact sensitivity, representation geometry, causal/mechanistic evidence, uncertainty, runtime latency/resource use, and immutable protocol/model/data identities.
+A strong result in one dimension does not silently promote another. Representation similarity is not task utility. Attribution is not mechanism. Synthetic conformance is not human performance. Hardware qualification is not closed-loop qualification. Closed-loop evidence is not clinical certification.
 
-A strong result in one dimension does not silently promote another. Representation similarity is not task utility. Attribution is not mechanism. Hardware qualification is not closed-loop qualification. Closed-loop evidence is not clinical certification.
+See [`docs/REAL_WORLD_EVIDENCE.md`](docs/REAL_WORLD_EVIDENCE.md), [`docs/SCIENTIFIC_CLAIMS.md`](docs/SCIENTIFIC_CLAIMS.md), and [`docs/FINAL_ASSESSMENT_AUTHORITY.md`](docs/FINAL_ASSESSMENT_AUTHORITY.md).
 
 ## ORION
 
@@ -251,9 +259,9 @@ python scripts/orion/run_tokenizer_benchmark.py \
   --output /tmp/orion-tokenization
 ```
 
-Synthetic motif benchmarks are falsification tools, not proof that a tokenizer is superior on real human neural data. ORION promotion requires leakage-controlled, deployment-unit-disjoint evidence.
+Synthetic motif benchmarks are falsification tools, not proof that a tokenizer is superior on real human neural data. ORION promotion requires leakage-controlled, deployment-unit-disjoint evidence. Adaptation cannot consume final-assessment rows, and the selected state evaluated at final assessment must be the exact state qualified before those rows were opened.
 
-A central ORION research target is to measure whether learned representations can preserve or improve held-out neural utility while reducing per-user calibration, without trading away robustness, latency, provenance, uncertainty calibration, or representation stability.
+A central ORION target is to measure whether learned representations can preserve or improve held-out neural utility while reducing per-user calibration, without trading away robustness, latency, provenance, uncertainty calibration, or representation stability.
 
 ## Models, transfer, and mechanisms
 
@@ -279,11 +287,14 @@ neuros.encoders
 neuros.decoders
 neuros.sinks
 neuros.monitors
+neuros.world_models
 ```
 
-The kernel does not import concrete hardware, model ecosystems, UI/cloud integrations, or ORION implementations.
+The kernel does not import concrete hardware, model ecosystems, UI/cloud integrations, ORION implementations, or Arena world-model implementations. A world-model plugin owns neural dynamics, not display/device/transport/application semantics.
 
 A useful integration should solve a concrete boundary problem: canonical conversion, synchronization, conformance, reproducibility, evidence, transfer/adaptation, or duplicated glue assumptions. Package-name accumulation is not a goal.
+
+A maintained out-of-tree plugin authoring kit and clean-wheel compatibility lane are the next major developer-preview usability gate.
 
 ## Scientific trust and releases
 
@@ -297,32 +308,33 @@ The public repository treats project citizenship as an executable surface rather
 - [`docs/RELEASE_POLICY.md`](docs/RELEASE_POLICY.md) governs versioning, deprecation, exact-head release qualification, checksums, and publishing authority;
 - [`CHANGELOG.md`](CHANGELOG.md) records maintained user-facing changes going forward.
 
-Dedicated CI validates the citation schema and public contracts, builds documentation with warnings treated as failures, builds all workspace wheels, validates package metadata, creates SHA-256/component manifests, and smoke-installs the public SDK from the exact wheel set produced by the source revision.
+The root `pyproject.toml` workspace is the single maintained-package inventory. CI, repository hygiene, and release-candidate tooling derive package membership from it through `scripts/list_workspace_packages.py`. This prevents a new distribution from being added to the workspace while silently disappearing from wheel builds, checksums, or maintained-package documentation checks.
 
-Package publication remains intentionally separate from pull-request authority. PyPI publishing should only be enabled after trusted publishing/OIDC is configured and reviewed.
+Release-candidate CI builds every workspace wheel, validates package metadata, creates SHA-256/component manifests, and smoke-installs the public SDK plus Arena from the exact wheel set produced by the source revision. Package publication remains intentionally separate from pull-request authority. PyPI publishing should only be enabled after trusted publishing/OIDC is configured and reviewed.
 
 ## Internal workspace map
 
 ```text
 packages/
-  neuros-core/          stable runtime/data/replay contracts
+  neuros-core/          stable runtime/data/replay/plugin contracts
   neuros-drivers/       hardware, simulated, dataset, and LSL sources
   neuros/               user-facing SDK, CLI, interoperability composition
+  orion/                stable ORION token/representation/adaptation/assessment contracts
+  neuros-arena/         causal synthetic worlds, faults, populations, counterexamples
   neuros-models/        task decoders and inspectable model surfaces
-  orion/                stable ORION token/representation/adaptation contracts
   neuros-foundation/    foundation-model and real-dataset evidence adapters
-  neuros-sourceweigher/ transfer/source reliability
+  neuros-sourceweigher/ transfer/source reliability and similarity weighting
   neuros-mechint/       causal/mechanistic evidence framework
   neuros-neurofm/       experimental native neural foundation-model R&D
   neuros-ui/            Studio implementation substrate
   neuros-cloud/         optional distributed/provider integrations
 ```
 
-These are implementation boundaries, not eleven competing product identities.
+These are implementation boundaries, not twelve competing product identities.
 
 ## Quality
 
-CI separates kernel contracts across Python 3.10-3.12, installed BCI execution, wheel builds, recording/replay and NWB/Zarr interoperability, scientific/latency gates, model/mechanistic contracts, foundation interoperability, SourceWeigher, ORION, longitudinal real-dataset evidence, hardware-boundary drivers, ecosystem compatibility, NeuroAI upstream conformance, public trust, and release-candidate artifacts.
+CI separates kernel contracts across Python 3.10-3.12, installed BCI execution, workspace wheel builds, recording/replay and NWB/Zarr interoperability, scientific/latency gates, model/mechanistic contracts, foundation interoperability, SourceWeigher, ORION authority, longitudinal real-dataset evidence, hardware-boundary drivers, ecosystem compatibility, NeuroAI upstream conformance, Synthetic BCI Arena, public trust, and release-candidate artifacts.
 
 Hardware-specific claims require recorded qualification manifests for the exact device, firmware, transport, host, configuration, model, and artifact identities involved.
 
@@ -330,13 +342,13 @@ Hardware-specific claims require recorded qualification manifests for the exact 
 
 The highest-value sequence is now:
 
-1. turn the compatibility spine into reusable conformance/evidence manifests without polluting `neuros-core`;
-2. qualify richer ngc-learn predictive-coding/spiking/plasticity surfaces one exact upstream contract at a time;
-3. establish DANDI/SpikeInterface invasive-data interoperability and selected visual-neuroscience benchmark evidence;
-4. qualify one named real-device reference pipeline end to end;
-5. measure ORION calibration reduction on real subject/session/device-disjoint tasks alongside geometry, robustness, uncertainty, and runtime evidence;
-6. converge `neuros-ui` into a coherent Studio experience that displays runtime and claim/evidence status without creating a second execution engine;
-7. add an explicit closed-loop safety/constraint plane before making closed-loop product claims;
+1. ship a maintained out-of-tree plugin authoring kit and clean-wheel compatibility lane so external labs can extend neurOS without kernel forks;
+2. execute the predeclared longitudinal EEG model ladder and ORION calibration-reduction studies under identical frozen split/final-assessment authority;
+3. anchor Arena world banks against held-out public EEG and expand world models only behind the common causal contract;
+4. establish DANDI/SpikeInterface invasive-data interoperability and selected visual-neuroscience benchmark evidence;
+5. qualify one named real-device reference pipeline end to end;
+6. converge `neuros-ui` into a coherent Studio experience that displays runtime, Arena, ORION, and claim/evidence status without creating a second execution engine;
+7. add an explicit closed-loop safety/constraint plane before making stronger closed-loop product claims;
 8. make externally maintained plugins, reference deployments, and reproducible release artifacts easy to build without kernel forks.
 
 See [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md), [`ROADMAP.md`](ROADMAP.md), and [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/docs/EEG_WORLD_MODELS.md
+++ b/docs/EEG_WORLD_MODELS.md
@@ -1,0 +1,316 @@
+# EEG World Models in neurOS Arena
+
+## Goal
+
+`neuros-arena` is not trying to produce one universal fake human brain.
+
+It provides a versioned environment in which multiple neural world models can be tested against the **same** display, device, clock, transport, decoder and application conditions.
+
+The central causal chain is:
+
+```text
+application / experiment state
+        ↓
+requested stimulus or neural task
+        ↓
+actual emitted display / sensory history
+        ↓
+neural world model + latent state
+        ↓
+sensor-space neural signal
+        ↓
+device / montage / ADC / device clock
+        ↓
+transport / packetization / loss / jitter
+        ↓
+decoder + quality authority
+        ↓
+application action
+```
+
+A synthetic system can provide exact causal ground truth and reproduce faults. It cannot, by itself, establish human performance.
+
+## World-model plugin contract
+
+World models are neurOS plugins under:
+
+`neuros.world_models`
+
+A model receives:
+
+- EEG sample timestamps;
+- the **actually emitted** sensory/stimulus waveform after display timing effects;
+- the intended target/task state;
+- an attention/engagement drive for the current v1 SSVEP scenario;
+- model-specific, versioned parameters.
+
+It emits:
+
+- channels × samples sensor-space data;
+- channel names;
+- inspectable latent summaries such as entrainment strength or model state;
+- explicit provenance through the manifest/plugin identity.
+
+The device and transport layers remain outside the model. This prevents a learned generator from silently baking one headset or network into its physiology.
+
+## Current model ladder
+
+### W0: `legacy_synthetic`
+
+The original deterministic neurOS synthetic EEG generator.
+
+Purpose:
+
+- regression fixtures;
+- driver smoke tests;
+- simple frequency-decoder qualification.
+
+Limitation:
+
+- responds to the nominal target frequency rather than the emitted display history.
+
+It is retained deliberately so new models can be compared against a stable legacy baseline.
+
+### W1: `driven_state_space`
+
+Default dependency-light Arena model.
+
+Contains:
+
+- stochastic correlated background state;
+- endogenous posterior alpha;
+- response/entrainment state;
+- damped stimulus-driven dynamics;
+- posterior sensor topography;
+- explicit artifact overlays.
+
+Crucially, its response is forced by Arena's sample-and-held display luminance. Frame drops, frame timing jitter and held frames therefore alter downstream synthetic EEG.
+
+This is a phenomenological dynamical model, not a neural-mass or cellular simulation.
+
+### W2: `semi_synthetic_replay`
+
+Replays a recorded EEG background while injecting a known, display-driven BCI response.
+
+This retains real background covariance, spontaneous rhythms and nuisance structure while preserving known causal labels for the injected signal.
+
+Portable NPZ baseline contract:
+
+- `data_uv`: channels × samples;
+- `sampling_rate_hz`;
+- `channel_names`.
+
+This tier is particularly useful with public MOABB/MNE recordings before local headset access.
+
+It does **not** imply that the injected response is the true physiological response of the recorded participant.
+
+### W3: `leadfield_driven`
+
+Projects the Arena-driven neural response through a frozen sensor topography derived from a forward/lead-field model.
+
+The expensive research step can use MNE-Python:
+
+```python
+from neuros.arena import export_mne_forward_bundle
+
+export_mne_forward_bundle(
+    "subject-fwd.fif",
+    "visual-forward.npz",
+    visual_source_indices=[...],
+    nuisance_source_indices=[...],
+)
+```
+
+Arena then consumes the resulting compact bundle without requiring MNE at runtime.
+
+Source indices are explicit. Arena does not silently guess which cortical vertices correspond to visual cortex or another task generator.
+
+### W4: source/forward simulation adapters
+
+Planned optional research backends:
+
+- MNE `SourceSimulator` / `simulate_raw`;
+- ERP/EOG/ECG/noise injection;
+- head-position / geometry perturbation where supported;
+- subject-specific or template forward solutions.
+
+These models should be used offline or for smaller population studies when full source-space simulation is worth the cost.
+
+### W5: neural-mass / network world models
+
+Planned adapters for packages such as The Virtual Brain or neurolib.
+
+Potential uses:
+
+- sensory drive into occipital network nodes;
+- changing background network state;
+- cross-frequency and network-level propagation;
+- slow state drift;
+- multimodal source generation.
+
+The neural-mass backend must still project to a declared sensor montage and must expose its assumptions. More biological detail does not automatically mean more accurate BCI prediction.
+
+### W6: learned generative/dynamics models
+
+Future `neuros-models` plugins may implement the same world-model contract using learned EEG dynamics, diffusion/state-space generators, latent sequence models or future neural foundation models.
+
+A learned model is not promoted merely because its generated traces look realistic.
+
+Promotion should require:
+
+1. deterministic/reproducible sampling under a fixed seed;
+2. conditioning on declared causal inputs;
+3. held-out real-data comparisons;
+4. preservation of known interventions in generated outputs;
+5. uncertainty/provenance reporting;
+6. conformance under Arena metamorphic tests;
+7. mechanistic/representation diagnostics where useful.
+
+`neuros-mechint` should be used to probe learned generators for stimulus dependence, temporal shortcuts and spurious spectral memorization.
+
+## Synthetic populations, not an average fake person
+
+`neuros-arena` supports distributions over world parameters.
+
+Examples:
+
+- SSVEP response amplitude;
+- alpha frequency and amplitude;
+- response delay;
+- gaze duty cycle;
+- display frame drops;
+- ADC characteristics;
+- packet loss and jitter;
+- world-model parameters.
+
+A population run reports quantiles and retains per-world parameter values.
+
+The result describes coverage over the **declared synthetic envelope**, not prevalence in a human population.
+
+## Metamorphic verification
+
+Many useful properties can be tested without a perfect physiological model.
+
+Examples:
+
+- a higher deterministic packet-drop probability cannot deliver more packets;
+- a higher deterministic frame-drop probability cannot reduce the dropped-frame set;
+- a caller-declared degraded world must not create more gameplay authority;
+- a stale packet must never reactivate an expired application action;
+- source silence must produce a measurable transport gap and safe recovery;
+- display timing changes must causally alter a display-coupled world model.
+
+Arena can search a declared parameter envelope and return the worst resolved manifests as portable counterexamples.
+
+## Real-data anchoring with neurOS SourceWeigher
+
+Synthetic world weights are not manually tuned until one waveform "looks real."
+
+Instead, a bank of worlds can be compared with an observed real/public domain using a declared feature geometry.
+
+Current optional integrations:
+
+- `RiemannianCovarianceWeigher` for sensor covariance geometry;
+- `RepresentationSourceWeigher` for shared `neuros-foundation` embedding spaces.
+
+The resulting weights answer:
+
+> Which simulated domains are most similar to this observed domain under this declared comparison?
+
+They do **not** answer:
+
+> What is the probability that this simulated world is the participant's true brain state?
+
+## neurOS package responsibilities
+
+```text
+neuros-core
+    plugin contracts, provenance, runtime semantics
+
+neuros-drivers
+    physical/synthetic acquisition boundaries
+
+neuros-arena
+    causal worlds, population sweeps, faults, conformance
+
+neuros-foundation / neuros-neurofm
+    real/synthetic representation extraction and probing
+
+neuros-sourceweigher
+    domain similarity, transfer risk, population reweighting
+
+neuros-models
+    learned decoders and future learned world-model plugins
+
+neuros-mechint
+    learned generator/decoder mechanism and shortcut analysis
+
+neuros-cloud
+    distributed population and adversarial world execution
+
+neuros-ui
+    future visual Arena Studio / world builder
+```
+
+No package should duplicate another package's authority.
+
+## Public-data bridge
+
+Recommended progression before local hardware:
+
+1. use MOABB to obtain public SSVEP/P300/MI recordings with standardized paradigm metadata;
+2. convert selected resting/task background windows to the Arena semi-synthetic NPZ contract;
+3. replay real recordings through MNE-LSL/LSL to exercise online pipelines;
+4. extract sensor covariance and foundation-model embeddings;
+5. use SourceWeigher to reweight the synthetic world bank toward observed domains;
+6. hold out subjects/sessions when evaluating whether this improves predictive usefulness.
+
+Current useful SSVEP references in MOABB include datasets with 10 and 12 Hz conditions, making them directly relevant to Mindforge-style dual-target experiments.
+
+## Paradigm-general roadmap
+
+Manifest v1 remains backward-compatible and SSVEP-oriented.
+
+A future manifest v2 should introduce a generic neural drive/event interface rather than overloading `target_frequency_hz`:
+
+```text
+WorldInput
+  paradigm
+  task / intent label
+  sensory event timeline
+  emitted stimulus channels
+  gaze / eye state
+  movement / IMU state
+  controller actions
+  feedback state
+  context covariates
+```
+
+That enables world models for:
+
+- SSVEP / c-VEP;
+- P300 and other ERPs;
+- motor imagery / sensorimotor rhythms;
+- neurofeedback;
+- auditory BCIs;
+- hybrid EEG + IMU/controller systems;
+- creative custom paradigms.
+
+The v2 design should adapt v1 scenarios rather than invalidate existing shared worlds.
+
+## Evidence ladder
+
+```text
+A0 deterministic implementation
+A1 nuisance and intervention ground truth
+A2 display/sensory causality
+A3 acquisition device model
+A4 transport/clock model
+A5 decoder conformance
+A6 application conformance
+A7 public/recorded human-data anchoring
+A8 physical hardware substitution
+A9 local human closed-loop validation
+```
+
+Only the final tiers support corresponding physical/human claims.

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -1,6 +1,6 @@
 # neurOS Platform
 
-neurOS is being converged around four public product surfaces. The repository may contain many internal distributions, experiments, and adapters, but users should not need to learn the monorepo topology before they can understand what the platform does.
+neurOS is being converged around four public product surfaces. The repository may contain multiple distributions, experiments, and adapters, but users should not need to learn the monorepo topology before they can understand what the platform does.
 
 ## The four public surfaces
 
@@ -8,10 +8,12 @@ neurOS is being converged around four public product surfaces. The repository ma
 | --- | --- | --- | --- |
 | **neurOS** | Execute neural systems reliably | acquisition contracts, synchronization, runtime graphs, queues, recording/replay, plugins, configuration, deployment constraints | third-party model zoos, dataset catalogs, speculative research algorithms |
 | **ORION** | Build neural representations that can adapt | tokenization, learned representations, neural encoders, transfer, personalization, auditable adaptation | hardware drivers, transport protocols, application UI orchestration |
-| **Evidence** | Say exactly what a neural-system claim is supported by | benchmark authority, split identity, provenance, calibration curves, robustness, transfer, mechanistic interventions, qualification tiers | marketing claims, implicit validation, hidden benchmark state |
-| **Studio** | Make the running neural system inspectable | runtime graph visualization, signal/quality views, latency, replay comparison, representation diagnostics, adaptation events, evidence inspection | alternate runtime semantics or hidden execution paths |
+| **Evidence** | Say exactly what a neural-system claim is supported by | benchmark authority, split identity, provenance, calibration curves, robustness, transfer, mechanistic interventions, synthetic conformance worlds, qualification tiers | marketing claims, implicit validation, hidden benchmark state |
+| **Studio** | Make the running neural system inspectable | runtime graph visualization, signal/quality views, latency, replay comparison, representation diagnostics, adaptation events, Arena worlds, evidence inspection | alternate runtime semantics or hidden execution paths |
 
 These are conceptual product surfaces, not a demand for four Python distributions. Internal packages should stay split where dependency, release, or scientific boundaries justify it.
+
+`neuros-arena` belongs primarily to the **Evidence** surface. It is the deterministic systems wind tunnel for falsifying assumptions across display, neural-world, device, transport, decoder, and application boundaries. Synthetic success in Arena does not promote a physiological, hardware, human, or clinical claim.
 
 ## Architectural shape
 
@@ -35,14 +37,17 @@ These are conceptual product surfaces, not a demand for four Python distribution
                        | provenance  |
                        +------+------+ 
                               |
-                              v
-                       +-------------+
-                       |   Studio    |
-                       | inspection  |
-                       +-------------+
+                +-------------+-------------+
+                |                           |
+                v                           v
+         +-------------+             +-------------+
+         |    Arena    |             |   Studio    |
+         | falsify +   |             | inspection  |
+         | stress-test |             |             |
+         +-------------+             +-------------+
 ```
 
-Studio is a consumer of stable runtime/evidence contracts. It must never become a second orchestration system.
+Arena produces evidence inputs and counterexamples. Studio consumes stable runtime/evidence contracts. Neither is allowed to become a second orchestration system.
 
 ## Platform invariants
 
@@ -50,11 +55,11 @@ Studio is a consumer of stable runtime/evidence contracts. It must never become 
 
 `neuros-core` may define `SignalFrame`, `StreamDescriptor`, `DecoderOutput`, runtime queues, graph semantics, recording, and plugin contracts. It must not import MNE, BrainFlow, LSL, Braindecode, NeuralBench, MOABB, SpikeInterface, DANDI, ORION implementations, or UI/cloud packages.
 
-Third-party ecosystems are integrated at the edge through adapters and plugins.
+Third-party ecosystems are integrated at the edge through adapters and plugins. Neural world models follow the same rule through the `neuros.world_models` entry-point contract.
 
 ### 2. Interoperate instead of reimplement
 
-neurOS should not build a competing replacement for MNE preprocessing, the Braindecode model zoo, MOABB protocol catalog, NeuralBench task registry, SpikeInterface sorters, DANDI storage, or LSL transport.
+neurOS should not build a competing replacement for MNE preprocessing, the Braindecode model zoo, MOABB protocol catalog, NeuralBench task registry, SpikeInterface sorters, DANDI storage, LSL transport, or mature neural-mass simulators.
 
 The neurOS contribution is to translate these ecosystems into shared execution and evidence semantics:
 
@@ -72,6 +77,8 @@ stable contract + provenance
       v               v
  runtime/replay      Evidence
 ```
+
+Arena follows the same principle. MNE forward models, public EEG, neural-mass simulators, and learned generators may provide world-model inputs or plugins while Arena owns the causal systems envelope around them.
 
 ### 3. A support claim is a data structure
 
@@ -98,6 +105,9 @@ software contract
 integration
       |
       v
+scientific synthetic / replay
+      |
+      v
 real-dataset evidence
       |
       v
@@ -110,32 +120,39 @@ closed-loop qualification
 clinical evidence
 ```
 
-A higher software version never promotes a claim up this ladder automatically.
+A higher software version never promotes a claim up this ladder automatically. Arena lives in the synthetic/replay portion unless an explicitly separate real-data, hardware, or human protocol supplies stronger evidence.
 
 ### 5. Replay is the bridge between research and deployment
 
-A live session should be recordable into a canonical neurOS archive and replayable through the same runtime graph. That allows hardware-independent regression, model comparison, ORION experiments, fault injection, latency analysis, and evidence generation without changing the underlying neural contract.
+A live session should be recordable into a canonical neurOS archive and replayable through the same runtime graph. That allows hardware-independent regression, model comparison, ORION experiments, fault injection, latency analysis, Arena semi-synthetic studies, and evidence generation without changing the underlying neural contract.
 
 ### 6. Ambiguity fails closed
 
-Adapters must not silently guess channel axes, units, stream identity, model family, timestamps, or benchmark partitions. When information is insufficient, the correct behavior is a clear failure with enough context to repair the input.
+Adapters must not silently guess channel axes, units, stream identity, model family, timestamps, benchmark partitions, source-space identity, or assessment rows. When information is insufficient, the correct behavior is a clear failure with enough context to repair the input.
 
-The MNE bridge follows this rule: two-dimensional `SignalFrame` data can only be exported when `axis_order=('sample', 'channel')` is explicit.
+The MNE bridge follows this rule: two-dimensional `SignalFrame` data can only be exported when `axis_order=('sample', 'channel')` is explicit. Arena lead-field bundles require explicit source indices rather than silently guessing a visual source.
+
+### 7. Synthetic systems are adversaries, not authorities
+
+A simulator is useful when it can expose a software or systems failure before hardware or participant time is spent. It is dangerous when a plausible waveform is allowed to masquerade as biological evidence.
+
+Arena therefore keeps requested stimulus, actually emitted display history, neural world state, sensor/device effects, transport faults, decoder outputs, and application behavior as separate inspectable layers. Population summaries describe coverage over the declared synthetic envelope, not prevalence in people. Reality-anchor weights describe similarity under a declared geometry, not a probability that a synthetic participant is physiologically true.
 
 ## Internal package mapping
 
-The current workspace maps onto the public surfaces as follows:
+The current workspace maps onto the public surfaces as follows. `packages/orion` is the repository directory; its Python distribution name is `neuros-orion`.
 
 | Internal distribution | Public surface | Role |
 | --- | --- | --- |
-| `neuros-core` | neurOS | kernel contracts/runtime/replay |
-| `neuros-drivers` | neurOS | acquisition plugins |
+| `neuros-core` | neurOS | kernel contracts/runtime/replay/plugin semantics |
+| `neuros-drivers` | neurOS | physical, dataset, replay, and synthetic acquisition boundaries |
 | `neuros` | neurOS | SDK, CLI, interoperability composition |
+| `neuros-orion` (`packages/orion`) | ORION | stable token/representation/adaptation/assessment interfaces |
+| `neuros-arena` | Evidence | causal synthetic worlds, system faults, populations, counterexamples, reality anchoring |
 | `neuros-models` | neurOS + Evidence | deployable decoders and inspectable model contracts |
 | `neuros-foundation` | ORION + Evidence | external foundation-model adapters and representation benchmarks |
-| `neuros-sourceweigher` | ORION + Evidence | transfer/source reliability |
+| `neuros-sourceweigher` | ORION + Evidence | transfer/source reliability and declared similarity weighting |
 | `neuros-mechint` | Evidence | intervention and mechanistic evidence contracts |
-| `neuros-orion` | ORION | stable token/representation/adaptation interfaces |
 | `neuros-neurofm` | ORION research | native foundation-model experiments |
 | `neuros-ui` | Studio | dashboard and visualization surfaces |
 | `neuros-cloud` | optional infrastructure | distributed/provider integrations |
@@ -146,14 +163,15 @@ This mapping is intentionally asymmetric. Public architecture should be simple e
 
 The preferred sequence is evidence-driven:
 
-1. **Compatibility spine:** BrainFlow, LSL, MNE, NWB/Zarr and MOABB have explicit evidence-backed inventory entries.
-2. **Offline EEG interoperability:** mature MNE/Braindecode/MOABB adapters, without copying their algorithms.
-3. **External benchmark workers:** NeuralBench runs in an isolated environment and emits neurOS evidence artifacts rather than becoming a kernel dependency.
-4. **Invasive data lane:** NWB/DANDI/SpikeInterface adapters and replayable electrophysiology examples.
-5. **Real-device qualification:** named hardware/firmware/transport manifests with measured loss, drift, reconnect behavior and latency.
-6. **ORION real-data promotion:** representations compared on deployment-unit-disjoint datasets with calibration and transfer curves.
-7. **Studio convergence:** one inspection surface for live runtime state, replay, ORION representations and evidence.
-8. **Closed-loop safety plane:** explicit stale-data rejection, confidence/quality gates, action constraints, deadman behavior, rate limits and emergency stop semantics.
+1. **Compatibility spine:** keep BrainFlow, LSL, MNE, NWB/Zarr, MOABB, Braindecode, and selected NeuroAI integrations explicit and evidence-backed.
+2. **Arena public anchoring:** run held-out public EEG through reproducible semi-synthetic and reality-anchor protocols, without using synthetic results as human claims.
+3. **Offline neural interoperability:** mature MNE/Braindecode/MOABB and invasive-data bridges without copying upstream algorithms.
+4. **External benchmark workers:** isolate version-sensitive benchmark/model ecosystems and emit neurOS evidence artifacts rather than kernel dependencies.
+5. **Real-device qualification:** qualify named hardware/firmware/transport combinations with measured loss, drift, reconnect behavior, latency, and reproducible manifests.
+6. **ORION real-data promotion:** compare representations and adaptation on deployment-unit-disjoint datasets with calibration, transfer, robustness, uncertainty, and final-assessment authority.
+7. **World-model ladder:** add richer source-space, neural-mass, and learned world models only behind the common Arena contract and only with held-out real-data plus metamorphic qualification.
+8. **Studio convergence:** provide one inspection surface for live runtime state, replay, Arena worlds, ORION representations, and evidence.
+9. **Closed-loop safety plane:** add explicit stale-data rejection, confidence/quality gates, action constraints, deadman behavior, rate limits, and emergency-stop semantics before stronger closed-loop product claims.
 
 ## Design test for new work
 
@@ -163,6 +181,7 @@ Before adding a package or major abstraction, ask:
 2. Can neurOS integrate it through a stable contract instead?
 3. Which of the four public surfaces does the feature strengthen?
 4. What evidence tier does the implementation genuinely reach?
-5. Can the behavior be replayed, measured and falsified?
+5. Can the behavior be replayed, measured, falsified, and reproduced?
+6. If the component is synthetic or learned, what prevents it from silently promoting its own scientific claim?
 
 If those questions do not have crisp answers, the feature probably belongs in `experiments/` rather than the stable platform.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -6,7 +6,7 @@ This page is the current capability and maturity map for the monorepo. It is int
 
 ## Platform shape
 
-neurOS is organized as three cooperating layers:
+neurOS is organized around execution, intelligence, and evidence, with Studio as the inspection surface:
 
 ```text
 neural hardware / datasets / replay
@@ -20,30 +20,38 @@ neural hardware / datasets / replay
               v                             v
        model / transfer plane              ORION
  task decoders | foundation adapters   tokenization | representations
- mechanistic analysis | source trust   adaptation | personalization
+ mechanism analysis | source trust     adaptation | personalization
               |                             |
               +--------------+--------------+
+                             |
                              v
-                     application layer
+                       Evidence plane
+        frozen protocols | Arena | qualification | claims
+                             |
+                             v
+                           Studio
 ```
 
-The runtime plane should remain small and conservative. Research and model layers may move faster, but they must cross explicit contracts before they become deployment dependencies.
+The runtime plane should remain small and conservative. Research and model layers may move faster, but they must cross explicit contracts before they become deployment dependencies. Arena belongs to Evidence: it is a deterministic adversarial systems laboratory, not a biological-truth authority.
 
 ## Package maturity map
 
 | Surface | Role | Current evidence | Intended use now |
 | --- | --- | --- | --- |
-| `neuros-core` | data contracts, runtime graph, timing, recording/replay, config, quality | kernel contract matrix on Python 3.10-3.12; replay and recording tests | maintained kernel and integration substrate |
+| `neuros-core` | data contracts, runtime graph, timing, recording/replay, config, quality, plugin semantics | kernel contract matrix on Python 3.10-3.12; replay and recording tests | maintained kernel and integration substrate |
 | `neuros` | user-facing SDK and CLI composition | installed BCI/config/CLI/record/replay smoke execution | primary developer entry point |
-| `neuros-drivers` | hardware, simulated, and dataset sources | exercised through the BCI profile and plugin/config tests; device-specific qualification remains separate | maintained integration surface, not blanket hardware qualification |
+| `neuros-drivers` | hardware, simulated, and dataset sources | BCI profile, plugin/config tests, dedicated driver contracts; device-specific qualification remains separate | maintained integration surface, not blanket hardware qualification |
+| `neuros-arena` | causal synthetic BCI worlds, display/device/transport faults, populations, counterexamples, public-data anchoring utilities | dedicated deterministic Arena suite, scientific-validation policy, workspace-wheel/release-candidate qualification | maintained scientific-synthetic systems laboratory; not human physiological validation |
 | `neuros-models` | task-specific classical and neural decoders | v2.1 model/mech-int contract job; faithful PyTorch model identity; analysis-manifest regression tests | maintained decoder layer; model artifacts still need stronger deployment serialization |
 | `neuros-foundation` | neural foundation-model catalog, adapters, probes, benchmark protocols | package regressions plus dependency-light examples in monorepo CI | maintained interoperability/evaluation layer; upstream-model claims remain provenance-sensitive |
-| `neuros-sourceweigher` | reliability-aware source/domain weighting and fusion | regression matrix on Python 3.10-3.12 plus dependency-light examples | maintained research/deployment-support component for transfer and source trust |
-| `neuros-orion` | tokenization and neural-intelligence contracts | ORION contract tests and controlled synthetic tokenizer benchmark | experimental representation layer with explicit promotion gates |
+| `neuros-sourceweigher` | reliability-aware source/domain weighting and fusion | regression matrix on Python 3.10-3.12 plus dependency-light examples | maintained research/deployment-support component for transfer and declared domain similarity |
+| `neuros-orion` (`packages/orion`) | tokenization, representation, adaptation, and final-assessment authority | ORION contracts, controlled tokenizer benchmarks, leakage/adaptation/final-assessment authority workflows | active neural-intelligence layer with explicit promotion gates |
 | `neuros-mechint` | causal mechanism experiments, evidence artifacts, replication contracts | v1 software-contract gates, Python 3.10-3.12, executed CPU tutorials, ecosystem import checks | mature research software contract; empirical neuroscience evidence remains study-specific and incomplete by default |
 | `neuros-neurofm` | native neural foundation-model R&D | alpha research package and ORION/mech-int integration tests | experimental model research, not a promoted ORION implementation by default |
 | `neuros-ui` | dashboard/API/visualization surfaces | package metadata exists, but it is not yet a release-blocking qualification lane | integration/prototyping surface until dedicated product tests exist |
 | `neuros-cloud` | distributed/cloud/export/monitoring integrations | package metadata exists, but it is not yet a release-blocking qualification lane | optional integration surface until provider-specific tests and release gates exist |
+
+The repository directory is `packages/orion`, while the installable distribution is `neuros-orion`. The root `pyproject.toml` workspace is the canonical maintained-distribution inventory. CI, release-candidate wheel builds, and repository hygiene derive package membership from that authority rather than keeping parallel package lists.
 
 ## What is genuinely usable today
 
@@ -68,7 +76,17 @@ neuros replay /tmp/session --config configs/examples/mock_bci.yaml --json
 
 The canonical session archive preserves neurOS timing, quality, sequence, provenance, and integrity semantics. NWB and Zarr are interoperability exports rather than the authoritative replay format.
 
-### 3. Compare task-specific neural decoders without changing their algorithm identity
+### 3. Stress a BCI system in the deterministic Arena
+
+Arena separates requested stimulus, actually emitted display history, neural-world dynamics, sensor/device effects, transport faults, decoder behavior, and application authority. Built-in presets provide reproducible smoke and torture worlds, while portable manifests preserve complete world identity.
+
+```bash
+neuros-arena --preset dual-target-smoke --output arena-report.json
+```
+
+World models are extensible through the `neuros.world_models` entry-point group. The default driven state-space model is phenomenological. Semi-synthetic and lead-field-backed modes strengthen specific simulation assumptions without turning synthetic output into evidence about human prevalence or clinical performance.
+
+### 4. Compare task-specific neural decoders without changing their algorithm identity
 
 ```bash
 neuros-models list
@@ -78,23 +96,27 @@ neuros-models show eeg-conformer
 
 The maintained deep decoders expose logits, embeddings, stable model identity, and explicit mechanistic-analysis surfaces. Missing optional backends fail closed instead of silently swapping in a different algorithm.
 
-### 4. Inspect neural representations and foundation-model integrations
+### 5. Inspect neural representations and foundation-model integrations
 
 `neuros-foundation` separates catalog metadata from locally runnable adapters. Its probes and protocol fingerprints are intended to make cross-model comparisons explicit about subject/session/site/device split semantics and representation preprocessing.
 
-### 5. Estimate which sources should be trusted for a target domain
+### 6. Estimate which sources should be trusted for a target domain
 
 `neuros-sourceweigher` provides constrained source mixtures, distribution-distance baselines, online drift adaptation, representation-space weighting, and neurOS runtime fusion without forcing the HTTP service into the core install.
 
-### 6. Run causal mechanism studies without confusing tooling with evidence
+### 7. Run causal mechanism studies without confusing tooling with evidence
 
 `neuros-mechint` provides causal intervention, faithfulness, held-out evidence, replication, and artifact contracts. Its release status deliberately separates **software contract readiness** from **empirical evidence completion**.
 
-### 7. Benchmark neural tokenization behind one ORION contract
+### 8. Benchmark tokenization and auditable adaptation behind ORION contracts
 
-The current ORION benchmark compares seven tokenizer families under controlled synthetic motifs, separately seeded train/test sessions, timing jitter, unit dropout, compression, entropy, decoding, robustness, and runtime measurements.
+ORION compares tokenizer families under controlled synthetic motifs and exposes separate authority for calibration, qualification/model selection, and untouched final assessment. Synthetic known-ground-truth tests remain falsification tools. Real-data promotion requires deployment-unit-disjoint evidence and frozen assessment identity.
 
 ## Important gaps before neurOS should be marketed as a broadly deployable BCI platform
+
+### External plugin authoring journey
+
+The kernel has a real entry-point registry, but the developer preview still needs a maintained out-of-tree plugin template, clean-wheel install test, source/transform examples, and explicit compatibility/version negotiation. This is the next major usability gate because extensibility must work without editing the monorepo.
 
 ### Hardware qualification
 
@@ -104,9 +126,9 @@ There is not yet a public qualification matrix showing reproducible packet loss,
 
 The model layer still needs a production artifact format based on explicit architecture/configuration, `state_dict` or backend-native weights, input schema, calibration state, training/evaluation provenance, and immutable hashes. Trusted Python pickle should not be the long-term deployment boundary.
 
-### Real-data ORION evidence
+### Real-data ORION and Arena anchoring evidence
 
-Synthetic known-ground-truth tokenization tests are valuable falsification tools, but ORION needs leakage-controlled multi-session real neural datasets before tokenizer or representation superiority claims should be made.
+Synthetic known-ground-truth tests are valuable falsification tools, but ORION needs leakage-controlled multi-session real neural datasets before tokenizer or representation superiority claims should be made. Arena likewise needs held-out public-subject anchoring studies to characterize where its declared synthetic envelope resembles or misses real data. Similarity weighting is not a truth probability.
 
 ### Cross-subject/session/device mechanism stability
 
@@ -129,6 +151,7 @@ experiment
    -> research package
    -> stable contract adapter
    -> integration/replay evidence
+   -> scientific-synthetic evidence
    -> real-dataset evidence
    -> hardware qualification
    -> closed-loop qualification
@@ -140,13 +163,14 @@ Promotion should require evidence, not enthusiasm. A sophisticated method that c
 
 The next coherent public milestone should be a **developer preview** in which an external contributor can:
 
-1. install from a clean environment;
+1. install from a clean environment and verify exact built wheels;
 2. run and inspect a mock pipeline;
 3. record and replay it;
-4. select an inspectable decoder;
-5. compare or adapt representations through the foundation/SourceWeigher layers;
-6. run an ORION tokenizer benchmark;
-7. add an external plugin without modifying kernel code;
-8. understand exactly which claims are supported by software, dataset, hardware, or closed-loop evidence.
+4. run a deterministic Arena world and understand its evidence boundary;
+5. select an inspectable decoder;
+6. compare or adapt representations through the foundation/SourceWeigher layers;
+7. run an ORION tokenizer/adaptation study under frozen authority;
+8. add an external plugin without modifying kernel code;
+9. understand exactly which claims are supported by software, synthetic, dataset, hardware, or closed-loop evidence.
 
-That milestone is more valuable than simply adding more algorithms. It turns neurOS from a large repository into a legible platform.
+That milestone is more valuable than simply adding more algorithms. It turns neurOS from a large repository into a legible, extensible platform.

--- a/docs/PUBLIC_EEG_ANCHORING_STUDY.md
+++ b/docs/PUBLIC_EEG_ANCHORING_STUDY.md
@@ -1,0 +1,342 @@
+# Public EEG Anchoring Study v1
+
+## Research question
+
+Can a population of causal synthetic EEG worlds, calibrated only on training participants/sessions, provide useful information about **held-out real EEG domains** and help select closed-loop BCI configurations that transfer better than unweighted synthetic testing?
+
+This study is designed to fail cleanly. A negative result is useful evidence that a world family, similarity geometry, or calibration procedure does not transfer.
+
+## Two hypotheses, kept separate
+
+### H1: domain transfer
+
+Synthetic-world weights learned from training EEG should reduce the average declared domain distance to held-out EEG compared with a uniform synthetic-world population.
+
+Primary endpoint:
+
+`leave-one-domain-out relative improvement in held-out covariance/representation distance`
+
+This is a signal-domain hypothesis only.
+
+### H2: system-selection transfer
+
+BCI configurations selected using the training-anchored synthetic population should outperform or be more robust than configurations selected using an unweighted synthetic population when evaluated on held-out real EEG.
+
+Possible endpoints:
+
+- accepted precision;
+- abstention rate;
+- false activation rate;
+- switch/decision latency;
+- calibration burden;
+- robustness to channel removal or timing perturbation;
+- application-level authority errors when replayed through a closed-loop adapter.
+
+H2 is stronger than H1 and must not be inferred from H1 alone.
+
+## Initial datasets
+
+The campaign should begin with multiple MOABB-exposed SSVEP datasets rather than one Mindforge-specific dataset.
+
+### MAMEM2
+
+Useful properties:
+
+- 10 participants;
+- 256 EEG channels;
+- 250 Hz acquisition;
+- five SSVEP classes;
+- 20–30 trials per class;
+- 3 s trials;
+- raw EEG available through MOABB.
+
+This is especially useful for dense spatial/covariance studies and aligns well with 250 Hz device simulations.
+
+### Lee2019_SSVEP
+
+Useful properties:
+
+- 54 participants;
+- 62 EEG channels;
+- two sessions;
+- four SSVEP classes;
+- 50 trials per class;
+- 4 s trials;
+- raw EEG available;
+- MOABB exposes clean BIDS conversion.
+
+This dataset is valuable for participant-held-out and session-held-out transfer because it has a substantially larger cohort and repeated sessions.
+
+### Broader-frequency follow-up
+
+After the first pipeline is stable, add datasets such as Nakanishi2015 and Wang2016 to test whether Arena conclusions survive broader stimulus-frequency/codebook regimes rather than only the frequencies used by one game.
+
+## Canonical upstream data flow
+
+```text
+MOABB dataset
+    ↓
+dataset.get_data(...)
+subject → session → run → MNE Raw
+    ↓
+optional clean BIDS export / source provenance
+    ↓
+predeclared channel and time-window policy
+    ↓
+Arena baseline NPZ + RecordingMetadata sidecar
+```
+
+Arena must not silently infer participant identity, task semantics, reference or coordinate assumptions that belong to the upstream dataset.
+
+## Split policy
+
+### Participant-held-out study
+
+Default unit of independence: participant.
+
+For each fold:
+
+1. choose one participant as held out;
+2. fit any world-population/domain-weight parameters only on the remaining participants;
+3. freeze parameters;
+4. compute held-out EEG similarity and downstream decoder/system metrics;
+5. store the full fold artifact.
+
+### Session-held-out study
+
+For Lee2019, add a stronger longitudinal test:
+
+- fit on session 1 only;
+- evaluate the same participant in session 2;
+- and the reverse direction where appropriate.
+
+This directly tests session drift rather than allowing a simulator to overfit one recording day.
+
+### Run/window split
+
+Run-level or temporal splits are secondary analyses, not substitutes for participant-held-out evaluation.
+
+If windows are used, employ contiguous splits with a guard interval large enough to prevent overlap/preprocessing leakage.
+
+## Channel strategy
+
+Run at least two channel regimes.
+
+### Native montage
+
+Compare worlds in each dataset's native available EEG montage when a compatible world/source model exists.
+
+Purpose:
+
+- evaluate spatial covariance/topography faithfully within a dataset;
+- avoid throwing away useful dense-array information.
+
+### Portable game montage
+
+Define a predeclared low-channel posterior montage that approximates common game/consumer BCI access, for example available occipital/parietal channels nearest to a target set.
+
+Purpose:
+
+- test whether findings survive the constrained sensor regime relevant to interactive BCI applications;
+- compare device/channel sensitivity.
+
+Channel mapping rules must be declared before held-out evaluation and stored in provenance.
+
+## Preprocessing policy
+
+Keep a minimally processed branch for domain-realism analysis and a decoder-specific branch for task evaluation.
+
+### Domain comparison branch
+
+Suggested starting operations:
+
+- channel selection;
+- explicit unit normalization;
+- resampling only when needed for a common device model;
+- optional fixed notch/band limits chosen before held-out evaluation;
+- no subject-specific data-dependent normalization fitted using held-out data.
+
+### Decoder branch
+
+Decoder-specific preprocessing may be used, but every data-dependent transform must be fitted only on training/calibration partitions.
+
+The raw/derived path must be recorded in `RecordingMetadata.preprocessing`.
+
+## Synthetic world bank
+
+The v1 world bank should deliberately contain multiple model families rather than thousands of parameter variants from one family.
+
+Suggested composition:
+
+- W1 `driven_state_space` population;
+- W2 `semi_synthetic_replay` worlds using only training-domain backgrounds;
+- W3 `leadfield_driven` worlds with explicit source/topography variants;
+- selected nuisance/device/display/clock/network variants.
+
+Do not allow a held-out participant's background EEG into a W2 world used to predict that same participant.
+
+Population axes should include predeclared ranges for:
+
+- target response strength;
+- alpha peak/amplitude;
+- switching/entrainment dynamics;
+- channel/background covariance family;
+- artifact susceptibility;
+- sensor noise;
+- channel loss;
+- source clock offset/drift/jitter;
+- residual synchronization error;
+- display timing perturbation where the task simulation includes presentation.
+
+Synthetic ranges are engineering envelopes until empirical calibration justifies interpreting them as population priors.
+
+## Reality anchoring
+
+Run several declared geometries rather than selecting whichever looks best after seeing test results.
+
+### Sensor covariance
+
+Use `RiemannianCovarianceWeigher` through Arena's covariance anchor.
+
+Advantages:
+
+- interpretable for EEG domain structure;
+- independent of a learned embedding model;
+- useful baseline.
+
+### Foundation representation
+
+Use one or more fixed, predeclared `neuros-foundation` or external EEG representations.
+
+Rules:
+
+- embedding model must be frozen before held-out evaluation;
+- any adapter/task head must be trained only on training domains;
+- report source weighting diagnostics and effective world count;
+- do not call the resulting weight a probability of physiological truth.
+
+### Observable features
+
+Retain simple spectral/amplitude/correlation signatures as an audit layer. They are useful for explaining why a representation-level metric may behave unexpectedly.
+
+## Leave-one-domain-out test
+
+Arena implements:
+
+`run_leave_one_domain_out_covariance_study(...)`
+
+For every held-out domain:
+
+1. independently compute world weights for every training domain;
+2. average and normalize those training-domain weights;
+3. freeze them;
+4. inspect the held-out domain only to compute evaluation distances;
+5. compare weighted distance with uniform synthetic weighting.
+
+Primary summary:
+
+- mean relative improvement;
+- median relative improvement;
+- fraction of held-out domains improved;
+- mean weighted distance;
+- mean uniform distance;
+- per-domain counterexamples.
+
+A model family should not be promoted merely because the mean improves if a meaningful subgroup degrades severely.
+
+## Decoder/system-selection experiment
+
+Choose a small predeclared set of candidate decoder/system configurations. For SSVEP this could include variants of:
+
+- analysis-window length;
+- hop size;
+- harmonic count;
+- filter-bank configuration;
+- quality threshold;
+- winner/runner-up margin threshold;
+- dwell/confirmation count;
+- channel subset;
+- frequency/codebook configuration where appropriate.
+
+For every training fold:
+
+1. evaluate candidates over the training-anchored synthetic population;
+2. select the candidate under a declared utility function;
+3. freeze it;
+4. evaluate on the held-out real participant/session;
+5. compare against baselines such as default configuration, real-training-only selection, and unweighted synthetic selection.
+
+A useful initial utility should reward accepted precision and fail-closed behavior rather than raw selection rate alone.
+
+## Application replay experiment
+
+Once game/application traces are available:
+
+```text
+held-out EEG or semi-synthetic replay
+        ↓
+real decoder
+        ↓
+portable neural events
+        ↓
+application/game adapter
+        ↓
+ApplicationTrace
+        ↓
+Arena causal scoring
+```
+
+Use the engine-neutral `ApplicationTrace` contract to measure:
+
+- unintended neural actions during known no-target periods;
+- actions during source silence where disallowed by the application policy;
+- stale sequence regressions;
+- post-participant-stop actions;
+- link-loss and recovery timing;
+- application-specific authority metrics.
+
+Mindforge can be the first complete showcase, but the trace contract and benchmark packs must remain game-engine and application neutral.
+
+## Statistical reporting
+
+The first study should report distributions/folds rather than only a pooled mean.
+
+At minimum:
+
+- every held-out fold;
+- mean and median;
+- bootstrap confidence intervals where appropriate;
+- fraction of folds improved;
+- worst fold;
+- effect relative to uniform synthetic baseline;
+- all study/benchmark seeds and manifests;
+- failures and excluded recordings with reasons.
+
+If multiple metrics/geometries are explored, distinguish exploratory analyses from preregistered/primary endpoints.
+
+## Promotion criterion for reality anchoring
+
+Do not claim that Arena is empirically calibrated to public human EEG until a frozen study shows reproducible held-out transfer.
+
+A reasonable first promotion gate is:
+
+1. positive median held-out improvement over uniform world weighting across at least two independent datasets or dataset/session regimes;
+2. no catastrophic hidden subgroup failure under the declared metric;
+3. reproducible world/recording provenance;
+4. independent rerun from a clean environment;
+5. H2 system-selection evidence reported separately from H1 signal-domain evidence.
+
+If this gate is not met, keep reality anchoring labeled experimental and publish the negative result.
+
+## Why this matters for games
+
+Game developers rarely have hundreds of headset sessions available while designing mechanics. A validated synthetic ecology could help answer questions earlier:
+
+- Is this BCI mechanic viable across weak/strong responders?
+- Does a longer evidence window make combat safer but unusably sluggish?
+- How much channel loss can the game tolerate?
+- What happens when rendering corrupts a visual code?
+- Does link recovery preserve agency?
+- Which settings remain robust when the real EEG domain shifts?
+
+The goal is not to remove human playtesting. The goal is to make the expensive human sessions much more informative because obvious software, timing and robustness failures have already been explored systematically.

--- a/docs/SCIENTIFIC_VALIDATION_POLICY.md
+++ b/docs/SCIENTIFIC_VALIDATION_POLICY.md
@@ -1,0 +1,351 @@
+# Synthetic BCI Arena Scientific Validation Policy
+
+## Purpose
+
+`neuros-arena` exists to accelerate interactive BCI development when physical hardware and human testing are limited. Its strongest contribution is not a claim to perfectly simulate a human brain. It is a reproducible environment in which causal assumptions, timing, device behavior, transport failures, decoder authority, application behavior, and synthetic-to-recorded similarity can be tested explicitly.
+
+The governing rule is:
+
+> **A more complex neural generator does not receive a larger scientific claim scope unless independent evidence justifies it.**
+
+Synthetic conformance, recorded-data similarity, device validation, and human closed-loop validation are distinct evidence classes. Reports must preserve those distinctions.
+
+## 1. Two independent evidence axes
+
+Arena separates **world-model evidence** from **system-validation evidence**.
+
+### 1.1 World-model evidence levels
+
+These levels describe what a neural generator represents. They are not a linear score of biological truth.
+
+| Level | Meaning | Typical use | Explicit limitation |
+|---|---|---|---|
+| W0 | Regression fixture / analytic signal source | driver, decoder, CI smoke tests | may not be stimulus-causal or physiologically meaningful |
+| W1 | Causal phenomenological dynamics | closed-loop stress, population testing, timing/display studies | not a biophysical cortical model or human distribution |
+| W2 | Recorded-background semi-synthetic model | real nuisance/covariance with known injected interventions | injected response is not evidence that the recorded participant produced it |
+| W3 | Explicit source-to-sensor / lead-field projection | montage/topography/source sensitivity | source response amplitudes/dynamics remain assumptions unless independently calibrated |
+| W4 | Biophysical / neural-mass model | mechanistic hypothesis testing | equations and parameters require external validation; complexity is not automatically realism |
+| W5 | Learned conditional neural generator | high-dimensional conditional worlds | vulnerable to memorization, shortcut learning, mode collapse and distribution leakage |
+| W6 | Externally calibrated multi-model ensemble | uncertainty-aware world populations anchored to held-out recordings | remains a model of a declared domain, not a substitute for human closed-loop testing |
+
+Built-in reports include a machine-readable `WorldModelEvidenceCard`. Third-party world models without an evidence card remain runnable but are reported as scientifically unqualified.
+
+### 1.2 System-validation levels
+
+| Level | Evidence |
+|---|---|
+| A0 | deterministic seed / manifest reproducibility |
+| A1 | known nuisance and intervention ground truth |
+| A2 | emitted-stimulus / display causality |
+| A3 | device/montage/ADC/clock behavior |
+| A4 | transport, synchronization, interruption and recovery behavior |
+| A5 | decoder / quality-authority conformance against known truth |
+| A6 | closed-loop application/game conformance |
+| A7 | held-out recorded/public EEG anchoring |
+| A8 | target physical device substitution and timing verification |
+| A9 | human closed-loop validation under a declared protocol |
+
+A project should report both axes. For example, `W2/A7` conveys a different evidence state from `W1/A6`.
+
+## 2. Claims Arena may and may not support
+
+### Synthetic evidence can support
+
+- deterministic software behavior under a declared world;
+- causal response to a known simulated intervention;
+- timing error relative to simulator ground truth;
+- fail-closed behavior during corrupted or absent input;
+- decoder/application performance over a declared synthetic parameter envelope;
+- relative differences between declared synthetic scenarios;
+- whether synthetic-domain weighting transfers to held-out recorded data under a declared similarity metric.
+
+### Synthetic evidence alone cannot support
+
+- expected accuracy on humans;
+- prevalence of responder/non-responder phenotypes;
+- human comfort, fatigue, cybersickness, visual safety or usability;
+- subject-specific physiology;
+- a claim that an injected semi-synthetic response occurred in the recorded participant;
+- anatomical localization without independently justified geometry/source assumptions;
+- clinical validity or diagnostic utility.
+
+## 3. Leakage and split policy
+
+Synthetic-to-real evaluation must be designed so that the result could fail.
+
+### 3.1 Never tune and judge on the same recording
+
+If world parameters or SourceWeigher weights are calibrated on real EEG, final similarity or downstream performance must be evaluated on independent data.
+
+Preferred split hierarchy, strongest first:
+
+1. held-out participants;
+2. held-out participant-sessions;
+3. held-out runs;
+4. temporally separated windows with a guard interval.
+
+Randomly shuffling overlapping EEG samples is not an acceptable independent validation split.
+
+### 3.2 Preprocessing belongs inside the split
+
+Any data-dependent operation must be fitted only on the training/calibration partition, including:
+
+- normalization/statistical scalers;
+- covariance shrinkage choices when tuned;
+- learned filters;
+- foundation-model adapters or task heads;
+- source/domain weighting temperatures when optimized;
+- generative-model training or fine-tuning;
+- learned artifact models.
+
+Fixed, predeclared signal transforms may be reused across partitions but must be recorded.
+
+### 3.3 Cohort calibration
+
+For public-data calibration, Arena supports leave-one-domain-out studies. A domain should normally be a participant or participant-session. Synthetic-world weights are fitted only on the non-held-out domains, frozen, then scored against the held-out EEG.
+
+The principal comparison is against a predeclared baseline such as uniform synthetic-world weighting. A positive transfer result is evidence for the anchoring procedure, not proof that the synthetic worlds are physiological digital twins.
+
+## 4. Timing and synchronization policy
+
+Interactive EEG systems must distinguish three clocks:
+
+1. **causal ground-truth time**: the simulator/application event timeline;
+2. **source/device time**: acquisition timestamps including offset, drift and timestamp jitter;
+3. **decoder-facing corrected time**: timestamps after synchronization/correction, including residual error.
+
+Network delivery latency is a fourth quantity and must not be used as a proxy for timestamp accuracy.
+
+Arena timing reports should include, where applicable:
+
+- source clock offset;
+- source clock drift in ppm;
+- source timestamp jitter;
+- packet loss;
+- arrival delay distribution;
+- sequence inversions/reordering;
+- interruption duration;
+- corrected timestamp RMSE;
+- corrected timestamp p95 absolute error;
+- maximum corrected timestamp error;
+- stimulus/event-marker to EEG alignment error.
+
+Physical A8 validation should compare software timestamps to independent measurements when feasible, such as photodiode traces for visual stimuli.
+
+## 5. Display and sensory causality
+
+For stimulus-driven paradigms, neural models promoted beyond W0 must consume the **emitted** stimulus after presentation effects, not merely the requested label/frequency.
+
+For visual BCI this includes, when modeled:
+
+- refresh-rate quantization;
+- sample-and-hold behavior;
+- frame drops/holds;
+- render jitter;
+- display response lag;
+- luminance modulation.
+
+Future paradigms should use `WorldInputBlock.emitted_streams` for actual sensory input, including audio, haptic or multimodal streams.
+
+A model that receives only the target class or requested frequency may remain useful as a regression fixture, but must not claim presentation-to-neural causality.
+
+## 6. Recorded EEG and BIDS alignment
+
+Arena does not invent a new canonical EEG storage standard.
+
+Preferred upstream flow:
+
+```text
+public/private EEG
+      ↓
+BIDS / MNE / MOABB
+      ↓
+explicit subject/session/run/task split
+      ↓
+Arena derived baseline + recording metadata sidecar
+```
+
+Arena's compact baseline NPZ is a derived simulation artifact. The accompanying `RecordingMetadata` sidecar records BIDS-aligned provenance such as dataset, subject/session/run identifiers, task, acquisition, channel units/types, reference, line frequency, electrode coordinates/coordinate system, preprocessing and source locator.
+
+Do not put direct participant identifiers or secrets in Arena metadata.
+
+## 7. Evaluation of learned EEG world models
+
+GAN/VAE/diffusion/foundation-style generators are experimental until they satisfy more than visual or spectral plausibility.
+
+A W5 candidate should be evaluated on at least the following dimensions.
+
+### 7.1 Held-out generalization
+
+- held-out participants;
+- preferably held-out sessions/sites/devices;
+- no test-subject fine-tuning unless separately reported as calibration.
+
+### 7.2 Observable signal structure
+
+- spectral density/band structure;
+- channel covariance / SPD geometry;
+- temporal autocorrelation;
+- cross-channel coherence where appropriate;
+- amplitude distributions and tails;
+- artifact statistics;
+- event-related or stimulus-locked structure appropriate to the paradigm.
+
+No single scalar should be called a universal realism score.
+
+### 7.3 Representation-level comparison
+
+Use predeclared `neuros-foundation`/external embeddings and SourceWeigher or other declared metrics to test whether synthetic and held-out real EEG occupy comparable representation domains.
+
+The embedding model used for evaluation should not be trained solely to make the generator look good.
+
+### 7.4 Intervention faithfulness
+
+Changing a known causal input should change the generated signal in the expected direction while preserving unrelated nuisance structure as appropriate.
+
+Examples:
+
+- remove visual modulation → stimulus-locked response should disappear/reduce;
+- weaken attention/gaze coupling → target evidence should not increase;
+- change source location → projected topography should change coherently;
+- increase device dropout → decoder authority must not increase solely because of missing data.
+
+### 7.5 Metamorphic testing
+
+A learned model must pass declared invariants and adversarial world search. Counterexamples are retained rather than averaged away.
+
+### 7.6 Mechanistic/shortcut audit
+
+Where model architecture permits, use `neuros-mechint` and controlled counterfactuals to determine whether output conditioning depends on intended temporal/spatial structure or shortcuts such as class-specific amplitude constants, trial position, subject identity leakage or preprocessing fingerprints.
+
+### 7.7 Uncertainty
+
+A generative model should expose stochastic variability or an ensemble/distribution over plausible worlds. One deterministic waveform should not be presented as the expected human response.
+
+## 8. Model promotion gates
+
+A new world model should enter Arena as experimental and be promoted only when its evidence card is updated with concrete validation artifacts.
+
+Minimum requirements:
+
+### W0 → W1
+
+- seeded determinism;
+- explicit causal inputs;
+- emitted-stimulus coupling tests;
+- intervention/metamorphic tests;
+- failure behavior and provenance.
+
+### W1 → W2/W3
+
+- W2: recorded-human background provenance and held-out usage policy;
+- W3: explicit source/forward projection provenance and geometry checks.
+
+### W3/W4/W5 → W6 ensemble
+
+- multiple independently useful world families;
+- held-out recorded-domain calibration;
+- transfer improvement over a declared baseline;
+- uncertainty/population reporting;
+- stable benchmark-pack results;
+- no hidden use of held-out test domains for tuning.
+
+No synthetic model can be promoted to A8/A9. Those are system evidence levels requiring physical hardware/human validation.
+
+## 9. Benchmark-pack policy
+
+Arena benchmark packs are versioned artifacts:
+
+`neuros.synthetic_bci_arena.benchmark_pack.v1`
+
+A pack should contain:
+
+- exact world manifests;
+- exact metric paths and thresholds;
+- a semantic version;
+- a written claim scope;
+- enough provenance to reproduce the run.
+
+Changing a threshold, world distribution, model family or evidence expectation requires a version change.
+
+A benchmark result must preserve failed assertions and the underlying world report. Passing a pack means only what the pack's `claim_scope` states.
+
+The initial `eeg-game-systems` pack tests clean causal display coupling and clock-domain recovery. It is deliberately a systems benchmark, not a decoder leaderboard or human-performance benchmark.
+
+## 10. Game/application integration policy
+
+A BCI game should keep fast physical controls and bounded neural authority semantically distinct unless the paradigm explicitly requires otherwise.
+
+Recommended application-level conformance properties include:
+
+- no neural action during declared rest unless the decoder explicitly accepts one;
+- no stale packet may resurrect expired authority;
+- transport loss cannot create gameplay authority;
+- degraded neural evidence should increase abstention/fallback rather than confident random action;
+- participant stop is terminal until explicitly reset;
+- calibration failure cannot silently enter live-authority mode;
+- recovery after link loss requires a stable re-entry period;
+- rendering/game hit-stop must not alter independently clocked stimulus timing assumptions without being detected.
+
+Developers may define additional metrics through benchmark evaluators rather than modifying Arena core.
+
+## 11. Public human anchoring campaign
+
+The first public SSVEP campaign should use multiple datasets and held-out domains rather than optimizing only for Mindforge frequencies.
+
+Initial candidates include MOABB-exposed SSVEP datasets such as:
+
+- MAMEM2, useful for 250 Hz recordings and a dense montage;
+- Lee2019_SSVEP, useful for larger subject count and two-session evaluation;
+- Nakanishi2015 / Wang2016 for broader frequency/codebook coverage;
+- additional datasets as licensing and acquisition metadata permit.
+
+Recommended experiment:
+
+1. convert/download through MOABB/MNE and preserve upstream provenance;
+2. define participant/session domains before analysis;
+3. select a predeclared common channel/montage strategy;
+4. create Arena baselines with recording sidecars;
+5. generate a declared synthetic world bank;
+6. fit world weights only on training domains;
+7. freeze the world bank and weights;
+8. evaluate covariance/representation transfer on held-out domains;
+9. evaluate whether synthetic-selected decoder/system configurations improve held-out real-data behavior relative to baselines;
+10. publish failures, negative results and counterexamples alongside positive results.
+
+Mindforge should be one downstream showcase, not the scientific definition of the benchmark.
+
+## 12. External ecosystem interoperability
+
+Arena should compose with existing tools rather than duplicate them:
+
+- **MNE-Python**: source/forward simulation, EEG signal analysis and artifact/noise utilities;
+- **MOABB**: standardized public BCI datasets/paradigms and BIDS conversion;
+- **BIDS / MNE-BIDS**: canonical dataset organization and metadata;
+- **LSL / XDF / MNE-LSL**: synchronized streaming and replay;
+- **BrainFlow**: board/device abstraction and synthetic-board comparison;
+- **TVB / neurolib**: optional neural-mass / whole-brain dynamics;
+- **external neural-data simulators**: complementary invasive/electrophysiology or task simulators;
+- **Unity/Godot/Web engines**: application adapters and event traces.
+
+Arena's unique focus is **reproducible closed-loop EEG systems conformance for interactive applications**, not ownership of every layer of neuroscience simulation.
+
+## 13. Reproducibility checklist
+
+Every published Arena result should record:
+
+- repository/package version or commit;
+- benchmark-pack version if used;
+- world manifest(s);
+- seeds;
+- world-model evidence cards;
+- dataset/source provenance for recorded EEG;
+- subject/session/run split;
+- preprocessing fitted on each split;
+- device/display/transport profiles;
+- timing metrics;
+- evaluation metrics and uncertainty/dispersion;
+- failed cases/counterexamples;
+- explicit unsupported claims.
+
+If an external party cannot reconstruct the causal world and evaluation boundary, the result is not yet an Arena-grade scientific artifact.

--- a/docs/SYNTHETIC_BCI_ARENA.md
+++ b/docs/SYNTHETIC_BCI_ARENA.md
@@ -1,0 +1,123 @@
+# Synthetic BCI Arena
+
+## Purpose
+
+The neurOS Synthetic BCI Arena is a hardware-independent systems test environment for interactive brain-computer interfaces.
+
+It is built around a narrow claim:
+
+> A synthetic arena can provide exact causal ground truth and reproducible operational stress. It cannot prove human physiological performance.
+
+This makes it useful before hardware access, between hardware sessions, in continuous integration, and for creative developers who may never own the target headset.
+
+## System layers
+
+A world manifest composes independently swappable layers:
+
+```text
+participant response model
+        ↓
+stimulus / display presentation
+        ↓
+electrode + acquisition device
+        ↓
+transport / clocks / packetization
+        ↓
+decoder / quality authority
+        ↓
+application / game / artwork
+        ↓
+closed-loop behavior
+```
+
+The first Arena release provides dependency-light SSVEP participant simulation plus display, device and transport models. The contract is intentionally paradigm-neutral so P300, c-VEP, motor imagery and other generators can be added without changing application-facing scenario semantics.
+
+## Verification ladder
+
+### A0 — Determinism
+
+Same manifest + seed must produce the same synthetic signal, timestamps, stimulus trace, fault schedule and report.
+
+### A1 — Controlled neural nuisance
+
+Sweep response strength, alpha overlap, switching delay, response attenuation, gaze duty cycle, blink/jaw/controller/motion contamination and electrode loss. The expected causal labels remain known.
+
+### A2 — Display fidelity
+
+Simulate refresh quantization, response lag, jitter and dropped frames. Report the observed transition frequency and timing error separately from the requested code.
+
+### A3 — Device fidelity
+
+Apply montage selection, sensor noise, mains interference, ADC clipping/quantization, clock drift and device chunk size.
+
+### A4 — Transport adversity
+
+Inject packet loss, delivery jitter, reordering and explicit source-silence windows. Measure delivery fraction, p95 delay and worst arrival gap.
+
+### A5 — Decoder conformance
+
+Feed an external decoder's timestamped accepted/abstained decisions back to Arena. Score accepted precision, false activation during known rest, and switch latency against ground truth.
+
+### A6 — Closed-loop application conformance
+
+Application adapters should expose state transitions such as `BCI_LOST`, recovery, participant stop, calibration ready/failed, or game actions. Arena can then assert safety properties such as “transport loss never becomes an unintended attack.”
+
+### A7 — Real-data anchoring
+
+Use recordings from public datasets or local sessions to compute observable feature signatures, then compare synthetic and real distributions. The result is a feature-distance report, not a universal realism score.
+
+Recommended interoperability:
+
+- **MOABB** for standardized public BCI datasets and evaluation splits;
+- **MNE-Python** for forward/source simulation, EOG/ECG/noise injection and signal analysis;
+- **MNE-LSL / LSL** for replaying recordings through the same online transport boundary;
+- **XDF/LabRecorder** for synchronized multimodal session capture;
+- **BrainFlow** for device abstraction and comparison with its hardware-free Synthetic Board.
+
+### A8 — Hardware substitution
+
+A real device replaces the synthetic source while every downstream boundary remains unchanged. This is the first tier that can support device-specific physical claims.
+
+## Portable creative worlds
+
+Arena manifests use schema:
+
+`neuros.synthetic_bci_arena.manifest.v1`
+
+They describe participant, scenario, device, display and transport state. A manifest should be small enough to paste into a bug report and complete enough to reproduce the run.
+
+Example:
+
+```bash
+neuros-arena \
+  --manifest examples/arena/dual_target_custom.json \
+  --output report.json \
+  --npz run.npz
+```
+
+This enables shared challenge worlds for game jams, classroom assignments, accessibility research and benchmark suites.
+
+## What “verified synthetic” should mean
+
+A project may say:
+
+> “The application passed Synthetic Arena scenario X across seeds 1–1000, including specified display, device and transport faults.”
+
+It should not say:
+
+> “The application is 95% accurate on humans.”
+
+unless that claim is independently supported by human recordings under an appropriate protocol.
+
+## Roadmap
+
+1. SSVEP closed-loop conformance and portable manifests.
+2. Application event adapters and generic decoder protocol.
+3. MNE-LSL/XDF replay adapter.
+4. MOABB reference-suite adapter for SSVEP/P300/MI datasets.
+5. Forward-model participant plugins using MNE head models.
+6. P300, c-VEP and motor-imagery synthetic participant plugins.
+7. Eye/gaze, IMU and controller multimodal nuisance streams.
+8. Monte Carlo population sweeps with coverage maps rather than one “average user.”
+9. Mutation/fuzz testing that automatically searches for scenarios causing unsafe application behavior.
+10. A small visual Arena dashboard for creators to build and share worlds without writing code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # neurOS Documentation
 
-**neurOS is an open execution and evidence platform for neural interfaces.** It is designed so neural systems can be replayed, measured, compared, adapted, and eventually qualified across changing hardware, models, datasets, and people.
+**neurOS is an open execution and evidence platform for neural interfaces.** It is designed so neural systems can be replayed, measured, compared, adapted, stress-tested, and eventually qualified across changing hardware, models, datasets, and people.
 
 The public architecture has four surfaces:
 
@@ -11,11 +11,15 @@ The public architecture has four surfaces:
 | **Evidence** | What does a neural-system claim actually have evidence for? |
 | **Studio** | How can a developer inspect the live/replayed system and its evidence? |
 
+`neuros-arena` is part of the **Evidence** surface: a deterministic BCI systems wind tunnel for falsifying assumptions across emitted stimuli, neural-world models, devices, transports, decoders, and applications. It is not a fifth product surface and synthetic success is not biological validation.
+
 > neurOS is an active research and engineering platform. Software tests are not hardware qualification, medical validation, biological proof, or clinical certification.
 
 ## Start here
 
 - [Platform architecture and design rules](PLATFORM.md)
+- [Synthetic BCI Arena](SYNTHETIC_BCI_ARENA.md)
+- [EEG world-model ladder](EEG_WORLD_MODELS.md)
 - [Evidence-backed ecosystem compatibility](COMPATIBILITY.md)
 - [Project status and maturity](PROJECT_STATUS.md)
 - [Real-world evidence program](REAL_WORLD_EVIDENCE.md)
@@ -28,7 +32,7 @@ The public architecture has four surfaces:
 neurOS should integrate established neuroscience software rather than replace it.
 
 ```text
-BrainFlow / LSL / datasets
+BrainFlow / LSL / datasets / replay
            |
            v
        SignalFrame
@@ -49,6 +53,8 @@ BrainFlow / LSL / datasets
                        ORION              Evidence
                  representation +      benchmarks +
                     adaptation          qualification
+                                             |
+                                             +-> Arena worlds / counterexamples
                          \                   /
                           +--------+--------+
                                    v
@@ -93,9 +99,21 @@ neuros replay /tmp/session \
 
 The canonical archive preserves sequence, timing, quality, provenance, configuration identity, runtime metrics, and frame integrity. NWB and Zarr remain interoperability exports rather than alternate runtime authorities.
 
+## Stress-test without spending participant time
+
+Arena provides deterministic synthetic worlds for systems-level falsification:
+
+```bash
+neuros-arena --preset dual-target-smoke --output arena-report.json
+```
+
+The important boundary is causal rather than cosmetic. Display-coupled models consume the **actually emitted** sample-and-held display history after refresh quantization, jitter, dropped frames, and held frames. Device effects and transport faults remain separate layers. Portable manifests preserve complete world identity, and `neuros.world_models` allows third-party world-model implementations without handing them ownership of device/network/application semantics.
+
+Use Arena to find software and systems failures early. Do not use a plausible synthetic waveform as evidence that a human BCI will achieve the same behavior.
+
 ## MNE bridge
 
-MNE is the first direct scientific object bridge under the convergence architecture:
+MNE is a direct scientific object bridge under the convergence architecture:
 
 ```bash
 pip install "neuros[interop-mne]"
@@ -119,19 +137,20 @@ The repository separates evidence into progressively stronger responsibilities:
 ```text
 software contract
       -> integration
+      -> replay / scientific synthetic
       -> real-dataset evidence
       -> hardware qualification
       -> closed-loop qualification
       -> clinical evidence
 ```
 
-The longitudinal EEG program already establishes frozen subject/session/run-aware evaluation and real MOABB dataset lanes. The next goal is not to add dozens of algorithms. It is to make the same evidence authority work across external model ecosystems, ORION representations, transfer methods, hardware sessions, and mechanistic interventions.
+The longitudinal EEG program establishes frozen subject/session/run-aware evaluation and real MOABB dataset lanes. ORION now separates calibration, qualification/model selection, selected state, and untouched final assessment. Arena adds deterministic synthetic systems falsification and a path toward explicitly declared public-data anchoring. None of those lower evidence layers silently promotes a hardware, human, or clinical claim.
 
 ## ORION
 
-ORION is the neural-intelligence plane. Current stable work begins with explicit neural tokenization and representation contracts, while research packages explore learned encoders, transfer, source reliability, adaptation, and native foundation models.
+ORION is the neural-intelligence plane. Current stable work begins with explicit neural tokenization and representation contracts, auditable adaptation, and frozen final-assessment authority, while research packages explore learned encoders, transfer, source reliability, and native foundation models.
 
-Promotion should require deployment-unit-disjoint evidence. A representation that wins on random windows but fails across subjects or sessions is not a useful ORION representation.
+Promotion should require deployment-unit-disjoint evidence. A representation that wins on random windows but fails across subjects or sessions is not a useful ORION representation. Adaptation that consumes assessment rows is not valid adaptation evidence.
 
 ## Studio
 
@@ -141,15 +160,16 @@ Promotion should require deployment-unit-disjoint evidence. A representation tha
 - synchronized live/replayed signals and quality flags;
 - latency and failure telemetry;
 - decoder probabilities, uncertainty, and embeddings;
+- Arena world state and counterexamples;
 - ORION representations and adaptation events;
 - source/transfer weights;
 - benchmark and qualification evidence;
 - replay-to-replay regression comparisons.
 
-The runtime remains authoritative. Studio observes it.
+The runtime and evidence artifacts remain authoritative. Studio observes them.
 
 ## Repository organization
 
-The workspace remains internally modular because dependency boundaries matter. Users should think in the four public surfaces rather than memorizing every internal distribution.
+The workspace remains internally modular because dependency boundaries matter. The root `pyproject.toml` workspace is the maintained-package inventory used by CI and release tooling. Users should think in the four public surfaces rather than memorizing every internal distribution.
 
 Research notebooks and exploratory algorithms remain under `experiments/` or research packages until they satisfy a stable contract and evidence gate. Historical migration notes live under `docs/archive/` and are retained for provenance, not as current architecture guidance.

--- a/examples/arena/benchmark_packs/eeg_game_system_v1.json
+++ b/examples/arena/benchmark_packs/eeg_game_system_v1.json
@@ -1,0 +1,64 @@
+{
+  "schema": "neuros.synthetic_bci_arena.benchmark_pack.v1",
+  "name": "eeg-game-systems",
+  "version": "1.0.0",
+  "description": "Dependency-light systems conformance for interactive EEG applications. It validates causal display coupling, clean transport, and explicit clock-domain recovery. It is not a human-performance benchmark.",
+  "claim_scope": "synthetic EEG game systems conformance",
+  "cases": [
+    {
+      "name": "clean-causal-loop",
+      "description": "A clean fixed-refresh dual-stage visual world should preserve display causality and lossless, aligned delivery.",
+      "manifest": {
+        "schema": "neuros.synthetic_bci_arena.manifest.v1",
+        "scenario": {
+          "name": "benchmark-clean-causal-loop",
+          "seed": 101,
+          "metadata": {"paradigm": "ssvep", "purpose": "portable benchmark"},
+          "stages": [
+            {"label": "rest", "duration_s": 1.0, "target_frequency_hz": null, "attention_gain": 0.0, "artifacts": []},
+            {"label": "target", "duration_s": 2.0, "target_frequency_hz": 10.0, "attention_gain": 0.9, "artifacts": [], "target": {"semantic": "selection"}, "task_state": {"phase": "active"}}
+          ]
+        },
+        "participant": {},
+        "device": {"line_noise_uv": 0.0},
+        "display": {},
+        "transport": {},
+        "world_model": {"name": "driven_state_space", "parameters": {}}
+      },
+      "rules": [
+        {"path": "world_model_evidence.evidence_level", "operator": "==", "expected": "W1-causal-phenomenological", "description": "the pack must not silently change model evidence tier"},
+        {"path": "metrics.world_model.display_coupled", "operator": "==", "expected": true, "description": "neural world must be driven by emitted display history"},
+        {"path": "metrics.transport.packet_drop_fraction", "operator": "==", "expected": 0.0},
+        {"path": "metrics.transport.corrected_timestamp_p95_abs_ms", "operator": "<=", "expected": 0.000001},
+        {"path": "metrics.device_clipped_fraction", "operator": "==", "expected": 0.0}
+      ]
+    },
+    {
+      "name": "clock-domain-recovery",
+      "description": "A badly offset/drifting source clock may be corrected without conflating clock error with delivery latency.",
+      "manifest": {
+        "schema": "neuros.synthetic_bci_arena.manifest.v1",
+        "scenario": {
+          "name": "benchmark-clock-domain-recovery",
+          "seed": 102,
+          "metadata": {"paradigm": "ssvep", "purpose": "portable benchmark"},
+          "stages": [
+            {"label": "rest", "duration_s": 1.0, "target_frequency_hz": null, "attention_gain": 0.0, "artifacts": []},
+            {"label": "target", "duration_s": 2.0, "target_frequency_hz": 12.0, "attention_gain": 0.8, "artifacts": []}
+          ]
+        },
+        "participant": {},
+        "device": {"line_noise_uv": 0.0, "clock_offset_ms": 25.0, "clock_drift_ppm": 100.0, "timestamp_jitter_ms": 0.0},
+        "display": {},
+        "transport": {"clock_correction_offset_error_ms": 1.5, "clock_correction_drift_error_ppm": 10.0, "clock_correction_noise_ms": 0.0},
+        "world_model": {"name": "driven_state_space", "parameters": {}}
+      },
+      "rules": [
+        {"path": "metrics.transport.source_clock_offset_ms_estimated", "operator": ">=", "expected": 24.9},
+        {"path": "metrics.transport.source_clock_drift_ppm_estimated", "operator": ">=", "expected": 99.0},
+        {"path": "metrics.transport.corrected_timestamp_p95_abs_ms", "operator": "<=", "expected": 1.7},
+        {"path": "metrics.transport.packet_drop_fraction", "operator": "==", "expected": 0.0}
+      ]
+    }
+  ]
+}

--- a/examples/arena/dual_target_custom.json
+++ b/examples/arena/dual_target_custom.json
@@ -1,0 +1,34 @@
+{
+  "schema": "neuros.synthetic_bci_arena.manifest.v1",
+  "scenario": {
+    "name": "community-dual-target-example",
+    "seed": 42,
+    "metadata": {"paradigm": "dual-target-ssvep", "purpose": "shareable example"},
+    "stages": [
+      {"label": "rest", "duration_s": 4.0, "target_frequency_hz": null, "attention_gain": 0.0, "artifacts": []},
+      {"label": "blue", "duration_s": 5.0, "target_frequency_hz": 10.0, "attention_gain": 0.8, "artifacts": [{"at_s": 2.0, "kind": "controller", "duration_s": 0.6, "severity": 0.8}]},
+      {"label": "green", "duration_s": 5.0, "target_frequency_hz": 12.0, "attention_gain": 0.7, "artifacts": [{"at_s": 2.5, "kind": "jaw", "duration_s": 0.5, "severity": 0.7}]}
+    ]
+  },
+  "participant": {
+    "name": "creative-builder-profile", "seed": 42, "colored_noise_uv": 5.5, "white_noise_uv": 1.8,
+    "alpha_frequency_hz": 9.8, "alpha_amplitude_uv": 4.0, "ssvep_amplitude_uv": 5.0,
+    "first_harmonic_ratio": 0.3, "response_delay_s": 0.25, "switch_time_constant_s": 0.55,
+    "response_attenuation_per_minute": 0.05, "gaze_duty_cycle": 0.75, "artifact_gain": 1.0
+  },
+  "device": {
+    "name": "unicorn-like", "sampling_rate_hz": 250.0,
+    "channel_names": ["Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8"],
+    "adc_bits": 24, "input_range_uv": 450000.0, "sensor_noise_uv": 0.5,
+    "line_frequency_hz": 60.0, "line_noise_uv": 1.0, "clock_drift_ppm": 12.0, "chunk_samples": 5
+  },
+  "display": {
+    "name": "community-60hz", "refresh_hz": 60.0, "response_lag_ms": 5.0,
+    "frame_jitter_ms": 0.5, "frame_drop_probability": 0.005,
+    "low_luminance": 0.18, "high_luminance": 1.0
+  },
+  "transport": {
+    "name": "wifi-stress", "drop_probability": 0.01, "jitter_ms": 10.0,
+    "reorder_probability": 0.005, "silence_windows": [[9.0, 1.0]]
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,8 @@ nav:
       - Installation: getting-started/installation.md
   - Platform:
       - Four Public Surfaces: PLATFORM.md
+      - Synthetic BCI Arena: SYNTHETIC_BCI_ARENA.md
+      - EEG World Models: EEG_WORLD_MODELS.md
       - Ecosystem Compatibility: COMPATIBILITY.md
       - NeuroAI Ecosystem: NEUROAI_ECOSYSTEM.md
       - Qualification Bundles: QUALIFICATION.md
@@ -74,9 +76,11 @@ nav:
       - Project Status: PROJECT_STATUS.md
   - Scientific Trust:
       - Scientific Claims: SCIENTIFIC_CLAIMS.md
+      - Scientific Validation Policy: SCIENTIFIC_VALIDATION_POLICY.md
       - Release Policy: RELEASE_POLICY.md
   - Real-World Evidence:
       - Evidence Program: REAL_WORLD_EVIDENCE.md
+      - Public EEG Anchoring Study: PUBLIC_EEG_ANCHORING_STUDY.md
       - Ranked Source Map: EVIDENCE_SOURCE_MAP.md
       - Longitudinal EEG Showcase: LONGITUDINAL_EEG_SHOWCASE.md
       - Longitudinal Model Ladder: LONGITUDINAL_MODEL_LADDER.md

--- a/packages/neuros-arena/README.md
+++ b/packages/neuros-arena/README.md
@@ -1,0 +1,523 @@
+# neurOS Synthetic BCI Arena
+
+**A reproducible BCI wind tunnel for games, interactive neurotechnology and research teams that do not have continuous access to physical hardware.**
+
+Arena is not a universal fake brain. It is a systems environment that keeps the causal layers of an interactive BCI separate and testable:
+
+```text
+application / task state
+        ↓
+requested stimulus
+        ↓
+ACTUALLY EMITTED sensory history
+        ↓
+neural world model
+        ↓
+sensor-space EEG
+        ↓
+device / montage / ADC / source clock
+        ↓
+synchronization + transport
+        ↓
+decoder / quality authority
+        ↓
+game or application behavior
+```
+
+The same application can be exercised against deterministic fixtures, stochastic causal worlds, recorded EEG backgrounds, source-projected worlds, public datasets and eventually physical hardware without changing the application-facing evidence model.
+
+Arena deliberately does **not** claim that synthetic success predicts human physiological performance. Every report carries a scientific evidence boundary.
+
+## Install
+
+```bash
+pip install neuros-arena
+```
+
+Research/public-data extras:
+
+```bash
+pip install "neuros-arena[real]"
+```
+
+`[real]` is intended for MNE/MOABB/replay and domain-anchoring workflows. The normal game/CI path remains dependency-light.
+
+---
+
+## 1. Game developer: run a complete synthetic world
+
+```bash
+neuros-arena \
+  --preset dual-target-smoke \
+  --output arena-report.json \
+  --write-manifest resolved-world.json
+```
+
+Or reproduce a world shared in a bug report:
+
+```bash
+neuros-arena \
+  --manifest examples/arena/dual_target_custom.json \
+  --output report.json \
+  --npz derived-signal.npz
+```
+
+The NPZ contains both source/device timestamps and causal ground-truth timestamps so synchronization behavior can be inspected rather than hidden behind network latency.
+
+---
+
+## 2. Game developer: prove what the game actually did
+
+Unity, Godot, Web and custom engines can export the engine-neutral application trace schema:
+
+`neuros.synthetic_bci_arena.application_trace.v1`
+
+Example events include:
+
+```text
+neural_action
+neural_accept
+neural_abstain
+calibration_ready
+calibration_failed
+bci_lost
+bci_recovered
+participant_stop
+application_state
+```
+
+Then score the trace against the exact world:
+
+```bash
+neuros-arena \
+  --manifest resolved-world.json \
+  --application-trace game-trace.json \
+  --output closed-loop-evidence.json
+```
+
+Arena can report observations such as:
+
+- neural actions during known no-target/rest intervals;
+- actions during declared transport silence;
+- stale/non-monotonic source sequences;
+- actions after participant stop;
+- link-loss and recovery timing;
+- authority distributions.
+
+Arena reports the observations. Your benchmark pack decides which thresholds are acceptable for your particular game.
+
+---
+
+## 3. Team/CI: run a versioned conformance pack
+
+Benchmark packs are portable JSON artifacts:
+
+`neuros.synthetic_bci_arena.benchmark_pack.v1`
+
+Run the initial systems pack:
+
+```bash
+neuros-arena \
+  --benchmark-pack examples/arena/benchmark_packs/eeg_game_system_v1.json \
+  --output benchmark-result.json
+```
+
+A failing pack exits non-zero and preserves the failed metric assertions plus the complete world report.
+
+The initial `eeg-game-systems` v1 pack checks two deliberately narrow claims:
+
+1. a clean display-driven EEG world remains causally coupled and lossless;
+2. a large source-clock offset/drift remains distinguishable from decoder-facing synchronization error.
+
+Passing the pack is a **systems conformance claim**, not a decoder leaderboard or human-performance claim.
+
+---
+
+## 4. Neural world-model ladder
+
+The generator is selected independently from device/display/network state through `WorldModelProfile` and the `neuros.world_models` plugin group.
+
+Current built-ins:
+
+### `legacy_synthetic` — W0
+
+Stable deterministic frequency fixture for regression/driver/decoder tests.
+
+It is intentionally **not** promoted as display-causal physiology.
+
+### `driven_state_space` — W1
+
+Default causal phenomenological model:
+
+- endogenous posterior alpha;
+- correlated stochastic background state;
+- response/entrainment state;
+- switching dynamics;
+- artifact overlays;
+- driven by the display trace that was actually emitted after frame holds/jitter/drops.
+
+### `semi_synthetic_replay` — W2
+
+Recorded EEG background plus a known injected causal response.
+
+Useful when you want authentic covariance/rhythms/nuisance texture while retaining exact ground truth for the injected intervention.
+
+It does **not** claim that the injected response occurred in the recorded participant.
+
+### `leadfield_driven` — W3
+
+Display-driven response projected through an explicit frozen lead-field/topography bundle.
+
+`export_mne_forward_bundle(...)` can derive the portable bundle from explicit source columns in an MNE forward solution. Source assumptions remain visible instead of being silently guessed.
+
+### External world models
+
+Third-party packages can register:
+
+`neuros.world_models`
+
+New models may implement the original SSVEP-friendly `render(...)` contract or the richer paradigm-neutral `render_world(WorldInputBlock)` contract.
+
+External plugins without a scientific evidence card remain runnable but are reported as `W?-external-unqualified` rather than inheriting built-in claims.
+
+---
+
+## 5. WorldInput: not trapped inside SSVEP
+
+Manifest v1 remains backwards compatible with frequency-coded visual stages, but the model boundary now carries a richer `WorldInputBlock`:
+
+```text
+sample_times
+paradigm
+stage label
+emitted sensory streams
+semantic target state
+task/application state
+participant state
+```
+
+Today a visual stage supplies `visual_luminance` after display simulation.
+
+The same contract is intended to support future plugins for:
+
+- c-VEP;
+- P300/ERP;
+- motor imagery;
+- auditory BCI;
+- neurofeedback;
+- EEG + eye tracking/IMU/controller hybrids;
+- VR interactions;
+- creative paradigms that do not fit an existing BCI taxonomy.
+
+Old models and manifests continue to work through the compatibility adapter.
+
+---
+
+## 6. Timing: three clocks, not one latency number
+
+Interactive EEG timing is modeled explicitly as:
+
+```text
+causal truth clock
+       ↓
+device/source clock
+(offset + drift + sample timestamp jitter)
+       ↓
+corrected decoder-facing clock
+(residual synchronization error)
+```
+
+Network delivery is measured separately.
+
+Arena reports metrics including:
+
+- source clock offset;
+- source clock drift in ppm;
+- source timestamp jitter;
+- packet loss;
+- p95 delivery delay;
+- sequence inversions;
+- corrected timestamp RMSE;
+- corrected p95/max absolute timestamp error.
+
+This lets you test a synchronization strategy rather than assuming “low network latency” means event-aligned EEG.
+
+---
+
+## 7. Populations instead of one fake user
+
+```python
+from neuros.arena import (
+    ParameterDistribution,
+    PopulationSpec,
+    run_population,
+)
+
+population = PopulationSpec(
+    size=1000,
+    seed=7,
+    parameters=(
+        ParameterDistribution(
+            "participant.ssvep_amplitude_uv",
+            "uniform",
+            low=1.0,
+            high=10.0,
+        ),
+        ParameterDistribution(
+            "participant.alpha_frequency_hz",
+            "uniform",
+            low=8.0,
+            high=13.0,
+        ),
+        ParameterDistribution(
+            "display.frame_drop_probability",
+            "uniform",
+            low=0.0,
+            high=0.05,
+        ),
+    ),
+)
+
+result = run_population(manifest, population)
+print(result.summary)
+```
+
+The result describes coverage over the **declared synthetic envelope**. It is not an estimate that some percentage of humans have those parameters.
+
+---
+
+## 8. Counterexample search and metamorphic tests
+
+Some correctness properties do not require a perfect human model.
+
+Arena can test invariants such as:
+
+- increasing deterministic packet loss cannot deliver more packets;
+- increasing deterministic display drops cannot reduce the dropped-frame set;
+- degraded evidence must not increase a caller-defined gameplay authority metric;
+- a display-causal world must change when emitted display timing changes.
+
+`search_counterexamples(...)` explores a declared parameter envelope and retains complete failing manifests.
+
+A GitHub issue can therefore contain the exact world that broke your decoder or game rather than “it sometimes gets weird when Wi-Fi is bad.”
+
+---
+
+## 9. Recorded EEG with traceable provenance
+
+Arena does not replace BIDS/MNE/MOABB.
+
+Preferred flow:
+
+```text
+BIDS / MOABB / MNE
+      ↓
+explicit participant/session/run/window selection
+      ↓
+Arena baseline NPZ
+      +
+RecordingMetadata JSON sidecar
+```
+
+`RecordingMetadata` carries BIDS-aligned concepts such as:
+
+- dataset;
+- subject/session/run;
+- task/acquisition;
+- source locator/license;
+- reference and line frequency;
+- channel units/types;
+- electrode coordinates and coordinate system;
+- preprocessing provenance.
+
+The compact NPZ remains a derived Arena artifact, not a homebrew claim of BIDS compliance.
+
+### MNE
+
+```python
+from neuros.arena import RecordingMetadata, export_mne_raw_baseline
+
+export_mne_raw_baseline(
+    raw,
+    "background.npz",
+    channel_names=["PO7", "Oz", "PO8"],
+    duration_s=30,
+    recording_metadata=RecordingMetadata(
+        dataset="my-bids-dataset",
+        subject="01",
+        session="01",
+        task="ssvep",
+    ),
+)
+```
+
+### MOABB
+
+`iter_moabb_raw_runs(...)` follows MOABB's documented `subject → session → run → MNE Raw` contract.
+
+`export_moabb_run_window(...)` exports only a window explicitly chosen by the study author. Arena does not decide that an arbitrary task segment is “resting baseline.”
+
+---
+
+## 10. Reality anchoring must be held out
+
+With `neuros-sourceweigher`, a synthetic world bank can be weighted toward observed EEG using declared geometries such as:
+
+- affine-invariant covariance distance;
+- shared `neuros-foundation` representations.
+
+The weights describe **similarity under that geometry**, not probabilities that a world is the participant's true brain.
+
+### Within-recording guard split
+
+`split_contiguous_recording(...)` and `validate_covariance_anchor_held_out(...)` prevent fitting and judging on the same samples.
+
+### Leave-one-domain-out cohort study
+
+`run_leave_one_domain_out_covariance_study(...)` is stronger:
+
+1. hold out a whole participant/session domain;
+2. estimate world weights only from the remaining domains;
+3. average/freeze training-domain weights;
+4. score the frozen weights against the unseen EEG;
+5. compare against uniform synthetic weighting.
+
+This is the starting point for testing whether synthetic calibration transfers rather than merely overfits recordings.
+
+See `docs/PUBLIC_EEG_ANCHORING_STUDY.md`.
+
+---
+
+## 11. Observable EEG audit, without a magic realism score
+
+```python
+from neuros.arena.audit import eeg_observable_audit
+
+audit = eeg_observable_audit(data_uv, sampling_rate_hz=250)
+```
+
+The versioned audit independently reports dimensions such as:
+
+- RMS/MAD/amplitude tails;
+- delta/theta/alpha/beta/gamma fractions;
+- alpha peak;
+- spectral entropy;
+- approximate log-log spectral slope;
+- temporal autocorrelation;
+- zero-crossing behavior;
+- channel correlation;
+- covariance effective rank;
+- simple flat/extreme-sample indicators.
+
+It intentionally does **not** collapse those values into one universal realism score.
+
+A learned generator should be capable of failing in several different ways.
+
+---
+
+## 12. Source/forward simulation
+
+`export_mne_forward_bundle(...)` converts explicit fixed-orientation source columns from an MNE forward solution into a portable sensor-topography bundle.
+
+That enables a two-stage workflow:
+
+```text
+research workstation
+MNE source/forward model
+       ↓
+portable lead-field bundle
+       ↓
+CI / student laptop / game studio
+leadfield_driven Arena worlds
+```
+
+Arena therefore gains source-to-sensor spatial structure without forcing every creator to install a full source-modeling environment.
+
+---
+
+## 13. Evidence cards and validation axes
+
+Every world model has a machine-readable evidence card.
+
+World-model levels:
+
+```text
+W0 regression fixture
+W1 causal phenomenological
+W2 recorded-background semi-synthetic
+W3 source/lead-field projected
+W4 future biophysical/neural-mass
+W5 future learned conditional generator
+W6 future externally calibrated ensemble
+```
+
+System-validation levels are separate:
+
+```text
+A0 deterministic implementation
+A1 nuisance/intervention ground truth
+A2 display/sensory causality
+A3 acquisition device
+A4 synchronization/transport
+A5 decoder conformance
+A6 application/game conformance
+A7 held-out public/recorded EEG anchoring
+A8 target physical hardware
+A9 human closed-loop validation
+```
+
+A result can therefore say something concrete such as `W2/A7` rather than “our simulator is realistic.”
+
+See `docs/SCIENTIFIC_VALIDATION_POLICY.md`.
+
+---
+
+## 14. Writing a third-party world model
+
+Install/package entry point:
+
+```toml
+[project.entry-points."neuros.world_models"]
+my_model = "my_package:MyWorldModel"
+```
+
+Minimum runtime surface:
+
+```python
+class MyWorldModel:
+    channel_names = ("Fz", "Cz", "Pz", "Oz")
+
+    def inject_artifact(self, kind, duration_seconds, severity):
+        ...
+
+    def render_world(self, block):
+        # block.emitted_streams contains physical/simulated sensory history
+        # block.target/task_state carry declared causal/task metadata
+        return WorldModelEmission(data_uv=..., latent={...})
+
+    def evidence_card(self):
+        return {...}
+```
+
+A plugin may omit an evidence card during experimentation, but Arena will mark it scientifically unqualified rather than assigning it a built-in evidence tier.
+
+---
+
+## 15. What Arena is trying to become
+
+There are already excellent tools for individual layers of the field:
+
+- MNE for EEG/MEG analysis and source simulation;
+- MOABB for standardized public BCI datasets/evaluation;
+- BIDS/MNE-BIDS for canonical neuroscience data organization;
+- LSL/XDF/MNE-LSL for synchronized streaming and replay;
+- BrainFlow for board/device abstraction;
+- dedicated neural-data simulators for other electrophysiology regimes.
+
+Arena's intended role is narrower and complementary:
+
+> **reproducible closed-loop EEG systems conformance for interactive applications.**
+
+The long-term target is a shared ecosystem where a game developer can publish a world or benchmark pack, another developer can reproduce it anywhere, a neuroscience lab can anchor it to held-out public/human EEG, and physical hardware can later substitute into the same application boundary.
+
+That should make scarce headset/human sessions more valuable, not make them disappear.

--- a/packages/neuros-arena/pyproject.toml
+++ b/packages/neuros-arena/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "neuros-arena"
+version = "0.1.0"
+description = "Deterministic closed-loop synthetic BCI systems arena for neurOS"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "neurOS Development Team"}]
+keywords = ["neuroscience", "bci", "eeg", "simulation", "benchmark", "testing", "world-model"]
+dependencies = [
+    "numpy>=1.24.0",
+    "neuros-core>=2.0.0",
+    "neuros-drivers>=2.1.0",
+]
+
+[project.optional-dependencies]
+reality = ["neuros-sourceweigher>=0.2.0"]
+real = [
+    "mne>=1.6",
+    "mne-lsl>=1.5",
+    "moabb>=1.0",
+    "neuros-sourceweigher>=0.2.0",
+]
+test = ["pytest>=7.4", "pytest-asyncio>=0.21"]
+
+[project.scripts]
+neuros-arena = "neuros.arena.cli:main"
+
+[project.entry-points."neuros.world_models"]
+legacy_synthetic = "neuros.arena.world_models:LegacySyntheticWorldModel"
+driven_state_space = "neuros.arena.world_models:DrivenStateSpaceWorldModel"
+semi_synthetic_replay = "neuros.arena.semi_synthetic:SemiSyntheticReplayWorldModel"
+leadfield_driven = "neuros.arena.leadfield:LeadFieldDrivenWorldModel"
+
+[project.urls]
+Homepage = "https://github.com/sidhulyalkar/neurOS-v1"
+Repository = "https://github.com/sidhulyalkar/neurOS-v1"
+Issues = "https://github.com/sidhulyalkar/neurOS-v1/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["neuros*"]
+namespaces = true

--- a/packages/neuros-arena/src/neuros/arena/__init__.py
+++ b/packages/neuros-arena/src/neuros/arena/__init__.py
@@ -1,0 +1,131 @@
+"""Deterministic closed-loop synthetic BCI systems arena."""
+
+from .application import (
+    ApplicationEvent,
+    ApplicationTrace,
+    evaluate_application_trace,
+    load_application_trace,
+    save_application_trace,
+)
+from .baselines import export_mne_raw_baseline, save_eeg_baseline
+from .benchmark import (
+    BenchmarkCase,
+    BenchmarkCaseResult,
+    BenchmarkPack,
+    BenchmarkPackResult,
+    MetricRule,
+    load_benchmark_pack,
+    run_benchmark_pack,
+    save_benchmark_pack,
+)
+from .conformance import (
+    AdversarialSearchResult,
+    MetamorphicResult,
+    check_display_drop_monotonicity,
+    check_fail_closed_degradation,
+    check_transport_drop_monotonicity,
+    search_counterexamples,
+)
+from .evaluation import ArenaDecision, evaluate_decisions
+from .evidence import WorldModelEvidenceCard, evidence_card_for_model
+from .leadfield import LeadFieldDrivenWorldModel, export_mne_forward_bundle, save_leadfield_bundle
+from .manifest import ArenaManifest, load_manifest, save_manifest
+from .population import ParameterDistribution, PopulationRun, PopulationSpec, run_population
+from .presets import get_preset, list_presets
+from .reality import RealityAnchorResult, anchor_worlds_by_covariance, anchor_worlds_by_embeddings
+from .recording import (
+    ElectrodeCoordinate,
+    RecordingMetadata,
+    load_recording_metadata,
+    recording_sidecar_path,
+    save_recording_metadata,
+)
+from .reference import compare_feature_signatures, feature_signature
+from .runner import ArenaRun, run_scenario
+from .semi_synthetic import SemiSyntheticReplayWorldModel
+from .specs import (
+    ArenaScenario,
+    ArtifactEvent,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    WorldModelProfile,
+)
+from .studies import CohortAnchorFold, CohortAnchorStudy, run_leave_one_domain_out_covariance_study
+from .validation import HeldOutRealityValidation, split_contiguous_recording, validate_covariance_anchor_held_out
+from .world_input import WorldInputBlock
+from .world_models import DrivenStateSpaceWorldModel, LegacySyntheticWorldModel, NeuralWorldModel, WorldModelEmission
+
+__all__ = [
+    "AdversarialSearchResult",
+    "ApplicationEvent",
+    "ApplicationTrace",
+    "ArenaDecision",
+    "ArenaManifest",
+    "ArenaRun",
+    "ArenaScenario",
+    "ArtifactEvent",
+    "BenchmarkCase",
+    "BenchmarkCaseResult",
+    "BenchmarkPack",
+    "BenchmarkPackResult",
+    "CohortAnchorFold",
+    "CohortAnchorStudy",
+    "DeviceProfile",
+    "DisplayProfile",
+    "DrivenStateSpaceWorldModel",
+    "ElectrodeCoordinate",
+    "HeldOutRealityValidation",
+    "LeadFieldDrivenWorldModel",
+    "LegacySyntheticWorldModel",
+    "MetamorphicResult",
+    "MetricRule",
+    "NeuralWorldModel",
+    "ParameterDistribution",
+    "ParticipantProfile",
+    "PopulationRun",
+    "PopulationSpec",
+    "RealityAnchorResult",
+    "RecordingMetadata",
+    "SemiSyntheticReplayWorldModel",
+    "StageSpec",
+    "TransportProfile",
+    "WorldInputBlock",
+    "WorldModelEmission",
+    "WorldModelEvidenceCard",
+    "WorldModelProfile",
+    "anchor_worlds_by_covariance",
+    "anchor_worlds_by_embeddings",
+    "check_display_drop_monotonicity",
+    "check_fail_closed_degradation",
+    "check_transport_drop_monotonicity",
+    "compare_feature_signatures",
+    "evaluate_application_trace",
+    "evaluate_decisions",
+    "evidence_card_for_model",
+    "export_mne_forward_bundle",
+    "export_mne_raw_baseline",
+    "feature_signature",
+    "get_preset",
+    "list_presets",
+    "load_application_trace",
+    "load_benchmark_pack",
+    "load_manifest",
+    "load_recording_metadata",
+    "recording_sidecar_path",
+    "run_benchmark_pack",
+    "run_leave_one_domain_out_covariance_study",
+    "run_population",
+    "run_scenario",
+    "save_application_trace",
+    "save_benchmark_pack",
+    "save_eeg_baseline",
+    "save_leadfield_bundle",
+    "save_manifest",
+    "save_recording_metadata",
+    "search_counterexamples",
+    "split_contiguous_recording",
+    "validate_covariance_anchor_held_out",
+]

--- a/packages/neuros-arena/src/neuros/arena/application.py
+++ b/packages/neuros-arena/src/neuros/arena/application.py
@@ -1,0 +1,190 @@
+"""Portable application/game traces for closed-loop Arena conformance.
+
+The application trace is intentionally engine-agnostic. Unity, Godot, Web,
+OpenViBE or custom applications can export the same small event schema and let
+Arena judge behavior against known world, timing and transport ground truth.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+from .runner import ArenaRun
+
+APPLICATION_TRACE_SCHEMA = "neuros.synthetic_bci_arena.application_trace.v1"
+
+STANDARD_EVENT_KINDS = {
+    "neural_action",
+    "neural_accept",
+    "neural_abstain",
+    "calibration_ready",
+    "calibration_failed",
+    "bci_lost",
+    "bci_recovered",
+    "participant_stop",
+    "application_state",
+}
+
+
+@dataclass(frozen=True)
+class ApplicationEvent:
+    timestamp_s: float
+    kind: str
+    action: str = ""
+    source: str = "application"
+    authority: float | None = None
+    source_sequence: int | None = None
+    payload: dict[str, str | int | float | bool | None] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not np.isfinite(self.timestamp_s) or self.timestamp_s < 0:
+            raise ValueError("application event timestamp_s must be finite and non-negative")
+        if not self.kind:
+            raise ValueError("application event kind is required")
+        if self.authority is not None and (not np.isfinite(self.authority) or self.authority < 0):
+            raise ValueError("application authority must be finite and non-negative")
+        if self.source_sequence is not None and self.source_sequence < 0:
+            raise ValueError("source_sequence must be non-negative when present")
+        for key, value in self.payload.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError("application payload keys must be non-empty strings")
+            if not isinstance(value, (str, int, float, bool)) and value is not None:
+                raise ValueError(f"application payload {key!r} must be a JSON scalar")
+
+
+@dataclass(frozen=True)
+class ApplicationTrace:
+    application: str
+    version: str
+    events: tuple[ApplicationEvent, ...]
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.application or not self.version:
+            raise ValueError("application trace requires application and version")
+        previous = -np.inf
+        for event in self.events:
+            event.validate()
+            if event.timestamp_s < previous:
+                raise ValueError("application events must be monotonic by timestamp_s")
+            previous = event.timestamp_s
+        for key, value in self.metadata.items():
+            if not str(key) or not str(value):
+                raise ValueError("application trace metadata keys/values must be non-empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": APPLICATION_TRACE_SCHEMA,
+            "application": self.application,
+            "version": self.version,
+            "metadata": dict(self.metadata),
+            "events": [asdict(event) for event in self.events],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "ApplicationTrace":
+        if raw.get("schema") != APPLICATION_TRACE_SCHEMA:
+            raise ValueError(f"expected application trace schema {APPLICATION_TRACE_SCHEMA!r}")
+        trace = cls(
+            application=str(raw["application"]),
+            version=str(raw["version"]),
+            metadata={str(key): str(value) for key, value in dict(raw.get("metadata", {})).items()},
+            events=tuple(ApplicationEvent(**dict(item)) for item in raw.get("events", [])),
+        )
+        trace.validate()
+        return trace
+
+
+def load_application_trace(path: str | Path) -> ApplicationTrace:
+    return ApplicationTrace.from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+def save_application_trace(trace: ApplicationTrace, path: str | Path) -> Path:
+    trace.validate()
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(trace.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    return output
+
+
+def _truth_target_at(run: ArenaRun, timestamp_s: float) -> float | None:
+    for interval in run.stages:
+        if interval.start_s <= timestamp_s < interval.end_s:
+            return interval.target_frequency_hz
+    return None
+
+
+def _in_transport_silence(run: ArenaRun, timestamp_s: float, grace_s: float) -> bool:
+    for start, duration in run.transport.silence_windows:
+        if start - grace_s <= timestamp_s < start + duration + grace_s:
+            return True
+    return False
+
+
+def evaluate_application_trace(
+    run: ArenaRun,
+    trace: ApplicationTrace,
+    *,
+    neural_action_kind: str = "neural_action",
+    silence_grace_s: float = 0.0,
+) -> dict[str, float]:
+    """Score generic application safety/authority behavior against Arena truth.
+
+    The function deliberately reports observations rather than imposing a single
+    universal pass criterion. A benchmark pack or application-specific evaluator
+    decides which values are acceptable for a particular game/paradigm.
+    """
+    trace.validate()
+    if silence_grace_s < 0:
+        raise ValueError("silence_grace_s must be non-negative")
+    actions = [event for event in trace.events if event.kind == neural_action_kind]
+    accepts = [event for event in trace.events if event.kind == "neural_accept"]
+    abstains = [event for event in trace.events if event.kind == "neural_abstain"]
+    lost = [event for event in trace.events if event.kind == "bci_lost"]
+    recovered = [event for event in trace.events if event.kind == "bci_recovered"]
+    stops = [event for event in trace.events if event.kind == "participant_stop"]
+
+    actions_without_target = sum(_truth_target_at(run, event.timestamp_s) is None for event in actions)
+    actions_during_silence = sum(_in_transport_silence(run, event.timestamp_s, silence_grace_s) for event in actions)
+    authorities = np.asarray(
+        [event.authority for event in trace.events if event.authority is not None],
+        dtype=float,
+    )
+    sequences = [event.source_sequence for event in actions if event.source_sequence is not None]
+    sequence_regressions = sum(
+        int(sequences[index + 1] <= sequences[index])
+        for index in range(len(sequences) - 1)
+    )
+
+    recovery_latencies: list[float] = []
+    for silence_start, duration in run.transport.silence_windows:
+        silence_end = silence_start + duration
+        later = [event.timestamp_s for event in recovered if event.timestamp_s >= silence_end]
+        if later:
+            recovery_latencies.append(min(later) - silence_end)
+
+    participant_stop_violations = 0
+    if stops:
+        first_stop = stops[0].timestamp_s
+        participant_stop_violations = sum(event.timestamp_s > first_stop for event in actions)
+
+    return {
+        "events_total": float(len(trace.events)),
+        "neural_actions_total": float(len(actions)),
+        "neural_accepts_total": float(len(accepts)),
+        "neural_abstains_total": float(len(abstains)),
+        "neural_actions_without_target": float(actions_without_target),
+        "neural_actions_during_transport_silence": float(actions_during_silence),
+        "neural_action_sequence_regressions": float(sequence_regressions),
+        "participant_stop_action_violations": float(participant_stop_violations),
+        "bci_lost_events": float(len(lost)),
+        "bci_recovered_events": float(len(recovered)),
+        "recovery_latency_mean_s": float(np.mean(recovery_latencies)) if recovery_latencies else 0.0,
+        "recovery_latency_max_s": float(np.max(recovery_latencies)) if recovery_latencies else 0.0,
+        "authority_mean": float(np.mean(authorities)) if authorities.size else 0.0,
+        "authority_max": float(np.max(authorities)) if authorities.size else 0.0,
+    }

--- a/packages/neuros-arena/src/neuros/arena/audit.py
+++ b/packages/neuros-arena/src/neuros/arena/audit.py
@@ -1,0 +1,177 @@
+"""Multidimensional observable EEG audits for synthetic/recorded comparison.
+
+The audit intentionally returns separate interpretable measurements instead of a
+single 'realism score'. No finite set of sensor-space features establishes
+physiological equivalence, but diverse features make obvious simulator/generator
+shortcuts easier to detect.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+AUDIT_SCHEMA = "neuros.synthetic_bci_arena.eeg_observable_audit.v1"
+
+
+def _validate(data_uv: np.ndarray, sampling_rate_hz: float) -> np.ndarray:
+    data = np.asarray(data_uv, dtype=float)
+    if data.ndim != 2 or data.shape[0] < 1 or data.shape[1] < 64:
+        raise ValueError("expected channels x samples EEG with at least 64 samples")
+    if sampling_rate_hz <= 0:
+        raise ValueError("sampling_rate_hz must be positive")
+    if not np.all(np.isfinite(data)):
+        raise ValueError("observable EEG audit requires finite data")
+    return data
+
+
+def _median_channel_autocorrelation(centered: np.ndarray, lag: int) -> float:
+    if lag <= 0 or lag >= centered.shape[1] - 2:
+        return 0.0
+    values = []
+    for channel in centered:
+        a = channel[:-lag]
+        b = channel[lag:]
+        if np.std(a) <= 1e-12 or np.std(b) <= 1e-12:
+            continue
+        values.append(float(np.corrcoef(a, b)[0, 1]))
+    return float(np.median(values)) if values else 0.0
+
+
+def _band_fraction(power: np.ndarray, frequencies: np.ndarray, low: float, high: float) -> float:
+    valid = (frequencies >= 1.0) & (frequencies <= min(80.0, frequencies[-1]))
+    band = (frequencies >= low) & (frequencies < high)
+    denominator = float(np.sum(power[:, valid]))
+    return float(np.sum(power[:, band]) / denominator) if denominator > 0 else 0.0
+
+
+def _effective_rank(covariance: np.ndarray) -> tuple[float, float]:
+    values = np.maximum(np.linalg.eigvalsh(covariance), 0.0)
+    total = float(values.sum())
+    if total <= 1e-15:
+        return 0.0, 0.0
+    probabilities = values / total
+    positive = probabilities[probabilities > 0]
+    entropy = -float(np.sum(positive * np.log(positive)))
+    effective = float(np.exp(entropy))
+    largest = float(values[-1] / total)
+    return effective, largest
+
+
+def _aperiodic_loglog_slope(power_1d: np.ndarray, frequencies: np.ndarray) -> float:
+    # A deliberately simple observable summary, not a FOOOF/specparam replacement.
+    # Exclude DC, mains-adjacent bins, and canonical alpha to reduce domination by
+    # obvious oscillatory peaks. The value is reported as a regression slope,
+    # not interpreted as a biological exponent.
+    valid = (frequencies >= 2.0) & (frequencies <= min(40.0, frequencies[-1]))
+    valid &= ~((frequencies >= 7.5) & (frequencies <= 13.5))
+    valid &= ~((frequencies >= 49.0) & (frequencies <= 61.0))
+    x = frequencies[valid]
+    y = power_1d[valid]
+    positive = (x > 0) & (y > 0)
+    if np.count_nonzero(positive) < 8:
+        return 0.0
+    slope, _ = np.polyfit(np.log10(x[positive]), np.log10(y[positive]), 1)
+    return float(slope)
+
+
+def eeg_observable_audit(data_uv: np.ndarray, sampling_rate_hz: float) -> dict:
+    """Return a versioned sensor-space audit with no aggregate realism score."""
+    data = _validate(data_uv, sampling_rate_hz)
+    centered = data - np.mean(data, axis=1, keepdims=True)
+    abs_data = np.abs(centered)
+    channel_std = np.std(centered, axis=1)
+    channel_rms = np.sqrt(np.mean(centered**2, axis=1))
+    channel_mad = np.median(np.abs(centered - np.median(centered, axis=1, keepdims=True)), axis=1)
+
+    window = np.hanning(centered.shape[1])
+    fft = np.fft.rfft(centered * window[None, :], axis=1)
+    power = np.abs(fft) ** 2
+    frequencies = np.fft.rfftfreq(centered.shape[1], d=1.0 / sampling_rate_hz)
+    median_power = np.median(power, axis=0)
+    usable = (frequencies >= 1.0) & (frequencies <= min(80.0, frequencies[-1]))
+    normalized = median_power[usable]
+    normalized = normalized / max(float(normalized.sum()), 1e-15)
+    positive = normalized[normalized > 0]
+    spectral_entropy = -float(np.sum(positive * np.log(positive)))
+    if positive.size > 1:
+        spectral_entropy /= float(np.log(positive.size))
+
+    alpha = (frequencies >= 8.0) & (frequencies <= 13.0)
+    alpha_peak = 0.0
+    if np.any(alpha):
+        alpha_freqs = frequencies[alpha]
+        alpha_peak = float(alpha_freqs[int(np.argmax(median_power[alpha]))])
+
+    covariance = np.cov(centered, bias=True)
+    covariance = np.atleast_2d(covariance)
+    trace_scale = float(np.trace(covariance) / covariance.shape[0]) if covariance.size else 1.0
+    covariance = covariance + max(trace_scale, 1e-9) * 1e-6 * np.eye(covariance.shape[0])
+    effective_rank, first_component_fraction = _effective_rank(covariance)
+    correlation = np.corrcoef(centered)
+    if correlation.ndim == 2 and correlation.shape[0] > 1:
+        upper = np.abs(correlation[np.triu_indices(correlation.shape[0], 1)])
+        mean_abs_corr = float(np.mean(upper))
+        median_abs_corr = float(np.median(upper))
+    else:
+        mean_abs_corr = 0.0
+        median_abs_corr = 0.0
+
+    def lag_samples(seconds: float) -> int:
+        return max(1, int(round(seconds * sampling_rate_hz)))
+
+    zero_crossings = np.mean(np.diff(np.signbit(centered), axis=1) != 0, axis=1)
+    return {
+        "schema": AUDIT_SCHEMA,
+        "sampling_rate_hz": float(sampling_rate_hz),
+        "channels": int(data.shape[0]),
+        "samples": int(data.shape[1]),
+        "amplitude": {
+            "median_channel_rms_uv": float(np.median(channel_rms)),
+            "median_channel_mad_uv": float(np.median(channel_mad)),
+            "p95_abs_uv": float(np.percentile(abs_data, 95)),
+            "p99_abs_uv": float(np.percentile(abs_data, 99)),
+            "max_abs_uv": float(np.max(abs_data)),
+        },
+        "spectrum": {
+            "delta_1_4_fraction": _band_fraction(power, frequencies, 1.0, 4.0),
+            "theta_4_8_fraction": _band_fraction(power, frequencies, 4.0, 8.0),
+            "alpha_8_13_fraction": _band_fraction(power, frequencies, 8.0, 13.0),
+            "beta_13_30_fraction": _band_fraction(power, frequencies, 13.0, 30.0),
+            "gamma_30_45_fraction": _band_fraction(power, frequencies, 30.0, 45.0),
+            "high_45_80_fraction": _band_fraction(power, frequencies, 45.0, 80.0),
+            "alpha_peak_hz": alpha_peak,
+            "normalized_spectral_entropy": float(spectral_entropy),
+            "aperiodic_loglog_slope_2_40": _aperiodic_loglog_slope(median_power, frequencies),
+        },
+        "temporal": {
+            "median_autocorrelation_20ms": _median_channel_autocorrelation(centered, lag_samples(0.020)),
+            "median_autocorrelation_100ms": _median_channel_autocorrelation(centered, lag_samples(0.100)),
+            "median_autocorrelation_500ms": _median_channel_autocorrelation(centered, lag_samples(0.500)),
+            "median_zero_crossing_fraction": float(np.median(zero_crossings)),
+        },
+        "spatial": {
+            "mean_abs_channel_correlation": mean_abs_corr,
+            "median_abs_channel_correlation": median_abs_corr,
+            "covariance_effective_rank": effective_rank,
+            "largest_covariance_component_fraction": first_component_fraction,
+        },
+        "quality": {
+            "flat_channel_fraction_std_lt_0_2uv": float(np.mean(channel_std < 0.2)),
+            "extreme_sample_fraction_abs_gt_300uv": float(np.mean(abs_data > 300.0)),
+        },
+        "evidence_boundary": (
+            "Observable sensor-space audit only. Matching these features does not establish physiological equivalence or human performance."
+        ),
+    }
+
+
+def flatten_audit_metrics(audit: dict) -> dict[str, float]:
+    """Flatten numeric audit leaves for declared distance/weighting methods."""
+    if audit.get("schema") != AUDIT_SCHEMA:
+        raise ValueError(f"expected audit schema {AUDIT_SCHEMA!r}")
+    flattened: dict[str, float] = {}
+    for section in ("amplitude", "spectrum", "temporal", "spatial", "quality"):
+        values = audit.get(section, {})
+        for key, value in values.items():
+            if isinstance(value, (int, float)) and np.isfinite(value):
+                flattened[f"{section}.{key}"] = float(value)
+    return flattened

--- a/packages/neuros-arena/src/neuros/arena/baselines.py
+++ b/packages/neuros-arena/src/neuros/arena/baselines.py
@@ -1,0 +1,136 @@
+"""Portable recorded-background helpers for semi-synthetic Arena worlds."""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+from .recording import RecordingMetadata, recording_sidecar_path, save_recording_metadata
+
+BASELINE_SCHEMA = "neuros.arena.eeg_baseline.v1"
+
+
+def save_eeg_baseline(
+    path: str | Path,
+    *,
+    data_uv: np.ndarray,
+    sampling_rate_hz: float,
+    channel_names: Sequence[str],
+    metadata: dict[str, str] | None = None,
+    recording_metadata: RecordingMetadata | None = None,
+) -> None:
+    """Save a finite channels×samples EEG background with explicit units.
+
+    ``recording_metadata`` writes a traceable JSON sidecar next to the compact
+    NPZ. The sidecar is BIDS-aligned provenance, not a replacement for a
+    canonical BIDS dataset.
+    """
+    data = np.asarray(data_uv, dtype=float)
+    channels = tuple(str(name) for name in channel_names)
+    if data.ndim != 2 or data.shape[0] != len(channels) or data.shape[1] < 32:
+        raise ValueError("data_uv must be channels x samples with one channel name per row")
+    if not np.all(np.isfinite(data)):
+        raise ValueError("baseline EEG must be finite")
+    if sampling_rate_hz <= 0 or not channels:
+        raise ValueError("sampling_rate_hz and channel_names are required")
+    if len(set(channels)) != len(channels):
+        raise ValueError("channel_names must be unique")
+    info = metadata or {}
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        output,
+        schema=np.asarray(BASELINE_SCHEMA),
+        data_uv=data.astype(np.float32),
+        sampling_rate_hz=np.asarray(float(sampling_rate_hz)),
+        channel_names=np.asarray(channels),
+        metadata_keys=np.asarray(list(info), dtype=str),
+        metadata_values=np.asarray([str(info[key]) for key in info], dtype=str),
+    )
+    if recording_metadata is not None:
+        save_recording_metadata(
+            recording_metadata,
+            recording_sidecar_path(output),
+            channel_names=channels,
+        )
+
+
+def _mne_channel_types(raw: Any) -> dict[str, str]:
+    """Extract MNE channel types without depending on private Info fields."""
+    try:
+        types = raw.get_channel_types()
+    except AttributeError:  # pragma: no cover - old external MNE object
+        return {}
+    return {str(name): str(kind) for name, kind in zip(raw.ch_names, types, strict=True)}
+
+
+def export_mne_raw_baseline(
+    raw: Any,
+    path: str | Path,
+    *,
+    channel_names: Sequence[str],
+    tmin_s: float = 0.0,
+    duration_s: float | None = None,
+    target_sampling_rate_hz: float | None = None,
+    metadata: dict[str, str] | None = None,
+    recording_metadata: RecordingMetadata | None = None,
+) -> None:
+    """Export a selected MNE Raw window to Arena's semi-synthetic baseline.
+
+    The function uses only MNE's public Raw methods/properties and does not
+    download datasets. MOABB or any other dataset package can remain upstream.
+    EEG values returned by MNE are volts and are converted explicitly to µV.
+
+    If no ``recording_metadata`` object is supplied, Arena records only values
+    that can be obtained safely from the MNE object itself. Dataset/subject/task
+    provenance should normally be supplied by the caller because it belongs to
+    the upstream BIDS/MOABB dataset, not to signal inference inside Arena.
+    """
+    try:
+        import mne  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - optional research dependency
+        raise ImportError("MNE baseline export requires `neuros-arena[real]` or mne>=1.6") from exc
+    if tmin_s < 0 or (duration_s is not None and duration_s <= 0):
+        raise ValueError("tmin_s must be >= 0 and duration_s must be positive")
+    work = raw.copy().pick(list(channel_names))
+    preprocessing: list[str] = []
+    if target_sampling_rate_hz is not None:
+        if target_sampling_rate_hz <= 0:
+            raise ValueError("target_sampling_rate_hz must be positive")
+        work.resample(float(target_sampling_rate_hz))
+        preprocessing.append(f"resampled_to_{float(target_sampling_rate_hz):g}Hz")
+    sfreq = float(work.info["sfreq"])
+    start = int(round(tmin_s * sfreq))
+    stop = None if duration_s is None else start + int(round(duration_s * sfreq))
+    if start >= work.n_times:
+        raise ValueError("tmin_s is beyond the recording")
+    stop = work.n_times if stop is None else min(stop, work.n_times)
+    data_v = np.asarray(work.get_data(start=start, stop=stop), dtype=float)
+    if recording_metadata is None:
+        line_frequency = work.info.get("line_freq")
+        recording_metadata = RecordingMetadata(
+            source_format="mne.Raw",
+            line_frequency_hz=(None if line_frequency is None else float(line_frequency)),
+            channel_units={name: "uV" for name in work.ch_names},
+            channel_types=_mne_channel_types(work),
+            preprocessing=tuple(preprocessing),
+            notes=(
+                "Arena baseline values were converted from MNE SI volts to microvolts.",
+                "Dataset/task/subject provenance was not inferred; supply it explicitly when available.",
+            ),
+        )
+    elif preprocessing:
+        recording_metadata = replace(
+            recording_metadata,
+            preprocessing=tuple(recording_metadata.preprocessing) + tuple(preprocessing),
+        )
+    save_eeg_baseline(
+        path,
+        data_uv=data_v * 1e6,
+        sampling_rate_hz=sfreq,
+        channel_names=tuple(work.ch_names),
+        metadata={"source": "mne.Raw", **(metadata or {})},
+        recording_metadata=recording_metadata,
+    )

--- a/packages/neuros-arena/src/neuros/arena/benchmark.py
+++ b/packages/neuros-arena/src/neuros/arena/benchmark.py
@@ -1,0 +1,218 @@
+"""Portable benchmark packs for reproducible BCI systems claims."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal
+
+from .manifest import ArenaManifest, manifest_from_dict
+from .runner import ArenaRun, run_scenario
+
+BENCHMARK_SCHEMA = "neuros.synthetic_bci_arena.benchmark_pack.v1"
+RuleOperator = Literal["<", "<=", ">", ">=", "==", "!="]
+Scalar = str | int | float | bool | None
+
+
+@dataclass(frozen=True)
+class MetricRule:
+    path: str
+    operator: RuleOperator
+    expected: Scalar
+    description: str = ""
+
+    def validate(self) -> None:
+        if not self.path:
+            raise ValueError("benchmark rule path is required")
+        if self.operator not in {"<", "<=", ">", ">=", "==", "!="}:
+            raise ValueError(f"unsupported benchmark operator: {self.operator}")
+        if self.operator in {"<", "<=", ">", ">="} and not isinstance(self.expected, (int, float)):
+            raise ValueError("ordered benchmark comparisons require a numeric expected value")
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    manifest: ArenaManifest
+    rules: tuple[MetricRule, ...]
+    description: str = ""
+
+    def validate(self) -> None:
+        if not self.name or not self.rules:
+            raise ValueError("benchmark case requires a name and at least one rule")
+        self.manifest.validate()
+        for rule in self.rules:
+            rule.validate()
+
+
+@dataclass(frozen=True)
+class BenchmarkPack:
+    name: str
+    version: str
+    cases: tuple[BenchmarkCase, ...]
+    description: str = ""
+    claim_scope: str = "synthetic systems conformance"
+
+    def validate(self) -> None:
+        if not self.name or not self.version or not self.cases:
+            raise ValueError("benchmark pack requires name, version, and cases")
+        names = [case.name for case in self.cases]
+        if len(names) != len(set(names)):
+            raise ValueError("benchmark case names must be unique")
+        for case in self.cases:
+            case.validate()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": BENCHMARK_SCHEMA,
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "claim_scope": self.claim_scope,
+            "cases": [
+                {
+                    "name": case.name,
+                    "description": case.description,
+                    "manifest": case.manifest.to_dict(),
+                    "rules": [asdict(rule) for rule in case.rules],
+                }
+                for case in self.cases
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class BenchmarkCaseResult:
+    name: str
+    passed: bool
+    observations: dict[str, Scalar]
+    failures: tuple[str, ...]
+    report: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BenchmarkPackResult:
+    pack_name: str
+    pack_version: str
+    passed: bool
+    cases: tuple[BenchmarkCaseResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": "neuros.synthetic_bci_arena.benchmark_result.v1",
+            "pack_name": self.pack_name,
+            "pack_version": self.pack_version,
+            "passed": self.passed,
+            "cases": [asdict(case) for case in self.cases],
+            "evidence_boundary": (
+                "Passing this pack establishes only the declared synthetic systems-conformance claims. "
+                "It does not establish human physiological performance."
+            ),
+        }
+
+
+def _lookup(payload: dict[str, Any], path: str) -> Any:
+    value: Any = payload
+    for part in path.split("."):
+        if not isinstance(value, dict) or part not in value:
+            raise KeyError(f"benchmark metric path not found: {path!r}")
+        value = value[part]
+    return value
+
+
+def _compare(observed: Any, operator: RuleOperator, expected: Scalar) -> bool:
+    if operator == "==":
+        return observed == expected
+    if operator == "!=":
+        return observed != expected
+    if not isinstance(observed, (int, float)) or not isinstance(expected, (int, float)):
+        return False
+    if operator == "<":
+        return observed < expected
+    if operator == "<=":
+        return observed <= expected
+    if operator == ">":
+        return observed > expected
+    return observed >= expected
+
+
+def run_benchmark_pack(
+    pack: BenchmarkPack,
+    evaluator: Callable[[ArenaRun], dict[str, Scalar]] | None = None,
+) -> BenchmarkPackResult:
+    """Run a versioned conformance pack against Arena and optional application metrics."""
+    pack.validate()
+    case_results: list[BenchmarkCaseResult] = []
+    for case in pack.cases:
+        manifest = case.manifest
+        run = run_scenario(
+            manifest.scenario,
+            manifest.participant,
+            manifest.device,
+            manifest.display,
+            manifest.transport,
+            manifest.world_model,
+        )
+        payload = dict(run.report)
+        if evaluator is not None:
+            payload["application"] = dict(evaluator(run))
+        observations: dict[str, Scalar] = {}
+        failures: list[str] = []
+        for rule in case.rules:
+            try:
+                observed = _lookup(payload, rule.path)
+            except KeyError as exc:
+                failures.append(str(exc))
+                continue
+            observations[rule.path] = observed
+            if not _compare(observed, rule.operator, rule.expected):
+                message = f"{rule.path}: observed {observed!r} {rule.operator} expected {rule.expected!r} failed"
+                if rule.description:
+                    message += f" ({rule.description})"
+                failures.append(message)
+        case_results.append(BenchmarkCaseResult(
+            name=case.name,
+            passed=not failures,
+            observations=observations,
+            failures=tuple(failures),
+            report=payload,
+        ))
+    return BenchmarkPackResult(
+        pack_name=pack.name,
+        pack_version=pack.version,
+        passed=all(case.passed for case in case_results),
+        cases=tuple(case_results),
+    )
+
+
+def benchmark_pack_from_dict(raw: dict[str, Any]) -> BenchmarkPack:
+    if raw.get("schema") != BENCHMARK_SCHEMA:
+        raise ValueError(f"expected benchmark schema {BENCHMARK_SCHEMA!r}")
+    cases = []
+    for case_raw in raw.get("cases", []):
+        cases.append(BenchmarkCase(
+            name=str(case_raw["name"]),
+            description=str(case_raw.get("description", "")),
+            manifest=manifest_from_dict(dict(case_raw["manifest"])),
+            rules=tuple(MetricRule(**dict(rule)) for rule in case_raw.get("rules", [])),
+        ))
+    pack = BenchmarkPack(
+        name=str(raw["name"]),
+        version=str(raw["version"]),
+        description=str(raw.get("description", "")),
+        claim_scope=str(raw.get("claim_scope", "synthetic systems conformance")),
+        cases=tuple(cases),
+    )
+    pack.validate()
+    return pack
+
+
+def load_benchmark_pack(path: str | Path) -> BenchmarkPack:
+    return benchmark_pack_from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+def save_benchmark_pack(pack: BenchmarkPack, path: str | Path) -> None:
+    pack.validate()
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(pack.to_dict(), indent=2, sort_keys=True), encoding="utf-8")

--- a/packages/neuros-arena/src/neuros/arena/cli.py
+++ b/packages/neuros-arena/src/neuros/arena/cli.py
@@ -1,0 +1,125 @@
+"""Command-line entry point for reproducible Synthetic BCI Arena runs."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from .application import evaluate_application_trace, load_application_trace
+from .benchmark import load_benchmark_pack, run_benchmark_pack
+from .manifest import ArenaManifest, load_manifest, save_manifest
+from .presets import get_preset, list_presets
+from .runner import run_scenario
+
+
+def _write_json(payload: dict, path: str | Path) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--preset", choices=list_presets(), default=None)
+    parser.add_argument("--manifest", default=None, help="portable neuros.synthetic_bci_arena.manifest.v1 JSON")
+    parser.add_argument(
+        "--benchmark-pack",
+        default=None,
+        help="portable neuros.synthetic_bci_arena.benchmark_pack.v1 JSON",
+    )
+    parser.add_argument(
+        "--application-trace",
+        default=None,
+        help="optional engine-neutral neuros.synthetic_bci_arena.application_trace.v1 JSON for a single-world run",
+    )
+    parser.add_argument("--application-silence-grace-s", type=float, default=0.0)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--output", default="arena-report.json")
+    parser.add_argument("--npz", default=None, help="optional derived synthetic arrays for offline inspection")
+    parser.add_argument("--write-manifest", default=None, help="write the resolved world manifest before running")
+    parser.add_argument("--list-presets", action="store_true")
+    args = parser.parse_args()
+    if args.list_presets:
+        print("\n".join(list_presets()))
+        return
+    if args.application_silence_grace_s < 0:
+        parser.error("--application-silence-grace-s must be non-negative")
+
+    selected = sum(value is not None for value in (args.manifest, args.preset, args.benchmark_pack))
+    if selected > 1:
+        parser.error("choose only one of --manifest, --preset, or --benchmark-pack")
+
+    if args.benchmark_pack:
+        if args.npz or args.write_manifest or args.application_trace:
+            parser.error("--npz, --write-manifest, and --application-trace apply to single-world runs, not benchmark packs")
+        pack = load_benchmark_pack(args.benchmark_pack)
+        result = run_benchmark_pack(pack)
+        output = _write_json(result.to_dict(), args.output)
+        print(json.dumps({
+            "report": str(output),
+            "schema": "neuros.synthetic_bci_arena.benchmark_result.v1",
+            "pack": pack.name,
+            "version": pack.version,
+            "passed": result.passed,
+            "cases": {case.name: case.passed for case in result.cases},
+        }, indent=2, sort_keys=True))
+        if not result.passed:
+            raise SystemExit(2)
+        return
+
+    if args.manifest:
+        manifest = load_manifest(args.manifest)
+    else:
+        scenario, participant, device, display, transport = get_preset(args.preset or "dual-target-smoke", args.seed)
+        manifest = ArenaManifest(scenario, participant, device, display, transport)
+    if args.write_manifest:
+        save_manifest(manifest, args.write_manifest)
+    run = run_scenario(
+        manifest.scenario,
+        manifest.participant,
+        manifest.device,
+        manifest.display,
+        manifest.transport,
+        manifest.world_model,
+    )
+    report = dict(run.report)
+    if args.application_trace:
+        trace = load_application_trace(args.application_trace)
+        report["application_trace"] = {
+            "application": trace.application,
+            "version": trace.version,
+            "metadata": dict(trace.metadata),
+            "metrics": evaluate_application_trace(
+                run,
+                trace,
+                silence_grace_s=args.application_silence_grace_s,
+            ),
+            "evidence_boundary": (
+                "Application metrics are scored against this Arena world's causal truth; acceptance thresholds remain application-specific."
+            ),
+        }
+    output = _write_json(report, args.output)
+    if args.npz:
+        np.savez_compressed(
+            args.npz,
+            data_uv=run.device_output.data_uv,
+            timestamps_s=run.device_output.timestamps_s,
+            ground_truth_timestamps_s=run.device_output.ground_truth_timestamps_s,
+            ground_truth_target_hz=run.ground_truth_target_hz,
+            stage_index=run.stage_index,
+        )
+    print(json.dumps({
+        "report": str(output),
+        "schema": run.report["schema"],
+        "world_model": run.world_model.name,
+        "world_model_evidence_level": run.report["world_model_evidence"]["evidence_level"],
+        "application_trace": (None if not args.application_trace else report["application_trace"]),
+        "metrics": run.report["metrics"],
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/neuros-arena/src/neuros/arena/conformance.py
+++ b/packages/neuros-arena/src/neuros/arena/conformance.py
@@ -1,0 +1,257 @@
+"""Metamorphic conformance and adversarial counterexample search.
+
+Synthetic physiology need not be a perfect human model to verify many systems
+invariants. Arena therefore supports paired-world properties such as:
+
+- increasing transport drop probability cannot increase packets delivered;
+- increasing display drop probability cannot reduce the set of dropped frames
+  when the same deterministic random stream is used;
+- application-defined authority should fail closed under declared degradations.
+
+When a property fails, the resolved manifests are retained as portable
+counterexamples rather than summarized away into a single score.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Callable
+
+import numpy as np
+
+from .manifest import ArenaManifest
+from .population import ParameterDistribution, PopulationSpec, _replace_manifest_value
+from .runner import ArenaRun, run_scenario
+
+
+@dataclass(frozen=True)
+class MetamorphicResult:
+    name: str
+    passed: bool
+    base_value: float
+    mutated_value: float
+    relation: str
+    detail: str
+    base_manifest: dict
+    mutated_manifest: dict
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "passed": self.passed,
+            "base_value": self.base_value,
+            "mutated_value": self.mutated_value,
+            "relation": self.relation,
+            "detail": self.detail,
+            "base_manifest": self.base_manifest,
+            "mutated_manifest": self.mutated_manifest,
+        }
+
+
+@dataclass(frozen=True)
+class Counterexample:
+    rank: int
+    objective: float
+    sampled: dict[str, float]
+    manifest: dict
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class AdversarialSearchResult:
+    objective_name: str
+    minimize: bool
+    evaluated: int
+    counterexamples: tuple[Counterexample, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.synthetic_bci_arena.counterexamples.v1",
+            "objective_name": self.objective_name,
+            "minimize": self.minimize,
+            "evaluated": self.evaluated,
+            "counterexamples": [asdict(item) for item in self.counterexamples],
+            "evidence_boundary": "Counterexamples are failures within the declared synthetic envelope, not estimates of human failure prevalence.",
+        }
+
+
+def _run(manifest: ArenaManifest) -> ArenaRun:
+    manifest.validate()
+    return run_scenario(
+        manifest.scenario,
+        manifest.participant,
+        manifest.device,
+        manifest.display,
+        manifest.transport,
+        manifest.world_model,
+    )
+
+
+def _paired_result(
+    name: str,
+    base: ArenaManifest,
+    mutated: ArenaManifest,
+    base_value: float,
+    mutated_value: float,
+    *,
+    relation: str,
+    passed: bool,
+    detail: str,
+) -> MetamorphicResult:
+    return MetamorphicResult(
+        name=name,
+        passed=bool(passed),
+        base_value=float(base_value),
+        mutated_value=float(mutated_value),
+        relation=relation,
+        detail=detail,
+        base_manifest=base.to_dict(),
+        mutated_manifest=mutated.to_dict(),
+    )
+
+
+def check_transport_drop_monotonicity(
+    manifest: ArenaManifest,
+    *,
+    higher_drop_probability: float,
+) -> MetamorphicResult:
+    """Verify that a nested deterministic drop mask cannot deliver more packets."""
+    base_p = manifest.transport.drop_probability
+    if higher_drop_probability < base_p or higher_drop_probability >= 1.0:
+        raise ValueError("higher_drop_probability must be >= base and < 1")
+    mutated = replace(
+        manifest,
+        transport=replace(manifest.transport, drop_probability=float(higher_drop_probability)),
+    )
+    first = _run(manifest)
+    second = _run(mutated)
+    a = float(first.report["metrics"]["transport"]["packets_delivered"])
+    b = float(second.report["metrics"]["transport"]["packets_delivered"])
+    return _paired_result(
+        "transport_drop_monotonicity",
+        manifest,
+        mutated,
+        a,
+        b,
+        relation="mutated <= base",
+        passed=b <= a,
+        detail="Higher drop probability uses the same deterministic random stream, so delivered packet count must not increase.",
+    )
+
+
+def check_display_drop_monotonicity(
+    manifest: ArenaManifest,
+    *,
+    higher_drop_probability: float,
+) -> MetamorphicResult:
+    """Verify deterministic nested frame-drop masks at the display layer."""
+    base_p = manifest.display.frame_drop_probability
+    if higher_drop_probability < base_p or higher_drop_probability >= 1.0:
+        raise ValueError("higher_drop_probability must be >= base and < 1")
+    mutated = replace(
+        manifest,
+        display=replace(manifest.display, frame_drop_probability=float(higher_drop_probability)),
+    )
+    first = _run(manifest)
+    second = _run(mutated)
+    a = max((trace.frame_drop_fraction for trace in first.stimulus_traces), default=0.0)
+    b = max((trace.frame_drop_fraction for trace in second.stimulus_traces), default=0.0)
+    return _paired_result(
+        "display_drop_monotonicity",
+        manifest,
+        mutated,
+        a,
+        b,
+        relation="mutated >= base",
+        passed=b + 1e-12 >= a,
+        detail="Higher frame-drop probability uses the same per-stage seed, so the dropped-frame set must be a superset.",
+    )
+
+
+def check_fail_closed_degradation(
+    manifest: ArenaManifest,
+    mutated: ArenaManifest,
+    evaluator: Callable[[ArenaRun], float],
+    *,
+    name: str = "application_fail_closed",
+    tolerance: float = 0.0,
+) -> MetamorphicResult:
+    """Check an application-defined authority metric under a declared degradation.
+
+    ``evaluator`` should return a metric where *larger means more gameplay or
+    control authority*. The property asserts that the degraded world does not
+    gain authority beyond the configured tolerance. This deliberately leaves
+    task semantics outside Arena.
+    """
+    base_run = _run(manifest)
+    mutated_run = _run(mutated)
+    base_value = float(evaluator(base_run))
+    mutated_value = float(evaluator(mutated_run))
+    return _paired_result(
+        name,
+        manifest,
+        mutated,
+        base_value,
+        mutated_value,
+        relation=f"mutated <= base + {float(tolerance):g}",
+        passed=mutated_value <= base_value + float(tolerance),
+        detail="Application-defined authority should not increase when the caller declares the second world to be a degradation.",
+    )
+
+
+def search_counterexamples(
+    manifest: ArenaManifest,
+    spec: PopulationSpec,
+    evaluator: Callable[[ArenaRun], tuple[float, dict[str, float]]],
+    *,
+    objective_name: str,
+    minimize: bool = True,
+    top_k: int = 10,
+) -> AdversarialSearchResult:
+    """Search a parameter envelope and preserve the worst resolved worlds.
+
+    The sampler is intentionally deterministic and simple in v0.1. More advanced
+    optimizers can be added later without changing the counterexample artifact.
+    ``evaluator`` returns ``(objective, metrics)`` for one complete run.
+    """
+    manifest.validate()
+    spec.validate()
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    rng = np.random.default_rng(spec.seed)
+    candidates: list[tuple[float, dict[str, float], ArenaManifest, dict[str, float]]] = []
+    for index in range(spec.size):
+        world = manifest
+        sampled: dict[str, float] = {}
+        for distribution in spec.parameters:
+            value = distribution.sample(rng)
+            sampled[distribution.path] = value
+            world = _replace_manifest_value(world, distribution.path, value)
+        world = replace(
+            world,
+            participant=replace(
+                world.participant,
+                seed=world.participant.seed + spec.seed + index * 7919,
+            ),
+        )
+        objective, metrics = evaluator(_run(world))
+        if not np.isfinite(objective):
+            continue
+        candidates.append((float(objective), sampled, world, {k: float(v) for k, v in metrics.items()}))
+    candidates.sort(key=lambda item: item[0], reverse=not minimize)
+    selected = candidates[: min(top_k, len(candidates))]
+    counterexamples = tuple(
+        Counterexample(
+            rank=rank + 1,
+            objective=objective,
+            sampled=sampled,
+            manifest=world.to_dict(),
+            metrics=metrics,
+        )
+        for rank, (objective, sampled, world, metrics) in enumerate(selected)
+    )
+    return AdversarialSearchResult(
+        objective_name=objective_name,
+        minimize=bool(minimize),
+        evaluated=len(candidates),
+        counterexamples=counterexamples,
+    )

--- a/packages/neuros-arena/src/neuros/arena/evaluation.py
+++ b/packages/neuros-arena/src/neuros/arena/evaluation.py
@@ -1,0 +1,72 @@
+"""Score decoder/application decisions against the Arena's known causal timeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from .runner import ArenaRun
+
+
+@dataclass(frozen=True)
+class ArenaDecision:
+    timestamp_s: float
+    target_frequency_hz: float | None
+    accepted: bool
+    confidence: float = 0.0
+    reason: str | None = None
+
+
+def _truth_at(run: "ArenaRun", timestamp_s: float) -> float | None:
+    times = run.device_output.timestamps_s
+    if times.size == 0:
+        return None
+    index = int(np.clip(np.searchsorted(times, timestamp_s), 0, times.size - 1))
+    value = run.ground_truth_target_hz[index]
+    return None if np.isnan(value) else float(value)
+
+
+def evaluate_decisions(run: "ArenaRun", decisions: list[ArenaDecision]) -> dict[str, float]:
+    if not decisions:
+        return {
+            "decisions": 0.0,
+            "accepted_fraction": 0.0,
+            "accepted_precision": 0.0,
+            "false_activation_fraction": 0.0,
+            "median_switch_latency_s": 0.0,
+        }
+    accepted = [decision for decision in decisions if decision.accepted]
+    correct = 0
+    false_baseline = 0
+    for decision in accepted:
+        truth = _truth_at(run, decision.timestamp_s)
+        if truth is None:
+            false_baseline += 1
+        elif decision.target_frequency_hz is not None and abs(decision.target_frequency_hz - truth) < 1e-6:
+            correct += 1
+
+    switch_latencies: list[float] = []
+    prior_target: float | None = None
+    for stage in run.stages:
+        target = stage.target_frequency_hz
+        if target is None or target == prior_target:
+            prior_target = target
+            continue
+        match = next((decision for decision in decisions
+                      if decision.accepted
+                      and decision.timestamp_s >= stage.start_s
+                      and decision.target_frequency_hz is not None
+                      and abs(decision.target_frequency_hz - target) < 1e-6), None)
+        if match is not None:
+            switch_latencies.append(max(0.0, match.timestamp_s - stage.start_s))
+        prior_target = target
+
+    return {
+        "decisions": float(len(decisions)),
+        "accepted_fraction": float(len(accepted) / len(decisions)),
+        "accepted_precision": float(correct / max(len(accepted), 1)),
+        "false_activation_fraction": float(false_baseline / max(len(accepted), 1)),
+        "median_switch_latency_s": float(np.median(switch_latencies)) if switch_latencies else 0.0,
+    }

--- a/packages/neuros-arena/src/neuros/arena/evidence.py
+++ b/packages/neuros-arena/src/neuros/arena/evidence.py
@@ -1,0 +1,183 @@
+"""Scientific evidence cards for Arena neural world models.
+
+The purpose of this module is claim governance. Different synthetic generators
+can satisfy the same software protocol while supporting very different
+scientific statements. Evidence cards keep those differences machine-readable
+in every report and benchmark artifact.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class WorldModelEvidenceCard:
+    """Declared scientific scope of a neural world model.
+
+    ``evidence_level`` is an Arena engineering level, not a ranking of biological
+    truth. Higher levels require additional external evidence but never convert a
+    simulator into a substitute for human closed-loop validation.
+    """
+
+    model_name: str
+    evidence_level: str
+    model_family: str
+    stimulus_causal: bool
+    spatial_model: str
+    recorded_human_background: bool
+    known_intervention_ground_truth: bool
+    artifact_ground_truth: bool
+    uncertainty_representation: str
+    validated_against: tuple[str, ...]
+    intended_uses: tuple[str, ...]
+    unsupported_claims: tuple[str, ...]
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+_BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
+    "legacy_synthetic": WorldModelEvidenceCard(
+        model_name="legacy_synthetic",
+        evidence_level="W0-regression-fixture",
+        model_family="analytic frequency fixture",
+        stimulus_causal=False,
+        spatial_model="hand-authored channel weights",
+        recorded_human_background=False,
+        known_intervention_ground_truth=True,
+        artifact_ground_truth=True,
+        uncertainty_representation="seeded stochastic nuisance only",
+        validated_against=("internal deterministic contracts",),
+        intended_uses=(
+            "driver smoke tests",
+            "decoder regression tests",
+            "known-frequency fixtures",
+        ),
+        unsupported_claims=(
+            "display-to-cortex causality",
+            "human response distribution",
+            "anatomical source realism",
+        ),
+    ),
+    "driven_state_space": WorldModelEvidenceCard(
+        model_name="driven_state_space",
+        evidence_level="W1-causal-phenomenological",
+        model_family="stochastic driven state-space",
+        stimulus_causal=True,
+        spatial_model="hand-authored posterior/central/frontal mixing",
+        recorded_human_background=False,
+        known_intervention_ground_truth=True,
+        artifact_ground_truth=True,
+        uncertainty_representation="seeded stochastic latent/background dynamics",
+        validated_against=(
+            "internal deterministic contracts",
+            "display-causality metamorphic tests",
+        ),
+        intended_uses=(
+            "closed-loop systems qualification",
+            "display/device/network stress testing",
+            "population and counterexample search",
+        ),
+        unsupported_claims=(
+            "biophysical cortical mechanism",
+            "human prevalence estimates",
+            "subject-specific physiological prediction",
+        ),
+        notes=(
+            "Phenomenological oscillator/background dynamics are chosen for causal controllability rather than cortical-mechanism fidelity.",
+        ),
+    ),
+    "semi_synthetic_replay": WorldModelEvidenceCard(
+        model_name="semi_synthetic_replay",
+        evidence_level="W2-recorded-background-semi-synthetic",
+        model_family="recorded EEG background plus controlled intervention",
+        stimulus_causal=True,
+        spatial_model="recorded sensor covariance plus declared injected topography",
+        recorded_human_background=True,
+        known_intervention_ground_truth=True,
+        artifact_ground_truth=False,
+        uncertainty_representation="recorded nuisance plus seeded intervention",
+        validated_against=(
+            "portable recorded-background contract",
+            "internal intervention-causality contracts",
+        ),
+        intended_uses=(
+            "real-background decoder stress tests",
+            "public-dataset anchored development",
+            "held-out subject/session studies",
+        ),
+        unsupported_claims=(
+            "the injected response occurred in the recorded participant",
+            "full physiological interaction between intervention and background",
+            "human closed-loop performance",
+        ),
+    ),
+    "leadfield_driven": WorldModelEvidenceCard(
+        model_name="leadfield_driven",
+        evidence_level="W3-source-projected-causal",
+        model_family="display-driven source response projected by frozen lead field",
+        stimulus_causal=True,
+        spatial_model="explicit forward/lead-field projection",
+        recorded_human_background=False,
+        known_intervention_ground_truth=True,
+        artifact_ground_truth=True,
+        uncertainty_representation="seeded source/background nuisance with fixed spatial projection",
+        validated_against=(
+            "portable lead-field contract",
+            "explicit source-selection provenance",
+            "internal display-causality contracts",
+        ),
+        intended_uses=(
+            "montage/topography sensitivity studies",
+            "source-to-sensor systems qualification",
+            "forward-model based population studies",
+        ),
+        unsupported_claims=(
+            "subject-specific source localization unless the bundle is subject-specific and independently validated",
+            "human response amplitude distribution",
+            "human closed-loop performance",
+        ),
+    ),
+}
+
+
+def evidence_card_for_model(model: Any, model_name: str) -> WorldModelEvidenceCard:
+    """Resolve a model's evidence card, failing scientifically closed for plugins.
+
+    Third-party plugins may expose ``evidence_card()`` returning either a
+    ``WorldModelEvidenceCard`` or a compatible dictionary. Plugins without a
+    card remain runnable, but reports mark them as scientifically unqualified
+    rather than inheriting the claims of a built-in model.
+    """
+
+    provider = getattr(model, "evidence_card", None)
+    if callable(provider):
+        raw = provider()
+        if isinstance(raw, WorldModelEvidenceCard):
+            return raw
+        if isinstance(raw, dict):
+            return WorldModelEvidenceCard(**raw)
+        raise TypeError("world-model evidence_card() must return a WorldModelEvidenceCard or dict")
+    if model_name in _BUILTIN_CARDS:
+        return _BUILTIN_CARDS[model_name]
+    return WorldModelEvidenceCard(
+        model_name=model_name,
+        evidence_level="W?-external-unqualified",
+        model_family="external plugin",
+        stimulus_causal=False,
+        spatial_model="undeclared",
+        recorded_human_background=False,
+        known_intervention_ground_truth=False,
+        artifact_ground_truth=False,
+        uncertainty_representation="undeclared",
+        validated_against=(),
+        intended_uses=("software experimentation",),
+        unsupported_claims=(
+            "physiological validity",
+            "human performance prediction",
+            "causal neural interpretation",
+        ),
+        notes=("External plugin did not provide a machine-readable Arena evidence card.",),
+    )

--- a/packages/neuros-arena/src/neuros/arena/leadfield.py
+++ b/packages/neuros-arena/src/neuros/arena/leadfield.py
@@ -1,0 +1,249 @@
+"""Portable lead-field world model and optional MNE export adapter.
+
+The expensive anatomy/research step is separated from Arena execution:
+
+1. MNE reads a forward solution and exports a small ``.npz`` bundle containing
+   sensor-space topographies for explicitly selected cortical sources.
+2. Arena loads that bundle dependency-light and drives the topographies from the
+   actual emitted stimulus waveform.
+
+This preserves the causal display -> neural response -> scalp projection chain
+without requiring every creative developer or CI worker to install MNE or carry
+a full FreeSurfer subject.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+from .specs import ParticipantProfile
+from .world_models import WorldModelEmission, _ArtifactEngine
+
+
+BUNDLE_SCHEMA = "neuros.arena.leadfield_bundle.v1"
+
+
+def save_leadfield_bundle(
+    path: str | Path,
+    *,
+    channel_names: Sequence[str],
+    visual_topography: np.ndarray,
+    nuisance_topographies: np.ndarray | None = None,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    """Write a portable sensor-topography bundle used by the world model."""
+    channels = tuple(str(name) for name in channel_names)
+    visual = np.asarray(visual_topography, dtype=float).reshape(-1)
+    if not channels or visual.size != len(channels):
+        raise ValueError("visual_topography must have one value per channel")
+    scale = float(np.max(np.abs(visual)))
+    if scale <= 0 or not np.all(np.isfinite(visual)):
+        raise ValueError("visual_topography must be finite and non-zero")
+    visual = visual / scale
+    if nuisance_topographies is None:
+        nuisance = np.empty((0, len(channels)), dtype=float)
+    else:
+        nuisance = np.asarray(nuisance_topographies, dtype=float)
+        if nuisance.ndim != 2 or nuisance.shape[1] != len(channels) or not np.all(np.isfinite(nuisance)):
+            raise ValueError("nuisance_topographies must be finite sources x channels")
+        norms = np.max(np.abs(nuisance), axis=1, keepdims=True)
+        nuisance = nuisance / np.maximum(norms, 1e-12)
+    payload_meta = metadata or {}
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        output,
+        schema=np.asarray(BUNDLE_SCHEMA),
+        channel_names=np.asarray(channels),
+        visual_topography=visual.astype(np.float32),
+        nuisance_topographies=nuisance.astype(np.float32),
+        metadata_keys=np.asarray(list(payload_meta), dtype=str),
+        metadata_values=np.asarray([payload_meta[key] for key in payload_meta], dtype=str),
+    )
+
+
+def export_mne_forward_bundle(
+    forward_path: str | Path,
+    output_path: str | Path,
+    *,
+    visual_source_indices: Sequence[int],
+    visual_source_weights: Sequence[float] | None = None,
+    eeg_channel_names: Sequence[str] | None = None,
+    nuisance_source_indices: Sequence[int] = (),
+) -> None:
+    """Export an MNE forward solution into Arena's portable topography bundle.
+
+    Source selection is deliberately explicit. Arena will not guess which
+    cortical vertices represent the developer's visual or other task generator.
+    A research pipeline can obtain indices from anatomical labels and then freeze
+    the resulting bundle for portable tests.
+    """
+    try:
+        import mne
+    except ImportError as exc:  # pragma: no cover - optional research dependency
+        raise ImportError("MNE export requires `neuros-arena[real]` or mne>=1.6") from exc
+
+    forward = mne.read_forward_solution(str(forward_path), verbose=False)
+    forward = mne.convert_forward_solution(
+        forward,
+        surf_ori=True,
+        force_fixed=True,
+        use_cps=True,
+        verbose=False,
+    )
+    gain = np.asarray(forward["sol"]["data"], dtype=float)
+    row_names = tuple(str(name) for name in forward["sol"]["row_names"])
+    if eeg_channel_names is None:
+        picks = mne.pick_types(forward["info"], meg=False, eeg=True, exclude=[])
+        selected_names = tuple(forward["info"]["ch_names"][int(index)] for index in picks)
+    else:
+        selected_names = tuple(str(name) for name in eeg_channel_names)
+    row_indices = []
+    for name in selected_names:
+        if name not in row_names:
+            raise ValueError(f"EEG channel {name!r} is unavailable from the forward solution")
+        row_indices.append(row_names.index(name))
+    selected_gain = gain[np.asarray(row_indices, dtype=int)]
+
+    visual_idx = np.asarray(tuple(int(value) for value in visual_source_indices), dtype=int)
+    if visual_idx.size == 0 or np.any(visual_idx < 0) or np.any(visual_idx >= selected_gain.shape[1]):
+        raise ValueError("visual_source_indices must contain valid fixed-orientation source columns")
+    if visual_source_weights is None:
+        weights = np.ones(visual_idx.size, dtype=float) / visual_idx.size
+    else:
+        weights = np.asarray(tuple(float(value) for value in visual_source_weights), dtype=float)
+        if weights.shape != visual_idx.shape or not np.all(np.isfinite(weights)) or np.allclose(weights, 0.0):
+            raise ValueError("visual_source_weights must be finite and match visual_source_indices")
+        weights = weights / np.sum(np.abs(weights))
+    visual_topography = selected_gain[:, visual_idx] @ weights
+
+    nuisance = []
+    for index in nuisance_source_indices:
+        idx = int(index)
+        if not 0 <= idx < selected_gain.shape[1]:
+            raise ValueError(f"nuisance source index out of bounds: {idx}")
+        nuisance.append(selected_gain[:, idx])
+    save_leadfield_bundle(
+        output_path,
+        channel_names=selected_names,
+        visual_topography=visual_topography,
+        nuisance_topographies=(np.asarray(nuisance) if nuisance else None),
+        metadata={
+            "source": str(forward_path),
+            "projection": "mne-fixed-orientation-forward",
+            "visual_sources": ",".join(str(value) for value in visual_idx.tolist()),
+        },
+    )
+
+
+class LeadFieldDrivenWorldModel:
+    """Display-driven neural dynamics projected through a frozen lead field."""
+
+    name = "leadfield_driven"
+
+    def __init__(
+        self,
+        *,
+        participant: ParticipantProfile,
+        sampling_rate_hz: float,
+        seed: int,
+        parameters: dict[str, Any] | None = None,
+    ) -> None:
+        params = dict(parameters or {})
+        if not params.get("path"):
+            raise ValueError("leadfield_driven requires world_model.parameters.path")
+        path = Path(str(params["path"])).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(path)
+        with np.load(path, allow_pickle=False) as payload:
+            schema = str(np.asarray(payload["schema"]).reshape(-1)[0])
+            if schema != BUNDLE_SCHEMA:
+                raise ValueError(f"expected lead-field bundle schema {BUNDLE_SCHEMA!r}")
+            self.channel_names = tuple(str(value) for value in np.asarray(payload["channel_names"]).tolist())
+            self.visual_topography = np.asarray(payload["visual_topography"], dtype=float).reshape(-1)
+            self.nuisance_topographies = np.asarray(payload["nuisance_topographies"], dtype=float)
+        if self.visual_topography.size != len(self.channel_names):
+            raise ValueError("lead-field visual topography/channel mismatch")
+        self.participant = participant
+        self.fs = float(sampling_rate_hz)
+        self.rng = np.random.default_rng(seed)
+        self._entrainment = 0.0
+        self._response_state = 0.0
+        self._alpha_phase = self.rng.uniform(0.0, 2 * np.pi)
+        self._nuisance_state = np.zeros(self.nuisance_topographies.shape[0], dtype=float)
+        self._tau_s = float(params.get("entrainment_tau_s", 0.18))
+        self._response_tau_s = float(params.get("response_tau_s", 0.035))
+        if self._tau_s <= 0 or self._response_tau_s <= 0:
+            raise ValueError("lead-field time constants must be positive")
+        self._artifact = _ArtifactEngine(self.fs, seed + 1777) if len(self.channel_names) == 8 else None
+
+    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+        if self._artifact is None:
+            if kind != "dropout":
+                raise ValueError("generic artifact overlay currently requires the standard 8-channel Arena montage")
+            raise ValueError("dropout overlay currently requires the standard 8-channel Arena montage")
+        self._artifact.inject(kind, duration_seconds, severity)
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission:
+        times = np.asarray(sample_times_s, dtype=float)
+        drive = np.asarray(emitted_stimulus, dtype=float)
+        if times.ndim != 1 or drive.shape != times.shape:
+            raise ValueError("sample_times_s and emitted_stimulus must match")
+        n_channels = len(self.channel_names)
+        data = self.rng.normal(0.0, self.participant.white_noise_uv, size=(n_channels, times.size))
+        dt = 1.0 / self.fs
+        target_gain = max(0.0, float(attention_gain)) if target_frequency_hz is not None else 0.0
+        visual_response = np.zeros(times.size, dtype=float)
+        for i in range(times.size):
+            self._entrainment += (target_gain - self._entrainment) * min(1.0, dt / self._tau_s)
+            desired = float(np.clip(drive[i], -1.0, 1.0)) * self._entrainment
+            self._response_state += (desired - self._response_state) * min(1.0, dt / self._response_tau_s)
+            visual_response[i] = self._response_state
+        data += (
+            self.visual_topography[:, None]
+            * self.participant.ssvep_amplitude_uv
+            * visual_response[None, :]
+        )
+        # Use frozen lead-field nuisance topographies for low-frequency background
+        # sources, then add a global endogenous alpha component with channel gain
+        # derived from the absolute visual topography.
+        if self.nuisance_topographies.size:
+            persistence = 0.995
+            innovation = np.sqrt(1.0 - persistence**2)
+            for i in range(times.size):
+                self._nuisance_state = persistence * self._nuisance_state + innovation * self.rng.normal(size=self._nuisance_state.size)
+                data[:, i] += self.participant.colored_noise_uv * (self._nuisance_state @ self.nuisance_topographies)
+        else:
+            data += self.rng.normal(0.0, self.participant.colored_noise_uv, size=data.shape)
+        alpha_gain = np.abs(self.visual_topography)
+        alpha_gain /= max(float(np.max(alpha_gain)), 1e-12)
+        data += (
+            alpha_gain[:, None]
+            * self.participant.alpha_amplitude_uv
+            * np.sin(2 * np.pi * self.participant.alpha_frequency_hz * times + self._alpha_phase)[None, :]
+        )
+        if self._artifact is not None:
+            artifact, artifact_kind = self._artifact.render(times)
+            dropout = artifact_kind == "dropout"
+            if dropout:
+                artifact = np.nan_to_num(artifact, nan=0.0)
+            data += artifact
+            if dropout:
+                data[6, :] = 0.0
+        return WorldModelEmission(
+            data_uv=data.astype(np.float32),
+            latent={
+                "attention_gain": target_gain,
+                "entrainment": float(self._entrainment),
+                "stimulus_coupling": 1.0,
+                "leadfield_projection": 1.0,
+            },
+        )

--- a/packages/neuros-arena/src/neuros/arena/manifest.py
+++ b/packages/neuros-arena/src/neuros/arena/manifest.py
@@ -1,0 +1,80 @@
+"""Portable JSON manifests for sharing exact synthetic BCI worlds."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .specs import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, TransportProfile, WorldModelProfile
+
+SCHEMA = "neuros.synthetic_bci_arena.manifest.v1"
+
+
+@dataclass(frozen=True)
+class ArenaManifest:
+    scenario: ArenaScenario
+    participant: ParticipantProfile
+    device: DeviceProfile
+    display: DisplayProfile
+    transport: TransportProfile
+    world_model: WorldModelProfile = field(default_factory=WorldModelProfile)
+
+    def validate(self) -> None:
+        self.scenario.validate()
+        self.participant.validate()
+        self.device.validate()
+        self.display.validate()
+        self.transport.validate()
+        self.world_model.validate()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": SCHEMA,
+            "scenario": self.scenario.to_dict(),
+            "participant": asdict(self.participant),
+            "device": asdict(self.device),
+            "display": asdict(self.display),
+            "transport": asdict(self.transport),
+            "world_model": asdict(self.world_model),
+        }
+
+
+def _device(raw: dict[str, Any]) -> DeviceProfile:
+    values = dict(raw)
+    if "channel_names" in values:
+        values["channel_names"] = tuple(values["channel_names"])
+    return DeviceProfile(**values)
+
+
+def _transport(raw: dict[str, Any]) -> TransportProfile:
+    values = dict(raw)
+    if "silence_windows" in values:
+        values["silence_windows"] = tuple(tuple(float(v) for v in window) for window in values["silence_windows"])
+    return TransportProfile(**values)
+
+
+def manifest_from_dict(raw: dict[str, Any]) -> ArenaManifest:
+    if raw.get("schema") != SCHEMA:
+        raise ValueError(f"expected manifest schema {SCHEMA!r}")
+    manifest = ArenaManifest(
+        scenario=ArenaScenario.from_dict(dict(raw["scenario"])),
+        participant=ParticipantProfile(**dict(raw["participant"])),
+        device=_device(dict(raw["device"])),
+        display=DisplayProfile(**dict(raw["display"])),
+        transport=_transport(dict(raw["transport"])),
+        world_model=WorldModelProfile(**dict(raw.get("world_model", {}))),
+    )
+    manifest.validate()
+    return manifest
+
+
+def load_manifest(path: str | Path) -> ArenaManifest:
+    return manifest_from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+def save_manifest(manifest: ArenaManifest, path: str | Path) -> None:
+    manifest.validate()
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(manifest.to_dict(), indent=2, sort_keys=True), encoding="utf-8")

--- a/packages/neuros-arena/src/neuros/arena/population.py
+++ b/packages/neuros-arena/src/neuros/arena/population.py
@@ -1,0 +1,192 @@
+"""Monte Carlo population and adversarial world exploration for neurOS Arena."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from typing import Callable, Literal
+
+import numpy as np
+
+from .manifest import ArenaManifest
+from .runner import ArenaRun, run_scenario
+
+DistributionKind = Literal["uniform", "log_uniform", "normal", "choice"]
+
+
+@dataclass(frozen=True)
+class ParameterDistribution:
+    """A shareable distribution over one manifest parameter."""
+
+    path: str
+    kind: DistributionKind = "uniform"
+    low: float | None = None
+    high: float | None = None
+    mean: float | None = None
+    std: float | None = None
+    choices: tuple[float, ...] = ()
+
+    def validate(self) -> None:
+        root = self.path.split(".", 1)[0]
+        if root not in {"participant", "device", "display", "transport", "world_model"}:
+            raise ValueError(f"unsupported population path root: {root!r}")
+        if self.kind in {"uniform", "log_uniform"}:
+            if self.low is None or self.high is None or self.high < self.low:
+                raise ValueError(f"{self.kind} requires low <= high")
+            if self.kind == "log_uniform" and self.low <= 0:
+                raise ValueError("log_uniform requires low > 0")
+        elif self.kind == "normal":
+            if self.mean is None or self.std is None or self.std < 0:
+                raise ValueError("normal requires mean and std >= 0")
+        elif self.kind == "choice":
+            if not self.choices:
+                raise ValueError("choice requires at least one value")
+        else:
+            raise ValueError(f"unknown distribution: {self.kind}")
+
+    def sample(self, rng: np.random.Generator) -> float:
+        self.validate()
+        if self.kind == "uniform":
+            return float(rng.uniform(float(self.low), float(self.high)))
+        if self.kind == "log_uniform":
+            return float(np.exp(rng.uniform(np.log(float(self.low)), np.log(float(self.high)))))
+        if self.kind == "normal":
+            return float(rng.normal(float(self.mean), float(self.std)))
+        return float(rng.choice(np.asarray(self.choices, dtype=float)))
+
+
+@dataclass(frozen=True)
+class PopulationSpec:
+    size: int = 100
+    seed: int = 7
+    parameters: tuple[ParameterDistribution, ...] = ()
+
+    def validate(self) -> None:
+        if self.size <= 0:
+            raise ValueError("population size must be positive")
+        for parameter in self.parameters:
+            parameter.validate()
+
+
+@dataclass(frozen=True)
+class PopulationTrial:
+    index: int
+    sampled: dict[str, float]
+    metrics: dict[str, float]
+
+
+@dataclass(frozen=True)
+class PopulationRun:
+    spec: PopulationSpec
+    trials: tuple[PopulationTrial, ...]
+    summary: dict[str, dict[str, float]]
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.synthetic_bci_arena.population.v1",
+            "spec": {
+                "size": self.spec.size,
+                "seed": self.spec.seed,
+                "parameters": [asdict(value) for value in self.spec.parameters],
+            },
+            "trials": [asdict(trial) for trial in self.trials],
+            "summary": self.summary,
+            "evidence_boundary": "Synthetic population coverage only; not a human prevalence estimate.",
+        }
+
+
+def _replace_manifest_value(manifest: ArenaManifest, path: str, value: float) -> ArenaManifest:
+    parts = path.split(".")
+    if len(parts) < 2:
+        raise ValueError(f"population path must include a field: {path!r}")
+    root, tail = parts[0], parts[1:]
+    if root == "world_model" and tail[0] == "parameters":
+        if len(tail) != 2:
+            raise ValueError("world_model population paths must be world_model.parameters.KEY")
+        params = dict(manifest.world_model.parameters)
+        params[tail[1]] = value
+        return replace(manifest, world_model=replace(manifest.world_model, parameters=params))
+    if len(tail) != 1:
+        raise ValueError(f"nested population path is unsupported: {path!r}")
+    obj = getattr(manifest, root)
+    field = tail[0]
+    if not hasattr(obj, field):
+        raise ValueError(f"unknown population parameter: {path!r}")
+    current = getattr(obj, field)
+    cast_value: float | int
+    if isinstance(current, int) and not isinstance(current, bool):
+        cast_value = int(round(value))
+    else:
+        cast_value = float(value)
+    return replace(manifest, **{root: replace(obj, **{field: cast_value})})
+
+
+def default_run_metrics(run: ArenaRun) -> dict[str, float]:
+    snr_values = list(run.report["metrics"]["target_snr_db"].values())
+    display = run.report["metrics"]["display"]
+    transport = run.report["metrics"]["transport"]
+    return {
+        "target_snr_db_mean": float(np.mean(snr_values)) if snr_values else 0.0,
+        "target_snr_db_min": float(np.min(snr_values)) if snr_values else 0.0,
+        "display_frequency_error_hz_max": float(max((row["frequency_error_hz"] for row in display), default=0.0)),
+        "display_frame_drop_fraction_max": float(max((row["frame_drop_fraction"] for row in display), default=0.0)),
+        "transport_packet_drop_fraction": float(transport["packet_drop_fraction"]),
+        "transport_delivery_delay_p95_ms": float(transport["delivery_delay_p95_ms"]),
+        "device_clipped_fraction": float(run.report["metrics"]["device_clipped_fraction"]),
+    }
+
+
+def _summary(trials: list[PopulationTrial]) -> dict[str, dict[str, float]]:
+    keys = sorted({key for trial in trials for key in trial.metrics})
+    result: dict[str, dict[str, float]] = {}
+    for key in keys:
+        values = np.asarray([trial.metrics[key] for trial in trials if key in trial.metrics], dtype=float)
+        if values.size:
+            result[key] = {
+                "mean": float(np.mean(values)),
+                "std": float(np.std(values)),
+                "p05": float(np.percentile(values, 5)),
+                "p50": float(np.percentile(values, 50)),
+                "p95": float(np.percentile(values, 95)),
+                "min": float(np.min(values)),
+                "max": float(np.max(values)),
+            }
+    return result
+
+
+def run_population(
+    manifest: ArenaManifest,
+    spec: PopulationSpec,
+    evaluator: Callable[[ArenaRun], dict[str, float]] | None = None,
+) -> PopulationRun:
+    """Run a deterministic population over a shareable parameter envelope.
+
+    ``evaluator`` can add decoder/application metrics to the generic Arena
+    physics metrics, allowing the same population engine to qualify Mindforge or
+    any other closed-loop consumer.
+    """
+    manifest.validate()
+    spec.validate()
+    rng = np.random.default_rng(spec.seed)
+    trials: list[PopulationTrial] = []
+    for index in range(spec.size):
+        world = manifest
+        sampled: dict[str, float] = {}
+        for distribution in spec.parameters:
+            value = distribution.sample(rng)
+            sampled[distribution.path] = value
+            world = _replace_manifest_value(world, distribution.path, value)
+        # Each population member gets a deterministic background realization in
+        # addition to its sampled physiological/system parameters.
+        world = replace(world, participant=replace(world.participant, seed=world.participant.seed + spec.seed + index * 7919))
+        run = run_scenario(
+            world.scenario,
+            world.participant,
+            world.device,
+            world.display,
+            world.transport,
+            world.world_model,
+        )
+        metrics = default_run_metrics(run)
+        if evaluator is not None:
+            metrics.update({key: float(value) for key, value in evaluator(run).items()})
+        trials.append(PopulationTrial(index=index, sampled=sampled, metrics=metrics))
+    return PopulationRun(spec=spec, trials=tuple(trials), summary=_summary(trials))

--- a/packages/neuros-arena/src/neuros/arena/presets.py
+++ b/packages/neuros-arena/src/neuros/arena/presets.py
@@ -1,0 +1,44 @@
+"""Built-in deterministic profiles and scenarios for common closed-loop BCI stress cases."""
+from __future__ import annotations
+
+from .specs import ArenaScenario, ArtifactEvent, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile
+
+
+_PRESETS = {"dual-target-smoke", "dual-target-torture", "alpha-collision", "weak-responder"}
+
+
+def list_presets() -> tuple[str, ...]:
+    return tuple(sorted(_PRESETS))
+
+
+def get_preset(name: str, seed: int = 7) -> tuple[ArenaScenario, ParticipantProfile, DeviceProfile, DisplayProfile, TransportProfile]:
+    if name not in _PRESETS:
+        raise KeyError(f"unknown Arena preset {name!r}; choose from {', '.join(list_presets())}")
+    participant = ParticipantProfile(seed=seed)
+    device = DeviceProfile()
+    display = DisplayProfile()
+    transport = TransportProfile()
+    stages = (
+        StageSpec("rest", 5.0, None, 0.0),
+        StageSpec("sight", 6.0, 10.0, 1.0),
+        StageSpec("guard", 6.0, 12.0, 1.0),
+        StageSpec("sight-return", 5.0, 10.0, 1.0),
+    )
+    if name == "dual-target-torture":
+        stages = (
+            StageSpec("rest", 5.0, None, 0.0),
+            StageSpec("sight-controller", 6.0, 10.0, 1.0, (ArtifactEvent(2.0, "controller", 0.8, 1.0),)),
+            StageSpec("guard-jaw", 6.0, 12.0, 1.0, (ArtifactEvent(2.5, "jaw", 0.7, 1.0),)),
+            StageSpec("rest-2", 3.0, None, 0.0),
+            StageSpec("sight-motion", 6.0, 10.0, 0.78, (ArtifactEvent(1.8, "motion", 0.8, 1.0),)),
+            StageSpec("guard-return", 6.0, 12.0, 0.72),
+        )
+        participant = ParticipantProfile(seed=seed, gaze_duty_cycle=0.82, response_attenuation_per_minute=0.08)
+        display = DisplayProfile(name="busy-120hz", refresh_hz=120.0, frame_jitter_ms=0.8, frame_drop_probability=0.008)
+        transport = TransportProfile(name="crowded-demo-network", drop_probability=0.015, jitter_ms=8.0, reorder_probability=0.01, silence_windows=((18.0, 2.5),))
+    elif name == "alpha-collision":
+        participant = ParticipantProfile(name="alpha-collision", seed=seed, alpha_frequency_hz=10.0, alpha_amplitude_uv=8.0, ssvep_amplitude_uv=5.5)
+    elif name == "weak-responder":
+        participant = ParticipantProfile(name="weak-responder", seed=seed, ssvep_amplitude_uv=3.2, colored_noise_uv=6.0, white_noise_uv=2.0, gaze_duty_cycle=0.72, response_delay_s=0.28, switch_time_constant_s=0.65)
+    scenario = ArenaScenario(name=name, stages=stages, seed=seed, metadata={"paradigm": "dual-target-ssvep"})
+    return scenario, participant, device, display, transport

--- a/packages/neuros-arena/src/neuros/arena/public_data.py
+++ b/packages/neuros-arena/src/neuros/arena/public_data.py
@@ -1,0 +1,114 @@
+"""Thin public-dataset adapters for Arena studies.
+
+Core Arena remains dataset-library agnostic. This module intentionally relies on
+MOABB's documented ``subject -> session -> run -> MNE Raw`` contract rather than
+hard-coding individual dataset layouts or silently preprocessing task data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from .baselines import export_mne_raw_baseline
+from .recording import RecordingMetadata
+
+
+@dataclass(frozen=True)
+class MOABBDomainRun:
+    dataset: str
+    subject: str
+    session: str
+    run: str
+    raw: Any
+
+    @property
+    def domain_id(self) -> str:
+        return f"{self.dataset}:sub-{self.subject}:ses-{self.session}:run-{self.run}"
+
+
+def _dataset_name(dataset: Any) -> str:
+    for attr in ("code", "name"):
+        value = getattr(dataset, attr, None)
+        if value:
+            return str(value)
+    return dataset.__class__.__name__
+
+
+def iter_moabb_raw_runs(dataset: Any, *, subjects: Sequence[int] | None = None) -> Iterable[MOABBDomainRun]:
+    """Yield MOABB raw runs without applying hidden Arena preprocessing."""
+    getter = getattr(dataset, "get_data", None)
+    if not callable(getter):
+        raise TypeError("dataset must expose MOABB-compatible get_data(subjects=...)")
+    data = getter(subjects=None if subjects is None else list(subjects))
+    if not isinstance(data, dict) or not data:
+        raise ValueError("MOABB get_data returned no subject data")
+    dataset_name = _dataset_name(dataset)
+    for subject, sessions in data.items():
+        if not isinstance(sessions, dict):
+            raise TypeError("MOABB subject data must map sessions to runs")
+        for session, runs in sessions.items():
+            if not isinstance(runs, dict):
+                raise TypeError("MOABB session data must map run ids to Raw objects")
+            for run, raw in runs.items():
+                if not hasattr(raw, "get_data") or not hasattr(raw, "info") or not hasattr(raw, "ch_names"):
+                    raise TypeError("MOABB run does not expose the expected MNE Raw surface")
+                yield MOABBDomainRun(
+                    dataset=dataset_name,
+                    subject=str(subject),
+                    session=str(session),
+                    run=str(run),
+                    raw=raw,
+                )
+
+
+def export_moabb_run_window(
+    domain: MOABBDomainRun,
+    path: str | Path,
+    *,
+    channel_names: Sequence[str],
+    tmin_s: float,
+    duration_s: float,
+    target_sampling_rate_hz: float | None = None,
+    task: str = "",
+    acquisition: str = "",
+    source_license: str = "",
+    reference: str = "",
+    preprocessing_notes: Sequence[str] = (),
+) -> Path:
+    """Export one explicitly selected MOABB run window with traceable provenance.
+
+    Arena does not infer whether the window is resting state, task baseline or
+    evoked activity. The study author must make that semantic choice and record
+    it through ``task``/notes and the surrounding protocol.
+    """
+    if tmin_s < 0 or duration_s <= 0:
+        raise ValueError("tmin_s must be >= 0 and duration_s must be positive")
+    output = Path(path)
+    metadata = RecordingMetadata(
+        dataset=domain.dataset,
+        subject=domain.subject,
+        session=domain.session,
+        run=domain.run,
+        task=task,
+        acquisition=acquisition,
+        source_locator=domain.domain_id,
+        source_format="MOABB -> MNE Raw",
+        source_license=source_license,
+        reference=reference,
+        preprocessing=tuple(str(item) for item in preprocessing_notes),
+        notes=(
+            f"Explicit run window: tmin={float(tmin_s):g}s duration={float(duration_s):g}s.",
+            "Window semantics are declared by the study author; Arena did not infer baseline/task meaning.",
+        ),
+    )
+    export_mne_raw_baseline(
+        domain.raw,
+        output,
+        channel_names=channel_names,
+        tmin_s=tmin_s,
+        duration_s=duration_s,
+        target_sampling_rate_hz=target_sampling_rate_hz,
+        recording_metadata=metadata,
+    )
+    return output

--- a/packages/neuros-arena/src/neuros/arena/reality.py
+++ b/packages/neuros-arena/src/neuros/arena/reality.py
@@ -1,0 +1,122 @@
+"""Optional real-data anchoring for synthetic world populations.
+
+This module does not collapse synthetic-vs-real similarity into a universal
+'realism score'. It uses neurOS SourceWeigher to estimate which candidate worlds
+are most similar to an observed target domain under an explicitly chosen feature
+geometry (sensor covariance or representation embeddings).
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import numpy as np
+
+from .runner import ArenaRun
+
+
+@dataclass(frozen=True)
+class RealityAnchorResult:
+    world_ids: tuple[str, ...]
+    weights: np.ndarray
+    distances: tuple[float, ...]
+    method: str
+    effective_world_count: float
+    max_weight: float
+
+    def by_world(self) -> dict[str, float]:
+        return {world_id: float(weight) for world_id, weight in zip(self.world_ids, self.weights, strict=True)}
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.synthetic_bci_arena.reality_anchor.v1",
+            "method": self.method,
+            "weights": self.by_world(),
+            "source_distances": {key: float(value) for key, value in zip(self.world_ids, self.distances, strict=True)},
+            "effective_world_count": self.effective_world_count,
+            "max_weight": self.max_weight,
+            "evidence_boundary": (
+                "Similarity weighting to an observed domain; weights are not probabilities that a world is physiologically true."
+            ),
+        }
+
+
+def _require_sourceweigher():
+    try:
+        import neuros_sourceweigher
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Reality anchoring requires neuros-sourceweigher. Install `neuros-arena[reality]`."
+        ) from exc
+    return neuros_sourceweigher
+
+
+def _as_samples_by_channels(data: np.ndarray) -> np.ndarray:
+    array = np.asarray(data, dtype=float)
+    if array.ndim != 2 or min(array.shape) < 2:
+        raise ValueError("EEG domain must be a 2-D channels x samples array")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("EEG domain must be finite")
+    return array.T
+
+
+def anchor_worlds_by_covariance(
+    worlds: Mapping[str, ArenaRun],
+    target_data_uv: np.ndarray,
+    *,
+    temperature: float = 1.0,
+    shrinkage: float = 1e-3,
+) -> RealityAnchorResult:
+    """Weight synthetic worlds against target EEG covariance geometry."""
+    if not worlds:
+        raise ValueError("worlds cannot be empty")
+    sourceweigher = _require_sourceweigher()
+    source_samples = {
+        world_id: _as_samples_by_channels(run.device_output.data_uv)
+        for world_id, run in worlds.items()
+    }
+    target = _as_samples_by_channels(target_data_uv)
+    dims = {target.shape[1], *(samples.shape[1] for samples in source_samples.values())}
+    if len(dims) != 1:
+        raise ValueError("all worlds and target EEG must have the same channel count")
+    result = sourceweigher.RiemannianCovarianceWeigher(
+        temperature=temperature,
+        shrinkage=shrinkage,
+    ).estimate(source_samples, target)
+    return RealityAnchorResult(
+        world_ids=tuple(result.source_ids),
+        weights=np.asarray(result.weights, dtype=float),
+        distances=tuple(float(value) for value in result.diagnostics.source_distances),
+        method=result.diagnostics.method,
+        effective_world_count=float(result.diagnostics.effective_sample_size),
+        max_weight=float(result.diagnostics.max_weight),
+    )
+
+
+def anchor_worlds_by_embeddings(
+    world_embeddings: Mapping[str, np.ndarray],
+    target_embeddings: np.ndarray,
+    *,
+    statistics: tuple[str, ...] = ("mean", "log_std"),
+) -> RealityAnchorResult:
+    """Weight worlds in a shared neurOS foundation-model representation space.
+
+    Embedding extraction remains the responsibility of ``neuros-foundation`` or
+    another model package so Arena does not acquire model-specific preprocessing.
+    """
+    if not world_embeddings:
+        raise ValueError("world_embeddings cannot be empty")
+    sourceweigher = _require_sourceweigher()
+    result = sourceweigher.RepresentationSourceWeigher(statistics=statistics).estimate(
+        source_embeddings=world_embeddings,
+        target_embeddings=np.asarray(target_embeddings, dtype=float),
+    )
+    distances = tuple(float(value) for value in result.diagnostics.source_distances)
+    return RealityAnchorResult(
+        world_ids=tuple(result.source_ids),
+        weights=np.asarray(result.weights, dtype=float),
+        distances=distances,
+        method=result.diagnostics.method,
+        effective_world_count=float(result.diagnostics.effective_sample_size),
+        max_weight=float(result.diagnostics.max_weight),
+    )

--- a/packages/neuros-arena/src/neuros/arena/recording.py
+++ b/packages/neuros-arena/src/neuros/arena/recording.py
@@ -1,0 +1,116 @@
+"""BIDS-aligned provenance metadata for recorded EEG entering Arena.
+
+Arena's compact NPZ baseline format is intentionally not advertised as BIDS.
+This sidecar preserves the subset of acquisition/task/channel provenance needed
+to trace a derived Arena baseline back to a canonical BIDS/MNE/public-dataset
+source without inventing another primary neuroscience interchange standard.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+RECORDING_SCHEMA = "neuros.synthetic_bci_arena.recording_metadata.v1"
+
+
+@dataclass(frozen=True)
+class ElectrodeCoordinate:
+    name: str
+    x: float
+    y: float
+    z: float
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("electrode name is required")
+        for value in (self.x, self.y, self.z):
+            if not isinstance(value, (int, float)):
+                raise ValueError("electrode coordinates must be numeric")
+
+
+@dataclass(frozen=True)
+class RecordingMetadata:
+    """Minimal traceable metadata for an EEG recording or derived window.
+
+    Field names intentionally mirror common EEG-BIDS concepts where practical,
+    but this object is an Arena provenance record, not a BIDS validator/writer.
+    ``source_locator`` may be a BIDS-relative path, DOI, dataset identifier, or
+    other non-secret reproducibility locator. Do not put participant names or
+    other direct identifiers here.
+    """
+
+    dataset: str = ""
+    subject: str = ""
+    session: str = ""
+    run: str = ""
+    task: str = ""
+    acquisition: str = ""
+    source_locator: str = ""
+    source_format: str = ""
+    source_license: str = ""
+    reference: str = ""
+    line_frequency_hz: float | None = None
+    channel_units: Mapping[str, str] = field(default_factory=dict)
+    channel_types: Mapping[str, str] = field(default_factory=dict)
+    coordinate_system: str = ""
+    coordinate_units: str = ""
+    electrodes: tuple[ElectrodeCoordinate, ...] = ()
+    preprocessing: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def validate(self, channel_names: Sequence[str] | None = None) -> None:
+        if self.line_frequency_hz is not None and self.line_frequency_hz <= 0:
+            raise ValueError("line_frequency_hz must be positive when present")
+        for mapping_name, mapping in (("channel_units", self.channel_units), ("channel_types", self.channel_types)):
+            for key, value in mapping.items():
+                if not str(key) or not str(value):
+                    raise ValueError(f"{mapping_name} keys and values must be non-empty")
+        electrode_names = [electrode.name for electrode in self.electrodes]
+        if len(electrode_names) != len(set(electrode_names)):
+            raise ValueError("electrode names must be unique")
+        for electrode in self.electrodes:
+            electrode.validate()
+        if self.electrodes and (not self.coordinate_system or not self.coordinate_units):
+            raise ValueError("electrode coordinates require coordinate_system and coordinate_units")
+        if channel_names is not None:
+            allowed = set(str(name) for name in channel_names)
+            extras = (set(self.channel_units) | set(self.channel_types) | set(electrode_names)) - allowed
+            if extras:
+                raise ValueError(f"recording metadata references channels not present in data: {sorted(extras)}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"schema": RECORDING_SCHEMA, **asdict(self)}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "RecordingMetadata":
+        if raw.get("schema") != RECORDING_SCHEMA:
+            raise ValueError(f"expected recording metadata schema {RECORDING_SCHEMA!r}")
+        values = dict(raw)
+        values.pop("schema", None)
+        values["channel_units"] = dict(values.get("channel_units", {}))
+        values["channel_types"] = dict(values.get("channel_types", {}))
+        values["electrodes"] = tuple(ElectrodeCoordinate(**item) for item in values.get("electrodes", []))
+        values["preprocessing"] = tuple(values.get("preprocessing", []))
+        values["notes"] = tuple(values.get("notes", []))
+        metadata = cls(**values)
+        metadata.validate()
+        return metadata
+
+
+def recording_sidecar_path(baseline_path: str | Path) -> Path:
+    path = Path(baseline_path)
+    return path.with_suffix(path.suffix + ".json")
+
+
+def save_recording_metadata(metadata: RecordingMetadata, path: str | Path, *, channel_names: Sequence[str] | None = None) -> Path:
+    metadata.validate(channel_names)
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(metadata.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    return output
+
+
+def load_recording_metadata(path: str | Path) -> RecordingMetadata:
+    return RecordingMetadata.from_dict(json.loads(Path(path).read_text(encoding="utf-8")))

--- a/packages/neuros-arena/src/neuros/arena/reference.py
+++ b/packages/neuros-arena/src/neuros/arena/reference.py
@@ -1,0 +1,57 @@
+"""Dependency-light feature signatures for calibrating synthetic data against recordings."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _band_fraction(power: np.ndarray, frequencies: np.ndarray, low: float, high: float) -> float:
+    band = (frequencies >= low) & (frequencies < high)
+    total = (frequencies >= 1.0) & (frequencies <= 80.0)
+    denominator = float(np.sum(power[:, total]))
+    return float(np.sum(power[:, band]) / denominator) if denominator > 0 else 0.0
+
+
+def feature_signature(data_uv: np.ndarray, sampling_rate_hz: float) -> dict[str, float]:
+    """Return coarse observable features; this is not a claim of physiological realism."""
+    data = np.asarray(data_uv, dtype=float)
+    if data.ndim != 2 or data.shape[1] < 16 or sampling_rate_hz <= 0:
+        raise ValueError("expected channels x samples EEG and a positive sample rate")
+    centered = data - np.mean(data, axis=1, keepdims=True)
+    rms = np.sqrt(np.mean(centered**2, axis=1))
+    std = np.std(centered)
+    fourth = float(np.mean(centered**4) / max(std**4, 1e-12))
+    window = np.hanning(data.shape[1])
+    power = np.abs(np.fft.rfft(centered * window[None, :], axis=1)) ** 2
+    frequencies = np.fft.rfftfreq(data.shape[1], d=1.0 / sampling_rate_hz)
+    corr = np.corrcoef(centered)
+    upper = np.abs(corr[np.triu_indices(corr.shape[0], 1)]) if corr.shape[0] > 1 else np.asarray([0.0])
+    return {
+        "median_channel_rms_uv": float(np.median(rms)),
+        "alpha_8_13_fraction": _band_fraction(power, frequencies, 8.0, 13.0),
+        "beta_13_30_fraction": _band_fraction(power, frequencies, 13.0, 30.0),
+        "high_30_80_fraction": _band_fraction(power, frequencies, 30.0, 80.0),
+        "mean_abs_channel_correlation": float(np.mean(upper)),
+        "fourth_moment_ratio": fourth,
+    }
+
+
+def compare_feature_signatures(reference: dict[str, float], candidate: dict[str, float]) -> dict[str, float]:
+    """Compare observable feature scales without calling the result a realism score."""
+    common = sorted(set(reference) & set(candidate))
+    if not common:
+        raise ValueError("signatures share no features")
+    log_ratios = []
+    absolute = []
+    for key in common:
+        ref = float(reference[key])
+        cand = float(candidate[key])
+        if ref > 0 and cand > 0:
+            log_ratios.append(abs(float(np.log(cand / ref))))
+        else:
+            absolute.append(abs(cand - ref))
+    return {
+        "features_compared": float(len(common)),
+        "mean_abs_log_ratio": float(np.mean(log_ratios)) if log_ratios else 0.0,
+        "max_abs_log_ratio": float(np.max(log_ratios)) if log_ratios else 0.0,
+        "mean_absolute_difference_nonpositive": float(np.mean(absolute)) if absolute else 0.0,
+    }

--- a/packages/neuros-arena/src/neuros/arena/runner.py
+++ b/packages/neuros-arena/src/neuros/arena/runner.py
@@ -1,0 +1,273 @@
+"""Deterministic closed-loop arena runner."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+from neuros.plugins import PluginKind, load_plugin
+
+from .evidence import evidence_card_for_model
+from .simulators import DeviceOutput, StimulusTrace, TransportPacket, apply_device, packetize, sample_stimulus, simulate_stimulus
+from .specs import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, TransportProfile, WorldModelProfile
+from .world_input import WorldInputBlock
+from .world_models import NeuralWorldModel
+
+
+@dataclass(frozen=True)
+class StageInterval:
+    label: str
+    start_s: float
+    end_s: float
+    target_frequency_hz: float | None
+
+
+@dataclass(frozen=True)
+class ArenaRun:
+    scenario: ArenaScenario
+    participant: ParticipantProfile
+    device: DeviceProfile
+    display: DisplayProfile
+    transport: TransportProfile
+    world_model: WorldModelProfile
+    device_output: DeviceOutput
+    packets: tuple[TransportPacket, ...]
+    ground_truth_target_hz: np.ndarray
+    stage_index: np.ndarray
+    stages: tuple[StageInterval, ...]
+    stimulus_traces: tuple[StimulusTrace, ...]
+    report: dict
+
+
+def _spectral_snr_db(data_uv: np.ndarray, fs: float, target_hz: float) -> float:
+    if data_uv.shape[1] < max(32, int(fs)):
+        return 0.0
+    x = np.mean(data_uv, axis=0).astype(float)
+    x -= np.mean(x)
+    window = np.hanning(x.size)
+    power = np.abs(np.fft.rfft(x * window)) ** 2
+    freq = np.fft.rfftfreq(x.size, d=1.0 / fs)
+    signal = np.abs(freq - target_hz) <= 0.30
+    noise = (np.abs(freq - target_hz) >= 0.8) & (np.abs(freq - target_hz) <= 3.0)
+    signal_power = float(np.mean(power[signal])) if np.any(signal) else 0.0
+    noise_power = float(np.mean(power[noise])) if np.any(noise) else 1e-12
+    return float(10.0 * np.log10(max(signal_power, 1e-12) / max(noise_power, 1e-12)))
+
+
+def _create_world_model(
+    profile: WorldModelProfile,
+    participant: ParticipantProfile,
+    sampling_rate_hz: float,
+    seed: int,
+) -> NeuralWorldModel:
+    profile.validate()
+    model = load_plugin(
+        profile.name,
+        kind=PluginKind.WORLD_MODEL,
+        participant=participant,
+        sampling_rate_hz=sampling_rate_hz,
+        seed=seed,
+        parameters=profile.parameters,
+    )
+    if not hasattr(model, "render") and not hasattr(model, "render_world"):
+        raise TypeError(f"world model {profile.name!r} exposes neither render nor render_world")
+    if not hasattr(model, "inject_artifact") or not hasattr(model, "channel_names"):
+        raise TypeError(f"world model {profile.name!r} does not satisfy the Arena contract")
+    return model
+
+
+def _render_world_model(
+    model: NeuralWorldModel,
+    *,
+    input_block: WorldInputBlock,
+    target_frequency_hz: float | None,
+    attention_gain: float,
+):
+    render_world = getattr(model, "render_world", None)
+    if callable(render_world):
+        input_block.validate()
+        return render_world(input_block)
+    return model.render(
+        input_block.sample_times_s,
+        input_block.visual_luminance,
+        target_frequency_hz,
+        attention_gain,
+    )
+
+
+def run_scenario(
+    scenario: ArenaScenario,
+    participant: ParticipantProfile,
+    device: DeviceProfile,
+    display: DisplayProfile,
+    transport: TransportProfile,
+    world_model: WorldModelProfile | None = None,
+) -> ArenaRun:
+    scenario.validate()
+    participant.validate()
+    device.validate()
+    display.validate()
+    transport.validate()
+    model_profile = world_model or WorldModelProfile()
+    model = _create_world_model(
+        model_profile,
+        participant,
+        device.sampling_rate_hz,
+        seed=participant.seed + scenario.seed,
+    )
+    evidence_card = evidence_card_for_model(model, model_profile.name)
+    paradigm = scenario.metadata.get("paradigm", "ssvep")
+
+    block_samples = max(1, device.chunk_samples)
+    data_blocks: list[np.ndarray] = []
+    timestamp_blocks: list[np.ndarray] = []
+    truth_blocks: list[np.ndarray] = []
+    stage_blocks: list[np.ndarray] = []
+    stage_intervals: list[StageInterval] = []
+    stimulus_traces: list[StimulusTrace] = []
+    latent_stage_end: list[dict[str, float | str]] = []
+    global_start = 0.0
+
+    for stage_i, stage in enumerate(scenario.stages):
+        stage_start = global_start
+        stage_end = stage_start + stage.duration_s
+        stage_intervals.append(StageInterval(stage.label, stage_start, stage_end, stage.target_frequency_hz))
+        trace = simulate_stimulus(
+            stage.target_frequency_hz,
+            stage.duration_s,
+            display,
+            seed=scenario.seed * 1009 + stage_i,
+        )
+        stimulus_traces.append(trace)
+        samples_total = max(1, int(round(stage.duration_s * device.sampling_rate_hz)))
+        artifact_cursor: set[int] = set()
+        produced = 0
+        last_latent: dict[str, float] = {}
+        while produced < samples_total:
+            count = min(block_samples, samples_total - produced)
+            elapsed = produced / device.sampling_rate_hz
+            local_times = elapsed + np.arange(count, dtype=float) / device.sampling_rate_hz
+            global_times = stage_start + local_times
+            for artifact_i, artifact in enumerate(stage.artifacts):
+                if artifact_i not in artifact_cursor and elapsed <= artifact.at_s < elapsed + count / device.sampling_rate_hz:
+                    model.inject_artifact(
+                        artifact.kind,
+                        duration_seconds=artifact.duration_s,
+                        severity=artifact.severity * participant.artifact_gain,
+                    )
+                    artifact_cursor.add(artifact_i)
+            if stage.target_frequency_hz is None:
+                effective_gain = 0.0
+            else:
+                after_delay = max(0.0, elapsed - participant.response_delay_s)
+                switch_gain = 0.0 if elapsed < participant.response_delay_s else 1.0 - np.exp(-after_delay / participant.switch_time_constant_s)
+                global_elapsed_min = (stage_start + elapsed) / 60.0
+                attenuation = max(0.0, 1.0 - participant.response_attenuation_per_minute * global_elapsed_min)
+                effective_gain = stage.attention_gain * participant.gaze_duty_cycle * switch_gain * attenuation
+            emitted_drive = sample_stimulus(trace, local_times, display)
+            target = dict(stage.target)
+            if stage.target_frequency_hz is not None:
+                target.setdefault("frequency_hz", float(stage.target_frequency_hz))
+            input_block = WorldInputBlock(
+                sample_times_s=global_times,
+                paradigm=paradigm,
+                stage_label=stage.label,
+                emitted_streams={"visual_luminance": emitted_drive},
+                target=target,
+                task_state=dict(stage.task_state),
+                participant_state={"attention_gain": float(effective_gain)},
+            )
+            emission = _render_world_model(
+                model,
+                input_block=input_block,
+                target_frequency_hz=stage.target_frequency_hz,
+                attention_gain=float(effective_gain),
+            )
+            if emission.data_uv.shape != (len(model.channel_names), count):
+                raise ValueError(
+                    f"world model emitted {emission.data_uv.shape}; expected {(len(model.channel_names), count)}"
+                )
+            data_blocks.append(emission.data_uv)
+            timestamp_blocks.append(global_times)
+            last_latent = dict(emission.latent)
+            truth_value = np.nan if stage.target_frequency_hz is None else float(stage.target_frequency_hz)
+            truth_blocks.append(np.full(count, truth_value, dtype=float))
+            stage_blocks.append(np.full(count, stage_i, dtype=np.int32))
+            produced += count
+        latent_stage_end.append({"stage": stage.label, **last_latent})
+        global_start = stage_end
+
+    raw_data = np.concatenate(data_blocks, axis=1)
+    raw_timestamps = np.concatenate(timestamp_blocks)
+    truth = np.concatenate(truth_blocks)
+    stage_index = np.concatenate(stage_blocks)
+    output = apply_device(raw_data, raw_timestamps, tuple(model.channel_names), device, seed=scenario.seed + 2003)
+    packets, transport_metrics = packetize(
+        output.data_uv,
+        output.timestamps_s,
+        device.chunk_samples,
+        transport,
+        seed=scenario.seed + 3001,
+        ground_truth_timestamps_s=output.ground_truth_timestamps_s,
+    )
+
+    posterior = [index for index, name in enumerate(output.channel_names) if name in {"Pz", "PO7", "Oz", "PO8"}]
+    if not posterior:
+        posterior = list(range(output.data_uv.shape[0]))
+    snr: dict[str, float] = {}
+    for frequency in sorted({stage.target_frequency_hz for stage in scenario.stages if stage.target_frequency_hz is not None}):
+        mask = np.isclose(truth, frequency, equal_nan=False)
+        snr[f"{frequency:g}Hz"] = _spectral_snr_db(output.data_uv[posterior][:, mask], device.sampling_rate_hz, float(frequency))
+
+    display_metrics = []
+    for stage, trace in zip(scenario.stages, stimulus_traces, strict=True):
+        display_metrics.append({
+            "stage": stage.label,
+            "target_frequency_hz": stage.target_frequency_hz,
+            "observed_frequency_hz": trace.observed_frequency_hz,
+            "frequency_error_hz": (0.0 if stage.target_frequency_hz is None else abs(trace.observed_frequency_hz - stage.target_frequency_hz)),
+            "frame_drop_fraction": trace.frame_drop_fraction,
+            "interval_jitter_ms": trace.interval_jitter_ms,
+        })
+
+    report = {
+        "schema": "neuros.synthetic_bci_arena.v1",
+        "scenario": scenario.to_dict(),
+        "paradigm": paradigm,
+        "participant": asdict(participant),
+        "world_model": asdict(model_profile),
+        "world_model_evidence": evidence_card.to_dict(),
+        "device": asdict(device),
+        "display": asdict(display),
+        "transport": asdict(transport),
+        "metrics": {
+            "duration_s": float(output.ground_truth_timestamps_s[-1] - output.ground_truth_timestamps_s[0]) if output.ground_truth_timestamps_s.size > 1 else 0.0,
+            "samples": int(output.timestamps_s.size),
+            "device_lsb_uv": output.lsb_uv,
+            "device_clipped_fraction": output.clipped_fraction,
+            "target_snr_db": snr,
+            "transport": transport_metrics,
+            "display": display_metrics,
+            "world_model": {
+                "name": model_profile.name,
+                "display_coupled": bool(any(item.get("stimulus_coupling", 0.0) > 0 for item in latent_stage_end)),
+                "stage_end_latent": latent_stage_end,
+            },
+        },
+        "evidence_boundary": "Synthetic conformance evidence only; not human physiological performance.",
+    }
+    return ArenaRun(
+        scenario=scenario,
+        participant=participant,
+        device=device,
+        display=display,
+        transport=transport,
+        world_model=model_profile,
+        device_output=output,
+        packets=tuple(packets),
+        ground_truth_target_hz=truth,
+        stage_index=stage_index,
+        stages=tuple(stage_intervals),
+        stimulus_traces=tuple(stimulus_traces),
+        report=report,
+    )

--- a/packages/neuros-arena/src/neuros/arena/semi_synthetic.py
+++ b/packages/neuros-arena/src/neuros/arena/semi_synthetic.py
@@ -1,0 +1,138 @@
+"""Semi-synthetic EEG world model using real or recorded background data.
+
+The model replays an observed EEG background and injects a *known* response that
+is driven by Arena's emitted display waveform. This preserves much of the
+background covariance/artifact texture of recorded EEG while retaining exact
+causal ground truth for the injected BCI signal.
+
+Input NPZ contract:
+    data_uv: channels x samples
+    sampling_rate_hz: scalar
+    channel_names: string array
+
+The model never claims that its injected response is a faithful physiological
+model of the person represented by the background recording.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .specs import ParticipantProfile
+from .world_models import POSTERIOR_WEIGHTS, SOURCE_CHANNELS, WorldModelEmission, _ArtifactEngine
+
+
+class SemiSyntheticReplayWorldModel:
+    name = "semi_synthetic_replay"
+    channel_names = SOURCE_CHANNELS
+
+    def __init__(
+        self,
+        *,
+        participant: ParticipantProfile,
+        sampling_rate_hz: float,
+        seed: int,
+        parameters: dict[str, Any] | None = None,
+    ) -> None:
+        params = dict(parameters or {})
+        if not params.get("path"):
+            raise ValueError("semi_synthetic_replay requires world_model.parameters.path")
+        path = Path(str(params["path"])).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(path)
+        with np.load(path, allow_pickle=False) as payload:
+            if "data_uv" not in payload or "sampling_rate_hz" not in payload or "channel_names" not in payload:
+                raise ValueError("baseline NPZ requires data_uv, sampling_rate_hz and channel_names")
+            data = np.asarray(payload["data_uv"], dtype=float)
+            source_fs = float(np.asarray(payload["sampling_rate_hz"]).reshape(-1)[0])
+            names = tuple(str(value) for value in np.asarray(payload["channel_names"]).tolist())
+        if data.ndim != 2 or data.shape[1] < 32:
+            raise ValueError("baseline data_uv must be channels x samples with at least 32 samples")
+        if source_fs <= 0:
+            raise ValueError("baseline sampling_rate_hz must be positive")
+        missing = [name for name in SOURCE_CHANNELS if name not in names]
+        if missing:
+            raise ValueError(f"baseline is missing required Arena channels: {missing}")
+        selected = np.asarray([data[names.index(name)] for name in SOURCE_CHANNELS], dtype=float)
+        self.fs = float(sampling_rate_hz)
+        self.participant = participant
+        self.rng = np.random.default_rng(seed)
+        self._baseline = self._resample(selected, source_fs, self.fs)
+        if bool(params.get("demean", True)):
+            self._baseline = self._baseline - np.mean(self._baseline, axis=1, keepdims=True)
+        self._cursor = int(self.rng.integers(0, self._baseline.shape[1])) if bool(params.get("random_offset", True)) else 0
+        self._entrainment = 0.0
+        self._response_state = 0.0
+        self._tau_s = float(params.get("entrainment_tau_s", 0.18))
+        self._response_scale = float(params.get("response_scale", 1.0))
+        if self._tau_s <= 0 or self._response_scale < 0:
+            raise ValueError("semi-synthetic entrainment_tau_s/response_scale are invalid")
+        self._artifact = _ArtifactEngine(self.fs, seed + 1171)
+
+    @staticmethod
+    def _resample(data: np.ndarray, source_fs: float, target_fs: float) -> np.ndarray:
+        if abs(source_fs - target_fs) < 1e-9:
+            return data.astype(np.float32)
+        duration = (data.shape[1] - 1) / source_fs
+        count = max(32, int(round(duration * target_fs)) + 1)
+        old_t = np.arange(data.shape[1], dtype=float) / source_fs
+        new_t = np.arange(count, dtype=float) / target_fs
+        return np.vstack([np.interp(new_t, old_t, channel) for channel in data]).astype(np.float32)
+
+    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+        self._artifact.inject(kind, duration_seconds, severity)
+
+    def _next_background(self, samples: int) -> np.ndarray:
+        indices = (self._cursor + np.arange(samples)) % self._baseline.shape[1]
+        block = self._baseline[:, indices].copy()
+        self._cursor = int((self._cursor + samples) % self._baseline.shape[1])
+        return block
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission:
+        times = np.asarray(sample_times_s, dtype=float)
+        drive = np.asarray(emitted_stimulus, dtype=float)
+        if drive.shape != times.shape:
+            raise ValueError("sample_times_s and emitted_stimulus must match")
+        samples = times.size
+        data = self._next_background(samples).astype(float)
+        dt = 1.0 / self.fs
+        target_gain = max(0.0, float(attention_gain)) if target_frequency_hz is not None else 0.0
+        response = np.zeros(samples, dtype=float)
+        for i in range(samples):
+            self._entrainment += (target_gain - self._entrainment) * min(1.0, dt / self._tau_s)
+            desired = float(np.clip(drive[i], -1.0, 1.0)) * self._entrainment
+            self._response_state += (desired - self._response_state) * min(1.0, dt / 0.035)
+            response[i] = self._response_state
+        if target_frequency_hz is not None:
+            harmonic = np.sin(4.0 * np.pi * float(target_frequency_hz) * times + 0.4)
+            response = response + self.participant.first_harmonic_ratio * self._entrainment * harmonic
+        data += (
+            POSTERIOR_WEIGHTS[:, None]
+            * self.participant.ssvep_amplitude_uv
+            * self._response_scale
+            * response[None, :]
+        )
+        artifact, artifact_kind = self._artifact.render(times)
+        dropout = artifact_kind == "dropout"
+        if dropout:
+            artifact = np.nan_to_num(artifact, nan=0.0)
+        data += artifact
+        if dropout:
+            data[6, :] = 0.0
+        return WorldModelEmission(
+            data_uv=data.astype(np.float32),
+            latent={
+                "attention_gain": target_gain,
+                "entrainment": float(self._entrainment),
+                "stimulus_coupling": 1.0,
+                "baseline_replay": 1.0,
+            },
+        )

--- a/packages/neuros-arena/src/neuros/arena/simulators.py
+++ b/packages/neuros-arena/src/neuros/arena/simulators.py
@@ -1,0 +1,276 @@
+"""Display, acquisition-device and transport simulators with explicit ground truth."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .specs import DeviceProfile, DisplayProfile, TransportProfile
+
+
+@dataclass(frozen=True)
+class StimulusTrace:
+    frequency_hz: float | None
+    frame_times_s: np.ndarray
+    luminance: np.ndarray
+    dropped_frames: np.ndarray
+    observed_frequency_hz: float
+    frame_drop_fraction: float
+    interval_jitter_ms: float
+
+
+@dataclass(frozen=True)
+class DeviceOutput:
+    data_uv: np.ndarray
+    timestamps_s: np.ndarray
+    channel_names: tuple[str, ...]
+    lsb_uv: float
+    clipped_fraction: float
+    ground_truth_timestamps_s: np.ndarray
+
+
+@dataclass(frozen=True)
+class TransportPacket:
+    sequence: int
+    generated_s: float
+    arrival_s: float
+    timestamps_s: np.ndarray
+    data_uv: np.ndarray
+    source_timestamps_s: np.ndarray
+    ground_truth_timestamps_s: np.ndarray
+
+
+def simulate_stimulus(
+    frequency_hz: float | None,
+    duration_s: float,
+    profile: DisplayProfile,
+    seed: int,
+) -> StimulusTrace:
+    profile.validate()
+    if duration_s <= 0:
+        raise ValueError("duration_s must be positive")
+    if frequency_hz is not None and frequency_hz <= 0:
+        raise ValueError("frequency_hz must be positive")
+    rng = np.random.default_rng(seed)
+    frames = max(2, int(np.ceil(duration_s * profile.refresh_hz)))
+    nominal = 1.0 / profile.refresh_hz
+    jitter = rng.normal(0.0, profile.frame_jitter_ms / 1000.0, size=frames)
+    intervals = np.maximum(nominal * 0.25, nominal + jitter)
+    frame_times = np.cumsum(intervals) - intervals[0] + profile.response_lag_ms / 1000.0
+    dropped = rng.random(frames) < profile.frame_drop_probability
+    luminance = np.full(frames, profile.low_luminance, dtype=float)
+    previous = profile.low_luminance
+    for index, t_s in enumerate(frame_times):
+        if dropped[index]:
+            luminance[index] = previous
+            continue
+        if frequency_hz is None:
+            value = profile.low_luminance
+        else:
+            value = profile.high_luminance if np.sin(2 * np.pi * frequency_hz * t_s) >= 0 else profile.low_luminance
+        luminance[index] = value
+        previous = value
+    transitions = int(np.count_nonzero(np.diff(luminance) != 0))
+    span = max(float(frame_times[-1] - frame_times[0]), nominal)
+    observed = transitions / (2.0 * span) if frequency_hz is not None else 0.0
+    return StimulusTrace(
+        frequency_hz=frequency_hz,
+        frame_times_s=frame_times,
+        luminance=luminance,
+        dropped_frames=dropped,
+        observed_frequency_hz=float(observed),
+        frame_drop_fraction=float(np.mean(dropped)),
+        interval_jitter_ms=float(np.std(np.diff(frame_times) - nominal) * 1000.0),
+    )
+
+
+def sample_stimulus(
+    trace: StimulusTrace,
+    sample_times_s: np.ndarray,
+    profile: DisplayProfile,
+) -> np.ndarray:
+    """Sample-and-hold the physically emitted luminance at EEG sample times.
+
+    Values are normalized to [-1, 1] around the configured low/high luminance.
+    A no-target trace returns zeros so resting baseline does not become an
+    artificial negative periodic drive.
+    """
+    times = np.asarray(sample_times_s, dtype=float)
+    if times.ndim != 1:
+        raise ValueError("sample_times_s must be 1-D")
+    if trace.frequency_hz is None:
+        return np.zeros(times.size, dtype=float)
+    indices = np.searchsorted(trace.frame_times_s, times, side="right") - 1
+    values = np.full(times.size, profile.low_luminance, dtype=float)
+    valid = indices >= 0
+    if np.any(valid):
+        clipped = np.minimum(indices[valid], trace.luminance.size - 1)
+        values[valid] = trace.luminance[clipped]
+    midpoint = 0.5 * (profile.low_luminance + profile.high_luminance)
+    half_range = max(0.5 * (profile.high_luminance - profile.low_luminance), 1e-12)
+    return np.clip((values - midpoint) / half_range, -1.0, 1.0)
+
+
+def apply_device(
+    data_uv: np.ndarray,
+    timestamps_s: np.ndarray,
+    source_channel_names: tuple[str, ...],
+    profile: DeviceProfile,
+    seed: int,
+) -> DeviceOutput:
+    profile.validate()
+    if data_uv.ndim != 2 or timestamps_s.ndim != 1 or data_uv.shape[1] != timestamps_s.size:
+        raise ValueError("data must be channels x samples with one timestamp per sample")
+    indices = []
+    for name in profile.channel_names:
+        if name not in source_channel_names:
+            raise ValueError(f"device channel {name!r} is unavailable from source")
+        indices.append(source_channel_names.index(name))
+    rng = np.random.default_rng(seed)
+    selected = np.asarray(data_uv[indices], dtype=float).copy()
+    if profile.sensor_noise_uv > 0:
+        selected += rng.normal(0.0, profile.sensor_noise_uv, size=selected.shape)
+    if profile.line_noise_uv > 0:
+        phases = rng.uniform(0.0, 2 * np.pi, size=(selected.shape[0], 1))
+        selected += profile.line_noise_uv * np.sin(2 * np.pi * profile.line_frequency_hz * timestamps_s[None, :] + phases)
+    half_range = profile.input_range_uv
+    clipped = np.abs(selected) > half_range
+    selected = np.clip(selected, -half_range, half_range)
+    levels = float(2**profile.adc_bits - 1)
+    lsb = 2.0 * half_range / levels
+    selected = np.round((selected + half_range) / lsb) * lsb - half_range
+
+    truth = np.asarray(timestamps_s, dtype=float).copy()
+    clock_scale = 1.0 + profile.clock_drift_ppm * 1e-6
+    device_timestamps = profile.clock_offset_ms / 1000.0 + truth * clock_scale
+    if profile.timestamp_jitter_ms > 0:
+        device_timestamps += rng.normal(0.0, profile.timestamp_jitter_ms / 1000.0, size=truth.size)
+    return DeviceOutput(
+        data_uv=selected.astype(np.float32),
+        timestamps_s=device_timestamps,
+        channel_names=profile.channel_names,
+        lsb_uv=float(lsb),
+        clipped_fraction=float(np.mean(clipped)),
+        ground_truth_timestamps_s=truth,
+    )
+
+
+def _clock_metrics(source: np.ndarray, truth: np.ndarray) -> dict[str, float]:
+    if source.size < 2:
+        return {
+            "source_clock_offset_ms_estimated": 0.0,
+            "source_clock_drift_ppm_estimated": 0.0,
+            "source_timestamp_jitter_rms_ms": 0.0,
+        }
+    slope, intercept = np.polyfit(truth, source, 1)
+    residual = source - (slope * truth + intercept)
+    return {
+        "source_clock_offset_ms_estimated": float(intercept * 1000.0),
+        "source_clock_drift_ppm_estimated": float((slope - 1.0) * 1e6),
+        "source_timestamp_jitter_rms_ms": float(np.sqrt(np.mean(residual**2)) * 1000.0),
+    }
+
+
+def packetize(
+    data_uv: np.ndarray,
+    timestamps_s: np.ndarray,
+    chunk_samples: int,
+    profile: TransportProfile,
+    seed: int,
+    ground_truth_timestamps_s: np.ndarray | None = None,
+) -> tuple[list[TransportPacket], dict[str, float]]:
+    """Packetize a stream while preserving causal/source/corrected clocks.
+
+    ``timestamps_s`` represents the source/device clock. The optional ground-
+    truth clock is the simulator's causal time. Downstream ``packet.timestamps_s``
+    represents a decoder-facing clock after an ideal correction plus the
+    explicitly configured residual synchronization errors. This mirrors the
+    distinction between source timestamps and clock-offset correction in LSL
+    without pretending to reproduce one specific synchronization algorithm.
+    """
+    profile.validate()
+    if chunk_samples <= 0:
+        raise ValueError("chunk_samples must be positive")
+    source = np.asarray(timestamps_s, dtype=float)
+    truth = source.copy() if ground_truth_timestamps_s is None else np.asarray(ground_truth_timestamps_s, dtype=float)
+    if source.ndim != 1 or truth.shape != source.shape or data_uv.shape[1] != source.size:
+        raise ValueError("timestamp domains must be 1-D, equal length, and align with data")
+    rng = np.random.default_rng(seed)
+    packets: list[TransportPacket] = []
+    total = 0
+    dropped = 0
+    correction_scale = 1.0 + profile.clock_correction_drift_error_ppm * 1e-6
+    for sequence, start in enumerate(range(0, source.size, chunk_samples)):
+        stop = min(source.size, start + chunk_samples)
+        total += 1
+        generated = float(truth[stop - 1])
+        in_silence = any(window_start <= generated < window_start + duration for window_start, duration in profile.silence_windows)
+        if in_silence or rng.random() < profile.drop_probability:
+            dropped += 1
+            continue
+        delivery_jitter_s = float(rng.uniform(0.0, profile.jitter_ms / 1000.0)) if profile.jitter_ms > 0 else 0.0
+        correction_noise_s = (
+            float(rng.normal(0.0, profile.clock_correction_noise_ms / 1000.0))
+            if profile.clock_correction_noise_ms > 0
+            else 0.0
+        )
+        corrected = (
+            truth[start:stop] * correction_scale
+            + profile.clock_correction_offset_error_ms / 1000.0
+            + correction_noise_s
+        )
+        packets.append(TransportPacket(
+            sequence=sequence,
+            generated_s=generated,
+            arrival_s=generated + delivery_jitter_s,
+            timestamps_s=corrected.copy(),
+            data_uv=data_uv[:, start:stop].copy(),
+            source_timestamps_s=source[start:stop].copy(),
+            ground_truth_timestamps_s=truth[start:stop].copy(),
+        ))
+    if profile.reorder_probability > 0:
+        for index in range(len(packets) - 1):
+            if rng.random() < profile.reorder_probability:
+                first, second = packets[index], packets[index + 1]
+                packets[index] = TransportPacket(
+                    first.sequence,
+                    first.generated_s,
+                    second.arrival_s + 1e-6,
+                    first.timestamps_s,
+                    first.data_uv,
+                    first.source_timestamps_s,
+                    first.ground_truth_timestamps_s,
+                )
+    packets.sort(key=lambda packet: packet.arrival_s)
+    delays = np.asarray([packet.arrival_s - packet.generated_s for packet in packets], dtype=float)
+    max_gap = 0.0
+    if len(packets) > 1:
+        max_gap = float(np.max(np.diff([packet.arrival_s for packet in packets])))
+    corrected_errors = np.concatenate(
+        [packet.timestamps_s - packet.ground_truth_timestamps_s for packet in packets]
+    ) if packets else np.asarray([], dtype=float)
+    sequence_inversions = 0
+    if len(packets) > 1:
+        sequence_inversions = sum(
+            int(packets[index + 1].sequence < packets[index].sequence)
+            for index in range(len(packets) - 1)
+        )
+    metrics = {
+        "packets_total": float(total),
+        "packets_delivered": float(len(packets)),
+        "packet_drop_fraction": float(dropped / max(total, 1)),
+        "delivery_delay_p95_ms": float(np.percentile(delays, 95) * 1000.0) if delays.size else 0.0,
+        "max_arrival_gap_s": max_gap,
+        "arrival_sequence_inversion_fraction": float(sequence_inversions / max(len(packets) - 1, 1)),
+        "corrected_timestamp_rmse_ms": (
+            float(np.sqrt(np.mean(corrected_errors**2)) * 1000.0) if corrected_errors.size else 0.0
+        ),
+        "corrected_timestamp_p95_abs_ms": (
+            float(np.percentile(np.abs(corrected_errors), 95) * 1000.0) if corrected_errors.size else 0.0
+        ),
+        "corrected_timestamp_max_abs_ms": (
+            float(np.max(np.abs(corrected_errors)) * 1000.0) if corrected_errors.size else 0.0
+        ),
+        **_clock_metrics(source, truth),
+    }
+    return packets, metrics

--- a/packages/neuros-arena/src/neuros/arena/specs.py
+++ b/packages/neuros-arena/src/neuros/arena/specs.py
@@ -1,0 +1,201 @@
+"""Versionable manifests for the Synthetic BCI Arena."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+def _validate_scalar_mapping(name: str, values: dict[str, Any]) -> None:
+    for key, value in values.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{name} keys must be non-empty strings")
+        if not isinstance(value, (str, int, float, bool)) and value is not None:
+            raise ValueError(f"{name}.{key} must be a JSON scalar")
+
+
+@dataclass(frozen=True)
+class ParticipantProfile:
+    name: str = "strong-responder"
+    seed: int = 7
+    colored_noise_uv: float = 4.5
+    white_noise_uv: float = 1.25
+    alpha_frequency_hz: float = 9.4
+    alpha_amplitude_uv: float = 2.8
+    ssvep_amplitude_uv: float = 8.0
+    first_harmonic_ratio: float = 0.34
+    response_delay_s: float = 0.18
+    switch_time_constant_s: float = 0.35
+    response_attenuation_per_minute: float = 0.0
+    gaze_duty_cycle: float = 1.0
+    artifact_gain: float = 1.0
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("participant name is required")
+        if self.colored_noise_uv < 0 or self.white_noise_uv < 0:
+            raise ValueError("noise amplitudes must be non-negative")
+        if self.alpha_frequency_hz <= 0 or self.alpha_amplitude_uv < 0:
+            raise ValueError("alpha parameters are invalid")
+        if self.ssvep_amplitude_uv < 0:
+            raise ValueError("ssvep amplitude must be non-negative")
+        if self.response_delay_s < 0 or self.switch_time_constant_s <= 0:
+            raise ValueError("response timing must be non-negative/positive")
+        if not 0 <= self.response_attenuation_per_minute <= 1:
+            raise ValueError("response attenuation must be in [0, 1]")
+        if not 0 <= self.gaze_duty_cycle <= 1:
+            raise ValueError("gaze_duty_cycle must be in [0, 1]")
+        if self.artifact_gain < 0:
+            raise ValueError("artifact_gain must be non-negative")
+
+
+@dataclass(frozen=True)
+class WorldModelProfile:
+    """Selects the neural dynamics implementation independently of the world."""
+
+    name: str = "driven_state_space"
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.name:
+            raise ValueError("world model name is required")
+        _validate_scalar_mapping("world_model.parameters", self.parameters)
+
+
+@dataclass(frozen=True)
+class DeviceProfile:
+    name: str = "unicorn-like"
+    sampling_rate_hz: float = 250.0
+    channel_names: tuple[str, ...] = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+    adc_bits: int = 24
+    input_range_uv: float = 450_000.0
+    sensor_noise_uv: float = 0.35
+    line_frequency_hz: float = 60.0
+    line_noise_uv: float = 0.8
+    clock_offset_ms: float = 0.0
+    clock_drift_ppm: float = 0.0
+    timestamp_jitter_ms: float = 0.0
+    chunk_samples: int = 5
+
+    def validate(self) -> None:
+        if self.sampling_rate_hz <= 0 or not self.channel_names:
+            raise ValueError("device sample rate/channels are invalid")
+        if self.adc_bits < 8 or self.adc_bits > 32:
+            raise ValueError("adc_bits must be in [8, 32]")
+        if self.input_range_uv <= 0 or self.sensor_noise_uv < 0 or self.line_noise_uv < 0:
+            raise ValueError("device amplitude parameters are invalid")
+        if self.line_frequency_hz <= 0 or self.chunk_samples <= 0:
+            raise ValueError("device line frequency/chunk size are invalid")
+        if self.timestamp_jitter_ms < 0:
+            raise ValueError("timestamp_jitter_ms must be non-negative")
+
+
+@dataclass(frozen=True)
+class DisplayProfile:
+    name: str = "120hz-fixed"
+    refresh_hz: float = 120.0
+    response_lag_ms: float = 3.0
+    frame_jitter_ms: float = 0.0
+    frame_drop_probability: float = 0.0
+    low_luminance: float = 0.18
+    high_luminance: float = 1.0
+
+    def validate(self) -> None:
+        if self.refresh_hz <= 0 or self.response_lag_ms < 0 or self.frame_jitter_ms < 0:
+            raise ValueError("display timing parameters are invalid")
+        if not 0 <= self.frame_drop_probability < 1:
+            raise ValueError("frame_drop_probability must be in [0, 1)")
+        if not 0 <= self.low_luminance < self.high_luminance <= 1:
+            raise ValueError("luminance levels must satisfy 0 <= low < high <= 1")
+
+
+@dataclass(frozen=True)
+class TransportProfile:
+    name: str = "localhost-clean"
+    drop_probability: float = 0.0
+    jitter_ms: float = 0.0
+    reorder_probability: float = 0.0
+    silence_windows: tuple[tuple[float, float], ...] = ()
+    clock_correction_offset_error_ms: float = 0.0
+    clock_correction_drift_error_ppm: float = 0.0
+    clock_correction_noise_ms: float = 0.0
+
+    def validate(self) -> None:
+        if not 0 <= self.drop_probability < 1 or not 0 <= self.reorder_probability < 1:
+            raise ValueError("transport probabilities must be in [0, 1)")
+        if self.jitter_ms < 0 or self.clock_correction_noise_ms < 0:
+            raise ValueError("transport and clock-correction jitter must be non-negative")
+        for start, duration in self.silence_windows:
+            if start < 0 or duration <= 0:
+                raise ValueError("silence windows require start >= 0 and duration > 0")
+
+
+@dataclass(frozen=True)
+class ArtifactEvent:
+    at_s: float
+    kind: str
+    duration_s: float = 0.35
+    severity: float = 1.0
+
+    def validate(self, stage_duration_s: float) -> None:
+        if not 0 <= self.at_s < stage_duration_s:
+            raise ValueError("artifact onset must fall inside its stage")
+        if self.duration_s <= 0 or self.severity < 0:
+            raise ValueError("artifact duration/severity are invalid")
+
+
+@dataclass(frozen=True)
+class StageSpec:
+    label: str
+    duration_s: float
+    target_frequency_hz: float | None = None
+    attention_gain: float = 1.0
+    artifacts: tuple[ArtifactEvent, ...] = ()
+    target: dict[str, Any] = field(default_factory=dict)
+    task_state: dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.label or self.duration_s <= 0:
+            raise ValueError("stage label/duration are required")
+        if self.target_frequency_hz is not None and self.target_frequency_hz <= 0:
+            raise ValueError("target frequency must be positive")
+        if self.attention_gain < 0:
+            raise ValueError("attention gain must be non-negative")
+        for event in self.artifacts:
+            event.validate(self.duration_s)
+        _validate_scalar_mapping("stage.target", self.target)
+        _validate_scalar_mapping("stage.task_state", self.task_state)
+
+
+@dataclass(frozen=True)
+class ArenaScenario:
+    name: str
+    stages: tuple[StageSpec, ...]
+    seed: int = 7
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if not self.name or not self.stages:
+            raise ValueError("scenario name and at least one stage are required")
+        for stage in self.stages:
+            stage.validate()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ArenaScenario":
+        stages = []
+        for stage_raw in raw.get("stages", []):
+            artifacts = tuple(ArtifactEvent(**event) for event in stage_raw.get("artifacts", []))
+            stages.append(StageSpec(
+                label=stage_raw["label"],
+                duration_s=float(stage_raw["duration_s"]),
+                target_frequency_hz=(None if stage_raw.get("target_frequency_hz") is None else float(stage_raw["target_frequency_hz"])),
+                attention_gain=float(stage_raw.get("attention_gain", 1.0)),
+                artifacts=artifacts,
+                target=dict(stage_raw.get("target", {})),
+                task_state=dict(stage_raw.get("task_state", {})),
+            ))
+        scenario = cls(name=str(raw["name"]), stages=tuple(stages), seed=int(raw.get("seed", 7)), metadata=dict(raw.get("metadata", {})))
+        scenario.validate()
+        return scenario

--- a/packages/neuros-arena/src/neuros/arena/studies.py
+++ b/packages/neuros-arena/src/neuros/arena/studies.py
@@ -1,0 +1,140 @@
+"""Cross-domain studies for testing whether synthetic-world anchoring transfers.
+
+These protocols are intentionally dataset-library agnostic. MOABB/BIDS/MNE can
+supply de-identified EEG arrays upstream; Arena owns the leakage-resistant study
+logic and evidence artifact.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+from .reality import anchor_worlds_by_covariance
+from .runner import ArenaRun
+
+
+@dataclass(frozen=True)
+class CohortAnchorFold:
+    held_out_domain: str
+    training_domains: tuple[str, ...]
+    cohort_world_weights: dict[str, float]
+    held_out_world_distances: dict[str, float]
+    weighted_distance: float
+    uniform_distance: float
+    relative_improvement: float
+    best_weighted_world: str
+    closest_held_out_world: str
+
+
+@dataclass(frozen=True)
+class CohortAnchorStudy:
+    folds: tuple[CohortAnchorFold, ...]
+    mean_relative_improvement: float
+    median_relative_improvement: float
+    fraction_improved: float
+    mean_weighted_distance: float
+    mean_uniform_distance: float
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.synthetic_bci_arena.cohort_anchor_study.v1",
+            "folds": [asdict(fold) for fold in self.folds],
+            "summary": {
+                "mean_relative_improvement": self.mean_relative_improvement,
+                "median_relative_improvement": self.median_relative_improvement,
+                "fraction_improved": self.fraction_improved,
+                "mean_weighted_distance": self.mean_weighted_distance,
+                "mean_uniform_distance": self.mean_uniform_distance,
+            },
+            "evidence_boundary": (
+                "Leave-one-domain-out EEG similarity transfer only. Positive results do not establish human BCI accuracy, "
+                "gameplay quality, prevalence, or subject-specific physiological truth."
+            ),
+        }
+
+
+def _normalize(weights: np.ndarray) -> np.ndarray:
+    values = np.asarray(weights, dtype=float)
+    if values.ndim != 1 or values.size == 0 or not np.all(np.isfinite(values)) or np.any(values < 0):
+        raise ValueError("world weights must be finite non-negative values")
+    total = float(values.sum())
+    if total <= 0:
+        raise ValueError("world weights must have positive mass")
+    return values / total
+
+
+def run_leave_one_domain_out_covariance_study(
+    worlds: Mapping[str, ArenaRun],
+    domains: Mapping[str, np.ndarray],
+    *,
+    temperature: float = 1.0,
+    shrinkage: float = 1e-3,
+) -> CohortAnchorStudy:
+    """Test whether world weighting learned on other domains transfers.
+
+    Each fold holds one complete domain out. A domain should normally be a
+    participant or participant-session, not a random window. World weights are
+    estimated independently for every training domain, averaged, normalized,
+    then frozen before the held-out domain is inspected.
+    """
+    if len(worlds) < 2:
+        raise ValueError("study requires at least two synthetic worlds")
+    if len(domains) < 3:
+        raise ValueError("leave-one-domain-out study requires at least three real domains")
+    world_ids = tuple(worlds)
+    domain_ids = tuple(domains)
+    folds: list[CohortAnchorFold] = []
+
+    for held_out in domain_ids:
+        training = tuple(domain_id for domain_id in domain_ids if domain_id != held_out)
+        training_weights = []
+        for domain_id in training:
+            anchor = anchor_worlds_by_covariance(
+                worlds,
+                domains[domain_id],
+                temperature=temperature,
+                shrinkage=shrinkage,
+            )
+            by_world = anchor.by_world()
+            training_weights.append([by_world[world_id] for world_id in world_ids])
+        cohort = _normalize(np.mean(np.asarray(training_weights, dtype=float), axis=0))
+
+        held_anchor = anchor_worlds_by_covariance(
+            worlds,
+            domains[held_out],
+            temperature=temperature,
+            shrinkage=shrinkage,
+        )
+        held_distances_by_world = {
+            world_id: float(distance)
+            for world_id, distance in zip(held_anchor.world_ids, held_anchor.distances, strict=True)
+        }
+        distances = np.asarray([held_distances_by_world[world_id] for world_id in world_ids], dtype=float)
+        weighted = float(np.dot(cohort, distances))
+        uniform = float(np.mean(distances))
+        relative = float((uniform - weighted) / max(abs(uniform), 1e-12))
+        folds.append(CohortAnchorFold(
+            held_out_domain=held_out,
+            training_domains=training,
+            cohort_world_weights={world_id: float(value) for world_id, value in zip(world_ids, cohort, strict=True)},
+            held_out_world_distances={world_id: held_distances_by_world[world_id] for world_id in world_ids},
+            weighted_distance=weighted,
+            uniform_distance=uniform,
+            relative_improvement=relative,
+            best_weighted_world=world_ids[int(np.argmax(cohort))],
+            closest_held_out_world=min(world_ids, key=lambda world_id: held_distances_by_world[world_id]),
+        ))
+
+    improvements = np.asarray([fold.relative_improvement for fold in folds], dtype=float)
+    weighted_distances = np.asarray([fold.weighted_distance for fold in folds], dtype=float)
+    uniform_distances = np.asarray([fold.uniform_distance for fold in folds], dtype=float)
+    return CohortAnchorStudy(
+        folds=tuple(folds),
+        mean_relative_improvement=float(np.mean(improvements)),
+        median_relative_improvement=float(np.median(improvements)),
+        fraction_improved=float(np.mean(improvements > 0)),
+        mean_weighted_distance=float(np.mean(weighted_distances)),
+        mean_uniform_distance=float(np.mean(uniform_distances)),
+    )

--- a/packages/neuros-arena/src/neuros/arena/validation.py
+++ b/packages/neuros-arena/src/neuros/arena/validation.py
@@ -1,0 +1,139 @@
+"""Held-out validation protocols for reality-anchored synthetic populations.
+
+A simulator must not be tuned and judged on the same recording. These helpers
+freeze synthetic-world weights on calibration EEG, then evaluate those weights
+against independent EEG under the same declared feature geometry.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import numpy as np
+
+from .reality import RealityAnchorResult, anchor_worlds_by_covariance
+from .runner import ArenaRun
+
+
+@dataclass(frozen=True)
+class HeldOutRealityValidation:
+    calibration: RealityAnchorResult
+    validation_distances: dict[str, float]
+    weighted_validation_distance: float
+    uniform_validation_distance: float
+    relative_improvement: float
+    calibration_validation_distance_correlation: float
+    best_calibration_world: str
+    best_calibration_world_validation_distance: float
+    validation_best_world: str
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.synthetic_bci_arena.heldout_reality_validation.v1",
+            "calibration": self.calibration.to_dict(),
+            "validation_distances": self.validation_distances,
+            "weighted_validation_distance": self.weighted_validation_distance,
+            "uniform_validation_distance": self.uniform_validation_distance,
+            "relative_improvement": self.relative_improvement,
+            "calibration_validation_distance_correlation": self.calibration_validation_distance_correlation,
+            "best_calibration_world": self.best_calibration_world,
+            "best_calibration_world_validation_distance": self.best_calibration_world_validation_distance,
+            "validation_best_world": self.validation_best_world,
+            "evidence_boundary": (
+                "Out-of-sample domain-similarity validation only. Improvement does not establish human behavioral or decoder performance."
+            ),
+        }
+
+
+def split_contiguous_recording(
+    data_uv: np.ndarray,
+    *,
+    calibration_fraction: float = 0.5,
+    guard_samples: int = 0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Create a leakage-resistant temporal calibration/validation split.
+
+    A contiguous split is intentionally preferred to random sample shuffling for
+    nonstationary EEG. ``guard_samples`` can remove data around the split point
+    when preprocessing/window overlap would otherwise leak information.
+    """
+    data = np.asarray(data_uv, dtype=float)
+    if data.ndim != 2 or data.shape[1] < 8:
+        raise ValueError("expected channels x samples EEG with at least 8 samples")
+    if not 0.1 <= calibration_fraction <= 0.9:
+        raise ValueError("calibration_fraction must be in [0.1, 0.9]")
+    if guard_samples < 0:
+        raise ValueError("guard_samples must be non-negative")
+    split = int(round(data.shape[1] * calibration_fraction))
+    left_stop = split - guard_samples
+    right_start = split + guard_samples
+    if left_stop < 2 or data.shape[1] - right_start < 2:
+        raise ValueError("guard interval leaves too little data for calibration/validation")
+    return data[:, :left_stop].copy(), data[:, right_start:].copy()
+
+
+def _correlation(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size < 2 or b.size != a.size:
+        return 0.0
+    if np.std(a) <= 1e-12 or np.std(b) <= 1e-12:
+        return 0.0
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def validate_covariance_anchor_held_out(
+    worlds: Mapping[str, ArenaRun],
+    calibration_data_uv: np.ndarray,
+    validation_data_uv: np.ndarray,
+    *,
+    temperature: float = 1.0,
+    shrinkage: float = 1e-3,
+) -> HeldOutRealityValidation:
+    """Fit world weights on calibration EEG and score them on independent EEG."""
+    if len(worlds) < 2:
+        raise ValueError("held-out validation requires at least two synthetic worlds")
+    calibration = anchor_worlds_by_covariance(
+        worlds,
+        calibration_data_uv,
+        temperature=temperature,
+        shrinkage=shrinkage,
+    )
+    # A second anchor computation is used only to obtain validation distances in
+    # the identical covariance geometry. Its weights are not used for scoring.
+    validation = anchor_worlds_by_covariance(
+        worlds,
+        validation_data_uv,
+        temperature=temperature,
+        shrinkage=shrinkage,
+    )
+    calibration_weights = calibration.by_world()
+    calibration_distances = {
+        world_id: float(distance)
+        for world_id, distance in zip(calibration.world_ids, calibration.distances, strict=True)
+    }
+    validation_distances = {
+        world_id: float(distance)
+        for world_id, distance in zip(validation.world_ids, validation.distances, strict=True)
+    }
+    if set(calibration_weights) != set(validation_distances):
+        raise ValueError("calibration and validation world sets differ")
+    ids = tuple(calibration.world_ids)
+    weights = np.asarray([calibration_weights[world_id] for world_id in ids], dtype=float)
+    distances = np.asarray([validation_distances[world_id] for world_id in ids], dtype=float)
+    weighted = float(np.dot(weights, distances))
+    uniform = float(np.mean(distances))
+    relative = float((uniform - weighted) / max(abs(uniform), 1e-12))
+    calibration_vector = np.asarray([calibration_distances[world_id] for world_id in ids], dtype=float)
+    corr = _correlation(calibration_vector, distances)
+    best_calibration = min(ids, key=lambda world_id: calibration_distances[world_id])
+    best_validation = min(ids, key=lambda world_id: validation_distances[world_id])
+    return HeldOutRealityValidation(
+        calibration=calibration,
+        validation_distances=validation_distances,
+        weighted_validation_distance=weighted,
+        uniform_validation_distance=uniform,
+        relative_improvement=relative,
+        calibration_validation_distance_correlation=corr,
+        best_calibration_world=best_calibration,
+        best_calibration_world_validation_distance=validation_distances[best_calibration],
+        validation_best_world=best_validation,
+    )

--- a/packages/neuros-arena/src/neuros/arena/world_input.py
+++ b/packages/neuros-arena/src/neuros/arena/world_input.py
@@ -1,0 +1,64 @@
+"""Paradigm-neutral causal input blocks for neural world models.
+
+Manifest v1 remains SSVEP-friendly, but the model boundary should not be. A
+world model may consume this richer block through ``render_world`` while legacy
+models continue to implement the original ``render`` method.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+_JSON_SCALAR = str | int | float | bool | None
+
+
+@dataclass(frozen=True)
+class WorldInputBlock:
+    """One causal chunk presented to a paradigm-neutral neural world model.
+
+    ``emitted_streams`` contains physical/simulated sensory streams *after*
+    presentation effects. Examples include ``visual_luminance``, audio envelope,
+    haptic pulses, or future VR pose-dependent stimulus values. ``target`` and
+    ``task_state`` are declarative labels/metadata, not decoded neural truth.
+    """
+
+    sample_times_s: np.ndarray
+    paradigm: str
+    stage_label: str
+    emitted_streams: dict[str, np.ndarray]
+    target: dict[str, _JSON_SCALAR] = field(default_factory=dict)
+    task_state: dict[str, _JSON_SCALAR] = field(default_factory=dict)
+    participant_state: dict[str, _JSON_SCALAR] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        times = np.asarray(self.sample_times_s, dtype=float)
+        if times.ndim != 1 or not np.all(np.isfinite(times)):
+            raise ValueError("sample_times_s must be a finite 1-D array")
+        if not self.paradigm or not self.stage_label:
+            raise ValueError("paradigm and stage_label are required")
+        for name, values in self.emitted_streams.items():
+            if not name:
+                raise ValueError("emitted stream names must be non-empty")
+            array = np.asarray(values, dtype=float)
+            if array.shape != times.shape or not np.all(np.isfinite(array)):
+                raise ValueError(f"emitted stream {name!r} must be finite and match sample_times_s")
+        for mapping_name, mapping in (
+            ("target", self.target),
+            ("task_state", self.task_state),
+            ("participant_state", self.participant_state),
+        ):
+            for key, value in mapping.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"{mapping_name} keys must be non-empty strings")
+                if not isinstance(value, (str, int, float, bool)) and value is not None:
+                    raise ValueError(f"{mapping_name}.{key} must be a JSON scalar")
+
+    @property
+    def visual_luminance(self) -> np.ndarray:
+        values = self.emitted_streams.get("visual_luminance")
+        if values is None:
+            return np.zeros(np.asarray(self.sample_times_s).size, dtype=float)
+        return np.asarray(values, dtype=float)

--- a/packages/neuros-arena/src/neuros/arena/world_models.py
+++ b/packages/neuros-arena/src/neuros/arena/world_models.py
@@ -1,0 +1,289 @@
+"""Pluggable neural world models for closed-loop BCI simulation.
+
+World models own the latent neural dynamics that map an emitted stimulus and
+participant state into source/sensor-space EEG. Device/display/transport physics
+remain separate Arena layers so a model can be swapped without changing the
+rest of the systems test.
+
+The built-in models are deliberately phenomenological. They provide known
+causal ground truth for software qualification; they are not physiological
+human digital twins.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import numpy as np
+
+from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+
+from .specs import ParticipantProfile
+
+SOURCE_CHANNELS = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+POSTERIOR_WEIGHTS = np.asarray([0.05, 0.05, 0.08, 0.05, 0.45, 0.85, 1.0, 0.85], dtype=float)
+CENTRAL_WEIGHTS = np.asarray([0.18, 0.95, 1.0, 0.95, 0.25, 0.10, 0.08, 0.10], dtype=float)
+FRONTAL_WEIGHTS = np.asarray([1.0, 0.30, 0.55, 0.30, 0.22, 0.12, 0.10, 0.12], dtype=float)
+
+
+@dataclass(frozen=True)
+class WorldModelEmission:
+    """One emitted EEG block plus inspectable latent summaries."""
+
+    data_uv: np.ndarray
+    latent: dict[str, float]
+
+
+class NeuralWorldModel(Protocol):
+    """Minimal contract implemented by Arena-compatible neural generators."""
+
+    name: str
+    channel_names: tuple[str, ...]
+
+    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None: ...
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission: ...
+
+
+class LegacySyntheticWorldModel:
+    """Compatibility adapter around the original neurOS synthetic EEG driver.
+
+    This model responds to the nominal target frequency rather than the actual
+    frame-quantized luminance trace. It remains available for regression tests,
+    but the causally display-driven model is the Arena default.
+    """
+
+    name = "legacy_synthetic"
+    channel_names = SOURCE_CHANNELS
+
+    def __init__(
+        self,
+        *,
+        participant: ParticipantProfile,
+        sampling_rate_hz: float,
+        seed: int,
+        parameters: dict[str, Any] | None = None,
+    ) -> None:
+        del parameters
+        self.participant = participant
+        self.generator = SyntheticEEGGenerator(SyntheticEEGConfig(
+            sampling_rate_hz=sampling_rate_hz,
+            channel_names=SOURCE_CHANNELS,
+            colored_noise_uv=participant.colored_noise_uv,
+            white_noise_uv=participant.white_noise_uv,
+            alpha_frequency_hz=participant.alpha_frequency_hz,
+            alpha_amplitude_uv=participant.alpha_amplitude_uv,
+            ssvep_amplitude_uv=participant.ssvep_amplitude_uv,
+            first_harmonic_ratio=participant.first_harmonic_ratio,
+            seed=seed,
+        ))
+
+    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+        self.generator.inject_artifact(kind, duration_seconds=duration_seconds, severity=severity)
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission:
+        del emitted_stimulus
+        if target_frequency_hz is None:
+            self.generator.set_attention(None)
+        else:
+            self.generator.set_attention(target_frequency_hz, attention_gain)
+        block = self.generator.render(int(sample_times_s.size))
+        return WorldModelEmission(
+            data_uv=block.data_uv,
+            latent={
+                "attention_gain": float(attention_gain),
+                "entrainment": float(attention_gain if target_frequency_hz is not None else 0.0),
+                "stimulus_coupling": 0.0,
+            },
+        )
+
+
+class _ArtifactEngine:
+    """Stateful artifact overlay shared by phenomenological world models."""
+
+    def __init__(self, sampling_rate_hz: float, seed: int) -> None:
+        self.fs = float(sampling_rate_hz)
+        self.rng = np.random.default_rng(seed)
+        self.kind: str | None = None
+        self.remaining = 0
+        self.total = 0
+        self.severity = 1.0
+
+    def inject(self, kind: str, duration_seconds: float, severity: float) -> None:
+        if kind not in {"blink", "jaw", "controller", "motion", "saturation", "dropout"}:
+            raise ValueError(f"unsupported artifact kind: {kind}")
+        if duration_seconds <= 0 or severity < 0:
+            raise ValueError("artifact duration must be positive and severity non-negative")
+        self.kind = kind
+        self.total = max(1, int(round(duration_seconds * self.fs)))
+        self.remaining = self.total
+        self.severity = float(severity)
+
+    def render(self, times_s: np.ndarray) -> tuple[np.ndarray, str | None]:
+        samples = int(times_s.size)
+        output = np.zeros((8, samples), dtype=float)
+        if self.kind is None or self.remaining <= 0:
+            return output, None
+        kind = self.kind
+        count = min(samples, self.remaining)
+        start = self.total - self.remaining
+        phase = (np.arange(count, dtype=float) + start) / max(self.total - 1, 1)
+        severity = self.severity
+        if kind == "blink":
+            pulse = np.sin(np.pi * np.clip(phase, 0.0, 1.0)) ** 2
+            output[:, :count] += FRONTAL_WEIGHTS[:, None] * (120.0 * severity * pulse)
+        elif kind == "jaw":
+            t = times_s[:count]
+            hf = (
+                np.sin(2 * np.pi * 38.0 * t)
+                + 0.8 * np.sin(2 * np.pi * 53.0 * t + 0.7)
+                + 0.55 * np.sin(2 * np.pi * 71.0 * t + 1.1)
+            )
+            output[:, :count] += (0.55 * CENTRAL_WEIGHTS + 0.35)[:, None] * (48.0 * severity * hf)
+        elif kind == "controller":
+            t = times_s[:count]
+            hf = (
+                np.sin(2 * np.pi * 31.0 * t)
+                + 0.55 * np.sin(2 * np.pi * 46.0 * t + 0.4)
+                + 0.30 * self.rng.normal(size=count)
+            )
+            output[:, :count] += CENTRAL_WEIGHTS[:, None] * (24.0 * severity * hf)
+        elif kind == "motion":
+            drift = np.sin(np.pi * np.clip(phase, 0.0, 1.0)) * np.sign(np.sin(2 * np.pi * 2.2 * times_s[:count]))
+            output[:, :count] += (0.60 + 0.40 * FRONTAL_WEIGHTS)[:, None] * (55.0 * severity * drift)
+        elif kind == "saturation":
+            output[6, :count] += 480.0 * severity
+        elif kind == "dropout":
+            output[6, :count] = np.nan
+        self.remaining -= count
+        if self.remaining <= 0:
+            self.kind = None
+        return output, kind
+
+
+class DrivenStateSpaceWorldModel:
+    """Causal stochastic EEG state-space model driven by emitted luminance.
+
+    The model contains correlated background dynamics, an endogenous posterior
+    alpha oscillator, and a damped stimulus-entrainment state. The stimulus
+    state is driven by the *actual sample-and-held display waveform* supplied by
+    Arena, not by an ideal sine wave. This makes frame drops and timing jitter
+    causally visible in the generated EEG.
+
+    It is intentionally phenomenological rather than a biophysical neural-mass
+    model. More expensive MNE/TVB/learned models can implement the same contract.
+    """
+
+    name = "driven_state_space"
+    channel_names = SOURCE_CHANNELS
+
+    def __init__(
+        self,
+        *,
+        participant: ParticipantProfile,
+        sampling_rate_hz: float,
+        seed: int,
+        parameters: dict[str, Any] | None = None,
+    ) -> None:
+        self.participant = participant
+        self.fs = float(sampling_rate_hz)
+        if self.fs <= 0:
+            raise ValueError("sampling_rate_hz must be positive")
+        params = dict(parameters or {})
+        self.resonance_damping = float(params.get("resonance_damping", 0.22))
+        self.background_persistence = float(params.get("background_persistence", 0.985))
+        self.entrainment_tau_s = float(params.get("entrainment_tau_s", 0.18))
+        if not 0.02 <= self.resonance_damping <= 2.0:
+            raise ValueError("resonance_damping must be in [0.02, 2]")
+        if not 0.0 <= self.background_persistence < 1.0:
+            raise ValueError("background_persistence must be in [0, 1)")
+        if self.entrainment_tau_s <= 0:
+            raise ValueError("entrainment_tau_s must be positive")
+        self.rng = np.random.default_rng(seed)
+        self._background = np.zeros(8, dtype=float)
+        self._alpha_phase = self.rng.uniform(0.0, 2 * np.pi)
+        self._alpha_channel_phase = self.rng.normal(0.0, 0.12, size=8)
+        self._resonator_x = 0.0
+        self._resonator_v = 0.0
+        self._entrainment = 0.0
+        self._artifact = _ArtifactEngine(self.fs, seed + 991)
+
+    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+        self._artifact.inject(kind, duration_seconds, severity)
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission:
+        times = np.asarray(sample_times_s, dtype=float)
+        drive = np.asarray(emitted_stimulus, dtype=float)
+        if times.ndim != 1 or drive.shape != times.shape:
+            raise ValueError("sample_times_s and emitted_stimulus must be matching 1-D arrays")
+        samples = times.size
+        if samples == 0:
+            return WorldModelEmission(np.empty((8, 0), dtype=np.float32), {"entrainment": self._entrainment})
+        dt = 1.0 / self.fs
+        data = np.empty((8, samples), dtype=float)
+        target_gain = float(max(0.0, attention_gain)) if target_frequency_hz is not None else 0.0
+        alpha_omega = 2.0 * np.pi * self.participant.alpha_frequency_hz
+        target_omega = 0.0 if target_frequency_hz is None else 2.0 * np.pi * float(target_frequency_hz)
+        innovation_scale = np.sqrt(max(1.0 - self.background_persistence**2, 1e-9))
+        for i in range(samples):
+            self._background = (
+                self.background_persistence * self._background
+                + innovation_scale * self.rng.normal(size=8)
+            )
+            self._entrainment += (target_gain - self._entrainment) * min(1.0, dt / self.entrainment_tau_s)
+            alpha = np.sin(alpha_omega * times[i] + self._alpha_phase + self._alpha_channel_phase)
+            if target_frequency_hz is None:
+                self._resonator_x *= 0.98
+                self._resonator_v *= 0.95
+            else:
+                forcing = float(np.clip(drive[i], -1.0, 1.0)) * self._entrainment
+                acceleration = (
+                    target_omega * target_omega * (forcing - self._resonator_x)
+                    - 2.0 * self.resonance_damping * target_omega * self._resonator_v
+                )
+                self._resonator_v += acceleration * dt
+                self._resonator_x += self._resonator_v * dt
+            harmonic = np.sin(2.0 * target_omega * times[i] + 0.4) if target_frequency_hz is not None else 0.0
+            data[:, i] = (
+                self.participant.colored_noise_uv * self._background
+                + self.rng.normal(0.0, self.participant.white_noise_uv, size=8)
+                + POSTERIOR_WEIGHTS * self.participant.alpha_amplitude_uv * alpha
+                + POSTERIOR_WEIGHTS
+                * self.participant.ssvep_amplitude_uv
+                * (self._resonator_x + self.participant.first_harmonic_ratio * self._entrainment * harmonic)
+            )
+        artifact, artifact_kind = self._artifact.render(times)
+        dropout = artifact_kind == "dropout"
+        if dropout:
+            artifact = np.nan_to_num(artifact, nan=0.0)
+        data += artifact
+        if dropout:
+            data[6, :] = 0.0
+        return WorldModelEmission(
+            data_uv=data.astype(np.float32),
+            latent={
+                "attention_gain": target_gain,
+                "entrainment": float(self._entrainment),
+                "resonator_x": float(self._resonator_x),
+                "resonator_v": float(self._resonator_v),
+                "stimulus_coupling": 1.0,
+            },
+        )

--- a/packages/neuros-core/src/neuros/plugins/__init__.py
+++ b/packages/neuros-core/src/neuros/plugins/__init__.py
@@ -2,7 +2,8 @@
 
 Third-party packages can advertise entry points under ``neuros.sources``,
 ``neuros.transforms``, ``neuros.tokenizers``, ``neuros.encoders``,
-``neuros.decoders``, ``neuros.sinks`` and ``neuros.monitors``.
+``neuros.decoders``, ``neuros.sinks``, ``neuros.monitors`` and
+``neuros.world_models``.
 """
 
 from .registry import (

--- a/packages/neuros-core/src/neuros/plugins/registry.py
+++ b/packages/neuros-core/src/neuros/plugins/registry.py
@@ -16,6 +16,7 @@ class PluginKind(str, Enum):
     DECODER = "decoder"
     SINK = "sink"
     MONITOR = "monitor"
+    WORLD_MODEL = "world_model"
 
     @property
     def entry_point_group(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@
 members = [
     "packages/neuros-core",
     "packages/neuros-drivers",
+    "packages/neuros-arena",
     "packages/neuros-models",
     "packages/neuros-foundation",
     "packages/neuros-ui",

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -7,6 +7,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from list_workspace_packages import workspace_members
+
 
 EXACT_FORBIDDEN = {
     ".coverage",
@@ -36,17 +38,7 @@ ACTIVE_DOCS = (
     "docs/ARCHITECTURE.md",
     "docs/API_REFERENCE.md",
     "docs/getting-started/installation.md",
-    "packages/neuros-core/README.md",
-    "packages/neuros-drivers/README.md",
-    "packages/neuros-models/README.md",
-    "packages/neuros-foundation/README.md",
-    "packages/neuros-ui/README.md",
-    "packages/neuros-cloud/README.md",
-    "packages/neuros/README.md",
-    "packages/orion/README.md",
-    "packages/neuros-neurofm/README.md",
-    "packages/neuros-mechint/README.md",
-    "packages/neuros-sourceweigher/README.md",
+    *(f"{member}/README.md" for member in workspace_members()),
 )
 
 STALE_MARKERS = (

--- a/scripts/list_workspace_packages.py
+++ b/scripts/list_workspace_packages.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Print and validate the canonical neurOS workspace package inventory.
+
+The repository-level ``pyproject.toml`` is the single authority for maintained
+workspace distributions. CI/release tooling should consume this helper instead
+of duplicating package lists or hard-coding expected wheel counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_FILE = ROOT / "pyproject.toml"
+
+
+def _fallback_members(text: str) -> tuple[str, ...]:
+    """Parse the simple workspace-members array on Python 3.10.
+
+    Python 3.11+ uses ``tomllib`` below. The fallback is deliberately narrow:
+    it accepts the repository's quoted-string ``members = [...]`` contract and
+    fails closed instead of pretending to be a general TOML parser.
+    """
+
+    section_match = re.search(
+        r"(?ms)^\[tool\.uv\.workspace\]\s*(.*?)(?=^\[|\Z)",
+        text,
+    )
+    if section_match is None:
+        raise ValueError("missing [tool.uv.workspace] section")
+    members_match = re.search(r"(?ms)^members\s*=\s*\[(.*?)\]", section_match.group(1))
+    if members_match is None:
+        raise ValueError("missing tool.uv.workspace.members array")
+    members = tuple(re.findall(r'"([^"\n]+)"', members_match.group(1)))
+    if not members:
+        raise ValueError("tool.uv.workspace.members must not be empty")
+    return members
+
+
+def workspace_members(path: Path = WORKSPACE_FILE) -> tuple[str, ...]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        import tomllib  # Python 3.11+
+    except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+        members = _fallback_members(text)
+    else:
+        payload = tomllib.loads(text)
+        try:
+            raw_members = payload["tool"]["uv"]["workspace"]["members"]
+        except (KeyError, TypeError) as exc:
+            raise ValueError("missing tool.uv.workspace.members") from exc
+        if not isinstance(raw_members, list) or not raw_members:
+            raise ValueError("tool.uv.workspace.members must be a non-empty list")
+        if not all(isinstance(item, str) and item for item in raw_members):
+            raise ValueError("workspace members must be non-empty strings")
+        members = tuple(raw_members)
+
+    if len(set(members)) != len(members):
+        raise ValueError("workspace members must be unique")
+
+    for member in members:
+        candidate = (ROOT / member).resolve()
+        try:
+            candidate.relative_to(ROOT.resolve())
+        except ValueError as exc:
+            raise ValueError(f"workspace member escapes repository root: {member}") from exc
+        if candidate == ROOT or not candidate.is_dir():
+            raise ValueError(f"workspace member directory does not exist: {member}")
+        if not (candidate / "pyproject.toml").is_file():
+            raise ValueError(f"workspace member has no pyproject.toml: {member}")
+
+    return members
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument("--count", action="store_true", help="print only the validated member count")
+    output.add_argument("--json", action="store_true", help="print the validated inventory as JSON")
+    args = parser.parse_args()
+
+    members = workspace_members()
+    if args.count:
+        print(len(members))
+    elif args.json:
+        print(json.dumps({"schema": "neuros.workspace.v1", "count": len(members), "members": members}, indent=2))
+    else:
+        print("\n".join(members))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_arena_application_trace.py
+++ b/tests/test_arena_application_trace.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from neuros.arena import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile, run_scenario
+from neuros.arena.application import (
+    ApplicationEvent,
+    ApplicationTrace,
+    evaluate_application_trace,
+    load_application_trace,
+    save_application_trace,
+)
+
+
+def make_run():
+    return run_scenario(
+        ArenaScenario(
+            "application-trace",
+            (
+                StageSpec("rest", 1.0, None, 0.0),
+                StageSpec("active", 3.0, 10.0, 0.9),
+            ),
+            seed=61,
+        ),
+        ParticipantProfile(seed=3),
+        DeviceProfile(line_noise_uv=0.0),
+        DisplayProfile(),
+        TransportProfile(silence_windows=((2.0, 0.5),)),
+    )
+
+
+def test_application_trace_round_trip_and_causal_scoring(tmp_path):
+    trace = ApplicationTrace(
+        application="example-game",
+        version="0.1.0",
+        events=(
+            ApplicationEvent(0.50, "neural_action", action="bad-rest-action", source="neural", authority=0.8, source_sequence=1),
+            ApplicationEvent(1.50, "neural_action", action="valid-action", source="neural", authority=0.9, source_sequence=2),
+            ApplicationEvent(2.20, "bci_lost", source="system"),
+            ApplicationEvent(2.25, "neural_action", action="bad-silence-action", source="neural", authority=0.7, source_sequence=3),
+            ApplicationEvent(2.80, "bci_recovered", source="system"),
+            ApplicationEvent(3.00, "participant_stop", source="participant"),
+            ApplicationEvent(3.20, "neural_action", action="bad-post-stop-action", source="neural", authority=0.6, source_sequence=4),
+        ),
+        metadata={"engine": "test"},
+    )
+    path = save_application_trace(trace, tmp_path / "trace.json")
+    loaded = load_application_trace(path)
+    assert loaded == trace
+    metrics = evaluate_application_trace(make_run(), loaded)
+    assert metrics["neural_actions_total"] == 4.0
+    assert metrics["neural_actions_without_target"] == 1.0
+    assert metrics["neural_actions_during_transport_silence"] == 1.0
+    assert metrics["participant_stop_action_violations"] == 1.0
+    assert metrics["neural_action_sequence_regressions"] == 0.0
+    assert metrics["recovery_latency_mean_s"] > 0
+
+
+def test_application_trace_rejects_time_regression():
+    trace = ApplicationTrace(
+        application="bad-game",
+        version="0.1",
+        events=(
+            ApplicationEvent(1.0, "application_state"),
+            ApplicationEvent(0.9, "application_state"),
+        ),
+    )
+    try:
+        trace.validate()
+    except ValueError as exc:
+        assert "monotonic" in str(exc)
+    else:
+        raise AssertionError("non-monotonic application events should fail")

--- a/tests/test_arena_benchmark.py
+++ b/tests/test_arena_benchmark.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from neuros.arena.benchmark import MetricRule, load_benchmark_pack, run_benchmark_pack
+
+
+PACK = Path("examples/arena/benchmark_packs/eeg_game_system_v1.json")
+
+
+def test_portable_eeg_game_system_pack_passes_reference_arena():
+    pack = load_benchmark_pack(PACK)
+    result = run_benchmark_pack(pack)
+    assert result.passed
+    assert all(case.passed for case in result.cases)
+    payload = result.to_dict()
+    assert payload["pack_name"] == "eeg-game-systems"
+    assert "does not establish human" in payload["evidence_boundary"]
+
+
+def test_benchmark_pack_preserves_a_failing_rule_as_evidence():
+    pack = load_benchmark_pack(PACK)
+    first = pack.cases[0]
+    impossible = MetricRule(
+        "metrics.transport.packet_drop_fraction",
+        ">",
+        0.5,
+        "clean transport should deliberately fail this injected assertion",
+    )
+    mutated = replace(pack, cases=(replace(first, rules=first.rules + (impossible,)),) + pack.cases[1:])
+    result = run_benchmark_pack(mutated)
+    assert not result.passed
+    assert not result.cases[0].passed
+    assert any("clean transport" in failure for failure in result.cases[0].failures)

--- a/tests/test_arena_cohort_study.py
+++ b/tests/test_arena_cohort_study.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile, run_scenario
+from neuros.arena.studies import run_leave_one_domain_out_covariance_study
+
+
+def make_world(seed: int, *, amplitude: float, noise: float):
+    return run_scenario(
+        ArenaScenario(
+            "cohort-study",
+            (
+                StageSpec("rest", 1.0, None, 0.0),
+                StageSpec("target", 3.0, 10.0, 0.9),
+            ),
+            seed=37,
+        ),
+        ParticipantProfile(seed=seed, ssvep_amplitude_uv=amplitude, colored_noise_uv=noise),
+        DeviceProfile(sensor_noise_uv=0.05, line_noise_uv=0.0, chunk_samples=5),
+        DisplayProfile(),
+        TransportProfile(),
+    )
+
+
+def test_leave_one_domain_out_weights_transfer_to_unseen_similar_domains():
+    near = make_world(31, amplitude=7.0, noise=4.0)
+    far = make_world(91, amplitude=0.7, noise=13.0)
+    rng = np.random.default_rng(123)
+    base = near.device_output.data_uv.astype(float)
+    domains = {
+        f"subject-{index}": base + rng.normal(0.0, scale, size=base.shape)
+        for index, scale in enumerate((0.05, 0.08, 0.10, 0.12), start=1)
+    }
+    result = run_leave_one_domain_out_covariance_study(
+        {"near": near, "far": far},
+        domains,
+        temperature=0.25,
+    )
+    assert len(result.folds) == 4
+    assert result.fraction_improved == 1.0
+    assert result.mean_relative_improvement > 0
+    assert result.mean_weighted_distance < result.mean_uniform_distance
+    assert all(fold.best_weighted_world == "near" for fold in result.folds)
+    assert "human BCI accuracy" in result.to_dict()["evidence_boundary"]
+
+
+def test_leave_one_domain_out_rejects_too_few_real_domains():
+    near = make_world(31, amplitude=7.0, noise=4.0)
+    far = make_world(91, amplitude=0.7, noise=13.0)
+    domains = {
+        "a": near.device_output.data_uv,
+        "b": near.device_output.data_uv,
+    }
+    try:
+        run_leave_one_domain_out_covariance_study({"near": near, "far": far}, domains)
+    except ValueError as exc:
+        assert "at least three" in str(exc)
+    else:
+        raise AssertionError("a cross-domain study with fewer than three domains should fail")

--- a/tests/test_arena_conformance.py
+++ b/tests/test_arena_conformance.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from neuros.arena import ArenaManifest, ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile
+from neuros.arena.conformance import (
+    check_display_drop_monotonicity,
+    check_fail_closed_degradation,
+    check_transport_drop_monotonicity,
+    search_counterexamples,
+)
+from neuros.arena.population import ParameterDistribution, PopulationSpec
+
+
+def manifest() -> ArenaManifest:
+    return ArenaManifest(
+        ArenaScenario(
+            "metamorphic",
+            (
+                StageSpec("rest", 0.75, None, 0.0),
+                StageSpec("target", 1.5, 10.0, 0.9),
+            ),
+            seed=37,
+        ),
+        ParticipantProfile(seed=37, ssvep_amplitude_uv=6.0),
+        DeviceProfile(chunk_samples=5, sensor_noise_uv=0.0, line_noise_uv=0.0),
+        DisplayProfile(frame_drop_probability=0.01),
+        TransportProfile(drop_probability=0.01, jitter_ms=2.0),
+    )
+
+
+def test_transport_and_display_fault_masks_are_metamorphically_monotone():
+    world = manifest()
+    transport = check_transport_drop_monotonicity(world, higher_drop_probability=0.30)
+    display = check_display_drop_monotonicity(world, higher_drop_probability=0.35)
+    assert transport.passed
+    assert display.passed
+    assert transport.mutated_value <= transport.base_value
+    assert display.mutated_value >= display.base_value
+
+
+def test_application_fail_closed_property_can_detect_an_authority_regression():
+    world = manifest()
+    degraded = replace(world, participant=replace(world.participant, ssvep_amplitude_uv=1.0))
+
+    # This synthetic evaluator intentionally defines authority as inverse SNR,
+    # producing a failing property so the counterexample machinery itself is tested.
+    def bad_authority(run):
+        snr = run.report["metrics"]["target_snr_db"]["10Hz"]
+        return -float(snr)
+
+    result = check_fail_closed_degradation(world, degraded, bad_authority)
+    assert not result.passed
+    assert result.mutated_manifest["participant"]["ssvep_amplitude_uv"] == 1.0
+
+
+def test_adversarial_search_returns_portable_worst_worlds():
+    world = manifest()
+    spec = PopulationSpec(
+        size=8,
+        seed=44,
+        parameters=(
+            ParameterDistribution("participant.ssvep_amplitude_uv", "uniform", low=0.5, high=8.0),
+            ParameterDistribution("display.frame_drop_probability", "uniform", low=0.0, high=0.25),
+            ParameterDistribution("transport.drop_probability", "uniform", low=0.0, high=0.25),
+        ),
+    )
+
+    def objective(run):
+        snr = float(run.report["metrics"]["target_snr_db"]["10Hz"])
+        packet_drop = float(run.report["metrics"]["transport"]["packet_drop_fraction"])
+        # Lower is declared worse for this example.
+        score = snr - 10.0 * packet_drop
+        return score, {"snr": snr, "packet_drop": packet_drop}
+
+    result = search_counterexamples(
+        world,
+        spec,
+        objective,
+        objective_name="synthetic_robustness_proxy",
+        minimize=True,
+        top_k=3,
+    )
+    assert result.evaluated == 8
+    assert len(result.counterexamples) == 3
+    assert result.counterexamples[0].objective <= result.counterexamples[-1].objective
+    assert result.counterexamples[0].manifest["schema"] == "neuros.synthetic_bci_arena.manifest.v1"

--- a/tests/test_arena_leadfield.py
+++ b/tests/test_arena_leadfield.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile, WorldModelProfile, run_scenario
+from neuros.arena.leadfield import BUNDLE_SCHEMA, save_leadfield_bundle
+
+
+CHANNELS = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+
+
+def make_bundle(path) -> None:
+    visual = np.asarray([0.05, 0.08, 0.10, 0.08, 0.42, 0.86, 1.0, 0.81])
+    nuisance = np.asarray([
+        [1.0, 0.3, 0.4, 0.3, 0.2, 0.1, 0.05, 0.1],
+        [0.1, 0.8, 1.0, 0.8, 0.3, 0.1, 0.1, 0.1],
+    ])
+    save_leadfield_bundle(
+        path,
+        channel_names=CHANNELS,
+        visual_topography=visual,
+        nuisance_topographies=nuisance,
+        metadata={"test": "toy-forward"},
+    )
+
+
+def test_leadfield_bundle_round_trip_and_display_driven_projection(tmp_path):
+    path = tmp_path / "leadfield.npz"
+    make_bundle(path)
+    with np.load(path, allow_pickle=False) as payload:
+        assert str(np.asarray(payload["schema"]).reshape(-1)[0]) == BUNDLE_SCHEMA
+        assert tuple(payload["channel_names"].tolist()) == CHANNELS
+
+    scenario = ArenaScenario(
+        "leadfield",
+        (
+            StageSpec("rest", 1.0, None, 0.0),
+            StageSpec("sight", 2.0, 10.0, 0.85),
+        ),
+        seed=13,
+    )
+    args = (
+        scenario,
+        ParticipantProfile(seed=13, ssvep_amplitude_uv=6.0),
+        DeviceProfile(chunk_samples=5, sensor_noise_uv=0.0, line_noise_uv=0.0),
+    )
+    profile = WorldModelProfile("leadfield_driven", {"path": str(path)})
+    clean = run_scenario(*args, DisplayProfile(frame_drop_probability=0.0), TransportProfile(), profile)
+    broken = run_scenario(*args, DisplayProfile(frame_drop_probability=0.40, frame_jitter_ms=1.5), TransportProfile(), profile)
+    assert clean.report["metrics"]["world_model"]["display_coupled"] is True
+    latent = clean.report["metrics"]["world_model"]["stage_end_latent"][-1]
+    assert latent["leadfield_projection"] == 1.0
+    assert not np.array_equal(clean.device_output.data_uv, broken.device_output.data_uv)
+
+
+def test_leadfield_bundle_normalizes_visual_topography(tmp_path):
+    path = tmp_path / "normalized.npz"
+    save_leadfield_bundle(path, channel_names=CHANNELS, visual_topography=np.arange(1, 9, dtype=float))
+    with np.load(path, allow_pickle=False) as payload:
+        topography = np.asarray(payload["visual_topography"], dtype=float)
+    assert np.isclose(np.max(np.abs(topography)), 1.0)

--- a/tests/test_arena_observable_audit.py
+++ b/tests/test_arena_observable_audit.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena.audit import eeg_observable_audit, flatten_audit_metrics
+
+
+def test_observable_audit_separates_spectral_temporal_spatial_dimensions():
+    fs = 250.0
+    t = np.arange(1000, dtype=float) / fs
+    rng = np.random.default_rng(11)
+    source = 8.0 * np.sin(2 * np.pi * 10.0 * t)
+    data = np.vstack([
+        source + rng.normal(0, 1.0, size=t.size),
+        0.8 * source + rng.normal(0, 1.2, size=t.size),
+        rng.normal(0, 3.0, size=t.size),
+    ])
+    audit = eeg_observable_audit(data, fs)
+    assert audit["schema"] == "neuros.synthetic_bci_arena.eeg_observable_audit.v1"
+    assert 9.0 <= audit["spectrum"]["alpha_peak_hz"] <= 11.0
+    assert audit["spectrum"]["alpha_8_13_fraction"] > audit["spectrum"]["gamma_30_45_fraction"]
+    assert audit["spatial"]["mean_abs_channel_correlation"] > 0
+    assert audit["spatial"]["covariance_effective_rank"] > 1.0
+    assert 0 <= audit["spectrum"]["normalized_spectral_entropy"] <= 1.0
+    assert "physiological equivalence" in audit["evidence_boundary"]
+    flat = flatten_audit_metrics(audit)
+    assert "amplitude.median_channel_rms_uv" in flat
+    assert "temporal.median_autocorrelation_100ms" in flat
+
+
+def test_observable_audit_rejects_nonfinite_input():
+    data = np.zeros((2, 100), dtype=float)
+    data[0, 4] = np.nan
+    try:
+        eeg_observable_audit(data, 250.0)
+    except ValueError as exc:
+        assert "finite" in str(exc)
+    else:
+        raise AssertionError("non-finite EEG should not receive an audit")

--- a/tests/test_arena_population.py
+++ b/tests/test_arena_population.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+
+from neuros.arena import ArenaManifest, ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile
+from neuros.arena.population import ParameterDistribution, PopulationSpec, run_population
+
+
+def manifest() -> ArenaManifest:
+    return ArenaManifest(
+        ArenaScenario(
+            "population-smoke",
+            (
+                StageSpec("rest", 0.75, None, 0.0),
+                StageSpec("target", 1.5, 10.0, 0.9),
+            ),
+            seed=71,
+        ),
+        ParticipantProfile(seed=71, ssvep_amplitude_uv=6.0),
+        DeviceProfile(chunk_samples=5, sensor_noise_uv=0.1),
+        DisplayProfile(),
+        TransportProfile(),
+    )
+
+
+def spec() -> PopulationSpec:
+    return PopulationSpec(
+        size=6,
+        seed=101,
+        parameters=(
+            ParameterDistribution("participant.ssvep_amplitude_uv", "uniform", low=2.0, high=9.0),
+            ParameterDistribution("participant.alpha_frequency_hz", "uniform", low=8.0, high=12.5),
+            ParameterDistribution("display.frame_drop_probability", "uniform", low=0.0, high=0.08),
+            ParameterDistribution("transport.jitter_ms", "uniform", low=0.0, high=15.0),
+            ParameterDistribution("world_model.parameters.resonance_damping", "uniform", low=0.12, high=0.4),
+        ),
+    )
+
+
+def test_population_is_reproducible_and_reports_coverage_quantiles():
+    first = run_population(manifest(), spec())
+    second = run_population(manifest(), spec())
+    assert first.to_dict() == second.to_dict()
+    assert len(first.trials) == 6
+    assert "target_snr_db_mean" in first.summary
+    snr = first.summary["target_snr_db_mean"]
+    assert snr["min"] <= snr["p05"] <= snr["p50"] <= snr["p95"] <= snr["max"]
+
+
+def test_population_samples_remain_within_declared_world_envelope():
+    result = run_population(manifest(), spec())
+    for trial in result.trials:
+        assert 2.0 <= trial.sampled["participant.ssvep_amplitude_uv"] <= 9.0
+        assert 8.0 <= trial.sampled["participant.alpha_frequency_hz"] <= 12.5
+        assert 0.0 <= trial.sampled["display.frame_drop_probability"] <= 0.08
+        assert 0.0 <= trial.sampled["transport.jitter_ms"] <= 15.0
+        assert 0.12 <= trial.sampled["world_model.parameters.resonance_damping"] <= 0.4
+
+
+def test_population_custom_evaluator_can_score_application_contracts():
+    def evaluator(run):
+        # A deliberately simple application-facing metric for the contract test.
+        # Real applications can return precision, false activation, recovery, etc.
+        snr = list(run.report["metrics"]["target_snr_db"].values())
+        return {"application_proxy": float(np.mean(snr)) if snr else 0.0}
+
+    result = run_population(manifest(), replace(spec(), size=3), evaluator=evaluator)
+    assert all("application_proxy" in trial.metrics for trial in result.trials)
+    assert "application_proxy" in result.summary

--- a/tests/test_arena_public_data.py
+++ b/tests/test_arena_public_data.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from neuros.arena.public_data import iter_moabb_raw_runs
+
+
+class FakeRaw:
+    ch_names = ["Oz"]
+    info = {"sfreq": 250.0}
+
+    def get_data(self):
+        return None
+
+
+class FakeDataset:
+    code = "FakeSSVEP"
+
+    def get_data(self, subjects=None):
+        assert subjects == [1, 2]
+        return {
+            1: {"0": {"0": FakeRaw(), "1": FakeRaw()}},
+            2: {"0": {"0": FakeRaw()}},
+        }
+
+
+def test_moabb_adapter_uses_documented_subject_session_run_structure():
+    domains = list(iter_moabb_raw_runs(FakeDataset(), subjects=[1, 2]))
+    assert len(domains) == 3
+    assert domains[0].dataset == "FakeSSVEP"
+    assert domains[0].subject == "1"
+    assert domains[0].session == "0"
+    assert domains[0].run == "0"
+    assert domains[0].domain_id == "FakeSSVEP:sub-1:ses-0:run-0"
+    assert domains[-1].domain_id == "FakeSSVEP:sub-2:ses-0:run-0"

--- a/tests/test_arena_reality_anchor.py
+++ b/tests/test_arena_reality_anchor.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile, run_scenario
+from neuros.arena.reality import anchor_worlds_by_covariance, anchor_worlds_by_embeddings
+
+
+def make_world(seed: int, *, amplitude: float, noise: float):
+    scenario = ArenaScenario(
+        "reality-anchor",
+        (
+            StageSpec("rest", 1.0, None, 0.0),
+            StageSpec("target", 2.0, 10.0, 0.9),
+        ),
+        seed=17,
+    )
+    return run_scenario(
+        scenario,
+        ParticipantProfile(seed=seed, ssvep_amplitude_uv=amplitude, colored_noise_uv=noise),
+        DeviceProfile(chunk_samples=5, sensor_noise_uv=0.1, line_noise_uv=0.0),
+        DisplayProfile(),
+        TransportProfile(),
+    )
+
+
+def test_covariance_anchor_prefers_identity_domain_over_distant_world():
+    near = make_world(31, amplitude=6.5, noise=4.0)
+    far = make_world(83, amplitude=1.0, noise=11.0)
+    # The target is deliberately the exact observed domain of the near world.
+    # This verifies weighting semantics, not population prevalence.
+    result = anchor_worlds_by_covariance(
+        {"near": near, "far": far},
+        near.device_output.data_uv,
+        temperature=0.4,
+    )
+    weights = result.by_world()
+    assert weights["near"] > weights["far"]
+    assert result.effective_world_count >= 1.0
+    assert result.max_weight <= 1.0
+
+
+def test_embedding_anchor_prefers_matching_foundation_representation():
+    rng = np.random.default_rng(9)
+    target = rng.normal(size=(64, 12))
+    close = target + rng.normal(0.0, 0.02, size=target.shape)
+    far = rng.normal(4.0, 2.0, size=target.shape)
+    result = anchor_worlds_by_embeddings({"close": close, "far": far}, target)
+    weights = result.by_world()
+    assert weights["close"] > weights["far"]
+    payload = result.to_dict()
+    assert "not probabilities" in payload["evidence_boundary"]

--- a/tests/test_arena_recording_metadata.py
+++ b/tests/test_arena_recording_metadata.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena.baselines import save_eeg_baseline
+from neuros.arena.recording import (
+    ElectrodeCoordinate,
+    RecordingMetadata,
+    load_recording_metadata,
+    recording_sidecar_path,
+)
+
+
+def test_recording_metadata_round_trip_preserves_bids_aligned_provenance(tmp_path):
+    baseline = tmp_path / "subject-01-rest.npz"
+    channels = ("PO7", "Oz", "PO8")
+    metadata = RecordingMetadata(
+        dataset="public-ssvep-example",
+        subject="01",
+        session="01",
+        run="02",
+        task="ssvep",
+        acquisition="eeg",
+        source_locator="bids://sub-01/ses-01/eeg/sub-01_ses-01_task-ssvep_run-02_eeg.edf",
+        source_format="EDF via MNE",
+        source_license="dataset-defined",
+        reference="Cz",
+        line_frequency_hz=60.0,
+        channel_units={name: "uV" for name in channels},
+        channel_types={name: "eeg" for name in channels},
+        coordinate_system="CapTrak",
+        coordinate_units="m",
+        electrodes=(
+            ElectrodeCoordinate("PO7", -0.03, -0.08, 0.07),
+            ElectrodeCoordinate("Oz", 0.00, -0.10, 0.06),
+            ElectrodeCoordinate("PO8", 0.03, -0.08, 0.07),
+        ),
+        preprocessing=("selected_occipital_channels",),
+        notes=("de-identified public data",),
+    )
+    save_eeg_baseline(
+        baseline,
+        data_uv=np.zeros((3, 250), dtype=float),
+        sampling_rate_hz=250.0,
+        channel_names=channels,
+        recording_metadata=metadata,
+    )
+    sidecar = recording_sidecar_path(baseline)
+    assert sidecar.exists()
+    loaded = load_recording_metadata(sidecar)
+    assert loaded == metadata
+    assert loaded.task == "ssvep"
+    assert loaded.channel_units["Oz"] == "uV"
+    assert loaded.electrodes[1].name == "Oz"
+
+
+def test_recording_metadata_rejects_coordinates_for_absent_channel(tmp_path):
+    baseline = tmp_path / "bad.npz"
+    metadata = RecordingMetadata(
+        coordinate_system="CapTrak",
+        coordinate_units="m",
+        electrodes=(ElectrodeCoordinate("Pz", 0.0, -0.05, 0.08),),
+    )
+    try:
+        save_eeg_baseline(
+            baseline,
+            data_uv=np.zeros((1, 64), dtype=float),
+            sampling_rate_hz=250.0,
+            channel_names=("Oz",),
+            recording_metadata=metadata,
+        )
+    except ValueError as exc:
+        assert "not present" in str(exc)
+    else:
+        raise AssertionError("metadata referencing a missing channel should fail")

--- a/tests/test_arena_scientific_validation.py
+++ b/tests/test_arena_scientific_validation.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena import (
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    split_contiguous_recording,
+    validate_covariance_anchor_held_out,
+    run_scenario,
+)
+
+
+def make_world(seed: int, *, amplitude: float, noise: float):
+    scenario = ArenaScenario(
+        "scientific-validation",
+        (
+            StageSpec("rest", 2.0, None, 0.0),
+            StageSpec("sight", 3.0, 10.0, 0.9),
+            StageSpec("guard", 3.0, 12.0, 0.9),
+        ),
+        seed=23,
+    )
+    return run_scenario(
+        scenario,
+        ParticipantProfile(seed=seed, ssvep_amplitude_uv=amplitude, colored_noise_uv=noise),
+        DeviceProfile(chunk_samples=5, sensor_noise_uv=0.1, line_noise_uv=0.0),
+        DisplayProfile(),
+        TransportProfile(),
+    )
+
+
+def test_default_run_carries_scientific_world_model_evidence_card():
+    run = make_world(31, amplitude=6.0, noise=4.0)
+    card = run.report["world_model_evidence"]
+    assert card["model_name"] == "driven_state_space"
+    assert card["evidence_level"] == "W1-causal-phenomenological"
+    assert card["stimulus_causal"] is True
+    assert "biophysical cortical mechanism" in card["unsupported_claims"]
+
+
+def test_contiguous_split_supports_guard_interval_without_overlap():
+    data = np.arange(2 * 100, dtype=float).reshape(2, 100)
+    calibration, validation = split_contiguous_recording(
+        data,
+        calibration_fraction=0.5,
+        guard_samples=5,
+    )
+    assert calibration.shape == (2, 45)
+    assert validation.shape == (2, 45)
+    assert calibration[0, -1] == 44
+    assert validation[0, 0] == 55
+
+
+def test_reality_anchor_is_judged_on_independent_eeg():
+    near = make_world(41, amplitude=7.0, noise=3.8)
+    far = make_world(97, amplitude=0.8, noise=13.0)
+    calibration, validation = split_contiguous_recording(
+        near.device_output.data_uv,
+        calibration_fraction=0.5,
+        guard_samples=10,
+    )
+    result = validate_covariance_anchor_held_out(
+        {"near": near, "far": far},
+        calibration,
+        validation,
+        temperature=0.25,
+    )
+    assert result.calibration.by_world()["near"] > result.calibration.by_world()["far"]
+    assert result.weighted_validation_distance < result.uniform_validation_distance
+    assert result.relative_improvement > 0
+    assert result.best_calibration_world == "near"
+    payload = result.to_dict()
+    assert "Out-of-sample" in payload["evidence_boundary"]

--- a/tests/test_arena_timing.py
+++ b/tests/test_arena_timing.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena import (
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    run_scenario,
+)
+
+
+def make_timing_run(device: DeviceProfile, transport: TransportProfile):
+    scenario = ArenaScenario(
+        "timing",
+        (
+            StageSpec("rest", 1.0, None, 0.0),
+            StageSpec("target", 2.0, 10.0, 0.8),
+        ),
+        seed=71,
+    )
+    return run_scenario(
+        scenario,
+        ParticipantProfile(seed=5),
+        device,
+        DisplayProfile(),
+        transport,
+    )
+
+
+def test_ideal_clock_correction_recovers_causal_time_from_bad_source_clock():
+    run = make_timing_run(
+        DeviceProfile(
+            clock_offset_ms=37.0,
+            clock_drift_ppm=125.0,
+            timestamp_jitter_ms=0.0,
+            line_noise_uv=0.0,
+        ),
+        TransportProfile(),
+    )
+    metrics = run.report["metrics"]["transport"]
+    assert abs(metrics["source_clock_offset_ms_estimated"] - 37.0) < 0.1
+    assert abs(metrics["source_clock_drift_ppm_estimated"] - 125.0) < 0.1
+    assert metrics["corrected_timestamp_rmse_ms"] < 1e-8
+    packet = run.packets[len(run.packets) // 2]
+    source_error = np.mean(np.abs(packet.source_timestamps_s - packet.ground_truth_timestamps_s))
+    corrected_error = np.mean(np.abs(packet.timestamps_s - packet.ground_truth_timestamps_s))
+    assert corrected_error < source_error
+
+
+def test_residual_sync_error_is_reported_independently_from_delivery_latency():
+    run = make_timing_run(
+        DeviceProfile(
+            clock_offset_ms=-18.0,
+            clock_drift_ppm=75.0,
+            timestamp_jitter_ms=0.15,
+            line_noise_uv=0.0,
+        ),
+        TransportProfile(
+            jitter_ms=4.0,
+            clock_correction_offset_error_ms=2.5,
+            clock_correction_drift_error_ppm=30.0,
+            clock_correction_noise_ms=0.25,
+        ),
+    )
+    metrics = run.report["metrics"]["transport"]
+    assert metrics["delivery_delay_p95_ms"] > 0
+    assert metrics["source_timestamp_jitter_rms_ms"] > 0
+    assert metrics["corrected_timestamp_p95_abs_ms"] > 1.0
+    assert metrics["corrected_timestamp_max_abs_ms"] >= metrics["corrected_timestamp_p95_abs_ms"]
+    assert abs(metrics["source_clock_drift_ppm_estimated"] - 75.0) < 20.0

--- a/tests/test_arena_world_input.py
+++ b/tests/test_arena_world_input.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.arena import (
+    ArenaManifest,
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    WorldModelEmission,
+    WorldModelProfile,
+    run_scenario,
+)
+from neuros.arena.manifest import manifest_from_dict
+from neuros.plugins import PluginKind, registry
+
+
+class RichProbeWorldModel:
+    channel_names = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+    seen: list[dict] = []
+
+    def __init__(self, *, participant, sampling_rate_hz, seed, parameters):
+        self.sampling_rate_hz = float(sampling_rate_hz)
+
+    def inject_artifact(self, kind, duration_seconds, severity):
+        return None
+
+    def render_world(self, block):
+        RichProbeWorldModel.seen.append({
+            "paradigm": block.paradigm,
+            "stage": block.stage_label,
+            "target": dict(block.target),
+            "task_state": dict(block.task_state),
+            "attention_gain": block.participant_state.get("attention_gain"),
+            "visual_shape": block.visual_luminance.shape,
+        })
+        amplitude = 2.0 if block.target.get("oddball") is True else 0.0
+        data = np.full((len(self.channel_names), block.sample_times_s.size), amplitude, dtype=np.float32)
+        return WorldModelEmission(data_uv=data, latent={"rich_path": 1.0})
+
+    def evidence_card(self):
+        return {
+            "model_name": "rich_probe_test",
+            "evidence_level": "W?-test-only",
+            "model_family": "test probe",
+            "stimulus_causal": True,
+            "spatial_model": "none",
+            "recorded_human_background": False,
+            "known_intervention_ground_truth": True,
+            "artifact_ground_truth": True,
+            "uncertainty_representation": "none",
+            "validated_against": ("test-only WorldInput contract",),
+            "intended_uses": ("unit test",),
+            "unsupported_claims": ("all physiological claims",),
+            "notes": (),
+        }
+
+
+def _register_probe():
+    registry.register(
+        name="rich_probe_test",
+        kind=PluginKind.WORLD_MODEL,
+        factory=RichProbeWorldModel,
+        replace=True,
+    )
+
+
+def test_runner_prefers_paradigm_neutral_render_world_contract():
+    _register_probe()
+    RichProbeWorldModel.seen.clear()
+    scenario = ArenaScenario(
+        "p300-probe",
+        (
+            StageSpec(
+                "standard",
+                0.5,
+                None,
+                0.0,
+                target={"oddball": False, "symbol": "A"},
+                task_state={"trial_type": "standard"},
+            ),
+            StageSpec(
+                "oddball",
+                0.5,
+                None,
+                1.0,
+                target={"oddball": True, "symbol": "B"},
+                task_state={"trial_type": "target"},
+            ),
+        ),
+        seed=81,
+        metadata={"paradigm": "p300"},
+    )
+    run = run_scenario(
+        scenario,
+        ParticipantProfile(seed=9),
+        DeviceProfile(line_noise_uv=0.0, sensor_noise_uv=0.0),
+        DisplayProfile(),
+        TransportProfile(),
+        WorldModelProfile("rich_probe_test"),
+    )
+    assert run.report["paradigm"] == "p300"
+    assert run.report["world_model_evidence"]["evidence_level"] == "W?-test-only"
+    assert any(item["target"].get("oddball") is True for item in RichProbeWorldModel.seen)
+    assert all(item["paradigm"] == "p300" for item in RichProbeWorldModel.seen)
+    assert all(item["visual_shape"] for item in RichProbeWorldModel.seen)
+    assert float(np.max(run.device_output.data_uv)) > 1.5
+
+
+def test_manifest_v1_round_trip_preserves_rich_stage_metadata():
+    manifest = ArenaManifest(
+        ArenaScenario(
+            "rich-manifest",
+            (
+                StageSpec(
+                    "cue",
+                    1.0,
+                    None,
+                    0.0,
+                    target={"class": "left"},
+                    task_state={"instruction": "imagine"},
+                ),
+            ),
+            metadata={"paradigm": "motor_imagery"},
+        ),
+        ParticipantProfile(),
+        DeviceProfile(),
+        DisplayProfile(),
+        TransportProfile(),
+        WorldModelProfile("rich_probe_test"),
+    )
+    loaded = manifest_from_dict(manifest.to_dict())
+    assert loaded.scenario.metadata["paradigm"] == "motor_imagery"
+    assert loaded.scenario.stages[0].target == {"class": "left"}
+    assert loaded.scenario.stages[0].task_state == {"instruction": "imagine"}

--- a/tests/test_arena_world_models.py
+++ b/tests/test_arena_world_models.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.arena import (
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    WorldModelProfile,
+    run_scenario,
+)
+from neuros.plugins import PluginKind, PluginRegistry
+
+
+CHANNELS = np.asarray(["Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8"])
+
+
+def scenario() -> ArenaScenario:
+    return ArenaScenario(
+        "world-model-contract",
+        (
+            StageSpec("rest", 1.0, None, 0.0),
+            StageSpec("sight", 2.0, 10.0, 0.85),
+        ),
+        seed=23,
+    )
+
+
+def write_baseline(path, *, omit_oz: bool = False) -> None:
+    fs = 250.0
+    time = np.arange(int(12 * fs), dtype=float) / fs
+    rng = np.random.default_rng(991)
+    data = rng.normal(0.0, 4.0, size=(8, time.size))
+    data += 2.0 * np.sin(2 * np.pi * 9.2 * time)[None, :]
+    channels = CHANNELS.copy()
+    if omit_oz:
+        keep = channels != "Oz"
+        data = data[keep]
+        channels = channels[keep]
+    np.savez(path, data_uv=data.astype(np.float32), sampling_rate_hz=np.asarray(fs), channel_names=channels)
+
+
+def run_with_model(profile: WorldModelProfile):
+    return run_scenario(
+        scenario(),
+        ParticipantProfile(seed=23, ssvep_amplitude_uv=5.5),
+        DeviceProfile(chunk_samples=5, sensor_noise_uv=0.0, line_noise_uv=0.0),
+        DisplayProfile(frame_drop_probability=0.03, frame_jitter_ms=0.5),
+        TransportProfile(),
+        profile,
+    )
+
+
+def test_world_model_plugins_are_discoverable_from_installed_arena():
+    registry = PluginRegistry()
+    registry.discover([PluginKind.WORLD_MODEL])
+    names = {descriptor.name for descriptor in registry.list(PluginKind.WORLD_MODEL)}
+    assert {"legacy_synthetic", "driven_state_space", "semi_synthetic_replay"} <= names
+
+
+def test_semi_synthetic_replay_is_deterministic_and_display_coupled(tmp_path):
+    baseline = tmp_path / "baseline.npz"
+    write_baseline(baseline)
+    profile = WorldModelProfile(
+        "semi_synthetic_replay",
+        {"path": str(baseline), "random_offset": False, "response_scale": 0.8},
+    )
+    first = run_with_model(profile)
+    second = run_with_model(profile)
+    np.testing.assert_array_equal(first.device_output.data_uv, second.device_output.data_uv)
+    assert first.report["metrics"]["world_model"]["display_coupled"] is True
+    assert first.report["metrics"]["world_model"]["stage_end_latent"][-1]["baseline_replay"] == 1.0
+
+
+def test_semi_synthetic_replay_rejects_missing_required_montage_channel(tmp_path):
+    baseline = tmp_path / "missing-oz.npz"
+    write_baseline(baseline, omit_oz=True)
+    with pytest.raises(ValueError, match="missing required Arena channels"):
+        run_with_model(WorldModelProfile("semi_synthetic_replay", {"path": str(baseline)}))
+
+
+def test_display_distortion_changes_causal_state_space_emission():
+    base = dict(
+        scenario=scenario(),
+        participant=ParticipantProfile(seed=31, ssvep_amplitude_uv=6.0),
+        device=DeviceProfile(chunk_samples=5, sensor_noise_uv=0.0, line_noise_uv=0.0),
+        transport=TransportProfile(),
+        world_model=WorldModelProfile("driven_state_space"),
+    )
+    clean = run_scenario(
+        base["scenario"], base["participant"], base["device"],
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        base["transport"], base["world_model"],
+    )
+    broken = run_scenario(
+        base["scenario"], base["participant"], base["device"],
+        DisplayProfile(frame_drop_probability=0.45, frame_jitter_ms=2.0),
+        base["transport"], base["world_model"],
+    )
+    assert not np.array_equal(clean.device_output.data_uv, broken.device_output.data_uv)
+    clean_snr = clean.report["metrics"]["target_snr_db"]["10Hz"]
+    broken_snr = broken.report["metrics"]["target_snr_db"]["10Hz"]
+    assert np.isfinite(clean_snr) and np.isfinite(broken_snr)

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -11,6 +11,17 @@ def test_registry_register_and_create():
     assert registry.create("decoder", "constant", value=7) == {"value": 7}
 
 
+def test_registry_supports_world_model_plugins():
+    registry = PluginRegistry()
+    registry.register(
+        name="toy_world",
+        kind=PluginKind.WORLD_MODEL,
+        factory=lambda seed=1: {"seed": seed},
+    )
+    assert PluginKind.WORLD_MODEL.entry_point_group == "neuros.world_models"
+    assert registry.create("world_model", "toy_world", seed=9) == {"seed": 9}
+
+
 def test_registry_rejects_duplicate_names_within_kind():
     registry = PluginRegistry()
     registry.register(name="x", kind="source", factory=lambda: 1)

--- a/tests/test_synthetic_bci_arena.py
+++ b/tests/test_synthetic_bci_arena.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from neuros.arena import (
+    ArenaDecision,
+    ArenaManifest,
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    WorldModelProfile,
+    compare_feature_signatures,
+    evaluate_decisions,
+    feature_signature,
+    load_manifest,
+    run_scenario,
+    save_manifest,
+)
+
+
+def tiny_world(
+    *,
+    participant: ParticipantProfile | None = None,
+    display: DisplayProfile | None = None,
+    transport: TransportProfile | None = None,
+    world_model: WorldModelProfile | None = None,
+):
+    scenario = ArenaScenario("tiny", (
+        StageSpec("rest", 1.5, None, 0.0),
+        StageSpec("sight", 2.0, 10.0, 1.0),
+        StageSpec("guard", 2.0, 12.0, 1.0),
+    ), seed=11)
+    return run_scenario(
+        scenario,
+        participant or ParticipantProfile(seed=11),
+        DeviceProfile(chunk_samples=5),
+        display or DisplayProfile(),
+        transport or TransportProfile(),
+        world_model,
+    )
+
+
+def test_arena_is_deterministic_for_same_manifest():
+    first = tiny_world()
+    second = tiny_world()
+    np.testing.assert_array_equal(first.device_output.data_uv, second.device_output.data_uv)
+    np.testing.assert_array_equal(first.device_output.timestamps_s, second.device_output.timestamps_s)
+    assert first.report == second.report
+
+
+def test_default_world_model_is_driven_by_emitted_display():
+    clean = tiny_world(display=DisplayProfile(frame_drop_probability=0.0))
+    distorted = tiny_world(display=DisplayProfile(frame_drop_probability=0.35, frame_jitter_ms=1.5))
+    assert clean.world_model.name == "driven_state_space"
+    assert clean.report["metrics"]["world_model"]["display_coupled"] is True
+    assert distorted.report["metrics"]["world_model"]["display_coupled"] is True
+    assert any(stage["frame_drop_fraction"] > 0 for stage in distorted.report["metrics"]["display"])
+    assert not np.array_equal(clean.device_output.data_uv, distorted.device_output.data_uv)
+
+
+def test_legacy_world_model_remains_available_as_explicit_regression_adapter():
+    run = tiny_world(world_model=WorldModelProfile("legacy_synthetic"))
+    assert run.world_model.name == "legacy_synthetic"
+    assert run.report["metrics"]["world_model"]["display_coupled"] is False
+
+
+def test_weak_responder_has_lower_target_snr():
+    strong = tiny_world(participant=ParticipantProfile(seed=11, ssvep_amplitude_uv=9.0))
+    weak = tiny_world(participant=ParticipantProfile(seed=11, ssvep_amplitude_uv=2.0, colored_noise_uv=7.0))
+    assert strong.report["metrics"]["target_snr_db"]["10Hz"] > weak.report["metrics"]["target_snr_db"]["10Hz"]
+
+
+def test_display_and_transport_faults_are_observable():
+    run = tiny_world(
+        display=DisplayProfile(frame_drop_probability=0.08, frame_jitter_ms=1.0),
+        transport=TransportProfile(drop_probability=0.10, jitter_ms=12.0, silence_windows=((2.0, 0.6),)),
+    )
+    display = run.report["metrics"]["display"]
+    transport = run.report["metrics"]["transport"]
+    assert any(stage["frame_drop_fraction"] > 0 for stage in display)
+    assert transport["packet_drop_fraction"] > 0
+    assert transport["delivery_delay_p95_ms"] > 0
+
+
+def test_external_decoder_decisions_score_against_ground_truth():
+    run = tiny_world()
+    decisions = [
+        ArenaDecision(0.5, 10.0, True),  # false activation during rest
+        ArenaDecision(1.9, 10.0, True),
+        ArenaDecision(3.9, 12.0, True),
+        ArenaDecision(4.6, None, False),
+    ]
+    metrics = evaluate_decisions(run, decisions)
+    assert metrics["accepted_precision"] < 1.0
+    assert metrics["false_activation_fraction"] > 0
+    assert metrics["median_switch_latency_s"] >= 0
+
+
+def test_feature_signature_comparison_is_identity_for_same_data():
+    run = tiny_world()
+    signature = feature_signature(run.device_output.data_uv, run.device.sampling_rate_hz)
+    comparison = compare_feature_signatures(signature, signature)
+    assert comparison["mean_abs_log_ratio"] == 0.0
+    assert comparison["max_abs_log_ratio"] == 0.0
+
+
+def test_manifest_round_trip(tmp_path):
+    run = tiny_world(world_model=WorldModelProfile("driven_state_space", {"resonance_damping": 0.31}))
+    manifest = ArenaManifest(
+        run.scenario,
+        run.participant,
+        run.device,
+        run.display,
+        run.transport,
+        run.world_model,
+    )
+    path = tmp_path / "world.json"
+    save_manifest(manifest, path)
+    loaded = load_manifest(path)
+    assert loaded == manifest
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["schema"] == "neuros.synthetic_bci_arena.manifest.v1"
+    assert raw["world_model"]["name"] == "driven_state_space"
+    assert raw["world_model"]["parameters"]["resonance_damping"] == 0.31


### PR DESCRIPTION
## Summary

Introduces `neuros-arena`, a deterministic closed-loop synthetic BCI systems laboratory directly on current `main`.

The goal is **not** a universal fake human brain. The goal is a reproducible **BCI wind tunnel** where neural world models can be swapped while display, device, clock, transport, decoder and application boundaries stay fixed and inspectable.

Synthetic evidence remains explicitly separate from human physiological claims.

## Core causal architecture

```text
application / task state
        ↓
requested stimulus
        ↓
ACTUALLY EMITTED display history
        ↓
neural world model + latent state
        ↓
sensor-space EEG
        ↓
device / montage / ADC / device clock
        ↓
transport / loss / jitter / silence
        ↓
decoder / quality authority
        ↓
application behavior
```

Display-coupled world models are driven by the **sample-and-held luminance trace after frame quantization, jitter, drops and held frames**, not by an ideal target-frequency oracle.

## World-model contract

`neuros-core` adds `PluginKind.WORLD_MODEL` and the `neuros.world_models` entry-point group. Arena manifests carry a versioned `WorldModelProfile`, so external research backends can implement neural dynamics without taking ownership of display/device/network/application semantics.

Current ladder:

- `legacy_synthetic`: preserved deterministic regression fixture;
- `driven_state_space`: dependency-light phenomenological dynamics with background state, alpha, entrainment/switching state, artifacts and emitted-display coupling;
- `semi_synthetic_replay`: recorded EEG background plus causally known injected display response;
- `leadfield_driven`: emitted-display response projected through a frozen explicit sensor topography exported from a forward/lead-field model.

No model in this PR is presented as a physiological digital twin.

## Systems layers

Arena makes participant, display, device and transport effects separately inspectable:

- participant/background/alpha/response/artifact susceptibility;
- refresh quantization, response lag, frame jitter and dropped/held frames;
- montage, sample rate, sensor noise, line noise, ADC clipping/quantization and device-clock drift;
- packet loss, delivery jitter, reordering and source silence.

## Populations and adversarial conformance

`run_population(...)` samples declared synthetic envelopes and reports complete sampled worlds plus distribution summaries. These are **coverage summaries over the declared synthetic envelope**, not population prevalence claims.

Metamorphic properties and `search_counterexamples(...)` preserve failing complete world manifests rather than hiding them inside an aggregate score. Examples include monotonic packet/frame degradation and application-authority degradation checks.

## Public/recorded-data anchoring

Arena can consume portable recorded EEG baselines and optional `neuros-sourceweigher` geometry for covariance- or representation-space similarity.

Reality-anchor weights are **domain-similarity weights under a declared geometry**, not probabilities that a synthetic participant is physiologically true.

## Public architecture and documentation

This PR also makes Arena a legible public surface rather than a hidden workspace package:

- `docs/SYNTHETIC_BCI_ARENA.md`;
- `docs/EEG_WORLD_MODELS.md`;
- `docs/SCIENTIFIC_VALIDATION_POLICY.md`;
- `docs/PUBLIC_EEG_ANCHORING_STUDY.md`;
- maintained MkDocs navigation;
- README/docs homepage/project-status/contributor architecture aligned around neurOS, ORION, Evidence and Studio;
- explicit distinction between repository path `packages/orion` and installable distribution `neuros-orion`.

Arena belongs to **Evidence**, not a fifth product surface.

## Release/package authority hardening

During qualification this PR exposed a real release defect: adding a 12th workspace package could previously leave release tooling hard-coded to 11 wheels.

The fix makes root `[tool.uv.workspace].members` the single maintained-package inventory through `scripts/list_workspace_packages.py`.

CI, repository hygiene and release-candidate tooling now derive package membership/counts from that authority instead of parallel magic lists. The helper is exercised on Python 3.10–3.12.

Release-candidate CI now:

- builds every workspace wheel including `neuros-arena`;
- verifies unique package metadata and SHA-256 manifests;
- installs the public SDK and Arena from the **exact wheel set produced by the source revision**;
- runs `neuros doctor` / compatibility checks;
- executes `neuros-arena --preset dual-target-smoke` from the installed Arena wheel.

This prevents a workspace package from becoming green in source CI while silently disappearing from release artifacts.

## Verification ladder

A0 determinism → A1 nuisance/intervention ground truth → A2 display causality → A3 device → A4 transport → A5 decoder → A6 application → A7 public/recorded real-data anchoring → A8 physical hardware → A9 human closed-loop validation.

## Exact-head qualification

Exact head: `da8b846c586889133aa1fa249b421016aaaa076b`

All 11 triggered workflows are green:

- Synthetic BCI Arena;
- neurOS CI;
- Release Candidate Artifacts;
- Public Trust Contracts;
- ORION Adaptation Authority;
- Three-way Adaptive Study;
- NeuroAI Ecosystem Evidence;
- Ecosystem Compatibility;
- neurOS driver contracts;
- Neural Window Contracts;
- Braindecode Compatibility.

The dedicated Arena suite includes deterministic runs, emitted-display causality, semi-synthetic replay, lead-field projection, world-model plugin discovery, population reproducibility, metamorphic/counterexample contracts, SourceWeigher anchoring, portable manifests, application traces, scientific-validation contracts and packaging.

## Evidence boundary

This PR establishes a strong **scientific-synthetic/software systems** laboratory. It does not establish physical-device, human, clinical, or medical-device evidence.

The next promotion gates are held-out public EEG anchoring, named physical hardware qualification, and then separately governed human closed-loop studies.