### PR TITLE
Developer preview: prove out-of-tree plugin authoring through clean wheels

### DIFF
--- a/.github/workflows/external-plugin.yml
+++ b/.github/workflows/external-plugin.yml
@@ -1,0 +1,129 @@
+name: External Plugin Contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/external-plugin.yml"
+      - "examples/plugins/**"
+      - "docs/PLUGIN_AUTHORING.md"
+      - "mkdocs.yml"
+      - "scripts/list_workspace_packages.py"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/pyproject.toml"
+      - "packages/neuros-models/pyproject.toml"
+      - "packages/neuros-models/src/neuros/models/threshold_decoder.py"
+      - "packages/neuros/pyproject.toml"
+      - "packages/neuros/src/neuros/cli.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/external-plugin.yml"
+      - "examples/plugins/**"
+      - "docs/PLUGIN_AUTHORING.md"
+      - "mkdocs.yml"
+      - "scripts/list_workspace_packages.py"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/pyproject.toml"
+      - "packages/neuros-models/pyproject.toml"
+      - "packages/neuros-models/src/neuros/models/threshold_decoder.py"
+      - "packages/neuros/pyproject.toml"
+      - "packages/neuros/src/neuros/cli.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-plugin-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clean-wheel-contract:
+    name: Out-of-tree plugin / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Prove reference plugin is not a workspace member
+        run: |
+          set -euo pipefail
+          if python scripts/list_workspace_packages.py | grep -Fxq "examples/plugins/neuros-example-plugin"; then
+            echo "reference external plugin must remain outside the neurOS workspace" >&2
+            exit 1
+          fi
+      - name: Build exact neurOS and external plugin wheels
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install build
+          DIST="${RUNNER_TEMP}/plugin-wheels"
+          mkdir -p "${DIST}"
+          python -m build --wheel --outdir "${DIST}" packages/neuros-core
+          python -m build --wheel --outdir "${DIST}" packages/neuros-drivers
+          python -m build --wheel --outdir "${DIST}" packages/neuros-models
+          python -m build --wheel --outdir "${DIST}" packages/neuros
+          python -m build --wheel --outdir "${DIST}" examples/plugins/neuros-example-plugin
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 5
+      - name: Install only built neurOS/plugin artifacts in a clean environment
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/plugin-wheels"
+          python -m venv "${RUNNER_TEMP}/plugin-smoke"
+          PY="${RUNNER_TEMP}/plugin-smoke/bin/python"
+          PIP="${RUNNER_TEMP}/plugin-smoke/bin/pip"
+          "${PY}" -m pip install --upgrade pip
+          CORE="$(find "${DIST}" -name 'neuros_core-*.whl' -print -quit)"
+          DRIVERS="$(find "${DIST}" -name 'neuros_drivers-*.whl' -print -quit)"
+          MODELS="$(find "${DIST}" -name 'neuros_models-*.whl' -print -quit)"
+          SDK="$(find "${DIST}" -name 'neuros-[0-9]*.whl' -print -quit)"
+          PLUGIN="$(find "${DIST}" -name 'neuros_example_plugin-*.whl' -print -quit)"
+          test -n "${CORE}"
+          test -n "${DRIVERS}"
+          test -n "${MODELS}"
+          test -n "${SDK}"
+          test -n "${PLUGIN}"
+          "${PIP}" install "${CORE}" "${DRIVERS}" "${MODELS}" "${SDK}" "${PLUGIN}" pytest pytest-asyncio
+          "${PIP}" check
+      - name: Verify distribution metadata and entry-point provenance
+        run: |
+          set -euo pipefail
+          PY="${RUNNER_TEMP}/plugin-smoke/bin/python"
+          "${PY}" - <<'PY'
+          from importlib import metadata
+          from neuros.contracts import Source, Transform
+          from neuros.plugins import PluginKind, PluginRegistry
+
+          dist = metadata.distribution("neuros-example-plugin")
+          requirements = tuple(dist.requires or ())
+          assert any(req.startswith("neuros-core") and "<3.0.0" in req and ">=2.0.0" in req for req in requirements), requirements
+
+          registry = PluginRegistry()
+          registry.discover()
+          source_desc = registry.get(PluginKind.SOURCE, "example_sine")
+          transform_desc = registry.get(PluginKind.TRANSFORM, "example_gain")
+          assert source_desc.distribution == "neuros-example-plugin", source_desc
+          assert transform_desc.distribution == "neuros-example-plugin", transform_desc
+          assert source_desc.version == dist.version
+          assert transform_desc.version == dist.version
+          assert isinstance(registry.create(PluginKind.SOURCE, "example_sine"), Source)
+          assert isinstance(registry.create(PluginKind.TRANSFORM, "example_gain"), Transform)
+          PY
+      - name: Run external package protocol tests against installed wheel
+        run: |
+          PY="${RUNNER_TEMP}/plugin-smoke/bin/python"
+          "${PY}" -m pytest -q examples/plugins/neuros-example-plugin/tests
+      - name: Execute config-first runtime through installed entry points
+        run: |
+          set -euo pipefail
+          NEUROS="${RUNNER_TEMP}/plugin-smoke/bin/neuros"
+          CONFIG="examples/plugins/neuros-example-plugin/example.yaml"
+          "${NEUROS}" plugins --json
+          "${NEUROS}" validate "${CONFIG}" --json
+          "${NEUROS}" run "${CONFIG}" --duration 0.08 --json

