### PR TITLE
Unicorn Hybrid Black simulation suite: API, UDP, Recorder, Bandpower and LSL contracts

### DIFF
--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -9,6 +9,7 @@ on:
       - "tests/test_lsl_driver.py"
       - "tests/test_unicorn_*.py"
       - "examples/unicorn_*.py"
+      - "examples/game_engines/csharp/**"
       - ".github/workflows/drivers-ci.yml"
   push:
     branches:
@@ -21,6 +22,7 @@ on:
       - "tests/test_lsl_driver.py"
       - "tests/test_unicorn_*.py"
       - "examples/unicorn_*.py"
+      - "examples/game_engines/csharp/**"
       - ".github/workflows/drivers-ci.yml"
 
 permissions:
@@ -70,6 +72,9 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
       - name: Install driver test profile
         run: |
           python -m pip install --upgrade pip
@@ -99,6 +104,8 @@ jobs:
             --mode bandpower \
             --fault-profile delay-probe \
             --dry-run-packets 20
+      - name: Compile engine-facing C# receiver
+        run: dotnet build examples/game_engines/csharp/Neuros.Unicorn.Examples.csproj --configuration Release
       - name: Syntax-check real-time substitution endpoints
         run: |
           python -m py_compile \

--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -7,6 +7,8 @@ on:
       - "packages/neuros-drivers/**"
       - "tests/test_brainflow_driver.py"
       - "tests/test_lsl_driver.py"
+      - "tests/test_unicorn_*.py"
+      - "examples/unicorn_*.py"
       - ".github/workflows/drivers-ci.yml"
   push:
     branches:
@@ -17,6 +19,8 @@ on:
       - "packages/neuros-drivers/**"
       - "tests/test_brainflow_driver.py"
       - "tests/test_lsl_driver.py"
+      - "tests/test_unicorn_*.py"
+      - "examples/unicorn_*.py"
       - ".github/workflows/drivers-ci.yml"
 
 permissions:
@@ -56,3 +60,35 @@ jobs:
           python -m pip install -e "packages/neuros-drivers[test]"
       - name: Verify LSL discovery and timing semantics with deterministic fakes
         run: pytest -q tests/test_lsl_driver.py
+
+  unicorn-simulation-contracts:
+    name: Unicorn Hybrid Black simulation contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install driver test profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e "packages/neuros-drivers[test]"
+      - name: Verify device, API, raw UDP, Bandpower, and compatibility contracts
+        run: |
+          pytest -q \
+            tests/test_unicorn_hybrid_black_sim.py \
+            tests/test_unicorn_api_sim.py \
+            tests/test_unicorn_network_sim.py \
+            tests/test_unicorn_compatibility_suite.py
+      - name: Execute machine-readable compatibility receipt
+        run: |
+          OUT="${RUNNER_TEMP}/unicorn-compatibility.json"
+          python examples/unicorn_sim_conformance.py --seed 41 --output "${OUT}"
+          test -s "${OUT}"
+      - name: Syntax-check real-time substitution endpoint
+        run: |
+          python -m py_compile \
+            examples/unicorn_hybrid_black_simulator.py \
+            examples/unicorn_sim_conformance.py

--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -75,20 +75,32 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
           python -m pip install -e "packages/neuros-drivers[test]"
-      - name: Verify device, API, raw UDP, Bandpower, and compatibility contracts
+      - name: Verify device, API, UDP, Bandpower, transport, and compatibility contracts
         run: |
           pytest -q \
             tests/test_unicorn_hybrid_black_sim.py \
             tests/test_unicorn_api_sim.py \
             tests/test_unicorn_network_sim.py \
+            tests/test_unicorn_transport_sim.py \
             tests/test_unicorn_compatibility_suite.py
       - name: Execute machine-readable compatibility receipt
         run: |
           OUT="${RUNNER_TEMP}/unicorn-compatibility.json"
           python examples/unicorn_sim_conformance.py --seed 41 --output "${OUT}"
           test -s "${OUT}"
-      - name: Syntax-check real-time substitution endpoint
+      - name: Exercise deterministic UDP dry runs
+        run: |
+          python examples/unicorn_udp_simulator.py \
+            --mode raw \
+            --fault-profile mixed-torture \
+            --dry-run-packets 200
+          python examples/unicorn_udp_simulator.py \
+            --mode bandpower \
+            --fault-profile delay-probe \
+            --dry-run-packets 20
+      - name: Syntax-check real-time substitution endpoints
         run: |
           python -m py_compile \
             examples/unicorn_hybrid_black_simulator.py \
+            examples/unicorn_udp_simulator.py \
             examples/unicorn_sim_conformance.py

--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -75,13 +75,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
           python -m pip install -e "packages/neuros-drivers[test]"
-      - name: Verify device, API, UDP, Bandpower, transport, and compatibility contracts
+      - name: Verify device, API, UDP, Bandpower, transport, receiver, and compatibility contracts
         run: |
           pytest -q \
             tests/test_unicorn_hybrid_black_sim.py \
             tests/test_unicorn_api_sim.py \
             tests/test_unicorn_network_sim.py \
             tests/test_unicorn_transport_sim.py \
+            tests/test_unicorn_receiver_guard.py \
             tests/test_unicorn_compatibility_suite.py
       - name: Execute machine-readable compatibility receipt
         run: |

--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
           python -m pip install -e "packages/neuros-drivers[test]"
-      - name: Verify device, API, UDP, Bandpower, transport, receiver, and compatibility contracts
+      - name: Verify device, API, UDP, Bandpower, transport, receiver, trace, and compatibility contracts
         run: |
           pytest -q \
             tests/test_unicorn_hybrid_black_sim.py \
@@ -88,6 +88,7 @@ jobs:
             tests/test_unicorn_network_sim.py \
             tests/test_unicorn_transport_sim.py \
             tests/test_unicorn_receiver_guard.py \
+            tests/test_unicorn_trace.py \
             tests/test_unicorn_compatibility_suite.py
       - name: Execute machine-readable compatibility receipt
         run: |
@@ -106,9 +107,10 @@ jobs:
             --dry-run-packets 20
       - name: Compile engine-facing C# receiver
         run: dotnet build examples/game_engines/csharp/Neuros.Unicorn.Examples.csproj --configuration Release
-      - name: Syntax-check real-time substitution endpoints
+      - name: Syntax-check real-time substitution and capture endpoints
         run: |
           python -m py_compile \
             examples/unicorn_hybrid_black_simulator.py \
             examples/unicorn_udp_simulator.py \
+            examples/unicorn_raw_udp_trace_capture.py \
             examples/unicorn_sim_conformance.py

--- a/.github/workflows/synthetic-arena.yml
+++ b/.github/workflows/synthetic-arena.yml
@@ -9,6 +9,7 @@ on:
       - "packages/neuros-sourceweigher/**"
       - "tests/test_synthetic_bci_arena.py"
       - "tests/test_arena_*.py"
+      - "tests/test_unicorn_arena_profile.py"
       - "tests/test_plugin_registry.py"
       - "examples/arena/**"
       - ".github/workflows/synthetic-arena.yml"
@@ -51,6 +52,7 @@ jobs:
             tests/test_arena_timing.py \
             tests/test_arena_benchmark.py \
             tests/test_arena_recording_metadata.py \
+            tests/test_unicorn_arena_profile.py \
             tests/test_plugin_registry.py
       - name: Exercise preset, manifest, and benchmark CLI
         run: |

--- a/docs/UNICORN_GAME_DEVELOPMENT.md
+++ b/docs/UNICORN_GAME_DEVELOPMENT.md
@@ -1,0 +1,385 @@
+# Developing EEG games against the neurOS Unicorn Hybrid Black suite
+
+This guide is the shortest path from a game prototype with no headset attached to a game that can be exercised against the neurOS Unicorn Hybrid Black device/interface twin and later compared with a physical device.
+
+The simulator is designed to reduce **software and integration risk**. It cannot establish that a real participant will produce a decodable neural response.
+
+## The contract stack
+
+```text
+Arena neural world
+participant + display + artifacts + evoked response
+        ↓
+Unicorn device twin
+250 Hz + 24-bit + channel schemas + counter + IMU + validation
+        ↓
+interface
+Python API / raw UDP / Recorder19 / LSL / Bandpower70
+        ↓
+receiver health + authority guard
+        ↓
+decoder
+        ↓
+gameplay
+```
+
+Do not collapse these layers. A packet-loss test should not silently change the simulated participant. A weak SSVEP responder should not silently change UDP ordering. A receiver fault should revoke BCI authority without pausing the whole game.
+
+---
+
+## 1. Choose the interface your game will actually use
+
+### Raw UDP
+
+Best when the game owns the real-time signal-processing pipeline.
+
+Contract:
+
+```text
+250 source packets/s
+68 bytes/packet
+17 float32 values
+EEG1..8 | ACC X/Y/Z | GYR X/Y/Z | BAT | CNT | VALID
+```
+
+Important: standalone raw UDP uses `BAT, CNT, VALID` at the tail. The direct API/Recorder ordering uses `CNT, BAT, VALID`.
+
+### LSL
+
+Best when acquisition/decoding lives in Python and the game consumes a derived event stream, or when a research stack already uses Lab Streaming Layer.
+
+The neurOS LSL endpoint marks itself as synthetic in stream metadata. It does not claim byte-for-byte metadata parity with every Unicorn Suite release.
+
+### Bandpower UDP
+
+Best for prototypes that intentionally use the public Unicorn Bandpower-style feature interface.
+
+Contract:
+
+```text
+70 ASCII values/update
+25 Hz default update cadence
+56 channel-band values
+7 channel averages
+7 bipolar averages
+```
+
+The payload layout/cadence are compatibility targets. Numerical spectral values come from a transparent neurOS reference estimator because the proprietary estimator is not sufficiently documented for bit-for-bit claims.
+
+### Direct Python API twin
+
+Best for application code written around device enumeration, configuration, channel enabling/disabling, acquisition start/stop and failure handling.
+
+This is a conceptual API twin, not a replacement for the licensed vendor binary package.
+
+---
+
+## 2. Start a pristine raw UDP source
+
+```bash
+python examples/unicorn_udp_simulator.py \
+  --mode raw \
+  --host 127.0.0.1 \
+  --port 19745 \
+  --fault-profile pristine
+```
+
+The source targets the documented 250 Hz raw-UDP cadence. Python/OS scheduling is not presented as a calibrated Bluetooth timing measurement.
+
+Before launching the game, you can verify the exact encoder and fault engine without opening a socket:
+
+```bash
+python examples/unicorn_udp_simulator.py \
+  --mode raw \
+  --fault-profile pristine \
+  --dry-run-packets 500
+```
+
+---
+
+## 3. Put a receiver guard in front of game authority
+
+A receiver should not translate “I received some bytes” into “the brain may control gameplay.”
+
+`UnicornRawUdpGuard` implements a reference fail-closed policy:
+
+- malformed 68-byte payload → revoke authority;
+- non-finite values → revoke authority;
+- `VALID=0` → stream can still be alive, but revoke authority;
+- repeated counter → duplicate → revoke authority;
+- counter moves backwards → out of order → revoke authority;
+- counter skips forward → gap → revoke authority;
+- no decodable packet for the configured stale interval → revoke authority;
+- require N healthy sequential validated packets before authority returns.
+
+Default consumer policy:
+
+```text
+stale threshold   100 ms
+recovery streak   3 packets
+validation        required
+```
+
+Those values are neurOS application defaults, **not manufacturer specifications**.
+
+A game can keep rendering, moving the player and accepting controller input while BCI authority is false. The neural subsystem simply stops changing gameplay state.
+
+---
+
+## 4. Unity / Godot C# integration
+
+`examples/game_engines/csharp/UnicornRawUdpClient.cs` is dependency-free C# targeting `netstandard2.0`.
+
+Copy it into the engine project, then wrap it with an engine lifecycle component.
+
+Conceptual Unity usage:
+
+```csharp
+private UnicornRawUdpClient unicorn;
+
+void Awake()
+{
+    unicorn = new UnicornRawUdpClient(19745);
+    unicorn.Start();
+}
+
+void Update()
+{
+    if (!unicorn.AuthorityAllowed)
+    {
+        // Keep the game alive, but do not apply new BCI-derived authority.
+        return;
+    }
+
+    if (unicorn.TryGetLatest(out var sample))
+    {
+        // Feed sample.Values[0..7] into the decoder or signal bridge.
+    }
+}
+
+void OnDestroy()
+{
+    unicorn.Dispose();
+}
+```
+
+Raw UDP deliberately carries no “simulated vs physical” provenance field. The application must log the selected source separately, for example:
+
+```text
+bci_source_kind = synthetic
+bci_source_label = neuros-unicorn-pristine-seed-7
+```
+
+or:
+
+```text
+bci_source_kind = user_declared_physical
+bci_source_label = hackathon-headset-a
+```
+
+Do not infer provenance from raw packet bytes.
+
+---
+
+## 5. Turn on deterministic transport failures
+
+Named profiles:
+
+| profile | purpose |
+|---|---|
+| `pristine` | no synthetic transport faults |
+| `periodic-loss` | deterministic packet-loss probe |
+| `duplicate-probe` | repeated-packet handling |
+| `reorder-probe` | adjacent packet inversion |
+| `delay-probe` | periodic delivery delay |
+| `mixed-torture` | loss + duplicate + delay + reorder |
+
+Example:
+
+```bash
+python examples/unicorn_udp_simulator.py \
+  --mode raw \
+  --port 19745 \
+  --fault-profile mixed-torture
+```
+
+These cadences are deliberately synthetic test patterns. They are **not measured Unicorn Bluetooth statistics**.
+
+A correct game should remain playable through every fault profile. BCI authority may disappear temporarily; controller/game authority should not become corrupted.
+
+---
+
+## 6. Exercise Bandpower consumers
+
+```bash
+python examples/unicorn_udp_simulator.py \
+  --mode bandpower \
+  --port 19746 \
+  --fault-profile pristine
+```
+
+Or run a deterministic feature-stream check:
+
+```bash
+python examples/unicorn_udp_simulator.py \
+  --mode bandpower \
+  --fault-profile delay-probe \
+  --dry-run-packets 100
+```
+
+The first update internally requires the configured 250-sample analysis buffer. Later updates use the documented 10-sample hop.
+
+---
+
+## 7. Use Arena for neural/game worlds
+
+The device twin should not be asked to invent participant physiology.
+
+Use `neuros-arena` for worlds such as:
+
+- strong SSVEP responder;
+- weak responder;
+- endogenous alpha collision near a stimulus frequency;
+- blink contamination;
+- jaw/EMG contamination;
+- head/controller movement;
+- posterior contact degradation;
+- display frame drops;
+- participant fatigue/response attenuation;
+- source-space or recorded-background worlds.
+
+Then wrap the resulting sensor-space EEG in the Unicorn device/interface contract.
+
+For Unicorn EEG-only Arena scenarios:
+
+```python
+from neuros.arena import unicorn_hybrid_black_eeg_profile
+
+profile = unicorn_hybrid_black_eeg_profile(
+    sensor_noise_uv=0.5,
+    line_frequency_hz=60.0,
+    line_noise_uv=1.0,
+    chunk_samples=5,
+)
+```
+
+Environmental parameters remain explicit and should not be described as published headset behavior.
+
+---
+
+## 8. Capture a real-device interface trace without saving EEG
+
+When a physical Unicorn becomes available, run the game-facing raw UDP path and capture only interface diagnostics:
+
+```bash
+python examples/unicorn_raw_udp_trace_capture.py \
+  --host 127.0.0.1 \
+  --port 19745 \
+  --seconds 30 \
+  --source-kind user_declared_physical \
+  --source-label hackathon-headset-a \
+  --output headset-a-trace.json
+```
+
+The output contains:
+
+- packet count;
+- decoded/malformed count;
+- observed arrival cadence;
+- mean/p95 inter-arrival time;
+- first/last counter;
+- counter-gap events;
+- inferred missing packets at gap time;
+- duplicates;
+- out-of-order packets;
+- `VALID=0` count;
+- observed battery range;
+- nominal-contract diagnostics.
+
+It explicitly records:
+
+```text
+contains_raw_eeg = false
+raw_packets_persisted = false
+```
+
+`user_declared_physical` means exactly that. It is an operator statement, not cryptographic proof of device provenance.
+
+---
+
+## 9. Convert discrepancies into simulator corrections
+
+The desired hardware-validation loop is:
+
+```text
+same receiver/game
+      ↑           ↑
+neurOS twin    physical Unicorn
+      ↓           ↓
+trace summary  trace summary
+      └──── compare ────┘
+```
+
+If a physical capture disagrees with the simulator, do not tune the game around the simulator. Correct the relevant simulator layer and version the change.
+
+Examples:
+
+- raw field ordering mismatch → interface contract correction;
+- counter semantics mismatch → device-twin correction;
+- LSL metadata mismatch → LSL substitution correction;
+- physical arrival jitter differs → measured transport profile, clearly labeled as observed data;
+- EEG amplitude/covariance mismatch → Arena/reality-anchoring work, not UDP code;
+- participant cannot select the target → neural paradigm/decoder problem, not packet serialization.
+
+---
+
+# Recommended pre-hardware game qualification
+
+For an EEG action game, a useful minimum matrix is:
+
+1. pristine strong-responder world;
+2. weak-responder world;
+3. no-response/abstention world;
+4. alpha-frequency collision;
+5. blink/jaw/controller artifact sequence;
+6. posterior-channel degradation;
+7. `VALID=0` period and recovery;
+8. periodic packet loss;
+9. duplicate packets;
+10. reordering;
+11. delayed packets;
+12. source stale interval;
+13. mixed transport torture;
+14. game remains controllable without BCI authority;
+15. replay produces the same synthetic world and decisions.
+
+Passing all fifteen means the **software is much harder to surprise** when real hardware arrives. It does not mean the human BCI has been validated.
+
+---
+
+# Evidence vocabulary
+
+Use these phrases deliberately:
+
+### Safe before physical hardware
+
+- “tested against the neurOS Unicorn Hybrid Black simulator”
+- “hardware-free device/interface conformance”
+- “synthetic transport torture tested”
+- “Arena synthetic-population robustness”
+
+### Requires actual device observation
+
+- “observed on Unicorn Hybrid Black hardware”
+- “measured physical arrival cadence”
+- “observed physical validation behavior”
+
+### Requires human closed-loop data
+
+- “participant SSVEP accuracy”
+- “human false-switch rate”
+- “calibration time”
+- “comfort/usability”
+- “real gameplay performance with EEG”
+
+The simulator exists to make the transition between those evidence levels clean rather than blurry.

--- a/docs/UNICORN_HYBRID_BLACK_SIMULATION_SUITE.md
+++ b/docs/UNICORN_HYBRID_BLACK_SIMULATION_SUITE.md
@@ -1,0 +1,464 @@
+# neurOS Unicorn Hybrid Black Simulation Suite
+
+## Purpose
+
+The Unicorn Hybrid Black Simulation Suite is a hardware-substitution layer for EEG game and BCI development when a physical Unicorn Hybrid Black is not continuously available.
+
+It is designed to answer:
+
+> **If my application were connected through one of the documented Unicorn interfaces, does my acquisition, timing, decoding, failure handling, and game logic behave correctly?**
+
+It is **not** a claim that synthetic EEG is an exact human brain, that Bluetooth is physically reproduced, or that passing the simulator predicts a participant's BCI performance.
+
+The suite deliberately separates three systems:
+
+```text
+neural world model
+what voltages exist at the electrodes?
+        ↓
+Unicorn device twin
+how does Hybrid Black acquire/expose those voltages?
+        ↓
+application interface
+API / UDP / Recorder / LSL / Bandpower / game
+```
+
+That separation is essential. Better EEG world models can be introduced without rewriting the device interface, and device-interface corrections do not silently alter physiology.
+
+---
+
+## Published Hybrid Black acquisition envelope
+
+The canonical device constants used by neurOS are drawn from current public g.tec documentation:
+
+| Property | neurOS contract |
+|---|---:|
+| EEG channels | 8 |
+| EEG sample rate | 250 Hz/channel |
+| ADC resolution | 24 bit |
+| Sensitivity | ±750 mV |
+| Published input impedance | >1 GΩ |
+| Accelerometer | 3 axis |
+| Gyroscope | 3 axis |
+| Published battery duration | >3 h |
+| Hybrid electrodes | wet/dry |
+| g.Pype acquisition-delay compensation | approximately 40 ms |
+
+Canonical EEG montage used by the standard cap/game profile:
+
+```text
+Fz C3 Cz C4 Pz PO7 Oz PO8
+```
+
+The >1 GΩ specification is stored as provenance. neurOS does **not** synthesize an imaginary impedance sensor. Electrode/contact degradation belongs to the neural/world layer and influences observable signal quality instead.
+
+Current upstream references:
+
+- g.tec Unicorn Hybrid Black product page: https://www.gtec.at/product/unicorn-hybrid-black-bci-platform/
+- g.tec Unicorn Education Kit specification: https://www.gtec.at/product/unicorn-education-kit-teaching-platform/
+- g.Pype Hybrid Black source contract: https://gpype.gtec.at/content/7_sdk_reference/backend_sources/hybrid_black.html
+- Unicorn Suite: https://www.gtec.at/product/unicorn-suite/
+
+Specifications can evolve. A future neurOS release must not silently update them. Device-profile changes require explicit tests and release notes.
+
+---
+
+# Compatibility surfaces
+
+## 1. `eeg8_anatomical`
+
+Eight EEG channels only:
+
+```text
+Fz C3 Cz C4 Pz PO7 Oz PO8
+```
+
+Use this for:
+
+- FBCCA/SSVEP game pipelines;
+- model/decoder development;
+- low-level signal-quality testing;
+- Arena synthetic populations;
+- software that intentionally ignores motion/auxiliary channels.
+
+This is a normalized neurOS view, not the raw channel naming of every Unicorn API.
+
+---
+
+## 2. Direct API 17-channel acquisition
+
+The documented direct acquisition/API ordering is modeled as:
+
+```text
+EEG 1
+EEG 2
+EEG 3
+EEG 4
+EEG 5
+EEG 6
+EEG 7
+EEG 8
+Accelerometer X
+Accelerometer Y
+Accelerometer Z
+Gyroscope X
+Gyroscope Y
+Gyroscope Z
+Counter
+Battery Level
+Validation Indicator
+```
+
+The simulator provides:
+
+- configuration state;
+- enabled/disabled channels;
+- enabled-channel index lookup;
+- number of acquired channels;
+- acquisition start/stop;
+- measurement/test-signal mode;
+- 8-bit digital output state;
+- deterministic injected buffer underflow;
+- deterministic injected buffer overflow;
+- deterministic connection failures;
+- scan-major float32 reads;
+- optional binary scan buffers.
+
+`UnicornPythonApiSimulator` is a **conceptual API twin**, not a drop-in binary replacement for g.tec's licensed DLL/Python package.
+
+Synthetic serial identifiers must begin with `SIM-` so test evidence cannot masquerade as a physical device session.
+
+---
+
+## 3. Standalone raw UDP 17-float wire contract
+
+The standalone Unicorn UDP interface documents:
+
+```text
+250 packets/s
+17 float values / packet
+68 bytes / packet
+```
+
+A crucial compatibility distinction is encoded explicitly.
+
+Direct API / Recorder auxiliary tail:
+
+```text
+CNT → BAT → VALID
+```
+
+Standalone raw UDP auxiliary tail:
+
+```text
+BAT → CNT → VALID
+```
+
+Therefore neurOS maintains a **separate UDP wire order** rather than reusing the API array blindly.
+
+The encoder transforms:
+
+```text
+API17
+EEG ×8 | ACC ×3 | GYR ×3 | CNT | BAT | VALID
+                     ↓
+raw UDP17
+EEG ×8 | ACC ×3 | GYR ×3 | BAT | CNT | VALID
+```
+
+This difference is protected by regression tests.
+
+The public documentation specifies payload size and field order but does not clearly specify endianness. neurOS defaults to little-endian for the Windows/x86 Unicorn Suite environment and labels that choice as a compatibility assumption. Receivers can be fuzzed with alternative byte order intentionally.
+
+---
+
+## 4. Recorder/network 19-field view
+
+The Recorder-style view is modeled as:
+
+```text
+EEG 1..8
+ACC X/Y/Z
+GYR X/Y/Z
+CNT
+BAT
+VALID
+DT
+STATUS
+```
+
+At 250 Hz the default synthetic `DT` is 4 ms.
+
+`STATUS` can be controlled to exercise trigger/state consumers.
+
+This view targets the documented channel/field contract. neurOS does not claim to clone Recorder's GUI or proprietary file-writing internals.
+
+---
+
+## 5. LSL substitution endpoint
+
+Run:
+
+```bash
+python examples/unicorn_hybrid_black_simulator.py \
+  --schema device17_api \
+  --name UnicornMock \
+  --no-stdin
+```
+
+The endpoint publishes synthetic data through LSL with explicit provenance:
+
+```text
+synthetic=true
+producer=neurOS
+emulated_manufacturer=g.tec medical engineering
+emulated_device=Unicorn Hybrid Black
+contract=neuros.unicorn_hybrid_black_sim.lsl.v1
+```
+
+It intentionally does **not** invent a physical serial number.
+
+The stream can expose:
+
+- EEG8 anatomical view;
+- direct API17 view;
+- Recorder19 view.
+
+Local deterministic controls include target attention, EEG artifacts, motion telemetry, validation state, status/trigger state, response gain, and source silence.
+
+The public Unicorn LSL application does not expose enough stable documentation for neurOS to claim XML-metadata byte-for-byte parity. The LSL contract is therefore a clearly identified neurOS substitution interface.
+
+---
+
+## 6. Unicorn Bandpower-compatible feature stream
+
+Public Unicorn Bandpower documentation defines seven bands:
+
+```text
+delta      1–4 Hz
+theta      4–8 Hz
+alpha      8–12 Hz
+beta low  12–16 Hz
+beta mid  16–20 Hz
+beta high 20–30 Hz
+gamma     30–50 Hz
+```
+
+The documented default settings are:
+
+```text
+Unicorn sample rate = 250 Hz
+buffer size         = 250 samples
+buffer overlap      = 240 samples
+hop                 = 10 samples
+feature update      = 25 Hz
+```
+
+The UDP/CSV payload always contains 70 values:
+
+```text
+56  = 7 bands × 8 channels
+ 7  = band averages across enabled channels
+ 7  = averages across all enabled bipolar derivations
+---
+70
+```
+
+Disabled-channel values are represented as `NaN` in the per-channel portion.
+
+neurOS implements a transparent FFT/PSD reference estimator behind the exact public payload shape, band definitions, disabled-channel behavior, and cadence.
+
+**Important:** the public documentation does not specify enough numerical estimation detail to claim bit-for-bit equality with Unicorn Bandpower. Therefore this surface is classified as `reference_implementation`, not `exact_contract` for feature values.
+
+Reference:
+
+- https://github.com/unicorn-bi/Unicorn-Bandpower-Hybrid-Black
+
+---
+
+# Three evidence classes
+
+Every compatibility surface is classified as one of:
+
+## `exact_contract`
+
+Public documentation provides enough structural information for a deterministic compatibility assertion.
+
+Examples:
+
+- 250 Hz EEG acquisition;
+- 8 EEG channels;
+- API17 channel layout;
+- raw UDP 17-float/68-byte layout;
+- raw UDP BAT/CNT ordering;
+- Recorder19 layout;
+- Bandpower 70-field layout and 25 Hz default cadence.
+
+## `reference_implementation`
+
+The public interface is defined, but proprietary numerical internals are not sufficiently documented.
+
+Example:
+
+- exact Bandpower estimator values.
+
+## `synthetic_assumption`
+
+A useful stress model not attributed to the manufacturer.
+
+Examples:
+
+- accelerometer sensor-noise standard deviation;
+- gyroscope sensor-noise standard deviation;
+- battery discharge curve;
+- distribution of device-delay jitter;
+- Bluetooth packet-loss/jitter model;
+- synthetic participant/contact-quality distribution.
+
+This classification is included in `neuros.unicorn_hybrid_black_sim.compatibility.v1` reports.
+
+---
+
+# Generate a compatibility receipt
+
+Run:
+
+```bash
+python examples/unicorn_sim_conformance.py \
+  --seed 41 \
+  --output unicorn-simulation-compatibility.json
+```
+
+The receipt exercises:
+
+- EEG8 device envelope;
+- API17 scans;
+- standalone UDP17 wire order;
+- Recorder19 fields;
+- API lifecycle and underflow recovery;
+- Bandpower70 layout/cadence;
+- acquisition-delay timing;
+- explicit synthetic policy boundaries.
+
+A failing required surface exits non-zero.
+
+The receipt's evidence boundary is intentionally strong:
+
+> Synthetic device/interface compatibility cannot qualify Bluetooth radio behavior, physical electrode contact, real Unicorn firmware, proprietary Bandpower numerical parity, or human EEG performance.
+
+---
+
+# What should be simulated where?
+
+## Device twin
+
+Owns:
+
+- sample rate;
+- ADC sensitivity/quantization;
+- channel schemas;
+- API lifecycle;
+- auxiliary telemetry;
+- sample counter;
+- validation/status;
+- acquisition availability delay;
+- protocol/wire layouts.
+
+## Arena neural world model
+
+Owns:
+
+- endogenous EEG;
+- evoked responses;
+- participant variation;
+- gaze/attention effects;
+- electrode/contact degradation effects on EEG;
+- blink, jaw/EMG and movement contamination;
+- source-space or recorded-background realism.
+
+## Arena transport world
+
+Owns:
+
+- clock offset/drift/jitter;
+- synchronization correction residuals;
+- packet loss;
+- reordering;
+- radio/network silence;
+- burst delivery.
+
+## Game/application
+
+Owns:
+
+- calibration policy;
+- decoder;
+- confidence/quality authority;
+- abstention;
+- stale-event handling;
+- gameplay actions;
+- fair source-loss behavior;
+- telemetry.
+
+This prevents causality from becoming soup.
+
+---
+
+# Recommended game-development matrix
+
+A BCI game targeting Unicorn Hybrid Black should eventually test all of these:
+
+| Layer | Test |
+|---|---|
+| EEG | strong/weak/no responder worlds |
+| Endogenous activity | alpha collision near code frequencies |
+| Contact | posterior channel attenuation/dropout |
+| Artifact | blink, jaw, controller/hand, head movement |
+| Display | actual emitted stimulus after refresh quantization/drops |
+| EEG device | 24-bit / ±750 mV / 250 Hz |
+| Motion | still, turn, shake telemetry |
+| API | disabled channels and index changes |
+| Acquisition | 40 ms availability boundary and underruns |
+| Counter | continuity and deliberate gaps |
+| Validation | 1 → 0 → recovery |
+| Raw UDP | 68-byte scan and BAT/CNT order |
+| Recorder | 19-field schema and STATUS/DT |
+| Bandpower | 70 values and 25 Hz default cadence |
+| LSL | source discovery, stale data and restart |
+| Transport | loss/jitter/reordering/silence |
+| Decoder | false positives, abstention, switch time |
+| Game | no authority during invalid/stale states |
+| Replay | deterministic exact-world reproduction |
+
+Passing this matrix still means **hardware-free conformance**, not a human validation result.
+
+---
+
+# The physical substitution experiment
+
+The most important eventual validation of this suite is not another synthetic test. It is a paired run with a physical Unicorn.
+
+For the same consumer application:
+
+```text
+neurOS Unicorn twin ─┐
+                    ├─→ identical acquisition adapter → decoder → game
+physical Unicorn ───┘
+```
+
+Then compare:
+
+- discovered channel schemas;
+- units;
+- scan cadence;
+- counter semantics;
+- validation behavior;
+- motion channels;
+- acquisition age/delay;
+- LSL/UDP behavior;
+- source loss and reconnection;
+- receiver behavior.
+
+Any discrepancy becomes a versioned simulator correction rather than an anecdote.
+
+Until such paired hardware observations exist, the suite remains an unusually strong **device/interface emulator**, not a certified replacement for physical Unicorn validation.

