### PR TITLE
Developer Preview: qualify the complete installed-wheel newcomer journey

### DIFF
--- a/.github/workflows/developer-preview.yml
+++ b/.github/workflows/developer-preview.yml
@@ -1,0 +1,116 @@
+name: Developer Preview Journey
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/developer-preview.yml"
+      - "scripts/run_developer_preview_journey.py"
+      - "docs/getting-started/**"
+      - "mkdocs.yml"
+      - "configs/examples/mock_bci.yaml"
+      - "examples/plugins/**"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "packages/neuros-models/**"
+      - "packages/neuros/**"
+      - "packages/neuros-arena/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/developer-preview.yml"
+      - "scripts/run_developer_preview_journey.py"
+      - "docs/getting-started/**"
+      - "mkdocs.yml"
+      - "configs/examples/mock_bci.yaml"
+      - "examples/plugins/**"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "packages/neuros-models/**"
+      - "packages/neuros/**"
+      - "packages/neuros-arena/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: developer-preview-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  installed-wheel-journey:
+    name: Installed-wheel external-user journey
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Build exact public-path wheels
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install build
+          DIST="${RUNNER_TEMP}/developer-preview-wheels"
+          mkdir -p "${DIST}"
+          python -m build --wheel --outdir "${DIST}" packages/neuros-core
+          python -m build --wheel --outdir "${DIST}" packages/neuros-drivers
+          python -m build --wheel --outdir "${DIST}" packages/neuros-models
+          python -m build --wheel --outdir "${DIST}" packages/neuros
+          python -m build --wheel --outdir "${DIST}" packages/neuros-arena
+          python -m build --wheel --outdir "${DIST}" examples/plugins/neuros-example-plugin
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 6
+      - name: Install only built neurOS/plugin artifacts
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/developer-preview-wheels"
+          ENV="${RUNNER_TEMP}/developer-preview-env"
+          python -m venv "${ENV}"
+          PY="${ENV}/bin/python"
+          PIP="${ENV}/bin/pip"
+          "${PY}" -m pip install --upgrade pip
+          CORE="$(find "${DIST}" -name 'neuros_core-*.whl' -print -quit)"
+          DRIVERS="$(find "${DIST}" -name 'neuros_drivers-*.whl' -print -quit)"
+          MODELS="$(find "${DIST}" -name 'neuros_models-*.whl' -print -quit)"
+          SDK="$(find "${DIST}" -name 'neuros-[0-9]*.whl' -print -quit)"
+          ARENA="$(find "${DIST}" -name 'neuros_arena-*.whl' -print -quit)"
+          PLUGIN="$(find "${DIST}" -name 'neuros_example_plugin-*.whl' -print -quit)"
+          for artifact in "${CORE}" "${DRIVERS}" "${MODELS}" "${SDK}" "${ARENA}" "${PLUGIN}"; do
+            test -n "${artifact}"
+          done
+          "${PIP}" install "${CORE}" "${DRIVERS}" "${MODELS}" "${SDK}" "${ARENA}" "${PLUGIN}"
+          "${PIP}" check
+      - name: Run the complete installed-wheel journey
+        run: |
+          set -euo pipefail
+          PY="${RUNNER_TEMP}/developer-preview-env/bin/python"
+          OUT="${RUNNER_TEMP}/developer-preview-report"
+          "${PY}" scripts/run_developer_preview_journey.py \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --output "${OUT}" \
+            --duration 0.1
+          test -s "${OUT}/journey-report.json"
+          "${PY}" - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = Path(os.environ["RUNNER_TEMP"]) / "developer-preview-report" / "journey-report.json"
+          payload = json.loads(report.read_text(encoding="utf-8"))
+          assert payload["schema"] == "neuros.developer_preview_journey.v1"
+          assert payload["status"] == "pass", payload.get("failure")
+          assert len(payload["commands"]) >= 15
+          assert all(not item["editable"] for item in payload["distributions"].values())
+          required = {"session", "qualification", "arena_report"}
+          assert required <= set(payload["artifacts"])
+          PY
+      - name: Upload developer-preview evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: neurOS-developer-preview-${{ github.sha }}
+          path: ${{ runner.temp }}/developer-preview-report
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/getting-started/developer-preview.md
+++ b/docs/getting-started/developer-preview.md
@@ -1,0 +1,150 @@
+# Developer Preview Journey
+
+The neurOS developer preview is a **reproducible installed-product journey**, not a claim that every research package is production-ready.
+
+The governing question is:
+
+> Can a new developer install the public execution path from built wheels, inspect what is present, execute and replay a neural runtime, seal/reproduce evidence, inspect a decoder contract, stress the system in Arena, and extend it with an out-of-tree plugin without importing implementation code from the repository checkout?
+
+The repository answers that question with the `Developer Preview Journey` CI workflow and `scripts/run_developer_preview_journey.py`.
+
+## What the qualification environment contains
+
+The canonical journey installs only built wheel artifacts for:
+
+```text
+neuros-core
+neuros-drivers
+neuros-models
+neuros
+neuros-arena
+neuros-example-plugin   # deliberately outside the workspace
+```
+
+The orchestrator fails if any of those distributions is installed editable or resolves inside the repository checkout.
+
+This is intentionally different from normal contributor setup. Contributors may use editable installs for development; developer-preview qualification may not.
+
+## End-to-end path
+
+The current journey executes:
+
+```text
+wheel install + pip check
+        |
+        v
+neuros doctor / plugins / devices / compatibility
+        |
+        v
+validate + run mock RuntimeGraph
+        |
+        v
+record -> verify -> replay
+        |
+        v
+qualify -> reproduce
+        |
+        +------> inspect eeg-conformer decoder card
+        |
+        +------> run dual-target Arena smoke world
+        |
+        +------> discover external wheel entry points
+                        |
+                        v
+                  validate + run external YAML
+```
+
+Every command is a public console entry point. The Python orchestrator does not import internal runtime construction helpers to bypass those boundaries.
+
+## Machine-readable evidence
+
+A successful run writes:
+
+```text
+developer-preview/
+  journey-report.json
+  session/
+  qualification/
+  arena-report.json
+```
+
+`journey-report.json` uses schema:
+
+```text
+neuros.developer_preview_journey.v1
+```
+
+It records:
+
+- active Python/platform identity;
+- installed distribution names, versions, locations, and direct-install metadata;
+- whether any package was editable;
+- every command and argument vector;
+- command elapsed time;
+- captured stdout/stderr;
+- parsed JSON where the public command exposes it;
+- session, qualification, and Arena artifact locations;
+- failure type/message when the path aborts.
+
+This is onboarding evidence, not hardware or scientific validation.
+
+## Run it locally
+
+The script expects the required distributions to already be installed in the active environment. Until coordinated package publication is enabled, the easiest local developer setup remains the repository bootstrap described in [First 10 Minutes](first-10-minutes.md).
+
+To reproduce the *wheel-qualified* path exactly, build/install the six artifacts above into a fresh environment and then run:
+
+```bash
+python scripts/run_developer_preview_journey.py \
+  --repo-root . \
+  --output /tmp/neuros-developer-preview \
+  --duration 0.1
+```
+
+For ordinary exploratory development, editable installs are fine. The script rejects them because its purpose is specifically to detect package metadata, entry-point, missing-file, and install-boundary defects that editable monorepo tests can hide.
+
+## What this proves
+
+A green journey establishes that one exact neurOS revision can:
+
+- be assembled from ordinary wheel distributions;
+- report a healthy public SDK installation;
+- discover built-in and external plugins;
+- resolve versioned configuration into the native runtime;
+- execute, record, integrity-check, and replay a session;
+- create and independently reproduce a software qualification bundle;
+- expose a decoder capability card without requiring model training;
+- execute the deterministic BCI Arena;
+- run an independently packaged source/transform through the same YAML/runtime path.
+
+## What it does not prove
+
+The journey does **not** establish:
+
+- public PyPI availability;
+- compatibility with every optional research dependency;
+- physical device qualification;
+- physiological realism of Arena;
+- decoder accuracy on human data;
+- ORION superiority;
+- closed-loop safety;
+- medical or clinical validity.
+
+Those belong to stronger, separately governed evidence layers.
+
+## Why the external plugin is part of the journey
+
+A platform is not truly extensible if its own examples only work because they live inside the monorepo.
+
+`neuros-example-plugin` is therefore built as an independent wheel and kept outside the root workspace. The developer journey verifies that its `example_sine` source and `example_gain` transform are discovered through package entry points and can drive an ordinary versioned neurOS YAML graph.
+
+See [External Plugin Authoring](../PLUGIN_AUTHORING.md) for the extension contract.
+
+## Relation to release qualification
+
+The developer journey and release-candidate workflow answer different questions:
+
+- **Release Candidate Artifacts** asks whether every maintained workspace distribution builds, validates, hashes, and installs consistently.
+- **Developer Preview Journey** asks whether the minimal public developer path is coherent after installation.
+
+Both should be green before presenting a revision as a developer-preview candidate. A wheel can be perfectly packaged while the user journey is broken; conversely, a source checkout can demonstrate a journey while hiding a broken wheel. neurOS tests both boundaries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - First 10 Minutes: getting-started/first-10-minutes.md
+      - Developer Preview Journey: getting-started/developer-preview.md
       - Installation: getting-started/installation.md
   - Platform:
       - Four Public Surfaces: PLATFORM.md