--- a/.github/workflows/external-plugin.yml
+++ b/.github/workflows/external-plugin.yml
@@ -33,6 +33,8 @@ on:
 permissions:
   contents: read
 
+# Matrix values only exist inside jobs. Keep workflow-level cancellation scoped
+# to the PR/ref so a new revision cancels all stale Python-version jobs together.
 concurrency:
   group: external-plugin-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The repository contains multiple internal distributions, but the public product 
 
 `neuros-arena` belongs to **Evidence**. It is a deterministic BCI systems wind tunnel for finding failures across display, neural-world, device, transport, decoder, and application boundaries. It is not a fifth product surface and a simulator cannot self-promote a biological claim.
 
-Read [`docs/PLATFORM.md`](docs/PLATFORM.md) for the governing architecture, [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) for the evidence-backed ecosystem matrix, [`docs/SYNTHETIC_BCI_ARENA.md`](docs/SYNTHETIC_BCI_ARENA.md) for the Arena contract, and [`docs/getting-started/first-10-minutes.md`](docs/getting-started/first-10-minutes.md) for the shortest newcomer path.
+Read [`docs/PLATFORM.md`](docs/PLATFORM.md) for the governing architecture, [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) for the evidence-backed ecosystem matrix, [`docs/SYNTHETIC_BCI_ARENA.md`](docs/SYNTHETIC_BCI_ARENA.md) for the Arena contract, [`docs/PLUGIN_AUTHORING.md`](docs/PLUGIN_AUTHORING.md) for out-of-tree extension authoring, and [`docs/getting-started/first-10-minutes.md`](docs/getting-started/first-10-minutes.md) for the shortest newcomer path.
 
 ## Architecture
 
@@ -292,9 +292,11 @@ neuros.world_models
 
 The kernel does not import concrete hardware, model ecosystems, UI/cloud integrations, ORION implementations, or Arena world-model implementations. A world-model plugin owns neural dynamics, not display/device/transport/application semantics.
 
-A useful integration should solve a concrete boundary problem: canonical conversion, synchronization, conformance, reproducibility, evidence, transfer/adaptation, or duplicated glue assumptions. Package-name accumulation is not a goal.
+The maintained [`examples/plugins/neuros-example-plugin`](examples/plugins/neuros-example-plugin/README.md) distribution is deliberately kept **outside the workspace**. It contributes a structural `Source` and `Transform`, declares a bounded `neuros-core` compatibility range, and is built/installed as its own wheel in a clean Python 3.10–3.12 CI matrix. That matrix verifies entry-point distribution/version provenance, protocol conformance, `pip check`, YAML resolution, and execution through the installed `neuros` CLI.
 
-A maintained out-of-tree plugin authoring kit and clean-wheel compatibility lane are the next major developer-preview usability gate.
+See [`docs/PLUGIN_AUTHORING.md`](docs/PLUGIN_AUTHORING.md) for the supported authoring contract and how to copy the reference into a separate repository.
+
+A useful integration should solve a concrete boundary problem: canonical conversion, synchronization, conformance, reproducibility, evidence, transfer/adaptation, or duplicated glue assumptions. Package-name accumulation is not a goal.
 
 ## Scientific trust and releases
 
@@ -319,7 +321,7 @@ packages/
   neuros-core/          stable runtime/data/replay/plugin contracts
   neuros-drivers/       hardware, simulated, dataset, and LSL sources
   neuros/               user-facing SDK, CLI, interoperability composition
-  orion/                stable ORION token/representation/adaptation/assessment contracts
+  orion/                source directory for the neuros-orion distribution
   neuros-arena/         causal synthetic worlds, faults, populations, counterexamples
   neuros-models/        task decoders and inspectable model surfaces
   neuros-foundation/    foundation-model and real-dataset evidence adapters