--- a/examples/game_engines/csharp/Neuros.Unicorn.Examples.csproj
+++ b/examples/game_engines/csharp/Neuros.Unicorn.Examples.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+</Project>

--- a/examples/game_engines/csharp/UnicornRawUdpClient.cs
+++ b/examples/game_engines/csharp/UnicornRawUdpClient.cs
@@ -1,0 +1,350 @@
+// neurOS Unicorn Hybrid Black raw-UDP game receiver.
+//
+// This file intentionally has no UnityEngine or Godot dependency. It can be
+// dropped into either engine's C# project and wrapped by a MonoBehaviour/Node.
+//
+// Wire contract:
+//   17 little-endian float32 values / 68 bytes
+//   EEG1..8, ACC X/Y/Z, GYR X/Y/Z, BAT, CNT, VALID
+//
+// Raw UDP contains no provenance flag. Log the selected source (physical vs
+// synthetic) separately in application telemetry. Do not infer it from bytes.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Neuros.Unicorn
+{
+    public enum UnicornStreamHealth
+    {
+        Stale,
+        Healthy,
+        Malformed,
+        Invalid,
+        Gap,
+        Duplicate,
+        OutOfOrder
+    }
+
+    public sealed class UnicornRawUdpSample
+    {
+        public readonly float[] Values;
+        public readonly int Counter;
+        public readonly float BatteryLevel;
+        public readonly int Validation;
+        public readonly UnicornStreamHealth Health;
+        public readonly int MissedPackets;
+        public readonly int HealthyStreak;
+        public readonly bool AuthorityAllowed;
+        public readonly double ReceivedSeconds;
+        public readonly string Reason;
+
+        public UnicornRawUdpSample(
+            float[] values,
+            int counter,
+            float batteryLevel,
+            int validation,
+            UnicornStreamHealth health,
+            int missedPackets,
+            int healthyStreak,
+            bool authorityAllowed,
+            double receivedSeconds,
+            string reason)
+        {
+            Values = values;
+            Counter = counter;
+            BatteryLevel = batteryLevel;
+            Validation = validation;
+            Health = health;
+            MissedPackets = missedPackets;
+            HealthyStreak = healthyStreak;
+            AuthorityAllowed = authorityAllowed;
+            ReceivedSeconds = receivedSeconds;
+            Reason = reason;
+        }
+    }
+
+    public sealed class UnicornRawUdpClient : IDisposable
+    {
+        public const int ChannelCount = 17;
+        public const int PayloadBytes = 68;
+        public const int BatteryIndex = 14;
+        public const int CounterIndex = 15;
+        public const int ValidationIndex = 16;
+
+        private readonly object _sync = new object();
+        private readonly int _port;
+        private readonly double _staleAfterSeconds;
+        private readonly int _recoveryPackets;
+        private readonly IPAddress _bindAddress;
+        private readonly Stopwatch _clock = Stopwatch.StartNew();
+
+        private UdpClient _udp;
+        private Thread _thread;
+        private volatile bool _running;
+        private UnicornRawUdpSample _latest;
+        private int? _lastCounter;
+        private double? _lastDecodableReceiveSeconds;
+        private int _healthyStreak;
+        private UnicornStreamHealth _lastHealth = UnicornStreamHealth.Stale;
+
+        public UnicornRawUdpClient(
+            int port,
+            double staleAfterSeconds = 0.100,
+            int recoveryPackets = 3,
+            string bindAddress = "127.0.0.1")
+        {
+            if (port < 1 || port > 65535) throw new ArgumentOutOfRangeException(nameof(port));
+            if (staleAfterSeconds <= 0) throw new ArgumentOutOfRangeException(nameof(staleAfterSeconds));
+            if (recoveryPackets <= 0) throw new ArgumentOutOfRangeException(nameof(recoveryPackets));
+            _port = port;
+            _staleAfterSeconds = staleAfterSeconds;
+            _recoveryPackets = recoveryPackets;
+            _bindAddress = IPAddress.Parse(bindAddress);
+        }
+
+        public void Start()
+        {
+            lock (_sync)
+            {
+                if (_running) return;
+                _udp = new UdpClient(new IPEndPoint(_bindAddress, _port));
+                _running = true;
+                _thread = new Thread(ReceiveLoop)
+                {
+                    IsBackground = true,
+                    Name = "neurOS-UnicornRawUdp"
+                };
+                _thread.Start();
+            }
+        }
+
+        public void Stop()
+        {
+            _running = false;
+            UdpClient udp;
+            Thread thread;
+            lock (_sync)
+            {
+                udp = _udp;
+                thread = _thread;
+                _udp = null;
+                _thread = null;
+            }
+            try { udp?.Close(); } catch { }
+            if (thread != null && thread.IsAlive && thread != Thread.CurrentThread)
+            {
+                thread.Join(250);
+            }
+        }
+
+        public bool TryGetLatest(out UnicornRawUdpSample sample)
+        {
+            lock (_sync)
+            {
+                sample = _latest;
+                return sample != null;
+            }
+        }
+
+        public UnicornStreamHealth CurrentHealth
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    if (IsStaleLocked()) return UnicornStreamHealth.Stale;
+                    return _lastHealth;
+                }
+            }
+        }
+
+        public bool AuthorityAllowed
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return !IsStaleLocked()
+                        && _lastHealth == UnicornStreamHealth.Healthy
+                        && _healthyStreak >= _recoveryPackets;
+                }
+            }
+        }
+
+        private bool IsStaleLocked()
+        {
+            if (!_lastDecodableReceiveSeconds.HasValue) return true;
+            return (_clock.Elapsed.TotalSeconds - _lastDecodableReceiveSeconds.Value) > _staleAfterSeconds;
+        }
+
+        private void ReceiveLoop()
+        {
+            var remote = new IPEndPoint(IPAddress.Any, 0);
+            while (_running)
+            {
+                try
+                {
+                    var payload = _udp.Receive(ref remote);
+                    Ingest(payload, _clock.Elapsed.TotalSeconds);
+                }
+                catch (ObjectDisposedException) when (!_running) { return; }
+                catch (SocketException) when (!_running) { return; }
+                catch
+                {
+                    lock (_sync)
+                    {
+                        _healthyStreak = 0;
+                        _lastHealth = UnicornStreamHealth.Malformed;
+                    }
+                }
+            }
+        }
+
+        public UnicornRawUdpSample Ingest(byte[] payload, double receivedSeconds)
+        {
+            if (payload == null) throw new ArgumentNullException(nameof(payload));
+            if (double.IsNaN(receivedSeconds) || double.IsInfinity(receivedSeconds))
+                throw new ArgumentOutOfRangeException(nameof(receivedSeconds));
+
+            lock (_sync)
+            {
+                if (_lastDecodableReceiveSeconds.HasValue
+                    && receivedSeconds - _lastDecodableReceiveSeconds.Value > _staleAfterSeconds)
+                {
+                    _healthyStreak = 0;
+                    _lastHealth = UnicornStreamHealth.Stale;
+                }
+
+                if (payload.Length != PayloadBytes)
+                {
+                    return PublishFault(
+                        null, null, null, UnicornStreamHealth.Malformed, 0,
+                        receivedSeconds, $"Expected {PayloadBytes} bytes, received {payload.Length}.");
+                }
+
+                var values = new float[ChannelCount];
+                for (var i = 0; i < ChannelCount; i++)
+                {
+                    values[i] = ReadLittleEndianSingle(payload, i * 4);
+                    if (float.IsNaN(values[i]) || float.IsInfinity(values[i]))
+                    {
+                        return PublishFault(
+                            values, null, null, UnicornStreamHealth.Malformed, 0,
+                            receivedSeconds, "Packet contains a non-finite value.");
+                    }
+                }
+
+                var battery = values[BatteryIndex];
+                var counterFloat = values[CounterIndex];
+                var validationFloat = values[ValidationIndex];
+                var counter = (int)Math.Round(counterFloat);
+                var validation = (int)Math.Round(validationFloat);
+
+                if (Math.Abs(counterFloat - counter) > 0.25f)
+                {
+                    return PublishFault(
+                        values, null, validation, UnicornStreamHealth.Malformed, 0,
+                        receivedSeconds, "Counter is not sufficiently integer-like.");
+                }
+                if (validation != 0 && validation != 1)
+                {
+                    return PublishFault(
+                        values, counter, validation, UnicornStreamHealth.Malformed, 0,
+                        receivedSeconds, "Validation indicator is not binary.");
+                }
+
+                _lastDecodableReceiveSeconds = receivedSeconds;
+                if (validation != 1)
+                {
+                    _lastCounter = counter;
+                    return PublishFault(
+                        values, counter, validation, UnicornStreamHealth.Invalid, 0,
+                        receivedSeconds, "Validation indicator is not asserted.", battery);
+                }
+
+                if (_lastCounter.HasValue)
+                {
+                    var delta = counter - _lastCounter.Value;
+                    if (delta == 0)
+                    {
+                        return PublishFault(
+                            values, counter, validation, UnicornStreamHealth.Duplicate, 0,
+                            receivedSeconds, "Counter repeated.", battery);
+                    }
+                    if (delta < 0)
+                    {
+                        return PublishFault(
+                            values, counter, validation, UnicornStreamHealth.OutOfOrder, 0,
+                            receivedSeconds, "Counter moved backwards.", battery);
+                    }
+                    if (delta > 1)
+                    {
+                        _lastCounter = counter;
+                        return PublishFault(
+                            values, counter, validation, UnicornStreamHealth.Gap, delta - 1,
+                            receivedSeconds, $"Counter advanced by {delta}.", battery);
+                    }
+                }
+
+                _lastCounter = counter;
+                _healthyStreak += 1;
+                _lastHealth = UnicornStreamHealth.Healthy;
+                var allowed = _healthyStreak >= _recoveryPackets;
+                _latest = new UnicornRawUdpSample(
+                    values, counter, battery, validation, UnicornStreamHealth.Healthy,
+                    0, _healthyStreak, allowed, receivedSeconds,
+                    "Healthy sequential validated packet.");
+                return _latest;
+            }
+        }
+
+        private UnicornRawUdpSample PublishFault(
+            float[] values,
+            int? counter,
+            int? validation,
+            UnicornStreamHealth health,
+            int missedPackets,
+            double receivedSeconds,
+            string reason,
+            float? battery = null)
+        {
+            _healthyStreak = 0;
+            _lastHealth = health;
+            _latest = new UnicornRawUdpSample(
+                values ?? Array.Empty<float>(),
+                counter ?? -1,
+                battery ?? float.NaN,
+                validation ?? -1,
+                health,
+                missedPackets,
+                0,
+                false,
+                receivedSeconds,
+                reason);
+            return _latest;
+        }
+
+        private static float ReadLittleEndianSingle(byte[] bytes, int offset)
+        {
+            if (BitConverter.IsLittleEndian)
+            {
+                return BitConverter.ToSingle(bytes, offset);
+            }
+            var scratch = new byte[4];
+            scratch[0] = bytes[offset + 3];
+            scratch[1] = bytes[offset + 2];
+            scratch[2] = bytes[offset + 1];
+            scratch[3] = bytes[offset];
+            return BitConverter.ToSingle(scratch, 0);
+        }
+
+        public void Dispose()
+        {
+            Stop();
+        }
+    }
+}