--- a/scripts/run_developer_preview_journey.py
+++ b/scripts/run_developer_preview_journey.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Exercise the maintained neurOS developer-preview path from installed wheels.
+
+This script is intentionally an *orchestrator*, not another runtime. It invokes
+public console commands from the active Python environment and records exactly
+which public seams succeeded. The repository checkout supplies only maintained
+example configurations; the neurOS packages themselves must come from the
+active environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import sysconfig
+import time
+from dataclasses import dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Sequence
+
+SCHEMA = "neuros.developer_preview_journey.v1"
+REQUIRED_DISTRIBUTIONS = (
+    "neuros-core",
+    "neuros-drivers",
+    "neuros-models",
+    "neuros",
+    "neuros-arena",
+    "neuros-example-plugin",
+)
+
+
+@dataclass
+class CommandResult:
+    name: str
+    argv: list[str]
+    elapsed_s: float
+    stdout: str
+    stderr: str
+    parsed_json: Any | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "argv": self.argv,
+            "elapsed_s": self.elapsed_s,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "parsed_json": self.parsed_json,
+        }
+
+
+def _console_script(name: str) -> Path:
+    """Return a console script from the active interpreter environment.
+
+    Virtual-environment Python executables are commonly symlinks to the base
+    interpreter. Resolving ``sys.executable`` therefore escapes the venv and can
+    point at the host ``bin`` directory. ``sysconfig`` instead reports the
+    scripts directory for the active environment on both POSIX and Windows.
+    """
+
+    scripts_dir = sysconfig.get_path("scripts")
+    if not scripts_dir:
+        raise RuntimeError("active Python environment does not expose a scripts directory")
+    suffix = ".exe" if os.name == "nt" else ""
+    path = Path(scripts_dir) / f"{name}{suffix}"
+    if not path.is_file():
+        raise RuntimeError(
+            f"required console script {name!r} is not installed in the active environment: {path}"
+        )
+    return path
+
+
+def _distribution_identity(name: str, repo_root: Path) -> dict[str, Any]:
+    dist = metadata.distribution(name)
+    direct_url_text = dist.read_text("direct_url.json")
+    direct_url: dict[str, Any] | None = None
+    editable = False
+    if direct_url_text:
+        direct_url = json.loads(direct_url_text)
+        editable = bool(direct_url.get("dir_info", {}).get("editable"))
+    location = Path(dist.locate_file("")).resolve()
+    if editable:
+        raise RuntimeError(f"{name} is installed editable; developer-preview qualification requires wheels")
+    try:
+        location.relative_to(repo_root)
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError(
+            f"{name} resolves inside the repository checkout ({location}); expected an installed wheel"
+        )
+    return {
+        "name": dist.metadata["Name"],
+        "version": dist.version,
+        "location": str(location),
+        "editable": editable,
+        "direct_url": direct_url,
+    }
+
+
+def _run(
+    results: list[CommandResult],
+    name: str,
+    argv: Sequence[str | Path],
+    *,
+    expect_json: bool = False,
+) -> Any | None:
+    rendered = [str(item) for item in argv]
+    started = time.perf_counter()
+    proc = subprocess.run(rendered, text=True, capture_output=True, check=False)
+    elapsed = time.perf_counter() - started
+    parsed: Any | None = None
+    if expect_json and proc.returncode == 0:
+        try:
+            parsed = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"{name} succeeded but did not emit valid JSON: {exc}; stdout={proc.stdout!r}"
+            ) from exc
+    result = CommandResult(
+        name=name,
+        argv=rendered,
+        elapsed_s=elapsed,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        parsed_json=parsed,
+    )
+    results.append(result)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{name} failed with exit code {proc.returncode}\n"
+            f"command: {' '.join(rendered)}\n"
+            f"stdout:\n{proc.stdout}\n"
+            f"stderr:\n{proc.stderr}"
+        )
+    return parsed
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _write_report(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+
+
+def run_journey(repo_root: Path, output_dir: Path, duration_s: float) -> dict[str, Any]:
+    results: list[CommandResult] = []
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "environment": {
+            "python": sys.version,
+            "executable": sys.executable,
+            "resolved_executable": str(Path(sys.executable).resolve()),
+            "prefix": sys.prefix,
+            "scripts": sysconfig.get_path("scripts"),
+            "platform": platform.platform(),
+        },
+        "distributions": {},
+        "repo_root": str(repo_root),
+        "output_dir": str(output_dir),
+        "duration_s": duration_s,
+        "commands": [],
+        "artifacts": {},
+    }
+
+    try:
+        if duration_s <= 0:
+            raise ValueError("duration_s must be positive")
+
+        mock_config = repo_root / "configs/examples/mock_bci.yaml"
+        plugin_config = repo_root / "examples/plugins/neuros-example-plugin/example.yaml"
+        for required in (mock_config, plugin_config):
+            if not required.is_file():
+                raise FileNotFoundError(required)
+
+        neuros = _console_script("neuros")
+        models = _console_script("neuros-models")
+        arena = _console_script("neuros-arena")
+        report["console_scripts"] = {
+            "neuros": str(neuros),
+            "neuros-models": str(models),
+            "neuros-arena": str(arena),
+        }
+
+        identities: dict[str, Any] = {}
+        report["distributions"] = identities
+        for name in REQUIRED_DISTRIBUTIONS:
+            identities[name] = _distribution_identity(name, repo_root)
+
+        session_dir = output_dir / "session"
+        qualification_dir = output_dir / "qualification"
+        arena_report = output_dir / "arena-report.json"
+
+        doctor = _run(results, "doctor", [neuros, "doctor", "--json"], expect_json=True)
+        _require(isinstance(doctor, dict) and doctor.get("healthy") is True, "neuros doctor is not healthy")
+
+        plugins = _run(results, "plugins", [neuros, "plugins", "--json"], expect_json=True)
+        _require(isinstance(plugins, list), "plugin inventory must be a JSON list")
+        discovered = {(item.get("kind"), item.get("name")) for item in plugins if isinstance(item, dict)}
+        _require(("source", "example_sine") in discovered, "external example_sine source was not discovered")
+        _require(("transform", "example_gain") in discovered, "external example_gain transform was not discovered")
+
+        _run(results, "devices", [neuros, "devices", "--json"], expect_json=True)
+        _run(results, "compatibility", [neuros, "compatibility", "--json"], expect_json=True)
+
+        _run(results, "validate-mock", [neuros, "validate", mock_config, "--json"], expect_json=True)
+        _run(
+            results,
+            "run-mock",
+            [neuros, "run", mock_config, "--duration", str(duration_s), "--json"],
+            expect_json=True,
+        )
+
+        _run(
+            results,
+            "record",
+            [
+                neuros,
+                "record",
+                mock_config,
+                "--output",
+                session_dir,
+                "--session-id",
+                "developer-preview",
+                "--duration",
+                str(duration_s),
+                "--overwrite",
+                "--json",
+            ],
+            expect_json=True,
+        )
+        _require(session_dir.is_dir(), "record command did not create a session archive")
+        _run(
+            results,
+            "inspect-recording",
+            [neuros, "inspect", session_dir, "--verify", "--json"],
+            expect_json=True,
+        )
+        _run(
+            results,
+            "replay",
+            [neuros, "replay", session_dir, "--config", mock_config, "--json"],
+            expect_json=True,
+        )
+
+        qualify = _run(
+            results,
+            "qualify",
+            [
+                neuros,
+                "qualify",
+                mock_config,
+                "--output",
+                qualification_dir,
+                "--session-id",
+                "developer-preview",
+                "--duration",
+                str(duration_s),
+                "--overwrite",
+                "--json",
+            ],
+            expect_json=True,
+        )
+        _require(qualification_dir.is_dir(), "qualification command did not create a bundle")
+        reproduce = _run(
+            results,
+            "reproduce",
+            [neuros, "reproduce", qualification_dir, "--json"],
+            expect_json=True,
+        )
+
+        model_card = _run(
+            results,
+            "model-card",
+            [models, "show", "eeg-conformer", "--json"],
+            expect_json=True,
+        )
+        _require(
+            isinstance(model_card, dict) and model_card.get("id") == "eeg-conformer",
+            "decoder-card inspection did not return eeg-conformer",
+        )
+
+        arena_summary = _run(
+            results,
+            "arena",
+            [arena, "--preset", "dual-target-smoke", "--output", arena_report],
+            expect_json=True,
+        )
+        _require(arena_report.is_file(), "Arena did not produce its report")
+        arena_payload = json.loads(arena_report.read_text(encoding="utf-8"))
+        _require(isinstance(arena_payload, dict) and arena_payload.get("schema"), "Arena report lacks schema identity")
+
+        _run(
+            results,
+            "validate-external-plugin",
+            [neuros, "validate", plugin_config, "--json"],
+            expect_json=True,
+        )
+        _run(
+            results,
+            "run-external-plugin",
+            [neuros, "run", plugin_config, "--duration", str(duration_s), "--json"],
+            expect_json=True,
+        )
+
+        report["status"] = "pass"
+        report["artifacts"] = {
+            "session": str(session_dir),
+            "qualification": str(qualification_dir),
+            "arena_report": str(arena_report),
+            "qualification_result": qualify,
+            "reproduction_result": reproduce,
+            "arena_summary": arena_summary,
+        }
+        return report
+    except Exception as exc:
+        report["status"] = "fail"
+        report["failure"] = {"type": type(exc).__name__, "message": str(exc)}
+        raise
+    finally:
+        report["commands"] = [item.to_dict() for item in results]
+        _write_report(output_dir / "journey-report.json", report)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--duration", type=float, default=0.1)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    output_dir = args.output.resolve()
+    if output_dir.exists():
+        if not args.overwrite:
+            raise SystemExit(f"output already exists: {output_dir}; pass --overwrite to replace it")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        report = run_journey(repo_root, output_dir, args.duration)
+    except Exception as exc:
+        print(f"developer preview journey: FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({
+        "schema": report["schema"],
+        "status": report["status"],
+        "report": str(output_dir / "journey-report.json"),
+        "commands": len(report["commands"]),
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Superseded diagnostic attempt

This PR proved the installed-wheel Developer Preview concept and, importantly, exposed the first real newcomer-path defect: venv Python can be a symlink to the host interpreter, so resolving `sys.executable` before locating console scripts escaped the venv and looked for `neuros` in the host `bin/` directory.

That defect is repaired on the branch using the active interpreter's `sysconfig` scripts directory, failure reports are now initialized before preflight and uploaded with `always()`, and the branch has been flattened to one clean commit directly on current `main`.

GitHub's synthetic `refs/pull/50/merge` remained pinned to the obsolete pre-fix tree after the branch rewrite, so this PR is intentionally closed rather than using stale checks as qualification evidence. A fresh PR is being opened from exact head `6c84ba78397f23a61ed5f88ff91c279a4b1b9a40` to force a clean merge ref and exact-head Actions matrix.

No code is being abandoned; #50 remains the audit trail for the initial failure.