@@ -330,11 +332,11 @@ packages/
   neuros-cloud/         optional distributed/provider integrations
 ```
 
-These are implementation boundaries, not twelve competing product identities.
+These are implementation boundaries, not twelve competing product identities. External plugin examples under `examples/plugins/` are intentionally not workspace members.
 
 ## Quality
 
-CI separates kernel contracts across Python 3.10-3.12, installed BCI execution, workspace wheel builds, recording/replay and NWB/Zarr interoperability, scientific/latency gates, model/mechanistic contracts, foundation interoperability, SourceWeigher, ORION authority, longitudinal real-dataset evidence, hardware-boundary drivers, ecosystem compatibility, NeuroAI upstream conformance, Synthetic BCI Arena, public trust, and release-candidate artifacts.
+CI separates kernel contracts across Python 3.10-3.12, installed BCI execution, workspace wheel builds, recording/replay and NWB/Zarr interoperability, scientific/latency gates, model/mechanistic contracts, foundation interoperability, SourceWeigher, ORION authority, longitudinal real-dataset evidence, hardware-boundary drivers, ecosystem compatibility, NeuroAI upstream conformance, Synthetic BCI Arena, **External Plugin Contract**, public trust, and release-candidate artifacts.
 
 Hardware-specific claims require recorded qualification manifests for the exact device, firmware, transport, host, configuration, model, and artifact identities involved.
 
@@ -342,7 +344,7 @@ Hardware-specific claims require recorded qualification manifests for the exact 
 
 The highest-value sequence is now:
 
-1. ship a maintained out-of-tree plugin authoring kit and clean-wheel compatibility lane so external labs can extend neurOS without kernel forks;
+1. graduate the out-of-tree reference kit into an independent starter repository and use it to qualify a real external hardware/model plugin without kernel edits;
 2. execute the predeclared longitudinal EEG model ladder and ORION calibration-reduction studies under identical frozen split/final-assessment authority;
 3. anchor Arena world banks against held-out public EEG and expand world models only behind the common causal contract;
 4. establish DANDI/SpikeInterface invasive-data interoperability and selected visual-neuroscience benchmark evidence;

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -1,0 +1,204 @@
+# External Plugin Authoring
+
+neurOS is designed to be extended **without editing the kernel**. A hardware vendor, lab, research group, or application team should be able to publish an ordinary Python distribution that contributes one or more entry points and exchanges only stable neurOS contracts.
+
+The maintained reference package is [`examples/plugins/neuros-example-plugin`](../examples/plugins/neuros-example-plugin/README.md). It is intentionally excluded from the root workspace so CI proves that discovery works across a real distribution boundary.
+
+## Extension groups
+
+Current entry-point groups are:
+
+```text
+neuros.sources
+neuros.transforms
+neuros.tokenizers
+neuros.encoders
+neuros.decoders
+neuros.sinks
+neuros.monitors
+neuros.world_models
+```
+
+Use the narrowest group that expresses the component's responsibility. A world-model plugin, for example, should not also take over Arena's display, device, transport, or application semantics merely because those layers are convenient to access.
+
+## Minimal package metadata
+
+A source/transform plugin can depend on `neuros-core` rather than the complete SDK:
+
+```toml
+[project]
+name = "my-neuros-plugin"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+  "neuros-core>=2.0.0,<3.0.0",
+]
+
+[project.entry-points."neuros.sources"]
+my_device = "my_plugin.source:MySource"
+
+[project.entry-points."neuros.transforms"]
+my_transform = "my_plugin.transforms:MyTransform"
+```
+
+The bounded `neuros-core` dependency is version negotiation. If your package has only been qualified against the 2.x contracts, do not publish an unbounded dependency that silently accepts an incompatible future major version.
+
+## Source contract
+
+A source is structural. Subclassing a neurOS base driver is not required.
+
+```python
+from collections.abc import AsyncIterator
+from neuros.contracts import SignalFrame, StreamDescriptor
+
+class MySource:
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        ...
+
+    async def start(self) -> None:
+        ...
+
+    async def stop(self) -> None:
+        ...
+
+    def frames(self) -> AsyncIterator[SignalFrame]:
+        ...
+```
+
+A high-quality source makes the following explicit:
+
+- stable `stream_id`;
+- modality and sample rate;
+- channel names, channel types, and units;
+- actual device/manufacturer identity where known;
+- clock domain and which timestamps are genuinely available;
+- sample-array geometry in metadata when multidimensional;
+- quality flags for loss, clipping, saturation, disconnection, or suspected artifacts;
+- acquisition-specific metadata/provenance needed for replay or qualification.
+
+Do not synthesize a device timestamp or synchronized clock merely because downstream code can accept one.
+
+## Transform contract
+
+A transform exposes one method:
+
+```python
+class MyTransform:
+    def transform(self, item):
+        ...
+```
+
+When transforming a `SignalFrame`, preserve identity/timing/quality fields unless the operation has a documented reason to change them. Add provenance to metadata rather than replacing upstream metadata.
+
+For explicit one-to-many emission, use the kernel's `TransformEmission` contract rather than returning an ambiguous list/tuple.
+
+## Configuration path
+
+Entry-point discovery and config resolution are the same path used by the CLI. Plugin constructor options come from the versioned YAML `options` mapping:
+
+```yaml
+streams:
+  - id: eeg
+    source:
+      plugin: my_device
+      options:
+        serial_number: ABC123
+        sample_rate: 250
+    transforms:
+      - plugin: my_transform
+        options:
+          parameter: 1.0
+```
+
+Constructor validation should fail early and clearly. neurOS wraps common plugin-construction failures with the plugin kind/name so a bad configuration is diagnosable before a long session begins.
+
+## Dependency boundaries
+
+Prefer this order:
+
+1. `neuros-core` for contracts/runtime-facing plugins;
+2. a specific neurOS package only when you actually require its higher-level API;
+3. the full `neuros` SDK only when the plugin genuinely needs SDK composition.
+
+Keep vendor SDKs, large ML frameworks, and optional scientific stacks in plugin-specific dependencies or extras. `neuros-core` should never need a new concrete hardware/model dependency merely because one external plugin uses it.
+
+## Compatibility contract
+
+For each release of an external plugin:
+
+- declare bounded neurOS distribution ranges in package metadata;
+- run `pip check` after installing the release wheel;
+- test the oldest and newest Python versions you claim;
+- test every neurOS major/minor range you claim when contract behavior differs;
+- record the plugin distribution name/version in bug reports and qualification artifacts;
+- fail closed when required optional dependencies or capabilities are missing;
+- never silently substitute a different device/model/algorithm.
+
+Python package resolution is the first line of version negotiation. Runtime discovery additionally records the distribution and version that supplied an entry point.
+
+## Software contract vs qualification
+
+A source plugin can have excellent software tests and still have no hardware evidence.
+
+Keep the ladders separate:
+
+```text
+wheel/import/discovery
+        -> source contract
+        -> config/runtime integration
+        -> replay/fault regression
+        -> named hardware qualification
+        -> human closed-loop evidence
+```
+
+A hardware qualification should identify at minimum the manufacturer/model, firmware, transport, host OS, plugin version, neurOS version, acquisition config, duration, packet/sample loss, clock behavior, reconnect behavior, and latency methodology.
+
+Likewise, a world-model plugin can satisfy its software contract without establishing physiological truth. Synthetic and learned models need declared evidence boundaries and independent real-data/metamorphic tests appropriate to the claim.
+
+## Clean-wheel reference gate
+
+The repository's `External Plugin Contract` workflow deliberately:
+
+1. builds the relevant neurOS distributions as wheels;
+2. builds the example plugin as a separate wheel;
+3. creates a fresh virtual environment;
+4. installs the exact wheel set;
+5. runs `pip check`;
+6. verifies entry-point distribution/version metadata;
+7. instantiates the source and transform through `PluginRegistry`;
+8. runs the plugin's protocol tests;
+9. validates and executes the example YAML through the installed `neuros` CLI.
+
+This is stronger than an editable-install test because it catches missing package data, broken entry points, invalid dependency declarations, and accidental reliance on the repository checkout.
+
+## Recommended external repository layout
+
+```text
+my-neuros-plugin/
+  pyproject.toml
+  README.md
+  src/
+    my_neuros_plugin/
+      __init__.py
+      source.py
+  tests/
+    test_contract.py
+  examples/
+    pipeline.yaml
+  .github/workflows/
+    ci.yml
+```
+
+Keep generated recordings, participant data, vendor binaries, model checkpoints, and qualification outputs out of source control unless they are deliberately small reviewed fixtures.
+
+## When a kernel change is justified
+
+Do not request a `neuros-core` change just because your plugin implementation is awkward. A kernel change is justified when multiple independent integrations expose a genuinely missing general contract, for example:
+
+- a timestamp/clock semantic neurOS cannot express;
+- a necessary loss/quality state absent from the canonical data contract;
+- a reusable lifecycle or emission semantic needed by multiple plugin families;
+- a compatibility capability that cannot be represented through package metadata or current descriptors.
+
+That keeps the kernel conservative while allowing the ecosystem at the edges to move quickly.

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -2,7 +2,7 @@
 
 neurOS is designed to be extended **without editing the kernel**. A hardware vendor, lab, research group, or application team should be able to publish an ordinary Python distribution that contributes one or more entry points and exchanges only stable neurOS contracts.
 
-The maintained reference package is [`examples/plugins/neuros-example-plugin`](../examples/plugins/neuros-example-plugin/README.md). It is intentionally excluded from the root workspace so CI proves that discovery works across a real distribution boundary.
+The maintained reference package is [`examples/plugins/neuros-example-plugin`](https://github.com/sidhulyalkar/neurOS-v1/tree/main/examples/plugins/neuros-example-plugin). It is intentionally excluded from the root workspace so CI proves that discovery works across a real distribution boundary.
 
 ## Extension groups
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -53,6 +53,8 @@ The runtime plane should remain small and conservative. Research and model layer
 
 The repository directory is `packages/orion`, while the installable distribution is `neuros-orion`. The root `pyproject.toml` workspace is the canonical maintained-distribution inventory. CI, release-candidate wheel builds, and repository hygiene derive package membership from that authority rather than keeping parallel package lists.
 
+External plugin examples under `examples/plugins/` are deliberately **not** workspace members. Their separate wheel/install path is part of the compatibility test: an extension should be able to cross the same packaging boundary used by an independent lab or company.
+
 ## What is genuinely usable today
 
 ### 1. Build and execute a reproducible software BCI pipeline
@@ -112,11 +114,21 @@ The maintained deep decoders expose logits, embeddings, stable model identity, a
 
 ORION compares tokenizer families under controlled synthetic motifs and exposes separate authority for calibration, qualification/model selection, and untouched final assessment. Synthetic known-ground-truth tests remain falsification tools. Real-data promotion requires deployment-unit-disjoint evidence and frozen assessment identity.
 
+### 9. Build an extension outside the neurOS workspace
+
+The maintained `examples/plugins/neuros-example-plugin` reference is a standalone Python distribution, not a hidden workspace package. It contributes a structural source and transform through Python entry points, depends only on a bounded `neuros-core` range, and can be instantiated from ordinary versioned neurOS YAML.
+
+The `External Plugin Contract` matrix builds exact neurOS and plugin wheels on Python 3.10, 3.11, and 3.12, installs them into a fresh environment, runs `pip check`, verifies entry-point distribution/version provenance, tests the public `Source`/`Transform` protocols, and executes the external source/transform through the installed `neuros` CLI.
+
+This establishes the software extension boundary. It does not qualify a physical device or a scientific algorithm supplied by a plugin.
+
 ## Important gaps before neurOS should be marketed as a broadly deployable BCI platform
 
-### External plugin authoring journey
+### Independent plugin ecosystem and compatibility certification
 
-The kernel has a real entry-point registry, but the developer preview still needs a maintained out-of-tree plugin template, clean-wheel install test, source/transform examples, and explicit compatibility/version negotiation. This is the next major usability gate because extensibility must work without editing the monorepo.
+The repository now proves that out-of-tree wheels work. The next ecosystem gate is stronger: move the starter into an independent repository, exercise compatibility against released neurOS artifacts rather than only same-revision monorepo wheels, and qualify at least one genuinely external hardware or model integration without a kernel fork.
+
+Longer term, plugin authors should be able to run a reusable neurOS conformance suite and publish machine-readable compatibility evidence for the exact neurOS/plugin/Python/device or model tuple they claim.
 
 ### Hardware qualification
 
@@ -170,7 +182,9 @@ The next coherent public milestone should be a **developer preview** in which an
 5. select an inspectable decoder;
 6. compare or adapt representations through the foundation/SourceWeigher layers;
 7. run an ORION tokenizer/adaptation study under frozen authority;
-8. add an external plugin without modifying kernel code;
+8. build/install an out-of-tree plugin without modifying kernel code;
 9. understand exactly which claims are supported by software, synthetic, dataset, hardware, or closed-loop evidence.
+
+The repository now has executable evidence for item 8 through the clean-wheel external-plugin matrix. The remaining developer-preview work should focus on closing the other end-to-end usability and evidence gaps rather than multiplying internal packages.
 
 That milestone is more valuable than simply adding more algorithms. It turns neurOS from a large repository into a legible, extensible platform.

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,9 @@
+# External plugin examples
+
+This directory contains **standalone example distributions**, not neurOS workspace packages.
+
+The distinction is deliberate. These examples prove that Python entry-point discovery works across the same packaging boundary an external lab or company would use.
+
+- [`neuros-example-plugin`](neuros-example-plugin/README.md): reference `neuros.sources` + `neuros.transforms` package with a deterministic source, provenance-preserving transform, tests, version bounds, and config-first runtime example.
+
+Do not add an external-plugin example to the root workspace merely to make CI easier. A reference plugin should be built and installed as its own wheel in a clean environment.

--- a/examples/plugins/neuros-example-plugin/README.md
+++ b/examples/plugins/neuros-example-plugin/README.md
@@ -1,0 +1,121 @@
+# neurOS example external plugin
+
+This directory is a **real Python distribution kept outside the neurOS workspace**. It exists to prove that a lab or company can extend neurOS without editing `neuros-core`, subclassing an internal driver, or becoming a monorepo package.
+
+It contributes two entry points:
+
+```text
+neuros.sources:    example_sine
+neuros.transforms: example_gain
+```
+
+The package depends only on the narrow stable contract surface it needs:
+
+```toml
+dependencies = [
+  "neuros-core>=2.0.0,<3.0.0",
+  "numpy>=1.24.0",
+]
+```
+
+That version range is the plugin's compatibility declaration. Standard Python dependency resolution and `pip check` are the first compatibility gate. Do not depend on the full `neuros` SDK unless your plugin genuinely needs SDK-level functionality.
+
+## Source contract
+
+`SineSource` implements the public structural `neuros.contracts.Source` protocol directly:
+
+- `descriptor` returns an explicit `StreamDescriptor`;
+- `start()` and `stop()` own lifecycle;
+- `frames()` yields canonical `SignalFrame` chunks;
+- channel names/types/units and sample rate are explicit;
+- array geometry is declared as `sample x channel`;
+- deterministic samples are separated from host-monotonic receive timing;
+- no fictional device or synchronized clock is invented.
+
+A real hardware plugin should replace only the acquisition-specific internals. It should keep the same contract discipline and publish hardware qualification separately from software contract tests.
+
+## Transform contract
+
+`GainTransform` implements the public structural `Transform` protocol. For a `SignalFrame`, it uses dataclass replacement to preserve stream identity, sequence identity, timing, quality flags, and existing metadata while adding transform provenance.
+
+This is intentionally boring mathematics. The purpose of the example is to teach a correct extension boundary, not to smuggle a scientific algorithm into a plugin tutorial.
+
+## Local development
+
+From this directory:
+
+```bash
+python -m pip install -e ".[test]"
+pytest -q
+```
+
+When working from the neurOS repository, install a compatible `neuros-core` first or let your package manager resolve it.
+
+## Prove entry-point discovery
+
+After installation:
+
+```python
+from neuros.plugins import PluginKind, PluginRegistry
+
+registry = PluginRegistry()
+registry.discover()
+
+source = registry.create(
+    PluginKind.SOURCE,
+    "example_sine",
+    sampling_rate=250.0,
+    channels=4,
+)
+transform = registry.create(PluginKind.TRANSFORM, "example_gain", gain=0.5)
+```
+
+The descriptors returned by `PluginRegistry` include the plugin distribution name and version, so debugging does not require guessing which installed wheel supplied an entry point.
+
+## Prove config-first execution
+
+The repository CI installs this package **from its built wheel** together with exact neurOS workspace wheels, then executes:
+
+```bash
+neuros plugins --json
+neuros validate examples/plugins/neuros-example-plugin/example.yaml --json
+neuros run examples/plugins/neuros-example-plugin/example.yaml --duration 0.08 --json
+```
+
+The YAML uses the external `example_sine` source and `example_gain` transform while using neurOS' existing threshold decoder. That demonstrates the full boundary:
+
+```text
+external wheel
+    -> Python entry point
+    -> PluginRegistry
+    -> versioned YAML
+    -> RuntimeGraph
+    -> canonical SignalFrame
+```
+
+## Compatibility and failures
+
+For a maintained plugin:
+
+1. declare a bounded compatible `neuros-core` range in `Requires-Dist`;
+2. keep optional hardware/model dependencies in plugin extras where possible;
+3. validate constructor options and fail before starting acquisition;
+4. run `pip check` in release CI;
+5. test the oldest and newest supported Python versions;
+6. test against the neurOS contract versions you claim to support;
+7. publish hardware or scientific qualification as separate evidence.
+
+If a future neurOS major release changes an incompatible contract, the dependency range should make installation fail clearly rather than letting a subtly incompatible plugin enter a live neural pipeline.
+
+## Copying this template
+
+Copy the directory into a separate repository, then change:
+
+- project/distribution name;
+- Python import package;
+- entry-point names;
+- compatible neurOS version range;
+- source/transform implementations;
+- tests and domain-specific qualification.
+
+Do **not** add the copied plugin to the neurOS workspace simply to make discovery work. If the out-of-tree package cannot be installed and discovered independently, the extension contract is not doing its job.

--- a/examples/plugins/neuros-example-plugin/example.yaml
+++ b/examples/plugins/neuros-example-plugin/example.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+metadata:
+  name: external-plugin-smoke
+  purpose: prove an out-of-tree source and transform can execute through the neurOS config/runtime path
+
+streams:
+  - id: eeg
+    source:
+      plugin: example_sine
+      options:
+        stream_id: external/eeg
+        sampling_rate: 250.0
+        channels: 4
+        frequency_hz: 10.0
+        amplitude_uv: 20.0
+        chunk_samples: 16
+    transforms:
+      - plugin: example_gain
+        options:
+          gain: 0.5
+
+decoder:
+  plugin: threshold
+  options:
+    threshold: 0.0
+
+runtime:
+  queue_capacity: 8
+  overflow_policy: block
+
+sinks: []
+monitors: []

--- a/examples/plugins/neuros-example-plugin/pyproject.toml
+++ b/examples/plugins/neuros-example-plugin/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "neuros-example-plugin"
+version = "0.1.0"
+description = "Out-of-tree neurOS source and transform plugin reference package"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "neurOS Development Team"}]
+dependencies = [
+    "neuros-core>=2.0.0,<3.0.0",
+    "numpy>=1.24.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.4", "pytest-asyncio>=0.21"]
+
+[project.entry-points."neuros.sources"]
+example_sine = "neuros_example_plugin.source:SineSource"
+
+[project.entry-points."neuros.transforms"]
+example_gain = "neuros_example_plugin.transforms:GainTransform"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["neuros_example_plugin*"]

--- a/examples/plugins/neuros-example-plugin/src/neuros_example_plugin/__init__.py
+++ b/examples/plugins/neuros-example-plugin/src/neuros_example_plugin/__init__.py
@@ -1,0 +1,6 @@
+"""Reference external plugin package for neurOS."""
+
+from .source import SineSource
+from .transforms import GainTransform
+
+__all__ = ["GainTransform", "SineSource"]

--- a/examples/plugins/neuros-example-plugin/src/neuros_example_plugin/source.py
+++ b/examples/plugins/neuros-example-plugin/src/neuros_example_plugin/source.py
@@ -1,0 +1,111 @@
+"""Reference out-of-tree neurOS source plugin."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+
+import numpy as np
+
+from neuros.contracts import ClockDomain, SignalFrame, StreamDescriptor
+
+
+class SineSource:
+    """Deterministic multi-channel sine source implementing ``neuros.Source``.
+
+    The numerical samples are deterministic for a fixed configuration. Host
+    receive timestamps intentionally use the host monotonic clock because an
+    external source must not fabricate a device clock it does not possess.
+    """
+
+    def __init__(
+        self,
+        sampling_rate: float = 250.0,
+        channels: int = 4,
+        frequency_hz: float = 10.0,
+        amplitude_uv: float = 20.0,
+        chunk_samples: int = 25,
+        stream_id: str = "example-eeg",
+    ) -> None:
+        if sampling_rate <= 0:
+            raise ValueError("sampling_rate must be positive")
+        if channels <= 0:
+            raise ValueError("channels must be positive")
+        if frequency_hz <= 0 or frequency_hz >= sampling_rate / 2:
+            raise ValueError("frequency_hz must be between 0 and Nyquist")
+        if amplitude_uv < 0:
+            raise ValueError("amplitude_uv must be non-negative")
+        if chunk_samples <= 0:
+            raise ValueError("chunk_samples must be positive")
+        if not stream_id:
+            raise ValueError("stream_id must be non-empty")
+
+        self.sampling_rate = float(sampling_rate)
+        self.channels = int(channels)
+        self.frequency_hz = float(frequency_hz)
+        self.amplitude_uv = float(amplitude_uv)
+        self.chunk_samples = int(chunk_samples)
+        self.stream_id = stream_id
+        self._running = False
+        self._sequence_id = 0
+        self._sample_cursor = 0
+        self._descriptor = StreamDescriptor(
+            stream_id=stream_id,
+            modality="eeg",
+            sample_rate_hz=self.sampling_rate,
+            channel_names=tuple(f"EX{i + 1}" for i in range(self.channels)),
+            channel_types=("eeg",) * self.channels,
+            units=("uV",) * self.channels,
+            device="ExampleSineSource",
+            manufacturer="neurOS example plugin",
+            clock_domain=ClockDomain.HOST_MONOTONIC,
+            metadata={
+                "plugin": "neuros-example-plugin",
+                "generator": "deterministic_sine",
+                "frequency_hz": self.frequency_hz,
+                "amplitude_uv": self.amplitude_uv,
+                "axis_order": ("sample", "channel"),
+            },
+        )
+
+    @property
+    def descriptor(self) -> StreamDescriptor:
+        return self._descriptor
+
+    async def start(self) -> None:
+        self._running = True
+
+    async def stop(self) -> None:
+        self._running = False
+
+    def frames(self) -> AsyncIterator[SignalFrame]:
+        return self._frames()
+
+    async def _frames(self) -> AsyncIterator[SignalFrame]:
+        if not self._running:
+            raise RuntimeError("SineSource.start() must be called before frames()")
+
+        period_s = self.chunk_samples / self.sampling_rate
+        channel_phase = np.arange(self.channels, dtype=float) * (np.pi / 8.0)
+        while self._running:
+            sample_index = self._sample_cursor + np.arange(self.chunk_samples, dtype=float)
+            phase = (2.0 * np.pi * self.frequency_hz * sample_index / self.sampling_rate)[:, None]
+            data = self.amplitude_uv * np.sin(phase + channel_phase[None, :])
+            now_ns = time.monotonic_ns()
+            yield SignalFrame(
+                stream_id=self.stream_id,
+                sequence_id=self._sequence_id,
+                data=data,
+                sample_rate_hz=self.sampling_rate,
+                host_receive_time_ns=now_ns,
+                clock_domain=ClockDomain.HOST_MONOTONIC,
+                metadata={
+                    "axis_order": ("sample", "channel"),
+                    "plugin": "neuros-example-plugin",
+                    "generator": "deterministic_sine",
+                },
+            )
+            self._sequence_id += 1
+            self._sample_cursor += self.chunk_samples
+            await asyncio.sleep(period_s)

--- a/examples/plugins/neuros-example-plugin/src/neuros_example_plugin/transforms.py
+++ b/examples/plugins/neuros-example-plugin/src/neuros_example_plugin/transforms.py
@@ -1,0 +1,33 @@
+"""Reference out-of-tree neurOS transform plugin."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import numpy as np
+
+from neuros.contracts import SignalFrame
+
+
+class GainTransform:
+    """Multiply data by a fixed gain while preserving ``SignalFrame`` identity."""
+
+    def __init__(self, gain: float = 1.0) -> None:
+        value = float(gain)
+        if not np.isfinite(value):
+            raise ValueError("gain must be finite")
+        self.gain = value
+
+    def transform(self, item: Any) -> Any:
+        if not isinstance(item, SignalFrame):
+            return np.asarray(item) * self.gain
+        return replace(
+            item,
+            data=np.asarray(item.data) * self.gain,
+            metadata={
+                **dict(item.metadata),
+                "example_gain": self.gain,
+                "transform_plugin": "neuros-example-plugin",
+            },
+        )

--- a/examples/plugins/neuros-example-plugin/tests/test_contract.py
+++ b/examples/plugins/neuros-example-plugin/tests/test_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.contracts import ClockDomain, SignalFrame, Source, Transform
+from neuros_example_plugin import GainTransform, SineSource
+
+
+@pytest.mark.asyncio
+async def test_sine_source_implements_public_source_contract() -> None:
+    source = SineSource(
+        sampling_rate=200.0,
+        channels=3,
+        frequency_hz=10.0,
+        amplitude_uv=12.0,
+        chunk_samples=20,
+        stream_id="external/eeg",
+    )
+    assert isinstance(source, Source)
+    assert source.descriptor.stream_id == "external/eeg"
+    assert source.descriptor.channel_names == ("EX1", "EX2", "EX3")
+    assert source.descriptor.units == ("uV", "uV", "uV")
+    assert source.descriptor.clock_domain is ClockDomain.HOST_MONOTONIC
+
+    await source.start()
+    frame = await source.frames().__anext__()
+    await source.stop()
+
+    assert isinstance(frame, SignalFrame)
+    assert frame.data.shape == (20, 3)
+    assert frame.sample_rate_hz == 200.0
+    assert frame.sequence_id == 0
+    assert frame.clock_domain is ClockDomain.HOST_MONOTONIC
+    assert frame.metadata["axis_order"] == ("sample", "channel")
+    assert frame.device_time_ns is None
+    assert frame.synchronized_time_ns is None
+
+
+@pytest.mark.asyncio
+async def test_sine_samples_are_deterministic_for_same_configuration() -> None:
+    first = SineSource(chunk_samples=8, channels=2)
+    second = SineSource(chunk_samples=8, channels=2)
+    await first.start()
+    await second.start()
+    first_frame = await first.frames().__anext__()
+    second_frame = await second.frames().__anext__()
+    await first.stop()
+    await second.stop()
+    np.testing.assert_allclose(first_frame.data, second_frame.data)
+
+
+def test_gain_transform_preserves_frame_identity_and_adds_provenance() -> None:
+    transform = GainTransform(gain=0.25)
+    assert isinstance(transform, Transform)
+    frame = SignalFrame(
+        stream_id="external/eeg",
+        sequence_id=7,
+        data=np.asarray([[4.0, -8.0]]),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=123,
+        clock_domain=ClockDomain.HOST_MONOTONIC,
+        metadata={"axis_order": ("sample", "channel"), "upstream": "fixture"},
+    )
+
+    result = transform.transform(frame)
+
+    assert isinstance(result, SignalFrame)
+    assert result.stream_id == frame.stream_id
+    assert result.sequence_id == frame.sequence_id
+    assert result.host_receive_time_ns == frame.host_receive_time_ns
+    assert result.metadata["upstream"] == "fixture"
+    assert result.metadata["example_gain"] == 0.25
+    np.testing.assert_allclose(result.data, [[1.0, -2.0]])
+
+
+def test_example_configuration_rejects_invalid_options_early() -> None:
+    with pytest.raises(ValueError, match="Nyquist"):
+        SineSource(sampling_rate=100.0, frequency_hz=50.0)
+    with pytest.raises(ValueError, match="finite"):
+        GainTransform(gain=float("nan"))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Evaluation Protocol: neurotokenization/02_EVALUATION_PROTOCOL.md
       - Implementation Sprints: neurotokenization/03_IMPLEMENTATION_SPRINTS.md
   - SDK:
+      - External Plugin Authoring: PLUGIN_AUTHORING.md
       - Neural Windows: NEURAL_WINDOWS.md
       - Braindecode: BRAINDECODE.md
       - API Surface: API_REFERENCE.md


### PR DESCRIPTION
## Summary

Adds a maintained **out-of-tree plugin authoring kit** for the neurOS developer preview, directly on current `main` after the release-qualified Arena merge.

The requirement is stronger than “we have an entry-point registry.” It is: **an external lab can build an ordinary Python wheel outside the neurOS workspace, install it into a clean environment, have neurOS discover it, instantiate it from versioned YAML, and execute it through the native RuntimeGraph without editing `neuros-core`.**

## Reference external distribution

`examples/plugins/neuros-example-plugin` is a real standalone Python distribution and is deliberately **not** a root workspace member.

It declares only the narrow dependency surface it needs:

```toml
neuros-core>=2.0.0,<3.0.0
numpy>=1.24.0
```

and contributes:

```text
neuros.sources:    example_sine
neuros.transforms: example_gain
```

`SineSource` implements the structural `Source` protocol directly with explicit EEG descriptor/channel/unit/axis metadata, deterministic numerical samples, honest host-monotonic timing, and no fabricated device/synchronized clock. `GainTransform` preserves frame identity/timing/quality/upstream metadata while adding transform provenance.

## Config-first proof

`example.yaml` proves the complete path:

```text
external wheel
    -> Python entry point
    -> PluginRegistry
    -> versioned YAML
    -> RuntimeGraph
    -> canonical SignalFrame