--- a/examples/unicorn_hybrid_black_simulator.py
+++ b/examples/unicorn_hybrid_black_simulator.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Publish a device-faithful synthetic Unicorn Hybrid Black stream over LSL.
+
+This endpoint is a hardware-substitution tool, not a physical-hardware claim.
+It can expose one of three schemas:
+
+* ``eeg8_anatomical``: 8 EEG channels labeled by the standard cap montage;
+* ``device17_api``: 17 acquired channels in the device/API order;
+* ``recorder19``: Recorder/network-style 19-field view including DT/STATUS.
+
+Local controls (stdin or UDP 127.0.0.1:19744):
+
+    0 / 1 / 2              rest / attend 10 Hz / attend 12 Hz
+    b / j / c / m / s      blink / jaw / controller / motion / saturation
+    validation:0|1         validation-indicator state
+    status:INTEGER         Recorder/status trigger value
+    still                  accel=(0,0,1), gyro=(0,0,0)
+    turn                   deterministic head-turn telemetry
+    shake                  deterministic larger motion telemetry + EEG motion artifact
+    silence:SECONDS        stop publishing while the synthetic device keeps time
+    gain:VALUE             synthetic SSVEP response gain
+    q                      quit
+
+The stream metadata declares the synthetic provenance explicitly.  It does not
+claim to reproduce undocumented Unicorn LSL XML exactly.
+"""
+from __future__ import annotations
+
+import argparse
+import queue
+import socket
+import threading
+import time
+
+import numpy as np
+
+from neuros.drivers.unicorn_hybrid_black_sim import (
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+    UnicornHybridBlackSpec,
+)
+
+
+def _stdin_reader(commands: queue.Queue[str]) -> None:
+    while True:
+        try:
+            command = input().strip().lower()
+        except EOFError:
+            return
+        if command:
+            commands.put(command)
+        if command == "q":
+            return
+
+
+def _udp_reader(commands: queue.Queue[str], host: str, port: int) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((host, port))
+    sock.settimeout(0.25)
+    try:
+        while True:
+            try:
+                payload, _ = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            command = payload.decode("utf-8", errors="ignore").strip().lower()
+            if command:
+                commands.put(command)
+            if command == "q":
+                return
+    finally:
+        sock.close()
+
+
+def _parse_float(command: str, prefix: str, default: float) -> float:
+    if not command.startswith(prefix + ":"):
+        return default
+    try:
+        return float(command.split(":", 1)[1])
+    except ValueError:
+        return default
+
+
+def _channel_type(name: str) -> str:
+    upper = name.upper()
+    if name.startswith("EEG") or name in {"Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8"}:
+        return "EEG"
+    if "ACCELEROMETER" in upper or upper.startswith("ACC "):
+        return "Accelerometer"
+    if "GYROSCOPE" in upper or upper.startswith("GYR "):
+        return "Gyroscope"
+    if "BAT" in upper:
+        return "Battery"
+    if "VALID" in upper:
+        return "Validation"
+    if "COUNT" in upper or upper == "CNT":
+        return "Counter"
+    if upper == "DT":
+        return "Timing"
+    if upper == "STATUS":
+        return "Status"
+    return "MISC"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--schema",
+        choices=("eeg8_anatomical", "device17_api", "recorder19"),
+        default="device17_api",
+    )
+    parser.add_argument("--name", default="UnicornMock")
+    parser.add_argument("--source-id", default="neuros-unicorn-hybrid-black-sim")
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--block", type=int, default=5)
+    parser.add_argument("--drop-probability", type=float, default=0.0)
+    parser.add_argument("--jitter-ms", type=float, default=0.0)
+    parser.add_argument("--device-delay-jitter-ms", type=float, default=0.0)
+    parser.add_argument("--control-host", default="127.0.0.1")
+    parser.add_argument("--control-port", type=int, default=19744)
+    parser.add_argument("--no-stdin", action="store_true")
+    args = parser.parse_args()
+    if args.block <= 0:
+        raise SystemExit("--block must be positive")
+    if not 0.0 <= args.drop_probability < 1.0:
+        raise SystemExit("--drop-probability must be in [0,1)")
+    if args.jitter_ms < 0 or args.device_delay_jitter_ms < 0:
+        raise SystemExit("jitter values must be non-negative")
+    if not 1 <= args.control_port <= 65535:
+        raise SystemExit("--control-port must be a valid UDP port")
+
+    try:
+        from pylsl import StreamInfo, StreamOutlet, local_clock
+    except (ImportError, OSError, RuntimeError) as exc:
+        raise SystemExit("Install neuros-drivers[lsl] with a working liblsl runtime") from exc
+
+    spec = UnicornHybridBlackSpec()
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(
+            schema=args.schema,
+            seed=args.seed,
+            acquisition_delay_jitter_ms=args.device_delay_jitter_ms,
+        )
+    )
+    preview = sim.render(1)
+    # Re-create after metadata discovery so the published sample counter starts
+    # exactly at the configured origin.
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(
+            schema=args.schema,
+            seed=args.seed,
+            acquisition_delay_jitter_ms=args.device_delay_jitter_ms,
+        )
+    )
+
+    info = StreamInfo(
+        args.name,
+        "EEG",
+        len(preview.channel_names),
+        spec.sampling_rate_hz,
+        "float32",
+        args.source_id,
+    )
+    channels = info.desc().append_child("channels")
+    for label, unit in zip(preview.channel_names, preview.channel_units, strict=True):
+        channel = channels.append_child("channel")
+        channel.append_child_value("label", label)
+        channel.append_child_value("unit", unit)
+        channel.append_child_value("type", _channel_type(label))
+
+    provenance = info.desc().append_child("provenance")
+    provenance.append_child_value("synthetic", "true")
+    provenance.append_child_value("producer", "neurOS")
+    provenance.append_child_value("emulated_manufacturer", "g.tec medical engineering")
+    provenance.append_child_value("emulated_device", "Unicorn Hybrid Black")
+    provenance.append_child_value("contract", "neuros.unicorn_hybrid_black_sim.lsl.v1")
+    provenance.append_child_value("schema", args.schema)
+    provenance.append_child_value("evidence_boundary", "synthetic device substitution; not physical hardware")
+
+    hardware = info.desc().append_child("emulated_hardware")
+    hardware.append_child_value("sampling_rate_hz", str(spec.sampling_rate_hz))
+    hardware.append_child_value("resolution_bits", str(spec.resolution_bits))
+    hardware.append_child_value("sensitivity_uv", str(spec.sensitivity_uv))
+    hardware.append_child_value("device_delay_ms", str(spec.device_delay_ms))
+    hardware.append_child_value("eeg_lsb_uv", str(spec.eeg_lsb_uv))
+    hardware.append_child_value("montage", "Fz,C3,Cz,C4,Pz,PO7,Oz,PO8")
+
+    simulation = info.desc().append_child("simulation")
+    simulation.append_child_value("seed", str(args.seed))
+    simulation.append_child_value("drop_probability", str(args.drop_probability))
+    simulation.append_child_value("delivery_jitter_ms", str(args.jitter_ms))
+    simulation.append_child_value("device_delay_jitter_ms", str(args.device_delay_jitter_ms))
+    simulation.append_child_value("control_host", args.control_host)
+    simulation.append_child_value("control_port", str(args.control_port))
+
+    outlet = StreamOutlet(info, chunk_size=args.block, max_buffered=10)
+    commands: queue.Queue[str] = queue.Queue()
+    if not args.no_stdin:
+        threading.Thread(target=_stdin_reader, args=(commands,), daemon=True).start()
+    threading.Thread(
+        target=_udp_reader,
+        args=(commands, args.control_host, args.control_port),
+        daemon=True,
+    ).start()
+
+    transport_rng = np.random.default_rng(args.seed + 91009)
+    attention_gain = 1.0
+    silence_until = 0.0
+    running = True
+    deadline = time.monotonic()
+    print(
+        f"Publishing {args.name!r} schema={args.schema} channels={len(preview.channel_names)} "
+        f"at 250 Hz; synthetic Unicorn device delay={spec.device_delay_ms:g} ms."
+    )
+
+    while running:
+        while True:
+            try:
+                command = commands.get_nowait()
+            except queue.Empty:
+                break
+            if command == "0":
+                sim.eeg.set_attention(None)
+            elif command == "1":
+                sim.eeg.set_attention(10.0, attention_gain)
+            elif command == "2":
+                sim.eeg.set_attention(12.0, attention_gain)
+            elif command == "b":
+                sim.eeg.inject_artifact("blink", 0.35, 1.0)
+            elif command == "j":
+                sim.eeg.inject_artifact("jaw", 0.45, 1.0)
+            elif command == "c":
+                sim.eeg.inject_artifact("controller", 0.50, 1.0)
+            elif command == "m":
+                sim.eeg.inject_artifact("motion", 0.50, 1.0)
+            elif command == "s":
+                sim.eeg.inject_artifact("saturation", 0.40, 1.0)
+            elif command == "still":
+                sim.set_motion((0.0, 0.0, 1.0), (0.0, 0.0, 0.0))
+            elif command == "turn":
+                sim.set_motion((0.10, 0.05, 0.98), (0.0, 55.0, 8.0))
+            elif command == "shake":
+                sim.set_motion((0.75, -0.35, 1.20), (150.0, -90.0, 65.0))
+                sim.eeg.inject_artifact("motion", 0.75, 1.4)
+            elif command.startswith("validation:"):
+                try:
+                    sim.set_validation(int(command.split(":", 1)[1]))
+                except ValueError:
+                    print("validation must be 0 or 1")
+            elif command.startswith("status:"):
+                try:
+                    sim.set_status(int(command.split(":", 1)[1]))
+                except ValueError:
+                    print("status must be an integer")
+            elif command.startswith("silence:"):
+                duration = float(np.clip(_parse_float(command, "silence", 2.0), 0.1, 30.0))
+                silence_until = max(silence_until, time.monotonic() + duration)
+            elif command.startswith("gain:"):
+                attention_gain = float(np.clip(_parse_float(command, "gain", attention_gain), 0.0, 1.5))
+                if sim.eeg.target_frequency_hz is not None:
+                    sim.eeg.set_attention(sim.eeg.target_frequency_hz, attention_gain)
+            elif command == "q":
+                running = False
+
+        block = sim.render(args.block)
+        dropped = transport_rng.random() < args.drop_probability
+        silent = time.monotonic() < silence_until
+        if not dropped and not silent:
+            if args.jitter_ms > 0:
+                time.sleep(float(transport_rng.uniform(0.0, args.jitter_ms)) / 1000.0)
+            # LSL's explicit timestamp describes the newest sample in the chunk.
+            # Mark it as approximately 40 ms old at host availability, preserving
+            # acquisition latency as timestamp age instead of moving neural time.
+            newest_sample_timestamp = local_clock() - spec.device_delay_ms / 1000.0
+            outlet.push_chunk(block.data.T.tolist(), timestamp=newest_sample_timestamp)
+
+        deadline += args.block / spec.sampling_rate_hz
+        time.sleep(max(0.0, deadline - time.monotonic()))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/unicorn_raw_udp_trace_capture.py
+++ b/examples/unicorn_raw_udp_trace_capture.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Capture shareable Unicorn raw-UDP interface diagnostics without raw EEG.
+
+The process keeps datagrams only in memory long enough to reduce them to timing,
+packet-shape, counter, validation, and battery diagnostics. The output JSON does
+not contain EEG channel values or original packet bytes.
+
+`--source-kind user_declared_physical` records the operator's statement. It is
+not cryptographic evidence that a physical headset produced the stream.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import socket
+import time
+
+from neuros.drivers import analyze_unicorn_raw_udp_trace, compare_unicorn_trace_to_nominal_contract
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19745)
+    parser.add_argument("--seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--source-kind",
+        choices=("unknown", "synthetic", "user_declared_physical"),
+        default="unknown",
+    )
+    parser.add_argument("--source-label", default="")
+    parser.add_argument("--byte-order", choices=("<", ">", "=", "!"), default="<")
+    parser.add_argument("--rate-tolerance-hz", type=float, default=15.0)
+    parser.add_argument("--output", default="unicorn-raw-udp-trace-summary.json")
+    args = parser.parse_args()
+
+    if not 1 <= args.port <= 65535:
+        raise SystemExit("--port must be in [1, 65535]")
+    if args.seconds <= 0:
+        raise SystemExit("--seconds must be positive")
+    if args.rate_tolerance_hz <= 0:
+        raise SystemExit("--rate-tolerance-hz must be positive")
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((args.host, args.port))
+    sock.settimeout(0.100)
+    records: list[tuple[float, bytes]] = []
+    start = time.perf_counter()
+    deadline = start + args.seconds
+    try:
+        while time.perf_counter() < deadline:
+            try:
+                payload, _ = sock.recvfrom(4096)
+            except socket.timeout:
+                continue
+            records.append((time.perf_counter() - start, payload))
+    finally:
+        sock.close()
+
+    summary = analyze_unicorn_raw_udp_trace(
+        records,
+        source_kind=args.source_kind,
+        source_label=args.source_label,
+        byte_order=args.byte_order,
+    )
+    comparison = compare_unicorn_trace_to_nominal_contract(
+        summary,
+        rate_tolerance_hz=args.rate_tolerance_hz,
+    )
+    payload = {
+        "schema": "neuros.unicorn_raw_udp_capture_receipt.v1",
+        "summary": summary.to_dict(),
+        "nominal_contract_comparison": comparison.to_dict(),
+        "capture_requested_seconds": args.seconds,
+        "raw_packets_persisted": False,
+    }
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "output": str(output),
+        "packets": summary.packet_count,
+        "decoded": summary.decoded_packet_count,
+        "raw_packets_persisted": False,
+        "passed_diagnostic_checks": comparison.passed_diagnostic_checks,
+    }, sort_keys=True))
+    if summary.packet_count == 0:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/unicorn_sim_conformance.py
+++ b/examples/unicorn_sim_conformance.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Generate a machine-readable Unicorn Hybrid Black simulation receipt."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from neuros.drivers import run_unicorn_compatibility_suite
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--output", default="unicorn-simulation-compatibility.json")
+    args = parser.parse_args()
+    report = run_unicorn_compatibility_suite(seed=args.seed)
+    payload = report.to_dict()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(json.dumps({
+        "report": str(output),
+        "schema": payload["schema"],
+        "passed": payload["passed"],
+        "surfaces": {surface["name"]: surface["passed"] for surface in payload["surfaces"]},
+    }, indent=2, sort_keys=True))
+    if not report.passed:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/unicorn_udp_simulator.py
+++ b/examples/unicorn_udp_simulator.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Publish synthetic Unicorn-compatible raw or Bandpower datagrams over UDP.
+
+This is a game-development substitution endpoint. It reproduces the declared
+neurOS interface contracts and deterministic fault schedules, not physical
+Bluetooth radio timing. Python/OS scheduling is therefore not presented as a
+clock-certified 250 Hz hardware measurement.
+
+Examples:
+
+    # Raw 17-float / 68-byte Unicorn-compatible packets at nominal 250 Hz.
+    python examples/unicorn_udp_simulator.py --mode raw --port 19745
+
+    # Bandpower 70-value ASCII reference payloads at nominal 25 Hz.
+    python examples/unicorn_udp_simulator.py --mode bandpower --port 19746
+
+    # Exercise deterministic failures without opening a socket.
+    python examples/unicorn_udp_simulator.py --mode raw \
+        --fault-profile mixed-torture --dry-run-packets 200
+"""
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import socket
+import time
+
+from neuros.drivers import (
+    FAULT_PROFILES,
+    UnicornBandpowerUdpStreamSimulator,
+    UnicornRawUdpStreamSimulator,
+    decode_unicorn_bandpower_ascii,
+    decode_unicorn_udp_scan,
+    get_unicorn_udp_fault_profile,
+)
+
+
+def _build_stream(mode: str, seed: int, fault_profile: str, byte_order: str):
+    profile = get_unicorn_udp_fault_profile(fault_profile)
+    if mode == "raw":
+        return UnicornRawUdpStreamSimulator(seed=seed, fault_profile=profile, byte_order=byte_order)
+    return UnicornBandpowerUdpStreamSimulator(seed=seed, fault_profile=profile)
+
+
+def _dry_run(stream, mode: str, packets: int, byte_order: str) -> dict:
+    emitted = 0
+    source_updates = 0
+    duplicates = 0
+    reordered = 0
+    delayed = 0
+    counters: list[int] = []
+    while source_updates < packets:
+        datagrams = stream.next_datagrams()
+        source_updates += 1
+        for datagram in datagrams:
+            emitted += 1
+            duplicates += int(datagram.duplicate_ordinal > 0)
+            reordered += int(any(fault.startswith("reordered") for fault in datagram.faults))
+            delayed += int("delay" in datagram.faults)
+            if mode == "raw":
+                values = decode_unicorn_udp_scan(datagram.payload, byte_order=byte_order)
+                if values.shape != (17,):
+                    raise AssertionError("raw UDP payload did not decode to 17 values")
+                counters.append(int(round(float(values[15]))))
+            else:
+                values = decode_unicorn_bandpower_ascii(datagram.payload)
+                if values.shape != (70,):
+                    raise AssertionError("Bandpower UDP payload did not decode to 70 values")
+    for datagram in stream.flush():
+        emitted += 1
+        if mode == "raw":
+            values = decode_unicorn_udp_scan(datagram.payload, byte_order=byte_order)
+            counters.append(int(round(float(values[15]))))
+    return {
+        "schema": "neuros.unicorn_udp_simulator.dry_run.v1",
+        "mode": mode,
+        "source_updates": source_updates,
+        "emitted_datagrams": emitted,
+        "dropped_or_held_updates": source_updates - len(set(counters)) if mode == "raw" else None,
+        "duplicates": duplicates,
+        "reordered_datagrams": reordered,
+        "delayed_datagrams": delayed,
+        "first_counter": counters[0] if counters else None,
+        "last_counter": counters[-1] if counters else None,
+        "synthetic": True,
+        "evidence_boundary": "Interface/fault simulation only; not physical Bluetooth timing evidence.",
+    }
+
+
+def _run_live(stream, *, host: str, port: int, duration_s: float) -> None:
+    destination = (host, port)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    start = time.perf_counter()
+    next_source_deadline = start
+    pending: list[tuple[float, int, bytes]] = []
+    insertion_order = 0
+    sent = 0
+    source_updates = 0
+    try:
+        while True:
+            now = time.perf_counter()
+            if duration_s > 0 and now - start >= duration_s:
+                break
+
+            if now >= next_source_deadline:
+                for datagram in stream.next_datagrams():
+                    release_abs = start + datagram.release_time_s
+                    heapq.heappush(pending, (release_abs, insertion_order, datagram.payload))
+                    insertion_order += 1
+                source_updates += 1
+                next_source_deadline = start + source_updates * stream.interval_s
+
+            now = time.perf_counter()
+            while pending and pending[0][0] <= now:
+                _, _, payload = heapq.heappop(pending)
+                sock.sendto(payload, destination)
+                sent += 1
+
+            next_wakeup = next_source_deadline
+            if pending:
+                next_wakeup = min(next_wakeup, pending[0][0])
+            sleep_s = next_wakeup - time.perf_counter()
+            if sleep_s > 0:
+                time.sleep(min(sleep_s, 0.01))
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # Flush a packet held only because the process stopped between a reorder pair.
+        for datagram in stream.flush():
+            sock.sendto(datagram.payload, destination)
+            sent += 1
+        sock.close()
+        print(json.dumps({
+            "source_updates": source_updates,
+            "sent_datagrams": sent,
+            "destination": f"{host}:{port}",
+            "synthetic": True,
+        }, sort_keys=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("raw", "bandpower"), default="raw")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=19745)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--fault-profile", choices=tuple(sorted(FAULT_PROFILES)), default="pristine")
+    parser.add_argument("--byte-order", choices=("<", ">", "=", "!"), default="<")
+    parser.add_argument("--duration", type=float, default=0.0, help="Seconds; 0 runs until interrupted")
+    parser.add_argument("--dry-run-packets", type=int, default=0)
+    args = parser.parse_args()
+
+    if not 1 <= args.port <= 65535:
+        raise SystemExit("--port must be in [1, 65535]")
+    if args.duration < 0:
+        raise SystemExit("--duration must be non-negative")
+    if args.dry_run_packets < 0:
+        raise SystemExit("--dry-run-packets must be non-negative")
+
+    stream = _build_stream(args.mode, args.seed, args.fault_profile, args.byte_order)
+    cadence_hz = 1.0 / stream.interval_s
+    print(json.dumps({
+        "mode": args.mode,
+        "nominal_cadence_hz": cadence_hz,
+        "fault_profile": args.fault_profile,
+        "synthetic": True,
+        "transport_evidence_class": "synthetic_assumption",
+        "physical_radio_timing_claim": False,
+    }, sort_keys=True))
+
+    if args.dry_run_packets:
+        print(json.dumps(_dry_run(stream, args.mode, args.dry_run_packets, args.byte_order), sort_keys=True))
+        return
+    _run_live(stream, host=args.host, port=args.port, duration_s=args.duration)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ nav:
       - Four Public Surfaces: PLATFORM.md
       - Synthetic BCI Arena: SYNTHETIC_BCI_ARENA.md
       - EEG World Models: EEG_WORLD_MODELS.md
+      - Unicorn Hardware Substitution: UNICORN_HYBRID_BLACK_SIMULATION_SUITE.md
+      - Unicorn Game Development: UNICORN_GAME_DEVELOPMENT.md
       - Ecosystem Compatibility: COMPATIBILITY.md
       - NeuroAI Ecosystem: NEUROAI_ECOSYSTEM.md
       - Qualification Bundles: QUALIFICATION.md
@@ -92,6 +94,7 @@ nav:
       - Evaluation Protocol: neurotokenization/02_EVALUATION_PROTOCOL.md
       - Implementation Sprints: neurotokenization/03_IMPLEMENTATION_SPRINTS.md
   - SDK:
+      - Plugin Authoring: PLUGIN_AUTHORING.md
       - Neural Windows: NEURAL_WINDOWS.md
       - Braindecode: BRAINDECODE.md
       - API Surface: API_REFERENCE.md

--- a/packages/neuros-arena/src/neuros/arena/__init__.py
+++ b/packages/neuros-arena/src/neuros/arena/__init__.py
@@ -26,6 +26,7 @@ from .conformance import (
     check_transport_drop_monotonicity,
     search_counterexamples,
 )
+from .device_presets import unicorn_hybrid_black_eeg_profile
 from .evaluation import ArenaDecision, evaluate_decisions
 from .evidence import WorldModelEvidenceCard, evidence_card_for_model
 from .leadfield import LeadFieldDrivenWorldModel, export_mne_forward_bundle, save_leadfield_bundle
@@ -127,5 +128,6 @@ __all__ = [
     "save_recording_metadata",
     "search_counterexamples",
     "split_contiguous_recording",
+    "unicorn_hybrid_black_eeg_profile",
     "validate_covariance_anchor_held_out",
 ]

--- a/packages/neuros-arena/src/neuros/arena/device_presets.py
+++ b/packages/neuros-arena/src/neuros/arena/device_presets.py
@@ -1,0 +1,51 @@
+"""Canonical acquisition-device presets for Arena worlds.
+
+These presets encode published hardware constants while keeping environmental
+assumptions such as line noise, sensor noise, packet chunking, and clock error
+explicit at the call site.
+"""
+from __future__ import annotations
+
+from neuros.drivers.unicorn_hybrid_black_sim import UNICORN_SCALP_LABELS, UnicornHybridBlackSpec
+
+from .specs import DeviceProfile
+
+
+def unicorn_hybrid_black_eeg_profile(
+    *,
+    sensor_noise_uv: float = 0.0,
+    line_frequency_hz: float = 60.0,
+    line_noise_uv: float = 0.0,
+    clock_offset_ms: float = 0.0,
+    clock_drift_ppm: float = 0.0,
+    timestamp_jitter_ms: float = 0.0,
+    chunk_samples: int = 5,
+) -> DeviceProfile:
+    """Return an Arena EEG profile pinned to published Hybrid Black constants.
+
+    The returned profile models only the eight EEG channels because Arena's
+    neural-device layer operates on sensor-space EEG. Accelerometer, gyroscope,
+    battery, counter and validation channels live in the full
+    :class:`~neuros.drivers.unicorn_hybrid_black_sim.UnicornHybridBlackSimulator`
+    device twin.
+
+    ``sensor_noise_uv``, ``line_noise_uv``, clock terms and ``chunk_samples`` are
+    deliberately caller-controlled environment/runtime assumptions.  They are
+    not presented as manufacturer specifications.
+    """
+
+    spec = UnicornHybridBlackSpec()
+    return DeviceProfile(
+        name="unicorn-hybrid-black-eeg8",
+        sampling_rate_hz=spec.sampling_rate_hz,
+        channel_names=UNICORN_SCALP_LABELS,
+        adc_bits=spec.resolution_bits,
+        input_range_uv=spec.sensitivity_uv,
+        sensor_noise_uv=sensor_noise_uv,
+        line_frequency_hz=line_frequency_hz,
+        line_noise_uv=line_noise_uv,
+        clock_offset_ms=clock_offset_ms,
+        clock_drift_ppm=clock_drift_ppm,
+        timestamp_jitter_ms=timestamp_jitter_ms,
+        chunk_samples=chunk_samples,
+    )

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -65,6 +65,12 @@ from neuros.drivers.unicorn_receiver_guard import (  # noqa: F401
     UnicornRawUdpGuardState,
     UnicornRawUdpObservation,
 )
+from neuros.drivers.unicorn_trace import (  # noqa: F401
+    UnicornRawUdpTraceSummary,
+    UnicornTraceContractComparison,
+    analyze_unicorn_raw_udp_trace,
+    compare_unicorn_trace_to_nominal_contract,
+)
 from neuros.drivers.unicorn_transport_sim import (  # noqa: F401
     FAULT_PROFILES,
     DeterministicPacketFaultEngine,

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -59,6 +59,12 @@ from neuros.drivers.unicorn_network_sim import (  # noqa: F401
     encode_unicorn_udp_scan,
     raw_udp_scan_to_api17_order,
 )
+from neuros.drivers.unicorn_receiver_guard import (  # noqa: F401
+    UnicornRawUdpGuard,
+    UnicornRawUdpGuardConfig,
+    UnicornRawUdpGuardState,
+    UnicornRawUdpObservation,
+)
 from neuros.drivers.unicorn_transport_sim import (  # noqa: F401
     FAULT_PROFILES,
     DeterministicPacketFaultEngine,

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -59,6 +59,15 @@ from neuros.drivers.unicorn_network_sim import (  # noqa: F401
     encode_unicorn_udp_scan,
     raw_udp_scan_to_api17_order,
 )
+from neuros.drivers.unicorn_transport_sim import (  # noqa: F401
+    FAULT_PROFILES,
+    DeterministicPacketFaultEngine,
+    ScheduledDatagram,
+    UnicornBandpowerUdpStreamSimulator,
+    UnicornRawUdpStreamSimulator,
+    UnicornUdpFaultProfile,
+    get_unicorn_udp_fault_profile,
+)
 
 # additional drivers
 from neuros.drivers.dataset_driver import DatasetDriver  # noqa: F401

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -14,6 +14,51 @@ from neuros.drivers.synthetic_eeg import (  # noqa: F401
     SyntheticEEGGenerator,
 )
 from neuros.drivers.synthetic_eeg_driver import SyntheticEEGDriver  # noqa: F401
+from neuros.drivers.unicorn_api_sim import (  # noqa: F401
+    AmplifierChannelSim,
+    AmplifierConfigurationSim,
+    DeviceInformationSim,
+    UnicornApiSimError,
+    UnicornPythonApiSimulator,
+)
+from neuros.drivers.unicorn_compatibility import (  # noqa: F401
+    UnicornCompatibilityReport,
+    UnicornCompatibilitySurface,
+    run_unicorn_compatibility_suite,
+)
+from neuros.drivers.unicorn_hybrid_black_sim import (  # noqa: F401
+    UNICORN_ACCEL_NAMES,
+    UNICORN_AUX_NAMES,
+    UNICORN_DEVICE17_NAMES,
+    UNICORN_EEG_API_NAMES,
+    UNICORN_GYRO_NAMES,
+    UNICORN_RECORDER19_NAMES,
+    UNICORN_SCALP_LABELS,
+    UnicornConformanceReport,
+    UnicornHybridBlackBlock,
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+    UnicornHybridBlackSpec,
+    validate_unicorn_block,
+)
+from neuros.drivers.unicorn_network_sim import (  # noqa: F401
+    API_FROM_RAW_UDP_INDICES,
+    BANDPOWER_BANDS,
+    BANDPOWER_FEATURE_COUNT,
+    RAW_UDP_CHANNEL_COUNT,
+    RAW_UDP_FROM_API_INDICES,
+    RAW_UDP_PAYLOAD_BYTES,
+    UNICORN_RAW_UDP_NAMES,
+    BandpowerFrame,
+    UnicornBandpowerReferenceStream,
+    api17_scan_to_raw_udp_order,
+    compute_unicorn_bandpower_payload,
+    decode_unicorn_bandpower_ascii,
+    decode_unicorn_udp_scan,
+    encode_unicorn_bandpower_ascii,
+    encode_unicorn_udp_scan,
+    raw_udp_scan_to_api17_order,
+)
 
 # additional drivers
 from neuros.drivers.dataset_driver import DatasetDriver  # noqa: F401

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_api_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_api_sim.py
@@ -1,0 +1,231 @@
+"""Stateful high-level simulator for the Unicorn Hybrid Black API contract.
+
+The real Unicorn Python API exposes configuration, channel lookup, acquisition
+start/stop, test-signal mode, GetData, digital outputs and explicit device error
+conditions.  This module mirrors those *conceptual* contracts with Pythonic data
+objects so applications can exercise lifecycle and fail-closed behavior without
+physical hardware.
+
+It is not a binary-compatible replacement for g.tec's licensed Python/C/.NET
+libraries.  In particular, the manufacturer does not publicly specify enough
+information to reproduce the factory rectangular test signal numerically, so
+its frequency/amplitude are explicit simulator policy parameters.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Literal
+
+import numpy as np
+
+from .unicorn_hybrid_black_sim import (
+    UNICORN_DEVICE17_NAMES,
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+    UnicornHybridBlackSpec,
+)
+
+UnicornApiErrorCode = Literal[
+    "buffer_overflow",
+    "buffer_underflow",
+    "connection_problem",
+    "operation_not_allowed",
+    "invalid_configuration",
+]
+
+
+class UnicornApiSimError(RuntimeError):
+    def __init__(self, code: UnicornApiErrorCode, message: str | None = None) -> None:
+        self.code = code
+        super().__init__(message or code.replace("_", " "))
+
+
+@dataclass(frozen=True)
+class AmplifierChannelSim:
+    name: str
+    unit: str
+    range_min: float
+    range_max: float
+    enabled: bool = True
+
+
+@dataclass(frozen=True)
+class AmplifierConfigurationSim:
+    channels: tuple[AmplifierChannelSim, ...]
+
+    def with_channel(self, name: str, *, enabled: bool) -> "AmplifierConfigurationSim":
+        if name not in {channel.name for channel in self.channels}:
+            raise KeyError(name)
+        return AmplifierConfigurationSim(
+            tuple(replace(channel, enabled=enabled) if channel.name == name else channel for channel in self.channels)
+        )
+
+
+@dataclass(frozen=True)
+class DeviceInformationSim:
+    number_of_eeg_channels: int
+    serial: str
+    firmware_version: str = "synthetic"
+    device_version: str = "Unicorn Hybrid Black (simulated)"
+    pcb_version: str = "synthetic"
+    enclosure_version: str = "synthetic"
+
+
+class UnicornPythonApiSimulator:
+    """Pythonic lifecycle/configuration twin of the Unicorn API."""
+
+    def __init__(
+        self,
+        *,
+        serial: str = "SIM-UNICORN-0001",
+        seed: int = 7,
+        test_signal_frequency_hz: float = 5.0,
+        test_signal_amplitude_uv: float = 100.0,
+    ) -> None:
+        if not serial.startswith("SIM-"):
+            raise ValueError("synthetic serials must start with 'SIM-' to avoid physical-device ambiguity")
+        if test_signal_frequency_hz <= 0 or test_signal_amplitude_uv <= 0:
+            raise ValueError("test-signal policy parameters must be positive")
+        self.spec = UnicornHybridBlackSpec()
+        self.serial = serial
+        self.test_signal_frequency_hz = float(test_signal_frequency_hz)
+        self.test_signal_amplitude_uv = float(test_signal_amplitude_uv)
+        self.device = UnicornHybridBlackSimulator(
+            config=UnicornHybridBlackSimulationConfig(
+                schema="device17_api",
+                seed=seed,
+                accelerometer_noise_g=0.0,
+                gyroscope_noise_dps=0.0,
+            )
+        )
+        self.configuration = self._default_configuration()
+        self.acquiring = False
+        self.test_signal_enabled = False
+        self.digital_outputs = 0
+        self._next_error: UnicornApiErrorCode | None = None
+
+    def _default_configuration(self) -> AmplifierConfigurationSim:
+        units = (
+            ("microvolts",) * 8
+            + ("g",) * 3
+            + ("deg/s",) * 3
+            + ("count", "percent", "boolean")
+        )
+        ranges: list[tuple[float, float]] = []
+        for index, name in enumerate(UNICORN_DEVICE17_NAMES):
+            if index < 8:
+                ranges.append((-self.spec.sensitivity_uv, self.spec.sensitivity_uv))
+            elif 8 <= index < 14:
+                # Motion ranges are intentionally broad simulator bounds.  The
+                # device twin does not claim these are amplifier-channel specs.
+                ranges.append((-np.inf, np.inf))
+            elif name == "Battery Level":
+                ranges.append((0.0, 100.0))
+            elif name == "Validation Indicator":
+                ranges.append((0.0, 1.0))
+            else:
+                ranges.append((0.0, np.inf))
+        return AmplifierConfigurationSim(
+            tuple(
+                AmplifierChannelSim(name, unit, low, high, True)
+                for name, unit, (low, high) in zip(UNICORN_DEVICE17_NAMES, units, ranges, strict=True)
+            )
+        )
+
+    @staticmethod
+    def get_available_devices() -> list[str]:
+        return ["SIM-UNICORN-0001"]
+
+    def get_device_information(self) -> DeviceInformationSim:
+        return DeviceInformationSim(self.spec.eeg_channels, self.serial)
+
+    def get_configuration(self) -> AmplifierConfigurationSim:
+        return self.configuration
+
+    def set_configuration(self, configuration: AmplifierConfigurationSim) -> None:
+        if self.acquiring:
+            raise UnicornApiSimError("operation_not_allowed", "configuration cannot change during acquisition")
+        names = tuple(channel.name for channel in configuration.channels)
+        if names != UNICORN_DEVICE17_NAMES or len(set(names)) != 17:
+            raise UnicornApiSimError("invalid_configuration", "configuration must preserve the 17 known channels")
+        if not any(channel.enabled for channel in configuration.channels[:8]):
+            raise UnicornApiSimError("invalid_configuration", "at least one EEG channel must remain enabled")
+        self.configuration = configuration
+
+    def get_number_of_acquired_channels(self) -> int:
+        return sum(int(channel.enabled) for channel in self.configuration.channels)
+
+    def get_channel_index(self, name: str) -> int:
+        enabled = [channel.name for channel in self.configuration.channels if channel.enabled]
+        if name not in enabled:
+            raise KeyError(name)
+        return enabled.index(name)
+
+    def set_digital_outputs(self, value: int) -> None:
+        if not 0 <= int(value) <= 255:
+            raise ValueError("digital output state must fit in 8 bits")
+        self.digital_outputs = int(value)
+
+    def get_digital_outputs(self) -> int:
+        return self.digital_outputs
+
+    def start_acquisition(self, test_signal_enabled: bool = False) -> None:
+        if self.acquiring:
+            raise UnicornApiSimError("operation_not_allowed", "acquisition already started")
+        self.acquiring = True
+        self.test_signal_enabled = bool(test_signal_enabled)
+
+    def stop_acquisition(self) -> None:
+        if not self.acquiring:
+            raise UnicornApiSimError("operation_not_allowed", "acquisition is not running")
+        self.acquiring = False
+        self.test_signal_enabled = False
+
+    def inject_next_error(self, code: UnicornApiErrorCode) -> None:
+        if code not in {
+            "buffer_overflow",
+            "buffer_underflow",
+            "connection_problem",
+            "operation_not_allowed",
+            "invalid_configuration",
+        }:
+            raise ValueError(f"unsupported API error: {code}")
+        self._next_error = code
+
+    def _consume_error(self) -> None:
+        if self._next_error is None:
+            return
+        code = self._next_error
+        self._next_error = None
+        raise UnicornApiSimError(code)
+
+    def _test_signal(self, times_s: np.ndarray) -> np.ndarray:
+        # Transparent simulator policy only.  The current public API/Recorder
+        # documentation states that the hardware can emit a rectangular test
+        # signal but does not specify enough parameters for numerical cloning.
+        phase = np.sin(2.0 * np.pi * self.test_signal_frequency_hz * times_s)
+        square = np.where(phase >= 0.0, self.test_signal_amplitude_uv, -self.test_signal_amplitude_uv)
+        return np.repeat(square[None, :], 8, axis=0).astype(np.float32)
+
+    def get_data(self, number_of_scans: int) -> np.ndarray:
+        """Return scans × enabled-channels float32 data.
+
+        This Pythonic return value represents the same logical scans that the
+        physical API writes into a caller-provided float buffer.
+        """
+        if number_of_scans <= 0:
+            raise ValueError("number_of_scans must be positive")
+        if not self.acquiring:
+            raise UnicornApiSimError("operation_not_allowed", "start acquisition before reading data")
+        self._consume_error()
+        block = self.device.render(number_of_scans)
+        data = block.data.copy()
+        if self.test_signal_enabled:
+            data[:8] = self._test_signal(block.sample_timestamps_s)
+        enabled_indices = [index for index, channel in enumerate(self.configuration.channels) if channel.enabled]
+        return np.asarray(data[enabled_indices].T, dtype=np.float32)
+
+    def get_data_bytes(self, number_of_scans: int, *, byte_order: str = "<") -> bytes:
+        data = self.get_data(number_of_scans)
+        dtype = np.dtype(byte_order + "f4")
+        return np.asarray(data, dtype=dtype).tobytes(order="C")

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_compatibility.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_compatibility.py
@@ -236,12 +236,12 @@ def run_unicorn_compatibility_suite(*, seed: int = 7) -> UnicornCompatibilityRep
     delay = api17.available_timestamps_s - api17.sample_timestamps_s
     surfaces.append(_surface(
         "acquisition_availability_delay",
-        "exact_contract",
+        "reference_implementation",
         bool(np.allclose(delay, spec.device_delay_ms / 1000.0)),
         {
             "modeled_delay_ms": float(np.mean(delay) * 1000.0),
         },
-        "Models the documented approximately 40 ms compensation boundary; real hardware jitter/radio scheduling still require measurement.",
+        "Implements the documented approximately 40 ms g.Pype compensation reference. It does not assert exact physical Bluetooth delivery latency or jitter.",
     ))
 
     surfaces.append(_surface(

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_compatibility.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_compatibility.py
@@ -1,0 +1,259 @@
+"""Self-auditing Unicorn Hybrid Black compatibility suite.
+
+The goal is to make a statement such as "tested against the Unicorn simulator"
+inspectable. Each surface is tagged by evidence class:
+
+``exact_contract``
+    Public documentation specifies the shape/order/cadence strongly enough for
+    deterministic compatibility testing.
+
+``reference_implementation``
+    Public documentation specifies the interface/layout but not all numerical
+    internals. neurOS provides a transparent reference implementation without
+    claiming numerical identity.
+
+``synthetic_assumption``
+    A useful stress-model policy that is intentionally not attributed to the
+    manufacturer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .unicorn_api_sim import UnicornApiSimError, UnicornPythonApiSimulator
+from .unicorn_hybrid_black_sim import (
+    UNICORN_DEVICE17_NAMES,
+    UNICORN_RECORDER19_NAMES,
+    UNICORN_SCALP_LABELS,
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+    UnicornHybridBlackSpec,
+    validate_unicorn_block,
+)
+from .unicorn_network_sim import (
+    BANDPOWER_FEATURE_COUNT,
+    RAW_UDP_PAYLOAD_BYTES,
+    UNICORN_RAW_UDP_NAMES,
+    UnicornBandpowerReferenceStream,
+    decode_unicorn_udp_scan,
+    encode_unicorn_udp_scan,
+)
+
+EvidenceClass = Literal["exact_contract", "reference_implementation", "synthetic_assumption"]
+
+
+@dataclass(frozen=True)
+class UnicornCompatibilitySurface:
+    name: str
+    evidence_class: EvidenceClass
+    passed: bool
+    observations: dict[str, object]
+    boundary: str
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "evidence_class": self.evidence_class,
+            "passed": self.passed,
+            "observations": dict(self.observations),
+            "boundary": self.boundary,
+        }
+
+
+@dataclass(frozen=True)
+class UnicornCompatibilityReport:
+    surfaces: tuple[UnicornCompatibilitySurface, ...]
+    device: str = "Unicorn Hybrid Black"
+    synthetic: bool = True
+
+    @property
+    def passed(self) -> bool:
+        return all(surface.passed for surface in self.surfaces)
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.unicorn_hybrid_black_sim.compatibility.v1",
+            "device": self.device,
+            "synthetic": self.synthetic,
+            "passed": self.passed,
+            "surfaces": [surface.to_dict() for surface in self.surfaces],
+            "evidence_boundary": (
+                "Synthetic device/interface compatibility only. This report cannot qualify Bluetooth radio behavior, "
+                "physical electrode contact, actual Unicorn firmware, proprietary Bandpower numerics, or human EEG performance."
+            ),
+        }
+
+
+def _surface(
+    name: str,
+    evidence_class: EvidenceClass,
+    passed: bool,
+    observations: dict[str, object],
+    boundary: str,
+) -> UnicornCompatibilitySurface:
+    return UnicornCompatibilitySurface(name, evidence_class, bool(passed), observations, boundary)
+
+
+def run_unicorn_compatibility_suite(*, seed: int = 7) -> UnicornCompatibilityReport:
+    """Exercise the dependency-light published-interface contracts end to end."""
+
+    spec = UnicornHybridBlackSpec()
+    surfaces: list[UnicornCompatibilitySurface] = []
+
+    eeg8 = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(schema="eeg8_anatomical", seed=seed)
+    ).render(50)
+    eeg8_report = validate_unicorn_block(eeg8)
+    surfaces.append(_surface(
+        "eeg8_anatomical",
+        "exact_contract",
+        eeg8_report.passed and eeg8.channel_names == UNICORN_SCALP_LABELS,
+        {
+            "channels": len(eeg8.channel_names),
+            "sampling_rate_hz": spec.sampling_rate_hz,
+            "resolution_bits": spec.resolution_bits,
+            "sensitivity_uv": spec.sensitivity_uv,
+            "eeg_lsb_uv": eeg8.lsb_uv,
+        },
+        "Published acquisition envelope plus the standard cap montage used by neurOS; does not assert subject physiology.",
+    ))
+
+    api_device = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(
+            schema="device17_api",
+            seed=seed + 1,
+            accelerometer_noise_g=0.0,
+            gyroscope_noise_dps=0.0,
+            counter_start=44,
+            battery_start_percent=81.0,
+        )
+    )
+    api_device.set_motion((0.0, 0.0, 1.0), (0.0, 0.0, 0.0))
+    api17 = api_device.render(20)
+    api17_report = validate_unicorn_block(api17)
+    surfaces.append(_surface(
+        "direct_api17_scan",
+        "exact_contract",
+        api17_report.passed and api17.channel_names == UNICORN_DEVICE17_NAMES,
+        {
+            "channels": len(api17.channel_names),
+            "tail": list(api17.channel_names[-3:]),
+            "counter_first": int(api17.counter[0]),
+        },
+        "Mirrors documented acquired-channel order and lifecycle semantics, not the licensed g.tec binary API implementation.",
+    ))
+
+    udp_payload = encode_unicorn_udp_scan(api17, 0)
+    udp_values = decode_unicorn_udp_scan(udp_payload)
+    udp_order_ok = (
+        len(udp_payload) == RAW_UDP_PAYLOAD_BYTES
+        and tuple(UNICORN_RAW_UDP_NAMES[-3:]) == ("BAT", "CNT", "VALID")
+        and np.isclose(udp_values[14], api17.data[15, 0])
+        and np.isclose(udp_values[15], api17.data[14, 0])
+        and np.isclose(udp_values[16], api17.data[16, 0])
+    )
+    surfaces.append(_surface(
+        "raw_udp17_wire",
+        "exact_contract",
+        udp_order_ok,
+        {
+            "payload_bytes": len(udp_payload),
+            "channels": len(udp_values),
+            "auxiliary_tail": list(UNICORN_RAW_UDP_NAMES[-3:]),
+            "nominal_rate_hz": spec.sampling_rate_hz,
+        },
+        "Wire shape/order/rate are compatibility targets; byte order defaults to little-endian because public docs do not explicitly specify it.",
+    ))
+
+    recorder = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(schema="recorder19", seed=seed + 2)
+    ).render(20)
+    recorder_report = validate_unicorn_block(recorder)
+    surfaces.append(_surface(
+        "recorder19_fields",
+        "exact_contract",
+        recorder_report.passed and recorder.channel_names == UNICORN_RECORDER19_NAMES,
+        {
+            "fields": len(recorder.channel_names),
+            "tail": list(recorder.channel_names[-5:]),
+            "delta_time_ms": float(recorder.data[17, 0]),
+        },
+        "Matches documented Recorder/network field layout; file-format/GUI behavior is outside this dependency-light contract.",
+    ))
+
+    api = UnicornPythonApiSimulator(seed=seed + 3)
+    api.start_acquisition(False)
+    normal = api.get_data(5)
+    api.inject_next_error("buffer_underflow")
+    underflow_seen = False
+    try:
+        api.get_data(5)
+    except UnicornApiSimError as exc:
+        underflow_seen = exc.code == "buffer_underflow"
+    recovered = api.get_data(5)
+    api.stop_acquisition()
+    surfaces.append(_surface(
+        "python_api_lifecycle",
+        "exact_contract",
+        normal.shape == (5, 17) and recovered.shape == (5, 17) and underflow_seen,
+        {
+            "acquired_channels": normal.shape[1],
+            "underflow_injection_observed": underflow_seen,
+            "digital_output_bits": 8,
+        },
+        "Conceptual API/lifecycle/error semantics only; not a binary-compatible replacement for the licensed Unicorn API.",
+    ))
+
+    band = UnicornBandpowerReferenceStream()
+    t = np.arange(280, dtype=float) / spec.sampling_rate_hz
+    eeg = np.vstack([np.sin(2.0 * np.pi * (8.0 + 0.5 * index) * t) for index in range(8)])
+    frames = band.push(eeg)
+    band_ok = (
+        band.buffer_size == 250
+        and band.buffer_overlap == 240
+        and band.hop_samples == 10
+        and band.update_rate_hz == 25.0
+        and len(frames) == 4
+        and all(frame.values.shape == (BANDPOWER_FEATURE_COUNT,) for frame in frames)
+    )
+    surfaces.append(_surface(
+        "bandpower70_reference",
+        "reference_implementation",
+        band_ok,
+        {
+            "feature_count": BANDPOWER_FEATURE_COUNT,
+            "buffer_samples": band.buffer_size,
+            "overlap_samples": band.buffer_overlap,
+            "update_rate_hz": band.update_rate_hz,
+            "frames_from_280_samples": len(frames),
+        },
+        "Layout/bands/cadence match public documentation; numerical spectral estimator is neurOS reference code, not proprietary parity.",
+    ))
+
+    delay = api17.available_timestamps_s - api17.sample_timestamps_s
+    surfaces.append(_surface(
+        "acquisition_availability_delay",
+        "exact_contract",
+        bool(np.allclose(delay, spec.device_delay_ms / 1000.0)),
+        {
+            "modeled_delay_ms": float(np.mean(delay) * 1000.0),
+        },
+        "Models the documented approximately 40 ms compensation boundary; real hardware jitter/radio scheduling still require measurement.",
+    ))
+
+    surfaces.append(_surface(
+        "motion_and_battery_stress_policy",
+        "synthetic_assumption",
+        True,
+        {
+            "accelerometer_channels": spec.accelerometer_channels,
+            "gyroscope_channels": spec.gyroscope_channels,
+            "published_minimum_battery_hours": spec.minimum_published_battery_hours,
+        },
+        "Channel existence and minimum battery-duration provenance are published; sensor noise and discharge curves are explicit synthetic stress policies.",
+    ))
+
+    return UnicornCompatibilityReport(tuple(surfaces))

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_compatibility.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_compatibility.py
@@ -15,6 +15,11 @@ inspectable. Each surface is tagged by evidence class:
 ``synthetic_assumption``
     A useful stress-model policy that is intentionally not attributed to the
     manufacturer.