```

## Clean-wheel compatibility gate

`External Plugin Contract` runs on Python 3.10, 3.11, and 3.12. For each version it:

1. proves the reference plugin is not a neurOS workspace member;
2. builds exact wheels for `neuros-core`, `neuros-drivers`, `neuros-models`, `neuros`, and the external distribution;
3. installs only those artifacts into a fresh virtual environment;
4. runs `pip check`;
5. verifies bounded `Requires-Dist` compatibility;
6. verifies entry-point distribution/version provenance;
7. checks public structural `Source` / `Transform` conformance;
8. runs the installed-wheel protocol tests;
9. validates and executes the external source/transform through the installed `neuros` CLI and native runtime.

All three Python-version jobs pass on the exact current head.

## Maintained authoring contract

`docs/PLUGIN_AUTHORING.md` documents all current plugin groups including `neuros.world_models`, minimal package dependencies, timing/unit/quality/provenance expectations, constructor/config semantics, version bounds, clean-wheel validation, hardware/scientific evidence boundaries, and when a kernel change is actually justified.

README and `docs/PROJECT_STATUS.md` now describe out-of-tree authoring as an implemented developer-preview capability. The next ecosystem gate is independent plugin repositories and genuinely external hardware/model integrations, not more kernel coupling.

## First-attempt failures and repairs

The first qualification attempt on `b51df6159f94d681272b5387effe482c4d691a39` exposed three issues, all diagnosed and repaired without weakening a contract:

1. **External Plugin Contract** referenced `matrix.python-version` from workflow-level concurrency, where matrix context does not exist. Workflow-level cancellation is now scoped to the PR/ref; matrix values remain job-local.
2. **Public Trust Contracts** rejected a relative documentation link that escaped `docs/`. It now uses the canonical repository link.
3. **Release Candidate Artifacts** failed at the same strict-documentation step and is green after the same underlying documentation repair.

## Semantic review

Independent of CI:

- the source does not invent unavailable clock domains;
- numerical samples are deterministic while host timestamps remain truthful;
- units/channel identity/array axes are explicit;
- bad constructor options fail before runtime;
- transform provenance composes with upstream metadata;
- the nested `src/` package cannot be imported accidentally from repository root during the installed-wheel tests;
- the example depends on stable `neuros-core` contracts rather than internal driver implementations.

## Exact-head qualification

Exact head: `2c3403c466441c9331001f3cc6fd62018e778866`

The authoritative post-reopen workflow set is fully green:

- **External Plugin Contract** — Python 3.10, 3.11, and 3.12 all pass every clean-wheel/discovery/config/runtime step;
- **neurOS CI** — full monorepo matrix green;
- **Release Candidate Artifacts** — strict docs, every workspace wheel, checksums/manifests, exact-wheel SDK/Arena smoke install green;
- **Public Trust Contracts** — citation/claims/governance and strict docs green;
- **Ecosystem Compatibility** — green;
- **NeuroAI Ecosystem Evidence** — green;
- **ORION Adaptation Authority** — green;
- **Three-way Adaptive Study** — green.

Earlier cancelled runs on the same SHA were superseded when the pull request was deliberately reopened to generate a fresh `pull_request` event after the repaired head had not received a synchronize event. They are stale attempts, not failures of this revision.

## Evidence boundary

This PR establishes an **external software compatibility contract**. It does not qualify physical hardware, a scientific algorithm, or a human closed-loop BCI.

A real hardware plugin must publish named device/firmware/transport/host/protocol evidence separately from these software contract tests.