+
+Compatibility receipts also embed the exact upstream documentation snapshot used
+for those classifications. Public vendor documentation can change independently
+of neurOS; a historical receipt therefore needs to say which source revision or
+retrieval snapshot justified the contract at the time it was produced.
 """
 from __future__ import annotations
 
@@ -43,6 +48,101 @@ from .unicorn_network_sim import (
 )
 
 EvidenceClass = Literal["exact_contract", "reference_implementation", "synthetic_assumption"]
+
+
+@dataclass(frozen=True)
+class UnicornUpstreamReference:
+    """One auditable upstream source supporting the compatibility classification."""
+
+    reference_id: str
+    authority: str
+    title: str
+    locator: str
+    revision: str
+    retrieved_date: str
+    supports: tuple[str, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "reference_id": self.reference_id,
+            "authority": self.authority,
+            "title": self.title,
+            "locator": self.locator,
+            "revision": self.revision,
+            "retrieved_date": self.retrieved_date,
+            "supports": list(self.supports),
+        }
+
+
+# This snapshot is intentionally explicit rather than dynamically fetched at
+# runtime. A compatibility result should remain reproducible even if a vendor
+# edits a web page or moves a repository after the result was generated.
+UNICORN_UPSTREAM_CONTRACT_SNAPSHOT: tuple[UnicornUpstreamReference, ...] = (
+    UnicornUpstreamReference(
+        reference_id="gtec-hybrid-black-product-2026-08-26",
+        authority="g.tec medical engineering GmbH",
+        title="Unicorn Hybrid Black technical specifications",
+        locator="https://www.gtec.at/product/unicorn-hybrid-black-bci-platform/",
+        revision="retrieved:2026-08-26",
+        retrieved_date="2026-08-26",
+        supports=(
+            "eeg8_anatomical",
+            "direct_api17_scan",
+            "motion_and_battery_stress_policy",
+        ),
+    ),
+    UnicornUpstreamReference(
+        reference_id="unicorn-python-api-reference",
+        authority="unicorn-bi / g.tec medical engineering GmbH",
+        title="Unicorn Hybrid Black Windows Python API reference",
+        locator=(
+            "https://github.com/unicorn-bi/Unicorn-Hybrid-Black-Windows-APIs/"
+            "blob/main/python-api/unicorn-python-api-reference.md"
+        ),
+        revision="git-blob:9c34d49be17e1b147a2e05c2ec7c058d36d9b848",
+        retrieved_date="2026-08-26",
+        supports=("direct_api17_scan", "python_api_lifecycle"),
+    ),
+    UnicornUpstreamReference(
+        reference_id="unicorn-raw-udp-interface",
+        authority="unicorn-bi / g.tec medical engineering GmbH",
+        title="Unicorn Network Interfaces Hybrid Black raw UDP contract",
+        locator=(
+            "https://github.com/unicorn-bi/Unicorn-Network-Interfaces-Hybrid-Black/"
+            "blob/main/UDP/unicorn-udp-interface.md"
+        ),
+        revision="git-blob:c69de6cf17d88434acf71c96cb1752070199cdfc",
+        retrieved_date="2026-08-26",
+        supports=("raw_udp17_wire",),
+    ),
+    UnicornUpstreamReference(
+        reference_id="unicorn-recorder-hybrid-black",
+        authority="unicorn-bi / g.tec medical engineering GmbH",
+        title="Unicorn Recorder Hybrid Black acquisition/network contract",
+        locator="https://github.com/unicorn-bi/Unicorn-Recorder-Hybrid-Black/blob/main/README.md",
+        revision="git-blob:1e99c71cc7f7699ea8a1443a1928dc35674a9830",
+        retrieved_date="2026-08-26",
+        supports=("recorder19_fields",),
+    ),
+    UnicornUpstreamReference(
+        reference_id="unicorn-bandpower-hybrid-black",
+        authority="unicorn-bi / g.tec medical engineering GmbH",
+        title="Unicorn Bandpower Hybrid Black UDP payload and cadence contract",
+        locator="https://github.com/unicorn-bi/Unicorn-Bandpower-Hybrid-Black/blob/main/README.md",
+        revision="git-blob:3576791793bf169a35ae7c72fd2d4d880c154165",
+        retrieved_date="2026-08-26",
+        supports=("bandpower70_reference",),
+    ),
+    UnicornUpstreamReference(
+        reference_id="gpype-hybrid-black-3.0.9",
+        authority="g.tec medical engineering GmbH",
+        title="g.Pype HybridBlack source documentation",
+        locator="https://gpype.gtec.at/content/7_sdk_reference/backend_sources/hybrid_black.html",
+        revision="g.Pype-docs:3.0.9;retrieved:2026-08-26",
+        retrieved_date="2026-08-26",
+        supports=("direct_api17_scan", "acquisition_availability_delay"),
+    ),
+)
 
 
 @dataclass(frozen=True)
@@ -80,6 +180,9 @@ class UnicornCompatibilityReport:
             "synthetic": self.synthetic,
             "passed": self.passed,
             "surfaces": [surface.to_dict() for surface in self.surfaces],
+            "upstream_contract_snapshot": [
+                reference.to_dict() for reference in UNICORN_UPSTREAM_CONTRACT_SNAPSHOT
+            ],
             "evidence_boundary": (
                 "Synthetic device/interface compatibility only. This report cannot qualify Bluetooth radio behavior, "
                 "physical electrode contact, actual Unicorn firmware, proprietary Bandpower numerics, or human EEG performance."

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_hybrid_black_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_hybrid_black_sim.py
@@ -1,0 +1,382 @@
+"""Device-faithful Unicorn Hybrid Black simulation contracts.
+
+This module models the *acquisition/interface behavior* of the Unicorn Hybrid
+Black around an EEG source.  It deliberately does not claim to be a human
+physiology simulator.  Neural voltages come from ``SyntheticEEGGenerator`` (or,
+in higher-level Arena integrations, another world model); this layer adds the
+hardware-facing channel schemas, quantization/clipping envelope, motion/auxiliary
+telemetry, counter continuity, battery state, validation state, and acquisition
+availability timing that BCI applications need to exercise before hardware is
+available.
+
+Specification constants are intentionally restricted to values published by
+current g.tec/Unicorn documentation:
+
+* 8 EEG channels at 250 Hz;
+* 24-bit resolution;
+* sensitivity ±750 mV;
+* input impedance >1 GOhm (recorded here as a lower bound, not simulated as an
+  impedance measurement);
+* 3-axis accelerometer and 3-axis gyroscope;
+* acquired auxiliary counter, battery and validation channels;
+* about 40 ms device-delay compensation in g.Pype's HybridBlack source.
+
+The Recorder/network 19-field view additionally exposes delta-time and status /
+trigger fields.  Those two fields are application/interface products rather than
+extra amplifier electrodes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+
+UnicornSchema = Literal["eeg8_anatomical", "device17_api", "recorder19"]
+
+UNICORN_EEG_API_NAMES = tuple(f"EEG {index}" for index in range(1, 9))
+UNICORN_SCALP_LABELS = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+UNICORN_ACCEL_NAMES = ("Accelerometer X", "Accelerometer Y", "Accelerometer Z")
+UNICORN_GYRO_NAMES = ("Gyroscope X", "Gyroscope Y", "Gyroscope Z")
+UNICORN_AUX_NAMES = ("Counter", "Battery Level", "Validation Indicator")
+UNICORN_DEVICE17_NAMES = UNICORN_EEG_API_NAMES + UNICORN_ACCEL_NAMES + UNICORN_GYRO_NAMES + UNICORN_AUX_NAMES
+UNICORN_RECORDER19_NAMES = (
+    UNICORN_EEG_API_NAMES
+    + ("ACC X", "ACC Y", "ACC Z")
+    + ("GYR X", "GYR Y", "GYR Z")
+    + ("CNT", "BAT", "VALID", "DT", "STATUS")
+)
+
+
+@dataclass(frozen=True)
+class UnicornHybridBlackSpec:
+    """Published device constants used by the simulator.
+
+    ``input_impedance_lower_bound_ohm`` is descriptive provenance only.  The
+    physical headset specification states >1 GOhm; the simulator does not claim
+    to infer or reproduce electrode-skin impedance.
+    """
+
+    sampling_rate_hz: float = 250.0
+    eeg_channels: int = 8
+    resolution_bits: int = 24
+    sensitivity_uv: float = 750_000.0
+    input_impedance_lower_bound_ohm: float = 1_000_000_000.0
+    accelerometer_channels: int = 3
+    gyroscope_channels: int = 3
+    acquired_channels: int = 17
+    device_delay_ms: float = 40.0
+    minimum_published_battery_hours: float = 3.0
+
+    @property
+    def eeg_lsb_uv(self) -> float:
+        return 2.0 * self.sensitivity_uv / float(2**self.resolution_bits - 1)
+
+    def validate(self) -> None:
+        if self.sampling_rate_hz != 250.0:
+            raise ValueError("Unicorn Hybrid Black simulation is fixed at 250 Hz")
+        if self.eeg_channels != 8 or self.acquired_channels != 17:
+            raise ValueError("Unicorn Hybrid Black channel-count constants are fixed")
+        if self.resolution_bits != 24:
+            raise ValueError("Unicorn Hybrid Black resolution is fixed at 24 bits")
+        if self.sensitivity_uv <= 0 or self.device_delay_ms < 0:
+            raise ValueError("invalid Unicorn hardware constants")
+
+
+@dataclass(frozen=True)
+class UnicornHybridBlackSimulationConfig:
+    """Simulation policy around the published hardware contract.
+
+    Parameters such as battery discharge shape and motion-sensor noise are
+    explicit *stress-model assumptions*, not manufacturer specifications.
+    """
+
+    schema: UnicornSchema = "device17_api"
+    seed: int = 7
+    battery_start_percent: float = 100.0
+    battery_runtime_hours: float = 3.0
+    accelerometer_noise_g: float = 0.002
+    gyroscope_noise_dps: float = 0.05
+    acquisition_delay_jitter_ms: float = 0.0
+    counter_start: int = 0
+    validation_default: int = 1
+    status_default: int = 0
+
+    def validate(self) -> None:
+        if self.schema not in {"eeg8_anatomical", "device17_api", "recorder19"}:
+            raise ValueError(f"unsupported Unicorn schema: {self.schema!r}")
+        if not 0.0 <= self.battery_start_percent <= 100.0:
+            raise ValueError("battery_start_percent must be in [0, 100]")
+        if self.battery_runtime_hours <= 0:
+            raise ValueError("battery_runtime_hours must be positive")
+        if self.accelerometer_noise_g < 0 or self.gyroscope_noise_dps < 0:
+            raise ValueError("motion-sensor noise must be non-negative")
+        if self.acquisition_delay_jitter_ms < 0:
+            raise ValueError("acquisition_delay_jitter_ms must be non-negative")
+        if self.validation_default not in {0, 1}:
+            raise ValueError("validation_default must be 0 or 1")
+
+
+@dataclass(frozen=True)
+class UnicornHybridBlackBlock:
+    """One simulated acquisition block.
+
+    ``sample_timestamps_s`` represent causal sample times. ``available_timestamps_s``
+    represent when those samples become available to host software after the
+    configured device-delay model.  Keeping these separate prevents a transport
+    latency from silently becoming a neural timestamp.
+    """
+
+    data: np.ndarray
+    channel_names: tuple[str, ...]
+    channel_units: tuple[str, ...]
+    sample_timestamps_s: np.ndarray
+    available_timestamps_s: np.ndarray
+    eeg_data_uv: np.ndarray
+    counter: np.ndarray
+    battery_percent: np.ndarray
+    validation: np.ndarray
+    status: np.ndarray
+    clipped_fraction: float
+    lsb_uv: float
+    schema: UnicornSchema
+    synthetic: bool = True
+    emulated_device: str = "Unicorn Hybrid Black"
+
+
+@dataclass(frozen=True)
+class UnicornConformanceReport:
+    """Dependency-light structural conformance report for a simulated block."""
+
+    passed: bool
+    checks: dict[str, bool]
+    metrics: dict[str, float]
+    evidence_boundary: str = (
+        "Device/interface simulation conformance only; not physical-hardware or human-EEG validation."
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.unicorn_hybrid_black_sim.conformance.v1",
+            "passed": self.passed,
+            "checks": dict(self.checks),
+            "metrics": dict(self.metrics),
+            "evidence_boundary": self.evidence_boundary,
+        }
+
+
+class UnicornHybridBlackSimulator:
+    """Synthetic EEG wrapped in a Unicorn Hybrid Black acquisition contract."""
+
+    def __init__(
+        self,
+        eeg_generator: SyntheticEEGGenerator | None = None,
+        *,
+        config: UnicornHybridBlackSimulationConfig | None = None,
+        spec: UnicornHybridBlackSpec | None = None,
+    ) -> None:
+        self.spec = spec or UnicornHybridBlackSpec()
+        self.spec.validate()
+        self.config = config or UnicornHybridBlackSimulationConfig()
+        self.config.validate()
+        if eeg_generator is None:
+            eeg_generator = SyntheticEEGGenerator(
+                SyntheticEEGConfig(
+                    sampling_rate_hz=self.spec.sampling_rate_hz,
+                    channel_names=UNICORN_SCALP_LABELS,
+                    seed=self.config.seed,
+                )
+            )
+        if tuple(eeg_generator.config.channel_names) != UNICORN_SCALP_LABELS:
+            raise ValueError(
+                "Unicorn simulator expects the standard Fz/C3/Cz/C4/Pz/PO7/Oz/PO8 source montage"
+            )
+        if float(eeg_generator.config.sampling_rate_hz) != self.spec.sampling_rate_hz:
+            raise ValueError("Unicorn simulator source must run at 250 Hz")
+        self.eeg = eeg_generator
+        self.rng = np.random.default_rng(self.config.seed + 6011)
+        self.accel_g = np.asarray([0.0, 0.0, 1.0], dtype=float)
+        self.gyro_dps = np.zeros(3, dtype=float)
+        self.validation_value = int(self.config.validation_default)
+        self.status_value = int(self.config.status_default)
+        self.counter_value = int(self.config.counter_start)
+
+    @property
+    def schema(self) -> UnicornSchema:
+        return self.config.schema
+
+    def set_motion(self, accel_xyz_g: tuple[float, float, float], gyro_xyz_dps: tuple[float, float, float]) -> None:
+        accel = np.asarray(accel_xyz_g, dtype=float)
+        gyro = np.asarray(gyro_xyz_dps, dtype=float)
+        if accel.shape != (3,) or gyro.shape != (3,) or not np.all(np.isfinite(accel)) or not np.all(np.isfinite(gyro)):
+            raise ValueError("motion vectors must contain three finite values")
+        self.accel_g = accel
+        self.gyro_dps = gyro
+
+    def set_validation(self, value: int) -> None:
+        if value not in {0, 1}:
+            raise ValueError("validation indicator must be 0 or 1")
+        self.validation_value = int(value)
+
+    def set_status(self, value: int) -> None:
+        self.status_value = int(value)
+
+    def _quantize_eeg(self, eeg_uv: np.ndarray) -> tuple[np.ndarray, float]:
+        half_range = self.spec.sensitivity_uv
+        clipped_mask = np.abs(eeg_uv) > half_range
+        clipped = np.clip(np.asarray(eeg_uv, dtype=float), -half_range, half_range)
+        lsb = self.spec.eeg_lsb_uv
+        quantized = np.round((clipped + half_range) / lsb) * lsb - half_range
+        return quantized.astype(np.float32), float(np.mean(clipped_mask))
+
+    def _battery(self, sample_times_s: np.ndarray) -> np.ndarray:
+        runtime_s = self.config.battery_runtime_hours * 3600.0
+        elapsed = np.maximum(0.0, np.asarray(sample_times_s, dtype=float))
+        fraction = np.clip(elapsed / runtime_s, 0.0, 1.0)
+        return np.maximum(0.0, self.config.battery_start_percent * (1.0 - fraction))
+
+    def _availability(self, sample_times_s: np.ndarray) -> np.ndarray:
+        base = np.asarray(sample_times_s, dtype=float) + self.spec.device_delay_ms / 1000.0
+        if self.config.acquisition_delay_jitter_ms <= 0:
+            return base
+        jitter = self.rng.normal(0.0, self.config.acquisition_delay_jitter_ms / 1000.0, size=base.size)
+        return base + jitter
+
+    def _motion(self, samples: int) -> tuple[np.ndarray, np.ndarray]:
+        accel = np.repeat(self.accel_g[:, None], samples, axis=1)
+        gyro = np.repeat(self.gyro_dps[:, None], samples, axis=1)
+        if self.config.accelerometer_noise_g:
+            accel += self.rng.normal(0.0, self.config.accelerometer_noise_g, size=accel.shape)
+        if self.config.gyroscope_noise_dps:
+            gyro += self.rng.normal(0.0, self.config.gyroscope_noise_dps, size=gyro.shape)
+        return accel.astype(np.float32), gyro.astype(np.float32)
+
+    def render(self, samples: int) -> UnicornHybridBlackBlock:
+        if samples <= 0:
+            raise ValueError("samples must be positive")
+        source = self.eeg.render(samples)
+        eeg_uv, clipped_fraction = self._quantize_eeg(source.data_uv)
+        times = np.asarray(source.timestamps_s, dtype=float)
+        available = self._availability(times)
+        accel, gyro = self._motion(samples)
+        counter = self.counter_value + np.arange(samples, dtype=np.int64)
+        self.counter_value += samples
+        battery = self._battery(times).astype(np.float32)
+        validation = np.full(samples, self.validation_value, dtype=np.float32)
+        status = np.full(samples, self.status_value, dtype=np.float32)
+
+        if self.schema == "eeg8_anatomical":
+            data = eeg_uv
+            names = UNICORN_SCALP_LABELS
+            units = ("microvolts",) * 8
+        elif self.schema == "device17_api":
+            data = np.vstack(
+                [
+                    eeg_uv,
+                    accel,
+                    gyro,
+                    counter.astype(np.float32)[None, :],
+                    battery[None, :],
+                    validation[None, :],
+                ]
+            )
+            names = UNICORN_DEVICE17_NAMES
+            units = (
+                ("microvolts",) * 8
+                + ("g",) * 3
+                + ("deg/s",) * 3
+                + ("count", "percent", "boolean")
+            )
+        else:
+            delta_ms = np.full(samples, 1000.0 / self.spec.sampling_rate_hz, dtype=np.float32)
+            data = np.vstack(
+                [
+                    eeg_uv,
+                    accel,
+                    gyro,
+                    counter.astype(np.float32)[None, :],
+                    battery[None, :],
+                    validation[None, :],
+                    delta_ms[None, :],
+                    status[None, :],
+                ]
+            )
+            names = UNICORN_RECORDER19_NAMES
+            units = (
+                ("microvolts",) * 8
+                + ("g",) * 3
+                + ("deg/s",) * 3
+                + ("count", "percent", "boolean", "ms", "code")
+            )
+
+        return UnicornHybridBlackBlock(
+            data=np.asarray(data, dtype=np.float32),
+            channel_names=tuple(names),
+            channel_units=tuple(units),
+            sample_timestamps_s=times,
+            available_timestamps_s=available,
+            eeg_data_uv=eeg_uv,
+            counter=counter,
+            battery_percent=battery,
+            validation=validation,
+            status=status,
+            clipped_fraction=clipped_fraction,
+            lsb_uv=self.spec.eeg_lsb_uv,
+            schema=self.schema,
+        )
+
+
+def validate_unicorn_block(
+    block: UnicornHybridBlackBlock,
+    *,
+    spec: UnicornHybridBlackSpec | None = None,
+) -> UnicornConformanceReport:
+    """Validate observable invariants of one simulated acquisition block."""
+
+    device = spec or UnicornHybridBlackSpec()
+    samples = int(block.data.shape[1]) if block.data.ndim == 2 else 0
+    expected_channels = {
+        "eeg8_anatomical": 8,
+        "device17_api": 17,
+        "recorder19": 19,
+    }[block.schema]
+    if samples > 1:
+        sample_dt = np.diff(block.sample_timestamps_s)
+        available_delay_ms = (block.available_timestamps_s - block.sample_timestamps_s) * 1000.0
+        mean_rate = 1.0 / float(np.mean(sample_dt))
+        counter_continuity = bool(np.all(np.diff(block.counter) == 1))
+        mean_delay = float(np.mean(available_delay_ms))
+    else:
+        mean_rate = device.sampling_rate_hz
+        counter_continuity = True
+        mean_delay = float(np.mean((block.available_timestamps_s - block.sample_timestamps_s) * 1000.0)) if samples else 0.0
+    checks = {
+        "two_dimensional_samples": block.data.ndim == 2 and samples > 0,
+        "expected_channel_count": block.data.ndim == 2 and block.data.shape[0] == expected_channels,
+        "channel_metadata_count": len(block.channel_names) == expected_channels and len(block.channel_units) == expected_channels,
+        "250hz_sample_clock": abs(mean_rate - device.sampling_rate_hz) < 1e-6,
+        "counter_continuity": counter_continuity,
+        "battery_range": bool(np.all((block.battery_percent >= 0.0) & (block.battery_percent <= 100.0))),
+        "validation_binary": bool(np.all(np.isin(block.validation, [0.0, 1.0]))),
+        "eeg_within_sensitivity": bool(np.all(np.abs(block.eeg_data_uv) <= device.sensitivity_uv + block.lsb_uv)),
+        "published_quantization_lsb": abs(block.lsb_uv - device.eeg_lsb_uv) < 1e-12,
+        "availability_not_before_sample": bool(np.all(block.available_timestamps_s >= block.sample_timestamps_s)),
+    }
+    if block.schema == "device17_api":
+        checks["api_channel_order"] = block.channel_names == UNICORN_DEVICE17_NAMES
+    elif block.schema == "recorder19":
+        checks["recorder_channel_order"] = block.channel_names == UNICORN_RECORDER19_NAMES
+        checks["recorder_delta_time"] = bool(np.allclose(block.data[17], 4.0, atol=1e-6))
+    else:
+        checks["anatomical_eeg_order"] = block.channel_names == UNICORN_SCALP_LABELS
+    metrics = {
+        "observed_sampling_rate_hz": float(mean_rate),
+        "mean_availability_delay_ms": mean_delay,
+        "eeg_lsb_uv": float(block.lsb_uv),
+        "clipped_fraction": float(block.clipped_fraction),
+        "battery_min_percent": float(np.min(block.battery_percent)) if samples else 0.0,
+        "battery_max_percent": float(np.max(block.battery_percent)) if samples else 0.0,
+    }
+    return UnicornConformanceReport(passed=all(checks.values()), checks=checks, metrics=metrics)

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_network_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_network_sim.py
@@ -51,7 +51,6 @@ API_FROM_RAW_UDP_INDICES = RAW_UDP_FROM_API_INDICES  # the swap is its own inver
 
 def api17_scan_to_raw_udp_order(values: np.ndarray) -> np.ndarray:
     """Reorder one API17 scan into the standalone raw-UDP field order."""
-
     scan = np.asarray(values, dtype=np.float32)
     if scan.shape != (RAW_UDP_CHANNEL_COUNT,):
         raise ValueError("API17 scan must contain exactly 17 values")
@@ -60,7 +59,6 @@ def api17_scan_to_raw_udp_order(values: np.ndarray) -> np.ndarray:
 
 def raw_udp_scan_to_api17_order(values: np.ndarray) -> np.ndarray:
     """Reorder one raw-UDP scan back into direct API17 acquisition order."""
-
     scan = np.asarray(values, dtype=np.float32)
     if scan.shape != (RAW_UDP_CHANNEL_COUNT,):
         raise ValueError("raw UDP scan must contain exactly 17 values")
@@ -80,7 +78,6 @@ def encode_unicorn_udp_scan(
     endian representation matches the Windows/x86 environment of Unicorn Suite;
     callers can override it when testing defensive receivers.
     """
-
     if block.schema != "device17_api":
         raise ValueError("raw Unicorn UDP requires a device17_api block")
     if block.data.shape[0] != RAW_UDP_CHANNEL_COUNT:
@@ -102,23 +99,36 @@ def decode_unicorn_udp_scan(payload: bytes, *, byte_order: str = "<") -> np.ndar
     Use :func:`raw_udp_scan_to_api17_order` if downstream code expects the
     direct API/Recorder auxiliary order.
     """
-
     if len(payload) != RAW_UDP_PAYLOAD_BYTES:
         raise ValueError(f"expected {RAW_UDP_PAYLOAD_BYTES} bytes, received {len(payload)}")
     return np.asarray(struct.unpack(byte_order + "17f", payload), dtype=np.float32)
 
 
+def _integrate_frequency_bins(values: np.ndarray, frequencies: np.ndarray) -> np.ndarray:
+    """Integrate PSD bins across NumPy 1.x/2.x without relying on removed APIs."""
+    trapezoid = getattr(np, "trapezoid", None)
+    if trapezoid is not None:
+        return np.asarray(trapezoid(values, frequencies, axis=1), dtype=float)
+    # NumPy <2.0 exposed trapz instead. Access it only on versions that do not
+    # provide trapezoid so import under NumPy 2.4+ remains safe.
+    trapz = getattr(np, "trapz", None)
+    if trapz is not None:
+        return np.asarray(trapz(values, frequencies, axis=1), dtype=float)
+    # Defensive final fallback for unusual NumPy builds. FFT frequencies are
+    # uniformly spaced, so a rectangle rule remains deterministic and explicit.
+    if frequencies.size < 2:
+        return np.zeros(values.shape[0], dtype=float)
+    return np.sum(values, axis=1) * float(np.mean(np.diff(frequencies)))
+
+
 def _band_power(window_uv: np.ndarray, sampling_rate_hz: float) -> np.ndarray:
     """Return transparent reference band power as channels × seven bands."""
-
     data = np.asarray(window_uv, dtype=float)
     if data.ndim != 2 or data.shape[1] < 16:
         raise ValueError("bandpower window must be channels x samples")
     centered = data - np.mean(data, axis=1, keepdims=True)
     taper = np.hanning(data.shape[1])
     spectrum = np.fft.rfft(centered * taper[None, :], axis=1)
-    # Window-energy normalization produces an ordinary one-sided power-density
-    # estimate adequate for deterministic compatibility testing.
     scale = sampling_rate_hz * max(float(np.sum(taper**2)), 1e-12)
     psd = np.abs(spectrum) ** 2 / scale
     if psd.shape[1] > 2:
@@ -130,7 +140,7 @@ def _band_power(window_uv: np.ndarray, sampling_rate_hz: float) -> np.ndarray:
         if not np.any(mask):
             output[:, band_i] = np.nan
         else:
-            output[:, band_i] = np.trapz(psd[:, mask], frequencies[mask], axis=1)
+            output[:, band_i] = _integrate_frequency_bins(psd[:, mask], frequencies[mask])
     return output
 
 
@@ -151,7 +161,6 @@ def compute_unicorn_bandpower_payload(
     behavior. Averages ignore disabled channels. If fewer than two channels are
     enabled, bipolar features are NaN.
     """
-
     eeg = np.asarray(eeg_window_uv, dtype=float)
     if eeg.ndim != 2 or eeg.shape[0] != 8:
         raise ValueError("Unicorn Bandpower requires 8 EEG channels")
@@ -161,7 +170,7 @@ def compute_unicorn_bandpower_payload(
     if enabled.shape != (8,):
         raise ValueError("enabled_channels must contain exactly 8 booleans")
 
-    per_channel = _band_power(eeg, sampling_rate_hz)  # 8 × 7
+    per_channel = _band_power(eeg, sampling_rate_hz)
     visible = per_channel.copy()
     visible[~enabled, :] = np.nan
     band_major = visible.T.reshape(-1)
@@ -188,7 +197,6 @@ def compute_unicorn_bandpower_payload(
 
 def encode_unicorn_bandpower_ascii(values: np.ndarray) -> bytes:
     """Encode a 70-value Bandpower payload as comma-separated ASCII."""
-
     array = np.asarray(values, dtype=float)
     if array.shape != (BANDPOWER_FEATURE_COUNT,):
         raise ValueError("Bandpower payload must contain exactly 70 values")
@@ -219,7 +227,6 @@ class UnicornBandpowerReferenceStream:
     250-sample buffer, 240-sample overlap, therefore 10-sample hop / 25 Hz
     feature update rate at 250 Hz EEG.
     """
-
     def __init__(
         self,
         *,
@@ -275,8 +282,6 @@ class UnicornBandpowerReferenceStream:
                 )
             )
             self._next_emit += self.hop_samples
-        # Retain only enough history for the next overlapping window plus a
-        # small hop margin. This keeps long game simulations bounded.
         keep = self.buffer_size + self.hop_samples
         if self._data.shape[1] > keep:
             self._data = self._data[:, -keep:]

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_network_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_network_sim.py
@@ -1,0 +1,283 @@
+"""Protocol-compatible Unicorn Hybrid Black network simulation helpers.
+
+The raw UDP encoder follows the documented Unicorn UDP wire contract: one scan
+contains 17 float32 values (68 bytes) and is emitted at 250 Hz.
+
+A subtle but important compatibility detail is preserved explicitly: the
+standalone raw-UDP payload orders its auxiliary tail as ``BAT, CNT, VALID``,
+whereas the direct API/Recorder acquisition order is ``Counter, Battery,
+Validation``. The simulator therefore reorders an API17 device block at the
+wire boundary instead of pretending those interfaces share one schema.
+
+The Bandpower helper follows the documented *payload layout, frequency bands,
+window/hop cadence, disabled-channel NaN behavior, and 70-value ASCII shape* of
+Unicorn Bandpower. The exact proprietary numerical estimator is not documented,
+so neurOS deliberately uses a transparent reference FFT estimator and does not
+claim bit-for-bit numerical equivalence to the Unicorn Bandpower application.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import struct
+from typing import Iterable
+
+import numpy as np
+
+from .unicorn_hybrid_black_sim import UNICORN_EEG_API_NAMES, UnicornHybridBlackBlock
+
+BANDPOWER_BANDS: tuple[tuple[str, float, float], ...] = (
+    ("delta", 1.0, 4.0),
+    ("theta", 4.0, 8.0),
+    ("alpha", 8.0, 12.0),
+    ("beta_low", 12.0, 16.0),
+    ("beta_mid", 16.0, 20.0),
+    ("beta_high", 20.0, 30.0),
+    ("gamma", 30.0, 50.0),
+)
+BANDPOWER_FEATURE_COUNT = 70
+RAW_UDP_CHANNEL_COUNT = 17
+RAW_UDP_PAYLOAD_BYTES = RAW_UDP_CHANNEL_COUNT * 4
+UNICORN_RAW_UDP_NAMES = (
+    UNICORN_EEG_API_NAMES
+    + ("ACC X", "ACC Y", "ACC Z")
+    + ("GYR X", "GYR Y", "GYR Z")
+    + ("BAT", "CNT", "VALID")
+)
+# API17 rows are EEG[0:8], accel[8:11], gyro[11:14], CNT[14], BAT[15],
+# VALID[16]. The standalone raw UDP wire contract swaps only BAT/CNT.
+RAW_UDP_FROM_API_INDICES = tuple(range(14)) + (15, 14, 16)
+API_FROM_RAW_UDP_INDICES = RAW_UDP_FROM_API_INDICES  # the swap is its own inverse
+
+
+def api17_scan_to_raw_udp_order(values: np.ndarray) -> np.ndarray:
+    """Reorder one API17 scan into the standalone raw-UDP field order."""
+
+    scan = np.asarray(values, dtype=np.float32)
+    if scan.shape != (RAW_UDP_CHANNEL_COUNT,):
+        raise ValueError("API17 scan must contain exactly 17 values")
+    return scan[np.asarray(RAW_UDP_FROM_API_INDICES, dtype=int)]
+
+
+def raw_udp_scan_to_api17_order(values: np.ndarray) -> np.ndarray:
+    """Reorder one raw-UDP scan back into direct API17 acquisition order."""
+
+    scan = np.asarray(values, dtype=np.float32)
+    if scan.shape != (RAW_UDP_CHANNEL_COUNT,):
+        raise ValueError("raw UDP scan must contain exactly 17 values")
+    return scan[np.asarray(API_FROM_RAW_UDP_INDICES, dtype=int)]
+
+
+def encode_unicorn_udp_scan(
+    block: UnicornHybridBlackBlock,
+    sample_index: int,
+    *,
+    byte_order: str = "<",
+) -> bytes:
+    """Encode one API17 block sample as the documented 17-float UDP payload.
+
+    The official documentation specifies 17 floats / 68 bytes and the field
+    order, but does not explicitly document byte order. The default little-
+    endian representation matches the Windows/x86 environment of Unicorn Suite;
+    callers can override it when testing defensive receivers.
+    """
+
+    if block.schema != "device17_api":
+        raise ValueError("raw Unicorn UDP requires a device17_api block")
+    if block.data.shape[0] != RAW_UDP_CHANNEL_COUNT:
+        raise ValueError("raw Unicorn UDP requires exactly 17 channels")
+    if not 0 <= sample_index < block.data.shape[1]:
+        raise IndexError("sample_index out of range")
+    if byte_order not in {"<", ">", "=", "!"}:
+        raise ValueError("unsupported struct byte order")
+    values = api17_scan_to_raw_udp_order(block.data[:, sample_index])
+    payload = struct.pack(byte_order + "17f", *[float(value) for value in values])
+    if len(payload) != RAW_UDP_PAYLOAD_BYTES:
+        raise AssertionError("unexpected Unicorn UDP payload size")
+    return payload
+
+
+def decode_unicorn_udp_scan(payload: bytes, *, byte_order: str = "<") -> np.ndarray:
+    """Decode a 68-byte raw UDP payload in *wire order*.
+
+    Use :func:`raw_udp_scan_to_api17_order` if downstream code expects the
+    direct API/Recorder auxiliary order.
+    """
+
+    if len(payload) != RAW_UDP_PAYLOAD_BYTES:
+        raise ValueError(f"expected {RAW_UDP_PAYLOAD_BYTES} bytes, received {len(payload)}")
+    return np.asarray(struct.unpack(byte_order + "17f", payload), dtype=np.float32)
+
+
+def _band_power(window_uv: np.ndarray, sampling_rate_hz: float) -> np.ndarray:
+    """Return transparent reference band power as channels × seven bands."""
+
+    data = np.asarray(window_uv, dtype=float)
+    if data.ndim != 2 or data.shape[1] < 16:
+        raise ValueError("bandpower window must be channels x samples")
+    centered = data - np.mean(data, axis=1, keepdims=True)
+    taper = np.hanning(data.shape[1])
+    spectrum = np.fft.rfft(centered * taper[None, :], axis=1)
+    # Window-energy normalization produces an ordinary one-sided power-density
+    # estimate adequate for deterministic compatibility testing.
+    scale = sampling_rate_hz * max(float(np.sum(taper**2)), 1e-12)
+    psd = np.abs(spectrum) ** 2 / scale
+    if psd.shape[1] > 2:
+        psd[:, 1:-1] *= 2.0
+    frequencies = np.fft.rfftfreq(data.shape[1], d=1.0 / sampling_rate_hz)
+    output = np.empty((data.shape[0], len(BANDPOWER_BANDS)), dtype=float)
+    for band_i, (_, low, high) in enumerate(BANDPOWER_BANDS):
+        mask = (frequencies >= low) & (frequencies < high)
+        if not np.any(mask):
+            output[:, band_i] = np.nan
+        else:
+            output[:, band_i] = np.trapz(psd[:, mask], frequencies[mask], axis=1)
+    return output
+
+
+def compute_unicorn_bandpower_payload(
+    eeg_window_uv: np.ndarray,
+    *,
+    sampling_rate_hz: float = 250.0,
+    enabled_channels: Iterable[bool] | None = None,
+) -> np.ndarray:
+    """Compute the documented 70-value Bandpower layout.
+
+    Layout:
+      0..55  = seven bands × eight channels, band-major
+      56..62 = seven bands averaged over enabled channels
+      63..69 = seven bands averaged over all enabled bipolar derivations
+
+    Disabled channel values are NaN, matching Unicorn Bandpower's documented UDP
+    behavior. Averages ignore disabled channels. If fewer than two channels are
+    enabled, bipolar features are NaN.
+    """
+
+    eeg = np.asarray(eeg_window_uv, dtype=float)
+    if eeg.ndim != 2 or eeg.shape[0] != 8:
+        raise ValueError("Unicorn Bandpower requires 8 EEG channels")
+    if sampling_rate_hz <= 0:
+        raise ValueError("sampling_rate_hz must be positive")
+    enabled = np.ones(8, dtype=bool) if enabled_channels is None else np.asarray(tuple(enabled_channels), dtype=bool)
+    if enabled.shape != (8,):
+        raise ValueError("enabled_channels must contain exactly 8 booleans")
+
+    per_channel = _band_power(eeg, sampling_rate_hz)  # 8 × 7
+    visible = per_channel.copy()
+    visible[~enabled, :] = np.nan
+    band_major = visible.T.reshape(-1)
+
+    channel_average = np.full(7, np.nan, dtype=float)
+    if np.any(enabled):
+        channel_average = np.mean(per_channel[enabled], axis=0)
+
+    indices = np.flatnonzero(enabled)
+    bipolar_average = np.full(7, np.nan, dtype=float)
+    if indices.size >= 2:
+        bipolar = []
+        for first_i, first in enumerate(indices[:-1]):
+            for second in indices[first_i + 1 :]:
+                bipolar.append(eeg[first] - eeg[second])
+        bipolar_power = _band_power(np.asarray(bipolar, dtype=float), sampling_rate_hz)
+        bipolar_average = np.mean(bipolar_power, axis=0)
+
+    payload = np.concatenate([band_major, channel_average, bipolar_average]).astype(float)
+    if payload.shape != (BANDPOWER_FEATURE_COUNT,):
+        raise AssertionError("Bandpower payload layout must contain 70 values")
+    return payload
+
+
+def encode_unicorn_bandpower_ascii(values: np.ndarray) -> bytes:
+    """Encode a 70-value Bandpower payload as comma-separated ASCII."""
+
+    array = np.asarray(values, dtype=float)
+    if array.shape != (BANDPOWER_FEATURE_COUNT,):
+        raise ValueError("Bandpower payload must contain exactly 70 values")
+    text = ",".join("NaN" if np.isnan(value) else format(float(value), ".9g") for value in array)
+    return text.encode("ascii")
+
+
+def decode_unicorn_bandpower_ascii(payload: bytes | str) -> np.ndarray:
+    text = payload.decode("ascii") if isinstance(payload, bytes) else str(payload)
+    parts = text.strip().split(",")
+    if len(parts) != BANDPOWER_FEATURE_COUNT:
+        raise ValueError("Bandpower ASCII payload must contain exactly 70 comma-separated values")
+    values = [np.nan if part.strip().lower() == "nan" else float(part) for part in parts]
+    return np.asarray(values, dtype=float)
+
+
+@dataclass(frozen=True)
+class BandpowerFrame:
+    sample_index: int
+    timestamp_s: float
+    values: np.ndarray
+
+
+class UnicornBandpowerReferenceStream:
+    """Stateful documented-cadence Bandpower reference estimator.
+
+    Defaults match the currently documented Unicorn Bandpower settings:
+    250-sample buffer, 240-sample overlap, therefore 10-sample hop / 25 Hz
+    feature update rate at 250 Hz EEG.
+    """
+
+    def __init__(
+        self,
+        *,
+        sampling_rate_hz: float = 250.0,
+        buffer_size: int = 250,
+        buffer_overlap: int = 240,
+        enabled_channels: Iterable[bool] | None = None,
+    ) -> None:
+        if sampling_rate_hz <= 0:
+            raise ValueError("sampling_rate_hz must be positive")
+        if buffer_size <= 0 or not 0 <= buffer_overlap < buffer_size:
+            raise ValueError("buffer settings require 0 <= overlap < buffer_size")
+        self.sampling_rate_hz = float(sampling_rate_hz)
+        self.buffer_size = int(buffer_size)
+        self.buffer_overlap = int(buffer_overlap)
+        self.hop_samples = self.buffer_size - self.buffer_overlap
+        self.update_rate_hz = self.sampling_rate_hz / self.hop_samples
+        self.enabled_channels = np.ones(8, dtype=bool) if enabled_channels is None else np.asarray(tuple(enabled_channels), dtype=bool)
+        if self.enabled_channels.shape != (8,):
+            raise ValueError("enabled_channels must contain exactly 8 booleans")
+        self._data = np.empty((8, 0), dtype=float)
+        self._sample_count = 0
+        self._next_emit = self.buffer_size
+
+    def push(self, eeg_uv: np.ndarray) -> tuple[BandpowerFrame, ...]:
+        block = np.asarray(eeg_uv, dtype=float)
+        if block.ndim != 2 or block.shape[0] != 8:
+            raise ValueError("eeg_uv must be 8 x samples")
+        if block.shape[1] == 0:
+            return ()
+        self._data = np.concatenate([self._data, block], axis=1)
+        self._sample_count += block.shape[1]
+        frames: list[BandpowerFrame] = []
+        while self._sample_count >= self._next_emit:
+            global_stop = self._next_emit
+            global_start = global_stop - self.buffer_size
+            buffer_origin = self._sample_count - self._data.shape[1]
+            local_start = global_start - buffer_origin
+            local_stop = global_stop - buffer_origin
+            if local_start < 0 or local_stop > self._data.shape[1]:
+                break
+            window = self._data[:, local_start:local_stop]
+            values = compute_unicorn_bandpower_payload(
+                window,
+                sampling_rate_hz=self.sampling_rate_hz,
+                enabled_channels=self.enabled_channels,
+            )
+            frames.append(
+                BandpowerFrame(
+                    sample_index=global_stop - 1,
+                    timestamp_s=(global_stop - 1) / self.sampling_rate_hz,
+                    values=values,
+                )
+            )
+            self._next_emit += self.hop_samples
+        # Retain only enough history for the next overlapping window plus a
+        # small hop margin. This keeps long game simulations bounded.
+        keep = self.buffer_size + self.hop_samples
+        if self._data.shape[1] > keep:
+            self._data = self._data[:, -keep:]
+        return tuple(frames)

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
@@ -1,0 +1,252 @@
+"""Receiver-side safety contracts for Unicorn raw UDP game integrations.
+
+The device simulator answers what a source can emit. This module answers the
+other half of the contract: what a consumer should do when packets are malformed,
+invalid, missing, duplicated, reordered, or stale.
+
+The guard deliberately treats transport health as *control authority*. A game may
+continue rendering during faults, but neural data should not continue changing
+state until the stream has recovered for a configurable number of consecutive
+packets.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .unicorn_network_sim import RAW_UDP_PAYLOAD_BYTES, decode_unicorn_udp_scan
+
+RawUdpHealth = Literal[
+    "healthy",
+    "malformed",
+    "invalid",
+    "gap",
+    "duplicate",
+    "out_of_order",
+    "stale",
+]
+
+
+@dataclass(frozen=True)
+class UnicornRawUdpGuardConfig:
+    """Consumer policy, not a manufacturer specification."""
+
+    stale_after_s: float = 0.100
+    recovery_packets: int = 3
+    require_validation: bool = True
+    byte_order: str = "<"
+
+    def validate(self) -> None:
+        if self.stale_after_s <= 0:
+            raise ValueError("stale_after_s must be positive")
+        if self.recovery_packets <= 0:
+            raise ValueError("recovery_packets must be positive")
+        if self.byte_order not in {"<", ">", "=", "!"}:
+            raise ValueError("unsupported byte order")
+
+
+@dataclass(frozen=True)
+class UnicornRawUdpObservation:
+    health: RawUdpHealth
+    received_monotonic_s: float
+    counter: int | None
+    battery_level: float | None
+    validation: int | None
+    missed_packets: int = 0
+    healthy_streak: int = 0
+    authority_allowed: bool = False
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class UnicornRawUdpGuardState:
+    health: RawUdpHealth
+    authority_allowed: bool
+    healthy_streak: int
+    last_counter: int | None
+    age_s: float | None
+
+
+class UnicornRawUdpGuard:
+    """Fail-closed consumer state machine for 68-byte Unicorn raw UDP packets."""
+
+    def __init__(self, config: UnicornRawUdpGuardConfig | None = None) -> None:
+        self.config = config or UnicornRawUdpGuardConfig()
+        self.config.validate()
+        self._last_counter: int | None = None
+        self._last_valid_receive_s: float | None = None
+        self._healthy_streak = 0
+        self._last_health: RawUdpHealth = "stale"
+
+    @property
+    def last_counter(self) -> int | None:
+        return self._last_counter
+
+    @property
+    def healthy_streak(self) -> int:
+        return self._healthy_streak
+
+    def _fault(
+        self,
+        health: RawUdpHealth,
+        received_s: float,
+        *,
+        counter: int | None = None,
+        battery: float | None = None,
+        validation: int | None = None,
+        missed: int = 0,
+        reason: str,
+    ) -> UnicornRawUdpObservation:
+        self._healthy_streak = 0
+        self._last_health = health
+        return UnicornRawUdpObservation(
+            health=health,
+            received_monotonic_s=float(received_s),
+            counter=counter,
+            battery_level=battery,
+            validation=validation,
+            missed_packets=missed,
+            healthy_streak=0,
+            authority_allowed=False,
+            reason=reason,
+        )
+
+    def ingest(self, payload: bytes, *, received_monotonic_s: float) -> UnicornRawUdpObservation:
+        """Consume one datagram and update control-authority state."""
+
+        received_s = float(received_monotonic_s)
+        if not np.isfinite(received_s):
+            raise ValueError("received_monotonic_s must be finite")
+        if len(payload) != RAW_UDP_PAYLOAD_BYTES:
+            return self._fault(
+                "malformed",
+                received_s,
+                reason=f"expected {RAW_UDP_PAYLOAD_BYTES} bytes, received {len(payload)}",
+            )
+        try:
+            values = decode_unicorn_udp_scan(payload, byte_order=self.config.byte_order)
+        except (ValueError, TypeError) as exc:
+            return self._fault("malformed", received_s, reason=str(exc))
+        if values.shape != (17,) or not np.all(np.isfinite(values)):
+            return self._fault("malformed", received_s, reason="packet contains non-finite or malformed values")
+
+        # Standalone raw UDP order is ... GYR, BAT, CNT, VALID.
+        battery = float(values[14])
+        counter_float = float(values[15])
+        validation_float = float(values[16])
+        counter = int(round(counter_float))
+        validation = int(round(validation_float))
+        if abs(counter_float - counter) > 0.25:
+            return self._fault(
+                "malformed",
+                received_s,
+                battery=battery,
+                validation=validation,
+                reason="counter is not sufficiently integer-like",
+            )
+        if validation not in {0, 1}:
+            return self._fault(
+                "malformed",
+                received_s,
+                counter=counter,
+                battery=battery,
+                validation=validation,
+                reason="validation indicator is not binary",
+            )
+        if self.config.require_validation and validation != 1:
+            # An invalid device packet is observable but cannot grant authority.
+            self._last_valid_receive_s = received_s
+            return self._fault(
+                "invalid",
+                received_s,
+                counter=counter,
+                battery=battery,
+                validation=validation,
+                reason="validation indicator is not asserted",
+            )
+
+        if self._last_counter is not None:
+            delta = counter - self._last_counter
+            if delta == 0:
+                self._last_valid_receive_s = received_s
+                return self._fault(
+                    "duplicate",
+                    received_s,
+                    counter=counter,
+                    battery=battery,
+                    validation=validation,
+                    reason="counter repeated",
+                )
+            if delta < 0:
+                self._last_valid_receive_s = received_s
+                return self._fault(
+                    "out_of_order",
+                    received_s,
+                    counter=counter,
+                    battery=battery,
+                    validation=validation,
+                    reason="counter moved backwards",
+                )
+            if delta > 1:
+                missed = delta - 1
+                self._last_counter = counter
+                self._last_valid_receive_s = received_s
+                return self._fault(
+                    "gap",
+                    received_s,
+                    counter=counter,
+                    battery=battery,
+                    validation=validation,
+                    missed=missed,
+                    reason=f"counter advanced by {delta}; {missed} packet(s) missing",
+                )
+
+        self._last_counter = counter
+        self._last_valid_receive_s = received_s
+        self._healthy_streak += 1
+        self._last_health = "healthy"
+        allowed = self._healthy_streak >= self.config.recovery_packets
+        return UnicornRawUdpObservation(
+            health="healthy",
+            received_monotonic_s=received_s,
+            counter=counter,
+            battery_level=battery,
+            validation=validation,
+            healthy_streak=self._healthy_streak,
+            authority_allowed=allowed,
+            reason="healthy sequential validated packet",
+        )
+
+    def state(self, *, now_monotonic_s: float) -> UnicornRawUdpGuardState:
+        now = float(now_monotonic_s)
+        if not np.isfinite(now):
+            raise ValueError("now_monotonic_s must be finite")
+        if self._last_valid_receive_s is None:
+            return UnicornRawUdpGuardState(
+                health="stale",
+                authority_allowed=False,
+                healthy_streak=self._healthy_streak,
+                last_counter=self._last_counter,
+                age_s=None,
+            )
+        age = max(0.0, now - self._last_valid_receive_s)
+        if age > self.config.stale_after_s:
+            return UnicornRawUdpGuardState(
+                health="stale",
+                authority_allowed=False,
+                healthy_streak=0,
+                last_counter=self._last_counter,
+                age_s=age,
+            )
+        return UnicornRawUdpGuardState(
+            health=self._last_health,
+            authority_allowed=(
+                self._last_health == "healthy"
+                and self._healthy_streak >= self.config.recovery_packets
+            ),
+            healthy_streak=self._healthy_streak,
+            last_counter=self._last_counter,
+            age_s=age,
+        )

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
@@ -76,6 +76,8 @@ class UnicornRawUdpGuard:
         self.config = config or UnicornRawUdpGuardConfig()
         self.config.validate()
         self._last_counter: int | None = None
+        # Most recent structurally decodable packet, even if VALID=0. Stream
+        # liveness and gameplay authority are intentionally separate concepts.
         self._last_valid_receive_s: float | None = None
         self._healthy_streak = 0
         self._last_health: RawUdpHealth = "stale"
@@ -119,6 +121,13 @@ class UnicornRawUdpGuard:
         received_s = float(received_monotonic_s)
         if not np.isfinite(received_s):
             raise ValueError("received_monotonic_s must be finite")
+        if self._last_valid_receive_s is not None:
+            age_before_packet = max(0.0, received_s - self._last_valid_receive_s)
+            if age_before_packet > self.config.stale_after_s:
+                # Fresh traffic re-establishes liveness but cannot inherit neural
+                # authority accumulated before a stale interval.
+                self._healthy_streak = 0
+                self._last_health = "stale"
         if len(payload) != RAW_UDP_PAYLOAD_BYTES:
             return self._fault(
                 "malformed",
@@ -156,7 +165,9 @@ class UnicornRawUdpGuard:
                 reason="validation indicator is not binary",
             )
         if self.config.require_validation and validation != 1:
-            # An invalid device packet is observable but cannot grant authority.
+            # The packet is structurally observable and advances the device
+            # counter, but its neural payload cannot grant gameplay authority.
+            self._last_counter = counter
             self._last_valid_receive_s = received_s
             return self._fault(
                 "invalid",

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_trace.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_trace.py
@@ -1,0 +1,236 @@
+"""Privacy-safe raw-UDP trace diagnostics for Unicorn simulator calibration.
+
+The analyzer intentionally stores *no EEG sample arrays*. It reduces a sequence
+of received 68-byte datagrams to interface/timing diagnostics that hardware owners
+can share when validating the simulator: packet shape, arrival cadence, counter
+gaps, duplicates, reordering, validation state, and battery range.
+
+A source label is user-declared provenance. neurOS cannot cryptographically prove
+that a trace came from physical hardware merely because the caller says so.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal
+
+import numpy as np
+
+from .unicorn_network_sim import RAW_UDP_PAYLOAD_BYTES, decode_unicorn_udp_scan
+
+TraceSourceKind = Literal["unknown", "synthetic", "user_declared_physical"]
+
+
+@dataclass(frozen=True)
+class UnicornRawUdpTraceSummary:
+    packet_count: int
+    decoded_packet_count: int
+    malformed_packet_count: int
+    duration_s: float
+    estimated_arrival_rate_hz: float | None
+    mean_interarrival_ms: float | None
+    p95_interarrival_ms: float | None
+    first_counter: int | None
+    last_counter: int | None
+    counter_gap_events: int
+    inferred_missing_packets: int
+    duplicate_packets: int
+    out_of_order_packets: int
+    validation_zero_packets: int
+    battery_min: float | None
+    battery_max: float | None
+    source_kind: TraceSourceKind = "unknown"
+    source_label: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.unicorn_raw_udp_trace_summary.v1",
+            "packet_count": self.packet_count,
+            "decoded_packet_count": self.decoded_packet_count,
+            "malformed_packet_count": self.malformed_packet_count,
+            "duration_s": self.duration_s,
+            "estimated_arrival_rate_hz": self.estimated_arrival_rate_hz,
+            "mean_interarrival_ms": self.mean_interarrival_ms,
+            "p95_interarrival_ms": self.p95_interarrival_ms,
+            "first_counter": self.first_counter,
+            "last_counter": self.last_counter,
+            "counter_gap_events": self.counter_gap_events,
+            "inferred_missing_packets": self.inferred_missing_packets,
+            "duplicate_packets": self.duplicate_packets,
+            "out_of_order_packets": self.out_of_order_packets,
+            "validation_zero_packets": self.validation_zero_packets,
+            "battery_min": self.battery_min,
+            "battery_max": self.battery_max,
+            "source_kind": self.source_kind,
+            "source_label": self.source_label,
+            "contains_raw_eeg": False,
+            "evidence_boundary": (
+                "Wire/timing diagnostics only. Source provenance is user-declared; "
+                "this summary is not a hardware certification or a human-EEG record."
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class UnicornTraceContractComparison:
+    """Diagnostic comparison against the nominal public raw-UDP contract."""
+
+    packet_shape_clean: bool
+    arrival_rate_near_250hz: bool | None
+    counter_monotonic_without_duplicates: bool
+    observations: dict[str, object]
+
+    @property
+    def passed_diagnostic_checks(self) -> bool:
+        rate_ok = True if self.arrival_rate_near_250hz is None else self.arrival_rate_near_250hz
+        return self.packet_shape_clean and rate_ok and self.counter_monotonic_without_duplicates
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.unicorn_raw_udp_trace_contract_comparison.v1",
+            "passed_diagnostic_checks": self.passed_diagnostic_checks,
+            "checks": {
+                "packet_shape_clean": self.packet_shape_clean,
+                "arrival_rate_near_250hz": self.arrival_rate_near_250hz,
+                "counter_monotonic_without_duplicates": self.counter_monotonic_without_duplicates,
+            },
+            "observations": dict(self.observations),
+            "evidence_boundary": (
+                "Diagnostic comparison to nominal public interface behavior only; "
+                "not certification of physical hardware, Bluetooth, or EEG quality."
+            ),
+        }
+
+
+def analyze_unicorn_raw_udp_trace(
+    records: Iterable[tuple[float, bytes]],
+    *,
+    source_kind: TraceSourceKind = "unknown",
+    source_label: str = "",
+    byte_order: str = "<",
+) -> UnicornRawUdpTraceSummary:
+    """Reduce timestamped datagrams to shareable interface diagnostics."""
+
+    if source_kind not in {"unknown", "synthetic", "user_declared_physical"}:
+        raise ValueError("unsupported source_kind")
+    rows = [(float(timestamp), bytes(payload)) for timestamp, payload in records]
+    if any(not np.isfinite(timestamp) for timestamp, _ in rows):
+        raise ValueError("receive timestamps must be finite")
+    timestamps = np.asarray([timestamp for timestamp, _ in rows], dtype=float)
+    if timestamps.size > 1 and np.any(np.diff(timestamps) < 0):
+        raise ValueError("receive timestamps must be monotonic non-decreasing")
+
+    malformed = 0
+    decoded = 0
+    first_counter: int | None = None
+    last_counter: int | None = None
+    gap_events = 0
+    missing = 0
+    duplicates = 0
+    out_of_order = 0
+    validation_zero = 0
+    batteries: list[float] = []
+
+    for _, payload in rows:
+        if len(payload) != RAW_UDP_PAYLOAD_BYTES:
+            malformed += 1
+            continue
+        try:
+            values = decode_unicorn_udp_scan(payload, byte_order=byte_order)
+        except (ValueError, TypeError):
+            malformed += 1
+            continue
+        if values.shape != (17,) or not np.all(np.isfinite(values)):
+            malformed += 1
+            continue
+        counter_float = float(values[15])
+        validation_float = float(values[16])
+        counter = int(round(counter_float))
+        validation = int(round(validation_float))
+        if abs(counter_float - counter) > 0.25 or validation not in {0, 1}:
+            malformed += 1
+            continue
+
+        decoded += 1
+        batteries.append(float(values[14]))
+        validation_zero += int(validation == 0)
+        if first_counter is None:
+            first_counter = counter
+            last_counter = counter
+            continue
+        assert last_counter is not None
+        delta = counter - last_counter
+        if delta == 0:
+            duplicates += 1
+        elif delta < 0:
+            out_of_order += 1
+        else:
+            if delta > 1:
+                gap_events += 1
+                missing += delta - 1
+            last_counter = counter
+
+    if timestamps.size >= 2:
+        interarrival = np.diff(timestamps)
+        duration = float(timestamps[-1] - timestamps[0])
+        rate = float((timestamps.size - 1) / duration) if duration > 0 else None
+        mean_ms = float(np.mean(interarrival) * 1000.0)
+        p95_ms = float(np.percentile(interarrival, 95.0) * 1000.0)
+    else:
+        duration = 0.0
+        rate = None
+        mean_ms = None
+        p95_ms = None
+
+    return UnicornRawUdpTraceSummary(
+        packet_count=len(rows),
+        decoded_packet_count=decoded,
+        malformed_packet_count=malformed,
+        duration_s=duration,
+        estimated_arrival_rate_hz=rate,
+        mean_interarrival_ms=mean_ms,
+        p95_interarrival_ms=p95_ms,
+        first_counter=first_counter,
+        last_counter=last_counter,
+        counter_gap_events=gap_events,
+        inferred_missing_packets=missing,
+        duplicate_packets=duplicates,
+        out_of_order_packets=out_of_order,
+        validation_zero_packets=validation_zero,
+        battery_min=min(batteries) if batteries else None,
+        battery_max=max(batteries) if batteries else None,
+        source_kind=source_kind,
+        source_label=str(source_label),
+    )
+
+
+def compare_unicorn_trace_to_nominal_contract(
+    summary: UnicornRawUdpTraceSummary,
+    *,
+    rate_tolerance_hz: float = 15.0,
+) -> UnicornTraceContractComparison:
+    """Run deliberately broad diagnostics against the nominal 250 Hz interface.
+
+    The arrival-rate tolerance is a consumer diagnostic policy, not a published
+    Bluetooth jitter specification. Short captures or heavily loaded systems may
+    fail this check without proving a headset defect.
+    """
+
+    if rate_tolerance_hz <= 0:
+        raise ValueError("rate_tolerance_hz must be positive")
+    rate = summary.estimated_arrival_rate_hz
+    rate_ok = None if rate is None else abs(rate - 250.0) <= rate_tolerance_hz
+    counter_clean = summary.duplicate_packets == 0 and summary.out_of_order_packets == 0
+    return UnicornTraceContractComparison(
+        packet_shape_clean=summary.malformed_packet_count == 0,
+        arrival_rate_near_250hz=rate_ok,
+        counter_monotonic_without_duplicates=counter_clean,
+        observations={
+            "estimated_arrival_rate_hz": rate,
+            "rate_tolerance_hz": float(rate_tolerance_hz),
+            "counter_gap_events": summary.counter_gap_events,
+            "inferred_missing_packets": summary.inferred_missing_packets,
+            "validation_zero_packets": summary.validation_zero_packets,
+            "source_kind": summary.source_kind,
+            "source_label": summary.source_label,
+        },
+    )

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_transport_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_transport_sim.py
@@ -1,0 +1,310 @@
+"""Deterministic real-time transport simulation for Unicorn-compatible UDP streams.
+
+This module intentionally sits *after* the device twin. It does not alter EEG
+physiology or manufacturer telemetry semantics. Instead it turns already-encoded
+raw-UDP or Bandpower payloads into a reproducible delivery schedule with explicit
+loss, duplication, delay, and reordering probes.
+
+The fault profiles are synthetic test policies. They are not claimed to describe
+measured Unicorn Bluetooth or operating-system network statistics.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Literal
+
+from .unicorn_hybrid_black_sim import (
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+)
+from .unicorn_network_sim import (
+    UnicornBandpowerReferenceStream,
+    encode_unicorn_bandpower_ascii,
+    encode_unicorn_udp_scan,
+)
+
+TransportEvidenceClass = Literal["synthetic_assumption"]
+
+
+@dataclass(frozen=True)
+class UnicornUdpFaultProfile:
+    """Deterministic packet-fault policy for hardware-free robustness tests.
+
+    Periodic fields use one-based human-readable cadence. For example,
+    ``drop_every=10`` drops source packets 10, 20, 30, ... while source sequence
+    numbers remain zero-based internally. A zero value disables that fault.
+
+    ``reorder_every=N`` holds packet N, then releases packet N+1 before it. This
+    gives a receiver a deterministic adjacent-packet inversion without invoking
+    wall-clock randomness.
+    """
+
+    name: str = "pristine"
+    drop_every: int = 0
+    duplicate_every: int = 0
+    delay_every: int = 0
+    delay_ms: float = 0.0
+    reorder_every: int = 0
+    evidence_class: TransportEvidenceClass = "synthetic_assumption"
+    description: str = "No synthetic transport faults."
+
+    def validate(self) -> None:
+        if not self.name.strip():
+            raise ValueError("fault profile name must be non-empty")
+        for field_name in ("drop_every", "duplicate_every", "delay_every", "reorder_every"):
+            value = int(getattr(self, field_name))
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        if self.delay_ms < 0:
+            raise ValueError("delay_ms must be non-negative")
+        if self.delay_every == 0 and self.delay_ms != 0:
+            raise ValueError("delay_ms requires delay_every > 0")
+        if self.delay_every > 0 and self.delay_ms <= 0:
+            raise ValueError("delay_every requires delay_ms > 0")
+        if self.reorder_every == 1:
+            raise ValueError("reorder_every=1 cannot form stable adjacent pairs")
+
+
+FAULT_PROFILES: dict[str, UnicornUdpFaultProfile] = {
+    "pristine": UnicornUdpFaultProfile(),
+    "periodic-loss": UnicornUdpFaultProfile(
+        name="periodic-loss",
+        drop_every=50,
+        description="Synthetic 2% periodic packet-loss probe; not a measured hardware loss rate.",
+    ),
+    "duplicate-probe": UnicornUdpFaultProfile(
+        name="duplicate-probe",
+        duplicate_every=40,
+        description="Synthetic periodic duplicate-packet probe.",
+    ),
+    "reorder-probe": UnicornUdpFaultProfile(
+        name="reorder-probe",
+        reorder_every=40,
+        description="Synthetic adjacent-packet reordering probe.",
+    ),
+    "delay-probe": UnicornUdpFaultProfile(
+        name="delay-probe",
+        delay_every=25,
+        delay_ms=20.0,
+        description="Synthetic periodic delivery-delay probe.",
+    ),
+    "mixed-torture": UnicornUdpFaultProfile(
+        name="mixed-torture",
+        drop_every=29,
+        duplicate_every=41,
+        delay_every=17,
+        delay_ms=16.0,
+        reorder_every=53,
+        description=(
+            "Synthetic deterministic mixed loss/duplicate/delay/reorder torture profile. "
+            "Cadences are test choices, not manufacturer statistics."
+        ),
+    ),
+}
+for _profile in FAULT_PROFILES.values():
+    _profile.validate()
+
+
+def get_unicorn_udp_fault_profile(name: str) -> UnicornUdpFaultProfile:
+    """Return a named immutable synthetic fault profile."""
+
+    key = str(name).strip().lower()
+    try:
+        return FAULT_PROFILES[key]
+    except KeyError as exc:
+        raise KeyError(f"unknown Unicorn UDP fault profile {name!r}; choose from {sorted(FAULT_PROFILES)}") from exc
+
+
+@dataclass(frozen=True)
+class ScheduledDatagram:
+    """One synthetic transport delivery decision.
+
+    ``nominal_time_s`` is the source cadence time. ``release_time_s`` is the
+    earliest time a real-time sender should emit the datagram. Reordered packets
+    can have an older nominal time while being released after a newer packet.
+    """
+
+    payload: bytes
+    source_sequence: int
+    nominal_time_s: float
+    release_time_s: float
+    duplicate_ordinal: int = 0
+    faults: tuple[str, ...] = ()
+
+
+class DeterministicPacketFaultEngine:
+    """Stateful packet transformer with reproducible loss/reorder semantics."""
+
+    def __init__(self, profile: UnicornUdpFaultProfile, *, nominal_interval_s: float) -> None:
+        profile.validate()
+        if nominal_interval_s <= 0:
+            raise ValueError("nominal_interval_s must be positive")
+        self.profile = profile
+        self.nominal_interval_s = float(nominal_interval_s)
+        self._held_for_reorder: ScheduledDatagram | None = None
+
+    @staticmethod
+    def _periodic(sequence: int, every: int) -> bool:
+        return every > 0 and (sequence + 1) % every == 0
+
+    def _decorate(self, packet: ScheduledDatagram) -> tuple[ScheduledDatagram, ...]:
+        profile = self.profile
+        sequence = packet.source_sequence
+        faults = list(packet.faults)
+        release = packet.release_time_s
+        if self._periodic(sequence, profile.delay_every):
+            release += profile.delay_ms / 1000.0
+            faults.append("delay")
+        primary = replace(packet, release_time_s=release, faults=tuple(faults))
+        if self._periodic(sequence, profile.duplicate_every):
+            duplicate = replace(
+                primary,
+                duplicate_ordinal=1,
+                release_time_s=primary.release_time_s + 1e-9,
+                faults=primary.faults + ("duplicate",),
+            )
+            return (primary, duplicate)
+        return (primary,)
+
+    def process(
+        self,
+        payload: bytes,
+        *,
+        source_sequence: int,
+        nominal_time_s: float,
+    ) -> tuple[ScheduledDatagram, ...]:
+        """Apply deterministic faults to one source packet.
+
+        A dropped packet is still consumed by the source, so later device counter
+        values reveal the gap naturally. This mirrors the correct causal layer:
+        the transport loses a packet rather than rewinding the acquisition clock.
+        """
+
+        if source_sequence < 0:
+            raise ValueError("source_sequence must be non-negative")
+        packet = ScheduledDatagram(
+            payload=bytes(payload),
+            source_sequence=int(source_sequence),
+            nominal_time_s=float(nominal_time_s),
+            release_time_s=float(nominal_time_s),
+        )
+
+        # If the previous packet was held for a reordering probe, release the
+        # current packet first and the held packet second. Dropping the current
+        # packet still releases the held packet so the engine cannot deadlock.
+        if self._held_for_reorder is not None:
+            held = self._held_for_reorder
+            self._held_for_reorder = None
+            current_dropped = self._periodic(source_sequence, self.profile.drop_every)
+            outputs: list[ScheduledDatagram] = []
+            if not current_dropped:
+                current = replace(packet, faults=("reordered_before_previous",))
+                outputs.extend(self._decorate(current))
+            held_release = max(
+                held.release_time_s,
+                nominal_time_s + min(self.nominal_interval_s * 0.5, 0.001),
+            )
+            held = replace(
+                held,
+                release_time_s=held_release,
+                faults=held.faults + ("reordered_after_next",),
+            )
+            outputs.extend(self._decorate(held))
+            return tuple(outputs)
+
+        if self._periodic(source_sequence, self.profile.drop_every):
+            return ()
+
+        if self._periodic(source_sequence, self.profile.reorder_every):
+            self._held_for_reorder = replace(packet, faults=("held_for_reorder",))
+            return ()
+
+        return self._decorate(packet)
+
+    def flush(self) -> tuple[ScheduledDatagram, ...]:
+        """Release a final held packet when a stream stops between reorder pairs."""
+
+        if self._held_for_reorder is None:
+            return ()
+        held = self._held_for_reorder
+        self._held_for_reorder = None
+        return self._decorate(replace(held, faults=held.faults + ("flush",)))
+
+
+class UnicornRawUdpStreamSimulator:
+    """Generate raw Unicorn-compatible UDP datagrams at a 250 Hz source cadence."""
+
+    def __init__(
+        self,
+        *,
+        seed: int = 7,
+        fault_profile: UnicornUdpFaultProfile | None = None,
+        byte_order: str = "<",
+    ) -> None:
+        self.device = UnicornHybridBlackSimulator(
+            config=UnicornHybridBlackSimulationConfig(schema="device17_api", seed=seed)
+        )
+        self.byte_order = byte_order
+        self.sequence = 0
+        self.interval_s = 1.0 / self.device.spec.sampling_rate_hz
+        self.faults = DeterministicPacketFaultEngine(
+            fault_profile or FAULT_PROFILES["pristine"],
+            nominal_interval_s=self.interval_s,
+        )
+
+    def next_datagrams(self) -> tuple[ScheduledDatagram, ...]:
+        block = self.device.render(1)
+        payload = encode_unicorn_udp_scan(block, 0, byte_order=self.byte_order)
+        sequence = self.sequence
+        self.sequence += 1
+        return self.faults.process(
+            payload,
+            source_sequence=sequence,
+            nominal_time_s=sequence * self.interval_s,
+        )
+
+    def flush(self) -> tuple[ScheduledDatagram, ...]:
+        return self.faults.flush()
+
+
+class UnicornBandpowerUdpStreamSimulator:
+    """Generate 70-value Bandpower reference datagrams at the documented cadence."""
+
+    def __init__(
+        self,
+        *,
+        seed: int = 7,
+        fault_profile: UnicornUdpFaultProfile | None = None,
+    ) -> None:
+        self.device = UnicornHybridBlackSimulator(
+            config=UnicornHybridBlackSimulationConfig(schema="eeg8_anatomical", seed=seed)
+        )
+        self.bandpower = UnicornBandpowerReferenceStream(
+            sampling_rate_hz=self.device.spec.sampling_rate_hz
+        )
+        self.sequence = 0
+        self.interval_s = 1.0 / self.bandpower.update_rate_hz
+        self.faults = DeterministicPacketFaultEngine(
+            fault_profile or FAULT_PROFILES["pristine"],
+            nominal_interval_s=self.interval_s,
+        )
+        self._primed = False
+
+    def next_datagrams(self) -> tuple[ScheduledDatagram, ...]:
+        samples = self.bandpower.buffer_size if not self._primed else self.bandpower.hop_samples
+        self._primed = True
+        block = self.device.render(samples)
+        frames = self.bandpower.push(block.eeg_data_uv)
+        if len(frames) != 1:
+            raise AssertionError(f"expected one Bandpower frame per update, got {len(frames)}")
+        payload = encode_unicorn_bandpower_ascii(frames[0].values)
+        sequence = self.sequence
+        self.sequence += 1
+        return self.faults.process(
+            payload,
+            source_sequence=sequence,
+            nominal_time_s=sequence * self.interval_s,
+        )
+
+    def flush(self) -> tuple[ScheduledDatagram, ...]:
+        return self.faults.flush()

--- a/tests/test_unicorn_api_sim.py
+++ b/tests/test_unicorn_api_sim.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.drivers.unicorn_api_sim import UnicornApiSimError, UnicornPythonApiSimulator
+
+
+def test_api_simulator_requires_explicit_synthetic_serial_identity():
+    with pytest.raises(ValueError):
+        UnicornPythonApiSimulator(serial="REAL-LOOKING")
+    api = UnicornPythonApiSimulator()
+    assert api.get_available_devices() == ["SIM-UNICORN-0001"]
+    assert api.get_device_information().number_of_eeg_channels == 8
+
+
+def test_configuration_and_channel_lookup_follow_enabled_scan_order():
+    api = UnicornPythonApiSimulator()
+    config = api.get_configuration()
+    config = config.with_channel("Gyroscope Z", enabled=False)
+    api.set_configuration(config)
+    assert api.get_number_of_acquired_channels() == 16
+    assert api.get_channel_index("EEG 1") == 0
+    assert api.get_channel_index("Battery Level") == 14
+    with pytest.raises(KeyError):
+        api.get_channel_index("Gyroscope Z")
+
+
+def test_acquisition_lifecycle_and_get_data_shape():
+    api = UnicornPythonApiSimulator(seed=13)
+    with pytest.raises(UnicornApiSimError) as exc:
+        api.get_data(5)
+    assert exc.value.code == "operation_not_allowed"
+    api.start_acquisition(False)
+    data = api.get_data(7)
+    assert data.shape == (7, 17)
+    assert data.dtype == np.float32
+    with pytest.raises(UnicornApiSimError):
+        api.set_configuration(api.get_configuration())
+    api.stop_acquisition()
+
+
+def test_test_signal_mode_is_rectangular_and_explicitly_simulator_defined():
+    api = UnicornPythonApiSimulator(
+        seed=17,
+        test_signal_frequency_hz=5.0,
+        test_signal_amplitude_uv=80.0,
+    )
+    api.start_acquisition(True)
+    data = api.get_data(100)
+    eeg = data[:, :8]
+    assert set(np.unique(eeg)).issubset({-80.0, 80.0})
+    assert np.allclose(eeg[:, 0], eeg[0, 0])
+
+
+def test_digital_outputs_are_8_bit_state():
+    api = UnicornPythonApiSimulator()
+    api.set_digital_outputs(170)
+    assert api.get_digital_outputs() == 170
+    with pytest.raises(ValueError):
+        api.set_digital_outputs(256)
+
+
+def test_injected_api_errors_are_one_shot_and_recovery_is_explicit():
+    api = UnicornPythonApiSimulator(seed=19)
+    api.start_acquisition(False)
+    for code in ("buffer_underflow", "buffer_overflow", "connection_problem"):
+        api.inject_next_error(code)
+        with pytest.raises(UnicornApiSimError) as exc:
+            api.get_data(5)
+        assert exc.value.code == code
+        recovered = api.get_data(5)
+        assert recovered.shape == (5, 17)
+
+
+def test_binary_scan_buffer_matches_enabled_channel_count():
+    api = UnicornPythonApiSimulator(seed=23)
+    config = api.get_configuration().with_channel("Accelerometer Z", enabled=False)
+    api.set_configuration(config)
+    api.start_acquisition(False)
+    payload = api.get_data_bytes(4)
+    assert len(payload) == 4 * 16 * 4

--- a/tests/test_unicorn_api_sim.py
+++ b/tests/test_unicorn_api_sim.py
@@ -50,7 +50,12 @@ def test_test_signal_mode_is_rectangular_and_explicitly_simulator_defined():
     data = api.get_data(100)
     eeg = data[:, :8]
     assert set(np.unique(eeg)).issubset({-80.0, 80.0})
-    assert np.allclose(eeg[:, 0], eeg[0, 0])
+    # get_data is scan-major (scans x channels): every EEG electrode sees the
+    # same simulator-defined rectangular calibration level within a scan, while
+    # the level is allowed to toggle over time.
+    assert np.allclose(eeg, eeg[:, :1])
+    assert np.any(eeg[:, 0] > 0.0)
+    assert np.any(eeg[:, 0] < 0.0)
 
 
 def test_digital_outputs_are_8_bit_state():

--- a/tests/test_unicorn_arena_profile.py
+++ b/tests/test_unicorn_arena_profile.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from neuros.arena import unicorn_hybrid_black_eeg_profile
+from neuros.drivers.unicorn_hybrid_black_sim import UNICORN_SCALP_LABELS, UnicornHybridBlackSpec
+
+
+def test_arena_unicorn_profile_uses_published_hardware_constants():
+    spec = UnicornHybridBlackSpec()
+    profile = unicorn_hybrid_black_eeg_profile(chunk_samples=5)
+    assert profile.name == "unicorn-hybrid-black-eeg8"
+    assert profile.sampling_rate_hz == spec.sampling_rate_hz
+    assert profile.channel_names == UNICORN_SCALP_LABELS
+    assert profile.adc_bits == spec.resolution_bits
+    assert profile.input_range_uv == spec.sensitivity_uv
+    # Environmental assumptions remain explicit instead of being smuggled in as
+    # manufacturer specifications.
+    assert profile.sensor_noise_uv == 0.0
+    assert profile.line_noise_uv == 0.0
+
+
+def test_arena_unicorn_profile_allows_declared_environmental_noise_and_clocks():
+    profile = unicorn_hybrid_black_eeg_profile(
+        sensor_noise_uv=0.5,
+        line_frequency_hz=50.0,
+        line_noise_uv=1.5,
+        clock_offset_ms=7.0,
+        clock_drift_ppm=11.0,
+        timestamp_jitter_ms=0.2,
+        chunk_samples=10,
+    )
+    profile.validate()
+    assert profile.sensor_noise_uv == 0.5
+    assert profile.line_frequency_hz == 50.0
+    assert profile.line_noise_uv == 1.5
+    assert profile.clock_offset_ms == 7.0
+    assert profile.clock_drift_ppm == 11.0
+    assert profile.timestamp_jitter_ms == 0.2
+    assert profile.chunk_samples == 10

--- a/tests/test_unicorn_compatibility_suite.py
+++ b/tests/test_unicorn_compatibility_suite.py
@@ -14,5 +14,6 @@ def test_unicorn_compatibility_suite_passes_declared_synthetic_contracts():
     assert surfaces["direct_api17_scan"]["observations"]["channels"] == 17
     assert surfaces["recorder19_fields"]["observations"]["fields"] == 19
     assert surfaces["bandpower70_reference"]["evidence_class"] == "reference_implementation"
+    assert surfaces["acquisition_availability_delay"]["evidence_class"] == "reference_implementation"
     assert surfaces["motion_and_battery_stress_policy"]["evidence_class"] == "synthetic_assumption"
     assert "cannot qualify" in payload["evidence_boundary"]

--- a/tests/test_unicorn_compatibility_suite.py
+++ b/tests/test_unicorn_compatibility_suite.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from neuros.drivers.unicorn_compatibility import run_unicorn_compatibility_suite
+
+
+def test_unicorn_compatibility_suite_passes_declared_synthetic_contracts():
+    report = run_unicorn_compatibility_suite(seed=41)
+    assert report.passed, report.to_dict()
+    payload = report.to_dict()
+    assert payload["schema"] == "neuros.unicorn_hybrid_black_sim.compatibility.v1"
+    assert payload["synthetic"] is True
+    surfaces = {surface["name"]: surface for surface in payload["surfaces"]}
+    assert surfaces["raw_udp17_wire"]["observations"]["auxiliary_tail"] == ["BAT", "CNT", "VALID"]
+    assert surfaces["direct_api17_scan"]["observations"]["channels"] == 17
+    assert surfaces["recorder19_fields"]["observations"]["fields"] == 19
+    assert surfaces["bandpower70_reference"]["evidence_class"] == "reference_implementation"
+    assert surfaces["motion_and_battery_stress_policy"]["evidence_class"] == "synthetic_assumption"
+    assert "cannot qualify" in payload["evidence_boundary"]

--- a/tests/test_unicorn_compatibility_suite.py
+++ b/tests/test_unicorn_compatibility_suite.py
@@ -17,3 +17,38 @@ def test_unicorn_compatibility_suite_passes_declared_synthetic_contracts():
     assert surfaces["acquisition_availability_delay"]["evidence_class"] == "reference_implementation"
     assert surfaces["motion_and_battery_stress_policy"]["evidence_class"] == "synthetic_assumption"
     assert "cannot qualify" in payload["evidence_boundary"]
+
+
+def test_every_vendor_backed_unicorn_surface_has_frozen_upstream_provenance():
+    payload = run_unicorn_compatibility_suite(seed=43).to_dict()
+    references = payload["upstream_contract_snapshot"]
+    assert references
+
+    reference_ids = {reference["reference_id"] for reference in references}
+    assert {
+        "unicorn-python-api-reference",
+        "unicorn-raw-udp-interface",
+        "unicorn-recorder-hybrid-black",
+        "unicorn-bandpower-hybrid-black",
+    } <= reference_ids
+
+    covered_surfaces = {
+        surface_name
+        for reference in references
+        for surface_name in reference["supports"]
+    }
+    vendor_backed_surfaces = {
+        surface["name"]
+        for surface in payload["surfaces"]
+        if surface["evidence_class"] != "synthetic_assumption"
+    }
+    assert vendor_backed_surfaces <= covered_surfaces
+
+    github_references = [
+        reference
+        for reference in references
+        if "github.com/unicorn-bi/" in reference["locator"]
+    ]
+    assert github_references
+    assert all(reference["revision"].startswith("git-blob:") for reference in github_references)
+    assert all(reference["retrieved_date"] == "2026-08-26" for reference in references)

--- a/tests/test_unicorn_hybrid_black_sim.py
+++ b/tests/test_unicorn_hybrid_black_sim.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+from neuros.drivers.unicorn_hybrid_black_sim import (
+    UNICORN_DEVICE17_NAMES,
+    UNICORN_RECORDER19_NAMES,
+    UNICORN_SCALP_LABELS,
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+    UnicornHybridBlackSpec,
+    validate_unicorn_block,
+)
+
+
+def test_published_device_constants_and_quantization_are_explicit():
+    spec = UnicornHybridBlackSpec()
+    spec.validate()
+    assert spec.sampling_rate_hz == 250.0
+    assert spec.eeg_channels == 8
+    assert spec.acquired_channels == 17
+    assert spec.resolution_bits == 24
+    assert spec.sensitivity_uv == 750_000.0
+    assert spec.input_impedance_lower_bound_ohm == 1_000_000_000.0
+    assert spec.device_delay_ms == 40.0
+    assert 0.08 < spec.eeg_lsb_uv < 0.10
+
+
+def test_full_device_scan_matches_17_channel_api_order_and_units():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(schema="device17_api", seed=11)
+    )
+    block = sim.render(25)
+    assert block.data.shape == (17, 25)
+    assert block.channel_names == UNICORN_DEVICE17_NAMES
+    assert block.channel_units[:8] == ("microvolts",) * 8
+    assert block.channel_units[8:11] == ("g",) * 3
+    assert block.channel_units[11:14] == ("deg/s",) * 3
+    assert block.channel_units[14:] == ("count", "percent", "boolean")
+    assert np.all(np.diff(block.counter) == 1)
+    assert np.all(block.validation == 1)
+    report = validate_unicorn_block(block)
+    assert report.passed, report.to_dict()
+
+
+def test_recorder_view_adds_delta_time_and_status_without_inventing_eeg_channels():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(schema="recorder19", seed=17)
+    )
+    sim.set_status(23)
+    block = sim.render(20)
+    assert block.data.shape == (19, 20)
+    assert block.channel_names == UNICORN_RECORDER19_NAMES
+    assert np.allclose(block.data[17], 4.0)
+    assert np.all(block.data[18] == 23.0)
+    report = validate_unicorn_block(block)
+    assert report.passed, report.to_dict()
+
+
+def test_anatomical_eeg_view_keeps_standard_cap_order_for_game_decoders():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(schema="eeg8_anatomical", seed=19)
+    )
+    block = sim.render(10)
+    assert block.data.shape == (8, 10)
+    assert block.channel_names == UNICORN_SCALP_LABELS
+    assert validate_unicorn_block(block).passed
+
+
+def test_motion_aux_channels_do_not_silently_change_eeg_physiology():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(
+            schema="device17_api",
+            seed=23,
+            accelerometer_noise_g=0.0,
+            gyroscope_noise_dps=0.0,
+        )
+    )
+    sim.set_motion((0.25, -0.50, 0.90), (25.0, -10.0, 4.0))
+    block = sim.render(12)
+    assert np.allclose(block.data[8:11], np.asarray([[0.25], [-0.50], [0.90]]))
+    assert np.allclose(block.data[11:14], np.asarray([[25.0], [-10.0], [4.0]]))
+    # Motion telemetry is a device observable.  Motion-to-EEG contamination must
+    # be injected explicitly in the neural/world layer rather than hidden here.
+    assert np.all(np.isfinite(block.eeg_data_uv))
+
+
+def test_validation_and_counter_can_exercise_fail_closed_consumers():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(schema="device17_api", seed=29, counter_start=100)
+    )
+    first = sim.render(5)
+    sim.set_validation(0)
+    second = sim.render(5)
+    assert first.counter.tolist() == [100, 101, 102, 103, 104]
+    assert second.counter.tolist() == [105, 106, 107, 108, 109]
+    assert np.all(first.validation == 1)
+    assert np.all(second.validation == 0)
+
+
+def test_acquisition_availability_delay_is_separate_from_neural_sample_time():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(
+            schema="device17_api",
+            seed=31,
+            acquisition_delay_jitter_ms=0.0,
+        )
+    )
+    block = sim.render(50)
+    delay_ms = (block.available_timestamps_s - block.sample_timestamps_s) * 1000.0
+    assert np.allclose(delay_ms, 40.0)
+    assert np.allclose(np.diff(block.sample_timestamps_s), 1.0 / 250.0)
+
+
+def test_24_bit_clipping_and_quantization_are_applied_at_device_boundary():
+    generator = SyntheticEEGGenerator(
+        SyntheticEEGConfig(
+            sampling_rate_hz=250.0,
+            channel_names=UNICORN_SCALP_LABELS,
+            colored_noise_uv=0.0,
+            white_noise_uv=0.0,
+            alpha_amplitude_uv=0.0,
+            ssvep_amplitude_uv=0.0,
+            seed=37,
+        )
+    )
+    generator.inject_artifact("saturation", duration_seconds=0.1, severity=3000.0)
+    sim = UnicornHybridBlackSimulator(
+        generator,
+        config=UnicornHybridBlackSimulationConfig(schema="eeg8_anatomical", seed=37),
+    )
+    block = sim.render(10)
+    spec = UnicornHybridBlackSpec()
+    assert block.clipped_fraction > 0.0
+    assert np.max(np.abs(block.eeg_data_uv)) <= spec.sensitivity_uv + spec.eeg_lsb_uv
+    # Quantized values should sit on the advertised 24-bit grid to floating
+    # precision, after subtracting the negative full-scale origin.
+    grid = (block.eeg_data_uv.astype(float) + spec.sensitivity_uv) / spec.eeg_lsb_uv
+    assert np.max(np.abs(grid - np.round(grid))) < 0.25

--- a/tests/test_unicorn_network_sim.py
+++ b/tests/test_unicorn_network_sim.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuros.drivers.unicorn_hybrid_black_sim import (
+    UnicornHybridBlackSimulationConfig,
+    UnicornHybridBlackSimulator,
+)
+from neuros.drivers.unicorn_network_sim import (
+    BANDPOWER_BANDS,
+    BANDPOWER_FEATURE_COUNT,
+    RAW_UDP_PAYLOAD_BYTES,
+    UNICORN_RAW_UDP_NAMES,
+    UnicornBandpowerReferenceStream,
+    api17_scan_to_raw_udp_order,
+    compute_unicorn_bandpower_payload,
+    decode_unicorn_bandpower_ascii,
+    decode_unicorn_udp_scan,
+    encode_unicorn_bandpower_ascii,
+    encode_unicorn_udp_scan,
+    raw_udp_scan_to_api17_order,
+)
+
+
+def test_raw_udp_payload_is_exactly_one_17_float_scan_with_documented_wire_order():
+    sim = UnicornHybridBlackSimulator(
+        config=UnicornHybridBlackSimulationConfig(
+            schema="device17_api",
+            seed=101,
+            accelerometer_noise_g=0.0,
+            gyroscope_noise_dps=0.0,
+            counter_start=123,
+            battery_start_percent=73.0,
+        )
+    )
+    sim.set_motion((0.1, -0.2, 0.95), (1.0, 2.0, 3.0))
+    block = sim.render(3)
+    payload = encode_unicorn_udp_scan(block, 1)
+    assert len(payload) == RAW_UDP_PAYLOAD_BYTES == 68
+    decoded_wire = decode_unicorn_udp_scan(payload)
+    assert decoded_wire.shape == (17,)
+    assert UNICORN_RAW_UDP_NAMES[-3:] == ("BAT", "CNT", "VALID")
+    # API17 stores CNT/BAT/VALID at rows 14/15/16. Raw UDP is BAT/CNT/VALID.
+    assert np.isclose(decoded_wire[14], block.data[15, 1])
+    assert np.isclose(decoded_wire[15], block.data[14, 1])
+    assert np.isclose(decoded_wire[16], block.data[16, 1])
+    assert np.allclose(raw_udp_scan_to_api17_order(decoded_wire), block.data[:, 1])
+
+
+def test_api_udp_reorder_is_an_involution_and_does_not_touch_eeg_or_motion():
+    values = np.arange(17, dtype=np.float32) + 0.25
+    wire = api17_scan_to_raw_udp_order(values)
+    assert np.allclose(wire[:14], values[:14])
+    assert wire[14] == values[15]
+    assert wire[15] == values[14]
+    assert wire[16] == values[16]
+    assert np.allclose(raw_udp_scan_to_api17_order(wire), values)
+
+
+def test_bandpower_payload_has_documented_70_value_layout():
+    fs = 250.0
+    t = np.arange(250) / fs
+    eeg = np.vstack([
+        np.sin(2 * np.pi * (8.0 + index * 0.25) * t)
+        for index in range(8)
+    ])
+    payload = compute_unicorn_bandpower_payload(eeg, sampling_rate_hz=fs)
+    assert payload.shape == (BANDPOWER_FEATURE_COUNT,) == (70,)
+    assert len(BANDPOWER_BANDS) == 7
+    # First 56 values are seven band-major groups of eight channels.
+    assert payload[:56].reshape(7, 8).shape == (7, 8)
+    # Remaining values are seven channel averages + seven bipolar averages.
+    assert payload[56:63].shape == (7,)
+    assert payload[63:70].shape == (7,)
+
+
+def test_disabled_bandpower_channels_are_nan_but_averages_remain_defined():
+    rng = np.random.default_rng(5)
+    eeg = rng.normal(size=(8, 250))
+    enabled = [True, False, True, True, True, True, True, True]
+    payload = compute_unicorn_bandpower_payload(eeg, enabled_channels=enabled)
+    per_channel = payload[:56].reshape(7, 8)
+    assert np.all(np.isnan(per_channel[:, 1]))
+    assert np.all(np.isfinite(payload[56:63]))
+    assert np.all(np.isfinite(payload[63:70]))
+
+
+def test_bandpower_ascii_round_trip_preserves_nan_and_feature_count():
+    values = np.arange(70, dtype=float)
+    values[9] = np.nan
+    encoded = encode_unicorn_bandpower_ascii(values)
+    decoded = decode_unicorn_bandpower_ascii(encoded)
+    assert decoded.shape == (70,)
+    assert np.isnan(decoded[9])
+    assert np.allclose(decoded[np.isfinite(decoded)], values[np.isfinite(values)])
+
+
+def test_default_bandpower_stream_matches_documented_25hz_update_cadence():
+    stream = UnicornBandpowerReferenceStream()
+    assert stream.buffer_size == 250
+    assert stream.buffer_overlap == 240
+    assert stream.hop_samples == 10
+    assert stream.update_rate_hz == 25.0
+    rng = np.random.default_rng(11)
+    # First full 250-sample window emits once, then every 10 new samples.
+    first = stream.push(rng.normal(size=(8, 250)))
+    assert len(first) == 1
+    second = stream.push(rng.normal(size=(8, 30)))
+    assert len(second) == 3
+    assert [frame.sample_index for frame in second] == [259, 269, 279]

--- a/tests/test_unicorn_receiver_guard.py
+++ b/tests/test_unicorn_receiver_guard.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from neuros.drivers.unicorn_network_sim import decode_unicorn_udp_scan
+from neuros.drivers.unicorn_receiver_guard import UnicornRawUdpGuard, UnicornRawUdpGuardConfig
+from neuros.drivers.unicorn_transport_sim import UnicornRawUdpStreamSimulator, UnicornUdpFaultProfile
+
+
+def _packet(stream: UnicornRawUdpStreamSimulator) -> bytes:
+    datagrams = stream.next_datagrams()
+    assert len(datagrams) == 1
+    return datagrams[0].payload
+
+
+def _set_validation(payload: bytes, value: float) -> bytes:
+    values = decode_unicorn_udp_scan(payload).astype(float)
+    values[16] = value
+    return struct.pack("<17f", *values.tolist())
+
+
+def test_authority_requires_consecutive_valid_sequential_packets():
+    stream = UnicornRawUdpStreamSimulator(seed=101)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=3))
+    first = guard.ingest(_packet(stream), received_monotonic_s=0.000)
+    second = guard.ingest(_packet(stream), received_monotonic_s=0.004)
+    third = guard.ingest(_packet(stream), received_monotonic_s=0.008)
+    assert [first.authority_allowed, second.authority_allowed, third.authority_allowed] == [False, False, True]
+    assert guard.state(now_monotonic_s=0.009).authority_allowed is True
+
+
+def test_counter_gap_revokes_authority_and_requires_recovery_streak():
+    profile = UnicornUdpFaultProfile(name="drop-fourth", drop_every=4)
+    stream = UnicornRawUdpStreamSimulator(seed=103, fault_profile=profile)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=2))
+    assert guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.000).authority_allowed is False
+    assert guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.004).authority_allowed is True
+    guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.008)
+    assert stream.next_datagrams() == ()  # counter 3 lost in transport
+    gap = guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.016)
+    assert gap.health == "gap"
+    assert gap.missed_packets == 1
+    assert gap.authority_allowed is False
+    assert guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.020).authority_allowed is False
+    assert guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.024).authority_allowed is True
+
+
+def test_validation_zero_preserves_liveness_and_counter_but_revokes_authority():
+    stream = UnicornRawUdpStreamSimulator(seed=107)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=2))
+    guard.ingest(_packet(stream), received_monotonic_s=0.000)
+    assert guard.ingest(_packet(stream), received_monotonic_s=0.004).authority_allowed is True
+    invalid_payload = _set_validation(_packet(stream), 0.0)
+    invalid = guard.ingest(invalid_payload, received_monotonic_s=0.008)
+    assert invalid.health == "invalid"
+    assert invalid.counter == 2
+    assert invalid.authority_allowed is False
+    # Counter 3 follows the observed invalid packet sequentially; liveness is
+    # continuous but authority still has to rebuild from a fresh healthy streak.
+    recovered_one = guard.ingest(_packet(stream), received_monotonic_s=0.012)
+    recovered_two = guard.ingest(_packet(stream), received_monotonic_s=0.016)
+    assert recovered_one.health == recovered_two.health == "healthy"
+    assert recovered_one.authority_allowed is False
+    assert recovered_two.authority_allowed is True
+
+
+def test_duplicate_and_reordered_packets_fail_closed():
+    duplicate_stream = UnicornRawUdpStreamSimulator(
+        seed=109,
+        fault_profile=UnicornUdpFaultProfile(name="dup-third", duplicate_every=3),
+    )
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=1))
+    guard.ingest(duplicate_stream.next_datagrams()[0].payload, received_monotonic_s=0.000)
+    guard.ingest(duplicate_stream.next_datagrams()[0].payload, received_monotonic_s=0.004)
+    pair = duplicate_stream.next_datagrams()
+    assert len(pair) == 2
+    assert guard.ingest(pair[0].payload, received_monotonic_s=0.008).authority_allowed is True
+    duplicate = guard.ingest(pair[1].payload, received_monotonic_s=0.0081)
+    assert duplicate.health == "duplicate"
+    assert duplicate.authority_allowed is False
+
+    reorder_stream = UnicornRawUdpStreamSimulator(
+        seed=113,
+        fault_profile=UnicornUdpFaultProfile(name="reorder-third", reorder_every=3),
+    )
+    reorder_guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=1))
+    reorder_guard.ingest(reorder_stream.next_datagrams()[0].payload, received_monotonic_s=0.000)
+    reorder_guard.ingest(reorder_stream.next_datagrams()[0].payload, received_monotonic_s=0.004)
+    assert reorder_stream.next_datagrams() == ()
+    pair = reorder_stream.next_datagrams()
+    newer = reorder_guard.ingest(pair[0].payload, received_monotonic_s=0.012)
+    older = reorder_guard.ingest(pair[1].payload, received_monotonic_s=0.013)
+    assert newer.health == "gap"
+    assert older.health == "out_of_order"
+    assert newer.authority_allowed is older.authority_allowed is False
+
+
+def test_stale_interval_revokes_authority_and_fresh_packet_cannot_inherit_old_streak():
+    stream = UnicornRawUdpStreamSimulator(seed=127)
+    guard = UnicornRawUdpGuard(
+        UnicornRawUdpGuardConfig(stale_after_s=0.050, recovery_packets=2)
+    )
+    guard.ingest(_packet(stream), received_monotonic_s=0.000)
+    assert guard.ingest(_packet(stream), received_monotonic_s=0.004).authority_allowed is True
+    stale = guard.state(now_monotonic_s=0.100)
+    assert stale.health == "stale"
+    assert stale.authority_allowed is False
+    fresh_one = guard.ingest(_packet(stream), received_monotonic_s=0.104)
+    fresh_two = guard.ingest(_packet(stream), received_monotonic_s=0.108)
+    assert fresh_one.authority_allowed is False
+    assert fresh_two.authority_allowed is True
+
+
+def test_malformed_packet_never_updates_authority():
+    guard = UnicornRawUdpGuard()
+    malformed = guard.ingest(b"too short", received_monotonic_s=1.0)
+    assert malformed.health == "malformed"
+    assert malformed.authority_allowed is False
+    assert guard.state(now_monotonic_s=1.01).health == "stale"
+
+
+def test_guard_config_rejects_invalid_policies():
+    with pytest.raises(ValueError):
+        UnicornRawUdpGuardConfig(stale_after_s=0.0).validate()
+    with pytest.raises(ValueError):
+        UnicornRawUdpGuardConfig(recovery_packets=0).validate()

--- a/tests/test_unicorn_trace.py
+++ b/tests/test_unicorn_trace.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from neuros.drivers.unicorn_trace import (
+    analyze_unicorn_raw_udp_trace,
+    compare_unicorn_trace_to_nominal_contract,
+)
+from neuros.drivers.unicorn_transport_sim import UnicornRawUdpStreamSimulator, UnicornUdpFaultProfile
+
+
+def _collect(stream: UnicornRawUdpStreamSimulator, updates: int):
+    records = []
+    for _ in range(updates):
+        for datagram in stream.next_datagrams():
+            records.append((datagram.release_time_s, datagram.payload))
+    for datagram in stream.flush():
+        records.append((datagram.release_time_s, datagram.payload))
+    records.sort(key=lambda item: item[0])
+    return records
+
+
+def test_pristine_trace_reduces_to_shareable_metadata_without_raw_eeg():
+    stream = UnicornRawUdpStreamSimulator(seed=151)
+    summary = analyze_unicorn_raw_udp_trace(
+        _collect(stream, 251),
+        source_kind="synthetic",
+        source_label="ci-pristine",
+    )
+    payload = summary.to_dict()
+    assert payload["packet_count"] == 251
+    assert payload["decoded_packet_count"] == 251
+    assert payload["malformed_packet_count"] == 0
+    assert payload["estimated_arrival_rate_hz"] == pytest.approx(250.0)
+    assert payload["mean_interarrival_ms"] == pytest.approx(4.0)
+    assert payload["first_counter"] == 0
+    assert payload["last_counter"] == 250
+    assert payload["counter_gap_events"] == 0
+    assert payload["duplicate_packets"] == 0
+    assert payload["out_of_order_packets"] == 0
+    assert payload["contains_raw_eeg"] is False
+    assert "eeg" not in payload or payload["contains_raw_eeg"] is False
+
+    comparison = compare_unicorn_trace_to_nominal_contract(summary)
+    assert comparison.passed_diagnostic_checks is True
+
+
+def test_periodic_loss_is_visible_as_counter_gaps_without_malformed_packets():
+    stream = UnicornRawUdpStreamSimulator(
+        seed=157,
+        fault_profile=UnicornUdpFaultProfile(name="drop-10", drop_every=10),
+    )
+    summary = analyze_unicorn_raw_udp_trace(_collect(stream, 50), source_kind="synthetic")
+    assert summary.packet_count == 45
+    assert summary.malformed_packet_count == 0
+    assert summary.counter_gap_events == 4
+    assert summary.inferred_missing_packets == 4
+    assert summary.duplicate_packets == 0
+    assert summary.out_of_order_packets == 0
+    # The arrival rate is lower because the test records transport delivery
+    # times rather than pretending dropped packets arrived.
+    assert summary.estimated_arrival_rate_hz is not None
+    assert summary.estimated_arrival_rate_hz < 250.0
+
+
+def test_duplicate_and_reorder_probe_are_distinguished():
+    duplicate_stream = UnicornRawUdpStreamSimulator(
+        seed=163,
+        fault_profile=UnicornUdpFaultProfile(name="dup-five", duplicate_every=5),
+    )
+    duplicate_summary = analyze_unicorn_raw_udp_trace(_collect(duplicate_stream, 20))
+    assert duplicate_summary.duplicate_packets == 4
+    assert duplicate_summary.out_of_order_packets == 0
+
+    reorder_stream = UnicornRawUdpStreamSimulator(
+        seed=167,
+        fault_profile=UnicornUdpFaultProfile(name="reorder-five", reorder_every=5),
+    )
+    reorder_summary = analyze_unicorn_raw_udp_trace(_collect(reorder_stream, 20))
+    assert reorder_summary.out_of_order_packets > 0
+    assert reorder_summary.counter_gap_events > 0
+
+
+def test_malformed_payload_is_counted_but_never_persisted():
+    stream = UnicornRawUdpStreamSimulator(seed=173)
+    records = _collect(stream, 3)
+    records.insert(1, (0.002, b"bad"))
+    records.sort(key=lambda item: item[0])
+    summary = analyze_unicorn_raw_udp_trace(records, source_kind="unknown")
+    assert summary.packet_count == 4
+    assert summary.decoded_packet_count == 3
+    assert summary.malformed_packet_count == 1
+    assert summary.to_dict()["contains_raw_eeg"] is False
+
+
+def test_user_declared_physical_is_explicitly_not_cryptographic_provenance():
+    summary = analyze_unicorn_raw_udp_trace(
+        [],
+        source_kind="user_declared_physical",
+        source_label="lab-headset-a",
+    )
+    payload = summary.to_dict()
+    assert payload["source_kind"] == "user_declared_physical"
+    assert payload["source_label"] == "lab-headset-a"
+    assert "user-declared" in payload["evidence_boundary"]
+
+
+def test_trace_requires_monotonic_receive_timestamps():
+    with pytest.raises(ValueError):
+        analyze_unicorn_raw_udp_trace([(1.0, b"x"), (0.5, b"y")])

--- a/tests/test_unicorn_transport_sim.py
+++ b/tests/test_unicorn_transport_sim.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.drivers.unicorn_network_sim import (
+    RAW_UDP_PAYLOAD_BYTES,
+    decode_unicorn_bandpower_ascii,
+    decode_unicorn_udp_scan,
+)
+from neuros.drivers.unicorn_transport_sim import (
+    DeterministicPacketFaultEngine,
+    UnicornBandpowerUdpStreamSimulator,
+    UnicornRawUdpStreamSimulator,
+    UnicornUdpFaultProfile,
+    get_unicorn_udp_fault_profile,
+)
+
+
+def _counter(datagram) -> int:
+    # Raw UDP wire order is BAT, CNT, VALID at indices 14..16.
+    return int(round(float(decode_unicorn_udp_scan(datagram.payload)[15])))
+
+
+def test_pristine_raw_stream_preserves_68_byte_packets_and_counter_continuity():
+    stream = UnicornRawUdpStreamSimulator(seed=3)
+    packets = [stream.next_datagrams() for _ in range(4)]
+    assert all(len(item) == 1 for item in packets)
+    flattened = [item[0] for item in packets]
+    assert all(len(packet.payload) == RAW_UDP_PAYLOAD_BYTES for packet in flattened)
+    assert [_counter(packet) for packet in flattened] == [0, 1, 2, 3]
+    assert [packet.source_sequence for packet in flattened] == [0, 1, 2, 3]
+
+
+def test_transport_drop_does_not_rewind_device_counter():
+    profile = UnicornUdpFaultProfile(name="drop-third", drop_every=3)
+    stream = UnicornRawUdpStreamSimulator(seed=5, fault_profile=profile)
+    first = stream.next_datagrams()[0]
+    second = stream.next_datagrams()[0]
+    dropped = stream.next_datagrams()
+    fourth = stream.next_datagrams()[0]
+    assert dropped == ()
+    assert [_counter(first), _counter(second), _counter(fourth)] == [0, 1, 3]
+    assert fourth.source_sequence == 3
+
+
+def test_duplicate_probe_emits_same_payload_with_explicit_duplicate_ordinal():
+    profile = UnicornUdpFaultProfile(name="dup-second", duplicate_every=2)
+    stream = UnicornRawUdpStreamSimulator(seed=7, fault_profile=profile)
+    assert len(stream.next_datagrams()) == 1
+    pair = stream.next_datagrams()
+    assert len(pair) == 2
+    assert pair[0].payload == pair[1].payload
+    assert pair[0].source_sequence == pair[1].source_sequence == 1
+    assert pair[0].duplicate_ordinal == 0
+    assert pair[1].duplicate_ordinal == 1
+    assert "duplicate" in pair[1].faults
+
+
+def test_reorder_probe_releases_newer_packet_before_held_packet():
+    profile = UnicornUdpFaultProfile(name="reorder-third", reorder_every=3)
+    stream = UnicornRawUdpStreamSimulator(seed=11, fault_profile=profile)
+    assert stream.next_datagrams()[0].source_sequence == 0
+    assert stream.next_datagrams()[0].source_sequence == 1
+    assert stream.next_datagrams() == ()  # sequence 2 held
+    reordered = stream.next_datagrams()   # sequence 3 released before sequence 2
+    assert [packet.source_sequence for packet in reordered] == [3, 2]
+    assert [_counter(packet) for packet in reordered] == [3, 2]
+    assert "reordered_before_previous" in reordered[0].faults
+    assert "reordered_after_next" in reordered[1].faults
+
+
+def test_delay_probe_changes_release_time_without_changing_source_time():
+    profile = UnicornUdpFaultProfile(name="delay-second", delay_every=2, delay_ms=12.0)
+    engine = DeterministicPacketFaultEngine(profile, nominal_interval_s=0.004)
+    first = engine.process(b"a", source_sequence=0, nominal_time_s=0.0)[0]
+    second = engine.process(b"b", source_sequence=1, nominal_time_s=0.004)[0]
+    assert first.release_time_s == first.nominal_time_s
+    assert second.nominal_time_s == pytest.approx(0.004)
+    assert second.release_time_s == pytest.approx(0.016)
+    assert "delay" in second.faults
+
+
+def test_named_fault_profiles_are_explicit_synthetic_assumptions():
+    torture = get_unicorn_udp_fault_profile("mixed-torture")
+    assert torture.evidence_class == "synthetic_assumption"
+    assert torture.drop_every > 0
+    assert torture.duplicate_every > 0
+    assert torture.delay_every > 0
+    assert torture.reorder_every > 0
+    with pytest.raises(KeyError):
+        get_unicorn_udp_fault_profile("real-bluetooth-statistics")
+
+
+def test_bandpower_udp_stream_emits_one_70_value_frame_per_25hz_update():
+    stream = UnicornBandpowerUdpStreamSimulator(seed=13)
+    first = stream.next_datagrams()
+    second = stream.next_datagrams()
+    assert len(first) == len(second) == 1
+    assert first[0].nominal_time_s == pytest.approx(0.0)
+    assert second[0].nominal_time_s == pytest.approx(1.0 / 25.0)
+    values = decode_unicorn_bandpower_ascii(first[0].payload)
+    assert values.shape == (70,)
+    assert np.all(np.isfinite(values))
+
+
+def test_fault_profile_validation_rejects_ambiguous_delay_and_impossible_reorder():
+    with pytest.raises(ValueError):
+        UnicornUdpFaultProfile(name="bad-delay", delay_ms=5.0).validate()
+    with pytest.raises(ValueError):
+        UnicornUdpFaultProfile(name="bad-delay", delay_every=2, delay_ms=0.0).validate()
+    with pytest.raises(ValueError):
+        UnicornUdpFaultProfile(name="bad-reorder", reorder_every=1).validate()


### PR DESCRIPTION
## Summary

Adds a dedicated **Unicorn Hybrid Black hardware-substitution and game-integration suite** directly on current `main`, built on the release-qualified Synthetic BCI Arena, Phantom source, and external-plugin developer-preview layers.

The goal is not to call synthetic EEG a physical Unicorn. The goal is to let BCI/game developers exercise documented device/interface contracts, deterministic transport failures, receiver authority, and game-engine integration before continuous hardware access, while keeping three causal layers separate:

1. neural/physiological world models in Arena;
2. the Unicorn device/interface twin in `neuros-drivers`;
3. transport and application/game behavior downstream.

## Hardware/interface surfaces

The suite models the current public 8-channel / 250 Hz / 24-bit / ±750 mV Unicorn envelope, 3-axis accelerometer + gyroscope, direct API17 acquisition view, raw UDP17 wire view, Recorder19 fields, Bandpower70 interface, LSL substitution, API lifecycle/faults, and a canonical Arena device profile.

A regression-protected interface distinction is explicit:

```text
API/Recorder: CNT → BAT → VALID
raw UDP:      BAT → CNT → VALID
```

Raw UDP targets the official 250 Hz / 17 float / 68-byte contract. Little-endian remains a neurOS profile default based on the official Windows/BitConverter example rather than being promoted to an unconditional manufacturer guarantee where public documentation does not separately specify byte order.

Bandpower layout/bands/cadence are vendor-backed compatibility targets; the spectral estimator remains a transparent **neurOS reference implementation**, not a claim of proprietary numerical parity.

## Receiver authority and transport torture

`UnicornRawUdpGuard` and the dependency-free C# `UnicornRawUdpClient` fail closed for malformed/non-finite packets, `VALID=0`, duplicates, reordering, counter gaps, and stale streams, and require a healthy recovery streak before neural authority returns.

Game/application liveness remains separate from BCI authority. A game may keep rendering and accepting non-BCI controls while neural authority is revoked.

Deterministic fault profiles exercise loss, duplicates, delay, reordering, and mixed torture. These are test policies, not measured Unicorn Bluetooth statistics.

## C# game-engine integration

`examples/game_engines/csharp/UnicornRawUdpClient.cs` is engine-independent and is compiled in driver CI. It can be wrapped by Unity, Godot, or another .NET-capable application without giving the game responsibility for synthetic neural-world generation.

## Privacy-safe physical trace bridge

`unicorn_trace.py` and `examples/unicorn_raw_udp_trace_capture.py` produce shareable interface/timing summaries without persisting EEG arrays or raw packets. They preserve packet/cadence/counter/validation/battery diagnostics and deliberately label physical provenance as `user_declared_physical`, not cryptographically proven.

This creates the intended paired-substitution loop:

```text
same receiver / same application
       ↑             ↑
neurOS twin     physical Unicorn
       ↓             ↓
trace summary   trace summary
       └──── compare ────┘
```

A discrepancy should correct/version the appropriate simulator layer rather than be hidden by application tuning.

## Auditable compatibility receipts

`run_unicorn_compatibility_suite()` emits `neuros.unicorn_hybrid_black_sim.compatibility.v1` with surfaces classified as:

- `exact_contract`;
- `reference_implementation`;
- `synthetic_assumption`.

The receipt now embeds an immutable `upstream_contract_snapshot` for the public sources used on 2026-08-26. Official `unicorn-bi` Python API, raw UDP, Recorder, and Bandpower references carry frozen Git blob identities; the current g.tec product and g.Pype sources carry explicit retrieval/version markers.

CI requires every non-synthetic compatibility surface to have frozen upstream coverage. Historical “exact contract” results therefore remain auditable if vendor documentation later changes.

## Documentation

Maintained strict MkDocs navigation now exposes:

- `UNICORN_HYBRID_BLACK_SIMULATION_SUITE.md` — interface/evidence matrix and physical paired-validation protocol;
- `UNICORN_GAME_DEVELOPMENT.md` — end-to-end game workflow, authority guard, transport profiles, Arena worlds, C# integration and physical trace capture.

The external `PLUGIN_AUTHORING.md` developer-preview surface merged in #49 is preserved in the same branch state.

## Exact-head qualification

Exact head: `c25c8068c73c87514b6de1045558eba4415527c6`

All ten triggered workflows are green:

- **neurOS driver contracts** — BrainFlow/LSL plus full Unicorn device/API/UDP/Bandpower/transport/receiver/trace/provenance suite and C# compilation;
- **Synthetic BCI Arena**;
- **neurOS CI** — full workspace/kernel/BCI/recording/model/foundation/SourceWeigher/ORION/scientific matrix;
- **Release Candidate Artifacts** — strict docs, every workspace wheel, checksum/component manifests and exact-wheel SDK/Arena smoke install;
- **Public Trust Contracts**;
- **External Plugin Contract** — clean-wheel out-of-tree plugin path on Python 3.10, 3.11 and 3.12;
- **ORION Adaptation Authority**;
- **Three-way Adaptive Study**;
- **Ecosystem Compatibility**;
- **NeuroAI Ecosystem Evidence**.

The branch also contains current `main` as an explicit second parent, so this qualification includes the newly merged developer-preview plugin contract rather than relying on a stale stacked base.

## Evidence boundary

This PR establishes strong **hardware-free device/interface conformance and application-robustness evidence**.

It cannot self-award physical-hardware qualification, measured Bluetooth behavior, human BCI accuracy, physiological validity, or clinical evidence. The next stronger gate is a paired substitution study using one unchanged receiver/application against this twin and a named physical Unicorn/firmware/host configuration.