### PR TITLE
Unicorn simulator rigor v2: truthful clocks, receiver state, and trace reconciliation

### DIFF
--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -107,10 +107,11 @@ jobs:
             --dry-run-packets 20
       - name: Compile engine-facing C# receiver
         run: dotnet build examples/game_engines/csharp/Neuros.Unicorn.Examples.csproj --configuration Release
-      - name: Syntax-check real-time substitution and capture endpoints
+      - name: Syntax-check real-time substitution and trace endpoints
         run: |
           python -m py_compile \
             examples/unicorn_hybrid_black_simulator.py \
             examples/unicorn_udp_simulator.py \
             examples/unicorn_raw_udp_trace_capture.py \
+            examples/unicorn_trace_compare.py \
             examples/unicorn_sim_conformance.py

--- a/docs/UNICORN_GAME_DEVELOPMENT.md
+++ b/docs/UNICORN_GAME_DEVELOPMENT.md
@@ -1,39 +1,41 @@
-# Developing EEG games against the neurOS Unicorn Hybrid Black suite
+# Developing EEG games with the neurOS Unicorn suite
 
-This guide is the shortest path from a game prototype with no headset attached to a game that can be exercised against the neurOS Unicorn Hybrid Black device/interface twin and later compared with a physical device.
+This guide is the shortest path from a game prototype with no headset attached to a game that can be stressed against the neurOS Unicorn Hybrid Black substitution stack and later compared with a physical device.
 
-The simulator is designed to reduce **software and integration risk**. It cannot establish that a real participant will produce a decodable neural response.
+The simulator reduces **software and integration risk**. It does not prove that a participant will produce a decodable EEG response.
 
-## The contract stack
+## Keep the layers separate
 
 ```text
-Arena neural world
-participant + display + artifacts + evoked response
+participant / neural world
         ↓
 Unicorn device twin
-250 Hz + 24-bit + channel schemas + counter + IMU + validation
+250 Hz, quantization, schemas, CNT, BAT, VALID, IMU
         ↓
 interface
-Python API / raw UDP / Recorder19 / LSL / Bandpower70
+Python API | raw UDP | Recorder19 | LSL | Bandpower70
         ↓
-receiver health + authority guard
+transport faults
+loss | duplicate | delay | reorder | stale
+        ↓
+receiver diagnostics + authority guard
         ↓
 decoder
         ↓
 gameplay
 ```
 
-Do not collapse these layers. A packet-loss test should not silently change the simulated participant. A weak SSVEP responder should not silently change UDP ordering. A receiver fault should revoke BCI authority without pausing the whole game.
+A packet-loss test should not silently change physiology. A weak responder should not silently change UDP ordering. A bad neural stream should revoke BCI authority without freezing the rest of the game.
 
 ---
 
-## 1. Choose the interface your game will actually use
+## 1. Pick the interface your application will actually ship
 
 ### Raw UDP
 
-Best when the game owns the real-time signal-processing pipeline.
+Use raw UDP when the application owns real-time signal processing.
 
-Contract:
+Documented compatibility target:
 
 ```text
 250 source packets/s
@@ -42,39 +44,38 @@ Contract:
 EEG1..8 | ACC X/Y/Z | GYR X/Y/Z | BAT | CNT | VALID
 ```
 
-Important: standalone raw UDP uses `BAT, CNT, VALID` at the tail. The direct API/Recorder ordering uses `CNT, BAT, VALID`.
-
-### LSL
-
-Best when acquisition/decoding lives in Python and the game consumes a derived event stream, or when a research stack already uses Lab Streaming Layer.
-
-The neurOS LSL endpoint marks itself as synthetic in stream metadata. It does not claim byte-for-byte metadata parity with every Unicorn Suite release.
+The standalone raw-UDP tail is `BAT, CNT, VALID`. The direct API / Recorder ordering uses `CNT, BAT, VALID`.
 
 ### Bandpower UDP
 
-Best for prototypes that intentionally use the public Unicorn Bandpower-style feature interface.
-
-Contract:
+Use this only when the application intentionally consumes the public Bandpower-style feature interface.
 
 ```text
 70 ASCII values/update
-25 Hz default update cadence
-56 channel-band values
-7 channel averages
-7 bipolar averages
+250-sample analysis window
+10-sample hop
+25 Hz steady-state update cadence
 ```
 
-The payload layout/cadence are compatibility targets. Numerical spectral values come from a transparent neurOS reference estimator because the proprietary estimator is not sufficiently documented for bit-for-bit claims.
+A stream beginning with no history cannot produce its first complete feature window at `t=0`. The neurOS reference stream therefore emits its first nominal Bandpower update at **1.0 s**, then every **40 ms**.
+
+The payload layout and cadence are compatibility targets. Numerical spectral values are a transparent neurOS reference estimator, not a claim of bit-for-bit proprietary estimator equivalence.
+
+### LSL
+
+Use LSL when acquisition and decoding live outside the game process or when a research stack already uses Lab Streaming Layer.
+
+The synthetic source identifies itself as synthetic in metadata. neurOS does not claim metadata parity with every Unicorn Suite release.
 
 ### Direct Python API twin
 
-Best for application code written around device enumeration, configuration, channel enabling/disabling, acquisition start/stop and failure handling.
+Use the Python twin to exercise enumeration, configuration, channel enable/disable, acquisition lifecycle and failures.
 
-This is a conceptual API twin, not a replacement for the licensed vendor binary package.
+It is an application-facing conceptual twin, not a replacement for vendor binaries.
 
 ---
 
-## 2. Start a pristine raw UDP source
+## 2. Start a synthetic raw-UDP source
 
 ```bash
 python examples/unicorn_udp_simulator.py \
@@ -84,45 +85,56 @@ python examples/unicorn_udp_simulator.py \
   --fault-profile pristine
 ```
 
-The source targets the documented 250 Hz raw-UDP cadence. Python/OS scheduling is not presented as a calibrated Bluetooth timing measurement.
-
-Before launching the game, you can verify the exact encoder and fault engine without opening a socket:
+For deterministic CI without sockets:
 
 ```bash
 python examples/unicorn_udp_simulator.py \
   --mode raw \
-  --fault-profile pristine \
+  --fault-profile mixed-torture \
   --dry-run-packets 500
 ```
 
+The source clock targets the documented nominal 250 Hz interface. Python and operating-system scheduling are not presented as calibrated Bluetooth timing measurements.
+
 ---
 
-## 3. Put a receiver guard in front of game authority
+## 3. Do not equate traffic with neural authority
 
-A receiver should not translate “I received some bytes” into “the brain may control gameplay.”
+`UnicornRawUdpGuard` keeps four questions separate:
 
-`UnicornRawUdpGuard` implements a reference fail-closed policy:
+1. **packet status**: can the 68-byte datagram be decoded safely?
+2. **sequence status**: is `CNT` first, sequential, gapped, duplicated, reordered or precision-ambiguous?
+3. **validation**: is `VALID` asserted?
+4. **authority**: may the neural stream currently change gameplay?
 
-- malformed 68-byte payload → revoke authority;
-- non-finite values → revoke authority;
-- `VALID=0` → stream can still be alive, but revoke authority;
-- repeated counter → duplicate → revoke authority;
-- counter moves backwards → out of order → revoke authority;
-- counter skips forward → gap → revoke authority;
-- no decodable packet for the configured stale interval → revoke authority;
-- require N healthy sequential validated packets before authority returns.
+`health` remains a compact compatibility summary for simple clients, but advanced telemetry should log the orthogonal fields.
 
-Default consumer policy:
+A single packet can therefore be both:
 
 ```text
-stale threshold   100 ms
-recovery streak   3 packets
-validation        required
+VALID = 0
+sequence_status = gap
 ```
 
-Those values are neurOS application defaults, **not manufacturer specifications**.
+without one condition erasing the other.
 
-A game can keep rendering, moving the player and accepting controller input while BCI authority is false. The neural subsystem simply stops changing gameplay state.
+Default fail-closed policy:
+
+```text
+stale threshold     100 ms
+recovery streak     3 healthy packets
+VALID required      yes
+```
+
+These are neurOS application defaults, not manufacturer specifications.
+
+Authority is revoked on malformed packets, `VALID=0`, counter gaps, duplicates, out-of-order delivery, stale traffic and counter-step ambiguity. Recovery requires a fresh healthy streak.
+
+### CNT precision boundary
+
+The public raw-UDP interface transports `CNT` as float32. IEEE-754 float32 guarantees unit-step integer representation only through `2^24`.
+
+At 250 samples/s, that arithmetic corresponds to roughly 18.64 hours of uninterrupted counting. This **does not** establish physical device reset or wrap behavior. Because the public source does not document those semantics, the reference guard fails closed once exact step inference is no longer justified.
 
 ---
 
@@ -130,9 +142,7 @@ A game can keep rendering, moving the player and accepting controller input whil
 
 `examples/game_engines/csharp/UnicornRawUdpClient.cs` is dependency-free C# targeting `netstandard2.0`.
 
-Copy it into the engine project, then wrap it with an engine lifecycle component.
-
-Conceptual Unity usage:
+Conceptual usage:
 
 ```csharp
 private UnicornRawUdpClient unicorn;
@@ -147,13 +157,13 @@ void Update()
 {
     if (!unicorn.AuthorityAllowed)
     {
-        // Keep the game alive, but do not apply new BCI-derived authority.
+        // Controller/game authority remains live.
         return;
     }
 
     if (unicorn.TryGetLatest(out var sample))
     {
-        // Feed sample.Values[0..7] into the decoder or signal bridge.
+        // Decode or bridge sample.Values[0..7].
     }
 }
 
@@ -163,35 +173,35 @@ void OnDestroy()
 }
 ```
 
-Raw UDP deliberately carries no “simulated vs physical” provenance field. The application must log the selected source separately, for example:
+Raw UDP intentionally carries no synthetic/physical provenance bit. Log source provenance separately:
 
 ```text
-bci_source_kind = synthetic
-bci_source_label = neuros-unicorn-pristine-seed-7
+bci_source_kind  = synthetic
+bci_source_label = neuros-unicorn-seed-7
 ```
 
 or:
 
 ```text
-bci_source_kind = user_declared_physical
-bci_source_label = hackathon-headset-a
+bci_source_kind  = user_declared_physical
+bci_source_label = lab-headset-a
 ```
 
-Do not infer provenance from raw packet bytes.
+Do not infer provenance from packet bytes.
 
 ---
 
-## 5. Turn on deterministic transport failures
+## 5. Torture the transport deliberately
 
-Named profiles:
+Named deterministic profiles:
 
 | profile | purpose |
 |---|---|
-| `pristine` | no synthetic transport faults |
-| `periodic-loss` | deterministic packet-loss probe |
-| `duplicate-probe` | repeated-packet handling |
-| `reorder-probe` | adjacent packet inversion |
-| `delay-probe` | periodic delivery delay |
+| `pristine` | no synthetic transport fault |
+| `periodic-loss` | missing-packet handling |
+| `duplicate-probe` | duplicate handling |
+| `reorder-probe` | adjacent inversion |
+| `delay-probe` | delayed delivery |
 | `mixed-torture` | loss + duplicate + delay + reorder |
 
 Example:
@@ -203,73 +213,37 @@ python examples/unicorn_udp_simulator.py \
   --fault-profile mixed-torture
 ```
 
-These cadences are deliberately synthetic test patterns. They are **not measured Unicorn Bluetooth statistics**.
+These cadences are synthetic test choices, not measured Unicorn Bluetooth statistics.
 
-A correct game should remain playable through every fault profile. BCI authority may disappear temporarily; controller/game authority should not become corrupted.
-
----
-
-## 6. Exercise Bandpower consumers
-
-```bash
-python examples/unicorn_udp_simulator.py \
-  --mode bandpower \
-  --port 19746 \
-  --fault-profile pristine
-```
-
-Or run a deterministic feature-stream check:
-
-```bash
-python examples/unicorn_udp_simulator.py \
-  --mode bandpower \
-  --fault-profile delay-probe \
-  --dry-run-packets 100
-```
-
-The first update internally requires the configured 250-sample analysis buffer. Later updates use the documented 10-sample hop.
+A robust game stays playable while BCI authority disappears and recovers. Controller authority, simulation state and save state should remain coherent throughout.
 
 ---
 
-## 7. Use Arena for neural/game worlds
+## 6. Use neural worlds for physiology, not the packet layer
 
-The device twin should not be asked to invent participant physiology.
+The low-level device twin should not invent participant physiology.
 
-Use `neuros-arena` for worlds such as:
+Use `neuros-arena` or an explicit EEG source for worlds such as:
 
-- strong SSVEP responder;
-- weak responder;
-- endogenous alpha collision near a stimulus frequency;
-- blink contamination;
-- jaw/EMG contamination;
-- head/controller movement;
+- strong and weak SSVEP responders;
+- no-response / abstention cases;
+- endogenous alpha near a stimulus frequency;
+- blink, jaw and controller contamination;
+- head motion;
 - posterior contact degradation;
-- display frame drops;
-- participant fatigue/response attenuation;
-- source-space or recorded-background worlds.
+- display-frame perturbations;
+- fatigue / response attenuation;
+- recorded-background or source-space models.
 
-Then wrap the resulting sensor-space EEG in the Unicorn device/interface contract.
+Then wrap that EEG in the same Unicorn device/interface contract.
 
-For Unicorn EEG-only Arena scenarios:
-
-```python
-from neuros.arena import unicorn_hybrid_black_eeg_profile
-
-profile = unicorn_hybrid_black_eeg_profile(
-    sensor_noise_uv=0.5,
-    line_frequency_hz=60.0,
-    line_noise_uv=1.0,
-    chunk_samples=5,
-)
-```
-
-Environmental parameters remain explicit and should not be described as published headset behavior.
+Built-in neural worlds are phenomenological software-test models unless separately reality-anchored. They are not human digital twins.
 
 ---
 
-## 8. Capture a real-device interface trace without saving EEG
+## 7. Capture physical interface diagnostics without persisting EEG
 
-When a physical Unicorn becomes available, run the game-facing raw UDP path and capture only interface diagnostics:
+When a physical Unicorn is available:
 
 ```bash
 python examples/unicorn_raw_udp_trace_capture.py \
@@ -277,109 +251,116 @@ python examples/unicorn_raw_udp_trace_capture.py \
   --port 19745 \
   --seconds 30 \
   --source-kind user_declared_physical \
-  --source-label hackathon-headset-a \
+  --source-label lab-headset-a \
   --output headset-a-trace.json
 ```
 
-The output contains:
+The v2 capture receipt stores reduced diagnostics such as:
 
-- packet count;
-- decoded/malformed count;
-- observed arrival cadence;
-- mean/p95 inter-arrival time;
-- first/last counter;
+- packet and decode counts;
+- arrival rate and inter-arrival summaries;
 - counter-gap events;
-- inferred missing packets at gap time;
-- duplicates;
-- out-of-order packets;
+- **unresolved** missing counters after late-packet reconciliation;
+- recovered reordered packets;
+- duplicates and out-of-order packets;
 - `VALID=0` count;
-- observed battery range;
-- nominal-contract diagnostics.
+- counter precision / epoch ambiguity;
+- observed battery range.
 
-It explicitly records:
+It records:
 
 ```text
-contains_raw_eeg = false
+contains_raw_eeg      = false
 raw_packets_persisted = false
 ```
 
-`user_declared_physical` means exactly that. It is an operator statement, not cryptographic proof of device provenance.
+Raw datagrams exist transiently in process memory while the summary is computed. This tool does not persist their EEG samples or packet bytes.
+
+`user_declared_physical` is an operator statement, not cryptographic device provenance.
 
 ---
 
-## 9. Convert discrepancies into simulator corrections
+## 8. Compare synthetic and physical traces descriptively
 
-The desired hardware-validation loop is:
-
-```text
-same receiver/game
-      ↑           ↑
-neurOS twin    physical Unicorn
-      ↓           ↓
-trace summary  trace summary
-      └──── compare ────┘
+```bash
+python examples/unicorn_trace_compare.py \
+  synthetic-trace.json \
+  headset-a-trace.json \
+  --output comparison.json
 ```
 
-If a physical capture disagrees with the simulator, do not tune the game around the simulator. Correct the relevant simulator layer and version the change.
+The comparison reports deltas for cadence, inter-arrival timing, malformed fraction, validation-zero fraction, reorder fraction and unresolved-missing fraction.
 
-Examples:
+It intentionally returns:
 
-- raw field ordering mismatch → interface contract correction;
-- counter semantics mismatch → device-twin correction;
-- LSL metadata mismatch → LSL substitution correction;
-- physical arrival jitter differs → measured transport profile, clearly labeled as observed data;
-- EEG amplitude/covariance mismatch → Arena/reality-anchoring work, not UDP code;
-- participant cannot select the target → neural paradigm/decoder problem, not packet serialization.
+```text
+passed = null
+```
+
+neurOS does not invent a default “close enough to hardware” threshold. Tolerances should come from measured conditions and a declared validation objective.
+
+If physical behavior disagrees with the simulator, correct the lowest layer that is actually wrong:
+
+| discrepancy | correct layer |
+|---|---|
+| field ordering | interface contract |
+| CNT semantics | device / receiver contract |
+| LSL metadata | LSL substitution |
+| measured arrival jitter | transport model |
+| EEG covariance/amplitude | neural-world model |
+| participant cannot select a target | paradigm / decoder |
+
+Do not tune game logic around a simulator defect.
 
 ---
 
-# Recommended pre-hardware game qualification
+## 9. Recommended pre-hardware qualification
 
-For an EEG action game, a useful minimum matrix is:
+At minimum, exercise:
 
 1. pristine strong-responder world;
-2. weak-responder world;
-3. no-response/abstention world;
+2. weak responder;
+3. no-response / abstention;
 4. alpha-frequency collision;
-5. blink/jaw/controller artifact sequence;
+5. blink, jaw and controller artifacts;
 6. posterior-channel degradation;
-7. `VALID=0` period and recovery;
-8. periodic packet loss;
-9. duplicate packets;
+7. `VALID=0` and recovery;
+8. packet loss;
+9. duplicates;
 10. reordering;
-11. delayed packets;
-12. source stale interval;
+11. delay;
+12. stale source;
 13. mixed transport torture;
-14. game remains controllable without BCI authority;
-15. replay produces the same synthetic world and decisions.
+14. controller-only continuity while BCI authority is false;
+15. deterministic replay across different acquisition chunk sizes.
 
-Passing all fifteen means the **software is much harder to surprise** when real hardware arrives. It does not mean the human BCI has been validated.
+Passing this matrix means the software is harder to surprise. It does not validate human BCI performance.
 
 ---
 
-# Evidence vocabulary
+## Evidence vocabulary
 
-Use these phrases deliberately:
-
-### Safe before physical hardware
+Safe before hardware:
 
 - “tested against the neurOS Unicorn Hybrid Black simulator”
-- “hardware-free device/interface conformance”
+- “hardware-free interface conformance”
 - “synthetic transport torture tested”
-- “Arena synthetic-population robustness”
+- “synthetic neural-world robustness”
 
-### Requires actual device observation
+Requires physical observation:
 
 - “observed on Unicorn Hybrid Black hardware”
 - “measured physical arrival cadence”
 - “observed physical validation behavior”
 
-### Requires human closed-loop data
+Requires human closed-loop data:
 
-- “participant SSVEP accuracy”
-- “human false-switch rate”
-- “calibration time”
-- “comfort/usability”
-- “real gameplay performance with EEG”
+- participant SSVEP accuracy;
+- accepted precision / abstention;
+- false-switch rate;
+- decision-time decomposition;
+- calibration time;
+- comfort and usability;
+- real gameplay performance with EEG.
 
-The simulator exists to make the transition between those evidence levels clean rather than blurry.
+For the adversarial evidence ledger and current known limitations, see `docs/UNICORN_SIMULATOR_RIGOR.md`.

--- a/docs/UNICORN_GAME_DEVELOPMENT.md
+++ b/docs/UNICORN_GAME_DEVELOPMENT.md
@@ -136,6 +136,24 @@ The public raw-UDP interface transports `CNT` as float32. IEEE-754 float32 guara
 
 At 250 samples/s, that arithmetic corresponds to roughly 18.64 hours of uninterrupted counting. This **does not** establish physical device reset or wrap behavior. Because the public source does not document those semantics, the reference guard fails closed once exact step inference is no longer justified.
 
+### Explicit acquisition epochs
+
+The guard also does **not** infer a counter reset from a backward CNT value. That could be a late packet, a transport reorder, a device restart, or undocumented wrap behavior. Guessing would turn ambiguity into false authority.
+
+When the application itself knows that a new acquisition session has begun, explicitly start a new receiver epoch:
+
+```python
+guard.begin_new_epoch()
+```
+
+or in the dependency-free C# client:
+
+```csharp
+unicorn.BeginNewEpoch();
+```
+
+This clears the counter high-water and any precision-ambiguity state, revokes stream liveness and BCI authority, and requires the configured healthy recovery streak again. Stale traffic alone never triggers this reset automatically.
+
 ---
 
 ## 4. Unity / Godot C# integration
@@ -332,7 +350,8 @@ At minimum, exercise:
 12. stale source;
 13. mixed transport torture;
 14. controller-only continuity while BCI authority is false;
-15. deterministic replay across different acquisition chunk sizes.
+15. deterministic replay across different acquisition chunk sizes;
+16. explicit receiver epoch restart after a known acquisition reconnect.
 
 Passing this matrix means the software is harder to surprise. It does not validate human BCI performance.
 

--- a/docs/UNICORN_SIMULATOR_RIGOR.md
+++ b/docs/UNICORN_SIMULATOR_RIGOR.md
@@ -1,0 +1,162 @@
+# Unicorn simulator rigor ledger
+
+This document is the adversarial review checklist for the neurOS Unicorn Hybrid Black simulation stack. Its purpose is to make the simulator **harder to overclaim**, not easier to market.
+
+A simulator is useful when it tells developers exactly which surprises it can remove before hardware arrives and exactly which surprises remain unknown.
+
+## Evidence classes
+
+| class | meaning | allowed wording |
+|---|---|---|
+| `exact_contract` | frozen public interface or product fact reproduced directly | “matches the documented interface contract” |
+| `reference_implementation` | transparent neurOS implementation where public behavior is underspecified | “neurOS reference implementation” |
+| `measured_observation` | captured from identified physical test conditions | “observed under the recorded conditions” |
+| `synthetic_assumption` | deliberately invented stress/test policy | “synthetic stress profile” |
+| `unknown` | evidence is insufficient | “not yet established” |
+
+Never silently promote one class into another.
+
+## Current layer-by-layer assessment
+
+### Green: interface structure
+
+The strongest part of the simulator is the game-facing interface contract:
+
+- eight EEG channels at the documented nominal 250 Hz acquisition rate;
+- 17-value raw UDP payload shape and field order;
+- 68-byte float payload size;
+- API/Recorder versus standalone raw-UDP tail ordering;
+- Recorder field schema;
+- Bandpower payload layout and documented update cadence;
+- direct-API lifecycle semantics represented by the Python twin.
+
+These surfaces still do **not** establish proprietary binary compatibility with every Unicorn Suite release.
+
+### Green/yellow: deterministic transport and consumer safety
+
+The transport engine can generate deterministic loss, delay, duplicate and adjacent-reorder schedules. These are test policies, not measured Bluetooth statistics.
+
+The receiver guard fails neural gameplay authority closed on:
+
+- malformed packets;
+- stale streams;
+- `VALID=0`;
+- counter gaps;
+- duplicates;
+- out-of-order delivery;
+- counter precision beyond guaranteed float32 unit-step integer representation.
+
+Packet decodability, sequence continuity, validation and gameplay authority are separate diagnostics. A packet can therefore be both `VALID=0` and part of a counter gap without one condition hiding the other.
+
+### Yellow: timing
+
+Raw source cadence and Bandpower feature cadence are explicit. Bandpower now models the initial 250-sample analysis-window warm-up separately from its later 25 Hz feature updates.
+
+Still unknown until measurement:
+
+- physical Bluetooth latency distribution;
+- operating-system scheduling jitter for the actual vendor path;
+- device/host clock relationship;
+- dropped or batched packet behavior under RF interference;
+- exact timing semantics across vendor software versions.
+
+The approximately 40 ms compensation used by the reference path remains a `reference_implementation`, not a physical latency specification.
+
+### Yellow: trace calibration
+
+Privacy-safe trace receipts retain packet/timing/counter/validation/battery diagnostics and persist no raw EEG samples or packet bytes.
+
+Loss accounting is reorder-aware:
+
+1. a forward gap opens an unresolved missing interval;
+2. a late packet inside that interval reconciles the missing count;
+3. an unexplained backward counter marks the counter epoch ambiguous;
+4. exact missing-packet claims are suppressed when float32 counter precision is ambiguous.
+
+Synthetic and user-declared physical trace summaries can be compared descriptively. neurOS intentionally ships no default “close enough to hardware” threshold.
+
+### Red/yellow: physiological digital-twin realism
+
+`SyntheticEEGGenerator` is a controlled nuisance generator, **not a validated human or Unicorn physiological twin**.
+
+Known issues that must be resolved before promoting its replay/realism claims:
+
+1. **Chunk-dependent colored-noise normalization.** Colored noise is currently normalized using statistics from each render call. The same seed can therefore produce different scaled data when the same duration is requested with different chunk boundaries. This violates partition-invariant replay.
+2. **Dropout duration leak.** A dropout active at the start of a render call can zero the selected channel for the entire returned block even when the requested artifact expires partway through that block.
+3. **Single-artifact state.** Artifact injection currently permits one active artifact at a time, while real gameplay can combine eye, jaw, controller and head-motion contamination.
+4. **Stationary alpha.** Alpha frequency/amplitude are fixed rather than slowly varying across a session.
+5. **No explicit line-noise process in the base generator.** Arena can add environmental line noise, but the low-level generator itself does not yet exercise it.
+6. **Simplified spatial covariance.** Channel weighting is hand-authored and useful for stress tests, but not fitted to measured Unicorn covariance.
+7. **Simplified SSVEP morphology.** Fundamental/harmonic weights are controlled synthetic parameters, not a population model learned from Unicorn participants.
+8. **“Saturation” is a stress label, not yet a calibrated amplifier-clipping model.** It must not be described as measured ADC saturation behavior.
+
+These are not reasons to discard the generator. They define the next implementation gates.
+
+## Counter precision boundary
+
+The public raw-UDP interface transports `CNT` as float32. IEEE-754 float32 represents every integer exactly only through `2^24`.
+
+At 250 samples/s:
+
+```text
+2^24 / 250 ≈ 67,109 seconds ≈ 18.64 hours
+```
+
+This arithmetic does **not** prove the physical device counts continuously for 18.64 hours. Vendor reset/wrap semantics are not documented by the frozen raw-UDP source. neurOS therefore treats loss inference beyond unit-step float32 exactness as ambiguous and revokes game authority rather than inventing wrap behavior.
+
+## Rigor gates
+
+### R0: deterministic software
+
+Required:
+
+- same seed and same scenario produce the same data;
+- replay is invariant to reasonable render chunk partitioning;
+- artifact durations are sample-exact across chunk boundaries;
+- transport fault schedule is deterministic;
+- Python and C# receiver authority decisions agree on shared fixtures.
+
+### R1: public interface conformance
+
+Required:
+
+- exact documented shapes, order and cadence contracts;
+- compatibility receipt names frozen upstream sources;
+- reference implementations are visibly distinct from exact contracts.
+
+### R2: adversarial game integration
+
+Required:
+
+- controller remains authoritative during BCI failure;
+- stale/invalid/gap/duplicate/reorder all fail closed;
+- recovery requires a fresh healthy streak;
+- game telemetry records synthetic versus user-declared physical source out of band;
+- no raw EEG crosses a gameplay boundary unless the application intentionally owns raw decoding.
+
+### R3: physical interface observation
+
+Required before claiming hardware-observed compatibility:
+
+- trace at least one identified Unicorn Hybrid Black configuration;
+- record OS, vendor software version, transport path and capture conditions;
+- compare cadence/counter/validation behavior against the simulator;
+- turn differences into versioned simulator corrections rather than game-specific workarounds.
+
+### R4: human closed-loop qualification
+
+Required before claiming BCI performance:
+
+- participant-level calibration and held-out trials;
+- accepted precision and abstention rate;
+- false-switch rate;
+- decision latency decomposition;
+- movement/artifact stress;
+- usability and comfort;
+- full gameplay testing.
+
+## Development rule
+
+When realism is uncertain, prefer a named parameter or explicit `unknown` over a hidden constant. When a physical discrepancy appears, correct the lowest layer that is actually wrong.
+
+The target is not a simulator that looks convincing. The target is a simulator whose **failures are interpretable**.

--- a/examples/game_engines/csharp/UnicornRawUdpClient.cs
+++ b/examples/game_engines/csharp/UnicornRawUdpClient.cs
@@ -118,6 +118,7 @@ namespace Neuros.Unicorn
         private volatile bool _running;
         private UnicornRawUdpSample _latest;
         private int? _counterHighWater;
+        private bool _counterPrecisionAmbiguous;
         private double? _lastDecodableReceiveSeconds;
         private int _healthyStreak;
         private UnicornStreamHealth _lastHealth = UnicornStreamHealth.Stale;
@@ -269,10 +270,11 @@ namespace Neuros.Unicorn
                 var battery = values[BatteryIndex];
                 var counterFloat = values[CounterIndex];
                 var validationFloat = values[ValidationIndex];
-                var counter = (int)Math.Round(counterFloat);
+                var counterStepExact = Math.Abs(counterFloat) <= Float32ExactIntegerMax;
+                var counter = counterStepExact ? (int)Math.Round(counterFloat) : -1;
                 var validation = (int)Math.Round(validationFloat);
 
-                if (Math.Abs(counterFloat - counter) > 0.25f)
+                if (counterStepExact && Math.Abs(counterFloat - counter) > 0.25f)
                 {
                     return PublishMalformed(receivedSeconds, "Counter is not sufficiently integer-like.");
                 }
@@ -283,8 +285,7 @@ namespace Neuros.Unicorn
 
                 _lastDecodableReceiveSeconds = receivedSeconds;
                 int missedPackets;
-                bool counterStepExact;
-                var sequenceStatus = ClassifySequence(counter, counterFloat, out missedPackets, out counterStepExact);
+                var sequenceStatus = ClassifySequence(counter, counterStepExact, out missedPackets);
                 var validationAsserted = validation == 1;
                 var health = SummarizeHealth(validationAsserted, sequenceStatus);
 
@@ -324,19 +325,13 @@ namespace Neuros.Unicorn
 
         private UnicornSequenceStatus ClassifySequence(
             int counter,
-            float counterFloat,
-            out int missedPackets,
-            out bool counterStepExact)
+            bool counterStepExact,
+            out int missedPackets)
         {
             missedPackets = 0;
-            counterStepExact = Math.Abs(counterFloat) <= Float32ExactIntegerMax
-                && (!_counterHighWater.HasValue || Math.Abs(_counterHighWater.Value) <= Float32ExactIntegerMax);
-            if (!counterStepExact)
+            if (!counterStepExact || _counterPrecisionAmbiguous)
             {
-                if (!_counterHighWater.HasValue || counter > _counterHighWater.Value)
-                {
-                    _counterHighWater = counter;
-                }
+                _counterPrecisionAmbiguous = true;
                 return UnicornSequenceStatus.PrecisionAmbiguous;
             }
 
@@ -360,8 +355,6 @@ namespace Neuros.Unicorn
             bool validationAsserted,
             UnicornSequenceStatus sequenceStatus)
         {
-            // Keep the prior compact VALID=0 behavior while preserving sequence
-            // information independently on UnicornRawUdpSample.SequenceStatus.
             if (!validationAsserted) return UnicornStreamHealth.Invalid;
             switch (sequenceStatus)
             {

--- a/examples/game_engines/csharp/UnicornRawUdpClient.cs
+++ b/examples/game_engines/csharp/UnicornRawUdpClient.cs
@@ -173,6 +173,24 @@ namespace Neuros.Unicorn
             }
         }
 
+        public void BeginNewEpoch()
+        {
+            // Counter wrap/reset behavior is not documented by the public wire
+            // contract. Never infer it from CNT. Call this only when the
+            // application/device lifecycle knows a new acquisition has begun.
+            // Authority and liveness are revoked until the normal recovery
+            // streak is rebuilt from fresh packets.
+            lock (_sync)
+            {
+                _counterHighWater = null;
+                _counterPrecisionAmbiguous = false;
+                _lastDecodableReceiveSeconds = null;
+                _healthyStreak = 0;
+                _lastHealth = UnicornStreamHealth.Stale;
+                _latest = null;
+            }
+        }
+
         public bool TryGetLatest(out UnicornRawUdpSample sample)
         {
             lock (_sync)

--- a/examples/game_engines/csharp/UnicornRawUdpClient.cs
+++ b/examples/game_engines/csharp/UnicornRawUdpClient.cs
@@ -26,7 +26,25 @@ namespace Neuros.Unicorn
         Invalid,
         Gap,
         Duplicate,
-        OutOfOrder
+        OutOfOrder,
+        CounterAmbiguous
+    }
+
+    public enum UnicornPacketStatus
+    {
+        Decodable,
+        Malformed
+    }
+
+    public enum UnicornSequenceStatus
+    {
+        Unknown,
+        First,
+        Sequential,
+        Gap,
+        Duplicate,
+        OutOfOrder,
+        PrecisionAmbiguous
     }
 
     public sealed class UnicornRawUdpSample
@@ -41,6 +59,10 @@ namespace Neuros.Unicorn
         public readonly bool AuthorityAllowed;
         public readonly double ReceivedSeconds;
         public readonly string Reason;
+        public readonly UnicornPacketStatus PacketStatus;
+        public readonly UnicornSequenceStatus SequenceStatus;
+        public readonly bool? ValidationAsserted;
+        public readonly bool? CounterStepExact;
 
         public UnicornRawUdpSample(
             float[] values,
@@ -52,7 +74,11 @@ namespace Neuros.Unicorn
             int healthyStreak,
             bool authorityAllowed,
             double receivedSeconds,
-            string reason)
+            string reason,
+            UnicornPacketStatus packetStatus = UnicornPacketStatus.Decodable,
+            UnicornSequenceStatus sequenceStatus = UnicornSequenceStatus.Unknown,
+            bool? validationAsserted = null,
+            bool? counterStepExact = null)
         {
             Values = values;
             Counter = counter;
@@ -64,6 +90,10 @@ namespace Neuros.Unicorn
             AuthorityAllowed = authorityAllowed;
             ReceivedSeconds = receivedSeconds;
             Reason = reason;
+            PacketStatus = packetStatus;
+            SequenceStatus = sequenceStatus;
+            ValidationAsserted = validationAsserted;
+            CounterStepExact = counterStepExact;
         }
     }
 
@@ -74,6 +104,7 @@ namespace Neuros.Unicorn
         public const int BatteryIndex = 14;
         public const int CounterIndex = 15;
         public const int ValidationIndex = 16;
+        public const int Float32ExactIntegerMax = 16777216; // 2^24
 
         private readonly object _sync = new object();
         private readonly int _port;
@@ -86,7 +117,7 @@ namespace Neuros.Unicorn
         private Thread _thread;
         private volatile bool _running;
         private UnicornRawUdpSample _latest;
-        private int? _lastCounter;
+        private int? _counterHighWater;
         private double? _lastDecodableReceiveSeconds;
         private int _healthyStreak;
         private UnicornStreamHealth _lastHealth = UnicornStreamHealth.Stale;
@@ -221,8 +252,7 @@ namespace Neuros.Unicorn
 
                 if (payload.Length != PayloadBytes)
                 {
-                    return PublishFault(
-                        null, null, null, UnicornStreamHealth.Malformed, 0,
+                    return PublishMalformed(
                         receivedSeconds, $"Expected {PayloadBytes} bytes, received {payload.Length}.");
                 }
 
@@ -232,9 +262,7 @@ namespace Neuros.Unicorn
                     values[i] = ReadLittleEndianSingle(payload, i * 4);
                     if (float.IsNaN(values[i]) || float.IsInfinity(values[i]))
                     {
-                        return PublishFault(
-                            values, null, null, UnicornStreamHealth.Malformed, 0,
-                            receivedSeconds, "Packet contains a non-finite value.");
+                        return PublishMalformed(receivedSeconds, "Packet contains a non-finite value.");
                     }
                 }
 
@@ -246,85 +274,159 @@ namespace Neuros.Unicorn
 
                 if (Math.Abs(counterFloat - counter) > 0.25f)
                 {
-                    return PublishFault(
-                        values, null, validation, UnicornStreamHealth.Malformed, 0,
-                        receivedSeconds, "Counter is not sufficiently integer-like.");
+                    return PublishMalformed(receivedSeconds, "Counter is not sufficiently integer-like.");
                 }
                 if (validation != 0 && validation != 1)
                 {
-                    return PublishFault(
-                        values, counter, validation, UnicornStreamHealth.Malformed, 0,
-                        receivedSeconds, "Validation indicator is not binary.");
+                    return PublishMalformed(receivedSeconds, "Validation indicator is not binary.");
                 }
 
                 _lastDecodableReceiveSeconds = receivedSeconds;
-                if (validation != 1)
+                int missedPackets;
+                bool counterStepExact;
+                var sequenceStatus = ClassifySequence(counter, counterFloat, out missedPackets, out counterStepExact);
+                var validationAsserted = validation == 1;
+                var health = SummarizeHealth(validationAsserted, sequenceStatus);
+
+                var sequenceOk = sequenceStatus == UnicornSequenceStatus.First
+                    || sequenceStatus == UnicornSequenceStatus.Sequential;
+                if (sequenceOk && validationAsserted && counterStepExact)
                 {
-                    _lastCounter = counter;
-                    return PublishFault(
-                        values, counter, validation, UnicornStreamHealth.Invalid, 0,
-                        receivedSeconds, "Validation indicator is not asserted.", battery);
+                    _healthyStreak += 1;
+                }
+                else
+                {
+                    _healthyStreak = 0;
                 }
 
-                if (_lastCounter.HasValue)
-                {
-                    var delta = counter - _lastCounter.Value;
-                    if (delta == 0)
-                    {
-                        return PublishFault(
-                            values, counter, validation, UnicornStreamHealth.Duplicate, 0,
-                            receivedSeconds, "Counter repeated.", battery);
-                    }
-                    if (delta < 0)
-                    {
-                        return PublishFault(
-                            values, counter, validation, UnicornStreamHealth.OutOfOrder, 0,
-                            receivedSeconds, "Counter moved backwards.", battery);
-                    }
-                    if (delta > 1)
-                    {
-                        _lastCounter = counter;
-                        return PublishFault(
-                            values, counter, validation, UnicornStreamHealth.Gap, delta - 1,
-                            receivedSeconds, $"Counter advanced by {delta}.", battery);
-                    }
-                }
-
-                _lastCounter = counter;
-                _healthyStreak += 1;
-                _lastHealth = UnicornStreamHealth.Healthy;
-                var allowed = _healthyStreak >= _recoveryPackets;
+                _lastHealth = health;
+                var allowed = health == UnicornStreamHealth.Healthy
+                    && _healthyStreak >= _recoveryPackets;
+                var reason = BuildReason(validationAsserted, sequenceStatus, missedPackets);
                 _latest = new UnicornRawUdpSample(
-                    values, counter, battery, validation, UnicornStreamHealth.Healthy,
-                    0, _healthyStreak, allowed, receivedSeconds,
-                    "Healthy sequential validated packet.");
+                    values,
+                    counter,
+                    battery,
+                    validation,
+                    health,
+                    missedPackets,
+                    _healthyStreak,
+                    allowed,
+                    receivedSeconds,
+                    reason,
+                    UnicornPacketStatus.Decodable,
+                    sequenceStatus,
+                    validationAsserted,
+                    counterStepExact);
                 return _latest;
             }
         }
 
-        private UnicornRawUdpSample PublishFault(
-            float[] values,
-            int? counter,
-            int? validation,
-            UnicornStreamHealth health,
-            int missedPackets,
-            double receivedSeconds,
-            string reason,
-            float? battery = null)
+        private UnicornSequenceStatus ClassifySequence(
+            int counter,
+            float counterFloat,
+            out int missedPackets,
+            out bool counterStepExact)
+        {
+            missedPackets = 0;
+            counterStepExact = Math.Abs(counterFloat) <= Float32ExactIntegerMax
+                && (!_counterHighWater.HasValue || Math.Abs(_counterHighWater.Value) <= Float32ExactIntegerMax);
+            if (!counterStepExact)
+            {
+                if (!_counterHighWater.HasValue || counter > _counterHighWater.Value)
+                {
+                    _counterHighWater = counter;
+                }
+                return UnicornSequenceStatus.PrecisionAmbiguous;
+            }
+
+            if (!_counterHighWater.HasValue)
+            {
+                _counterHighWater = counter;
+                return UnicornSequenceStatus.First;
+            }
+
+            var delta = counter - _counterHighWater.Value;
+            if (delta == 0) return UnicornSequenceStatus.Duplicate;
+            if (delta < 0) return UnicornSequenceStatus.OutOfOrder;
+
+            _counterHighWater = counter;
+            if (delta == 1) return UnicornSequenceStatus.Sequential;
+            missedPackets = delta - 1;
+            return UnicornSequenceStatus.Gap;
+        }
+
+        private static UnicornStreamHealth SummarizeHealth(
+            bool validationAsserted,
+            UnicornSequenceStatus sequenceStatus)
+        {
+            // Keep the prior compact VALID=0 behavior while preserving sequence
+            // information independently on UnicornRawUdpSample.SequenceStatus.
+            if (!validationAsserted) return UnicornStreamHealth.Invalid;
+            switch (sequenceStatus)
+            {
+                case UnicornSequenceStatus.First:
+                case UnicornSequenceStatus.Sequential:
+                    return UnicornStreamHealth.Healthy;
+                case UnicornSequenceStatus.Gap:
+                    return UnicornStreamHealth.Gap;
+                case UnicornSequenceStatus.Duplicate:
+                    return UnicornStreamHealth.Duplicate;
+                case UnicornSequenceStatus.OutOfOrder:
+                    return UnicornStreamHealth.OutOfOrder;
+                case UnicornSequenceStatus.PrecisionAmbiguous:
+                    return UnicornStreamHealth.CounterAmbiguous;
+                default:
+                    return UnicornStreamHealth.Malformed;
+            }
+        }
+
+        private static string BuildReason(
+            bool validationAsserted,
+            UnicornSequenceStatus sequenceStatus,
+            int missedPackets)
+        {
+            var validationReason = validationAsserted ? "" : "Validation indicator is not asserted; ";
+            switch (sequenceStatus)
+            {
+                case UnicornSequenceStatus.First:
+                case UnicornSequenceStatus.Sequential:
+                    return validationAsserted
+                        ? "Healthy sequential validated packet."
+                        : validationReason + "sequence is continuous.";
+                case UnicornSequenceStatus.Gap:
+                    return validationReason + $"counter gap implies {missedPackets} missing packet(s).";
+                case UnicornSequenceStatus.Duplicate:
+                    return validationReason + "counter repeated.";
+                case UnicornSequenceStatus.OutOfOrder:
+                    return validationReason + "counter arrived below the observed high-water mark.";
+                case UnicornSequenceStatus.PrecisionAmbiguous:
+                    return validationReason
+                        + "counter exceeds float32 unit-step exactness; wrap/reset semantics are undocumented.";
+                default:
+                    return validationReason + "sequence status is unknown.";
+            }
+        }
+
+        private UnicornRawUdpSample PublishMalformed(double receivedSeconds, string reason)
         {
             _healthyStreak = 0;
-            _lastHealth = health;
+            _lastHealth = UnicornStreamHealth.Malformed;
             _latest = new UnicornRawUdpSample(
-                values ?? Array.Empty<float>(),
-                counter ?? -1,
-                battery ?? float.NaN,
-                validation ?? -1,
-                health,
-                missedPackets,
+                Array.Empty<float>(),
+                -1,
+                float.NaN,
+                -1,
+                UnicornStreamHealth.Malformed,
+                0,
                 0,
                 false,
                 receivedSeconds,
-                reason);
+                reason,
+                UnicornPacketStatus.Malformed,
+                UnicornSequenceStatus.Unknown,
+                null,
+                null);
             return _latest;
         }
 

--- a/examples/unicorn_raw_udp_trace_capture.py
+++ b/examples/unicorn_raw_udp_trace_capture.py
@@ -16,7 +16,10 @@ from pathlib import Path
 import socket
 import time
 
-from neuros.drivers import analyze_unicorn_raw_udp_trace, compare_unicorn_trace_to_nominal_contract
+from neuros.drivers import (
+    analyze_unicorn_raw_udp_trace,
+    compare_unicorn_trace_to_nominal_contract,
+)
 
 
 def main() -> None:
@@ -69,11 +72,15 @@ def main() -> None:
         rate_tolerance_hz=args.rate_tolerance_hz,
     )
     payload = {
-        "schema": "neuros.unicorn_raw_udp_capture_receipt.v1",
+        "schema": "neuros.unicorn_raw_udp_capture_receipt.v2",
         "summary": summary.to_dict(),
         "nominal_contract_comparison": comparison.to_dict(),
         "capture_requested_seconds": args.seconds,
         "raw_packets_persisted": False,
+        "evidence_boundary": (
+            "Capture receipt contains reduced interface diagnostics only. Raw datagrams "
+            "exist transiently in process memory and are not persisted by this tool."
+        ),
     }
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/unicorn_trace_compare.py
+++ b/examples/unicorn_trace_compare.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Compare two Unicorn raw-UDP diagnostic receipts without loading raw EEG.
+
+Inputs may be either a ``neuros.unicorn_raw_udp_capture_receipt`` JSON document
+or the nested ``neuros.unicorn_raw_udp_trace_summary`` object itself. The output
+is descriptive only. It intentionally has no built-in pass threshold because
+physical-vs-synthetic equivalence tolerances require measured evidence.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import fields
+import json
+from pathlib import Path
+
+from neuros.drivers import UnicornRawUdpTraceSummary, compare_unicorn_trace_summaries
+
+
+def _load_summary(path: Path) -> UnicornRawUdpTraceSummary:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    summary = payload.get("summary", payload)
+    if not isinstance(summary, dict):
+        raise ValueError(f"{path}: summary must be a JSON object")
+    allowed = {field.name for field in fields(UnicornRawUdpTraceSummary)}
+    kwargs = {name: summary[name] for name in allowed if name in summary}
+    try:
+        return UnicornRawUdpTraceSummary(**kwargs)
+    except TypeError as exc:
+        raise ValueError(f"{path}: incompatible trace-summary schema: {exc}") from exc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    reference = _load_summary(args.reference)
+    candidate = _load_summary(args.candidate)
+    report = compare_unicorn_trace_summaries(reference, candidate).to_dict()
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/unicorn_udp_simulator.py
+++ b/examples/unicorn_udp_simulator.py
@@ -11,7 +11,8 @@ Examples:
     # Raw 17-float / 68-byte Unicorn-compatible packets at nominal 250 Hz.
     python examples/unicorn_udp_simulator.py --mode raw --port 19745
 
-    # Bandpower 70-value ASCII reference payloads at nominal 25 Hz.
+    # Bandpower 70-value ASCII reference payloads at nominal 25 Hz after its
+    # analysis-window warm-up.
     python examples/unicorn_udp_simulator.py --mode bandpower --port 19746
 
     # Exercise deterministic failures without opening a socket.
@@ -50,10 +51,13 @@ def _dry_run(stream, mode: str, packets: int, byte_order: str) -> dict:
     reordered = 0
     delayed = 0
     counters: list[int] = []
+    first_nominal_time_s: float | None = None
     while source_updates < packets:
         datagrams = stream.next_datagrams()
         source_updates += 1
         for datagram in datagrams:
+            if first_nominal_time_s is None:
+                first_nominal_time_s = datagram.nominal_time_s
             emitted += 1
             duplicates += int(datagram.duplicate_ordinal > 0)
             reordered += int(any(fault.startswith("reordered") for fault in datagram.faults))
@@ -68,15 +72,19 @@ def _dry_run(stream, mode: str, packets: int, byte_order: str) -> dict:
                 if values.shape != (70,):
                     raise AssertionError("Bandpower UDP payload did not decode to 70 values")
     for datagram in stream.flush():
+        if first_nominal_time_s is None:
+            first_nominal_time_s = datagram.nominal_time_s
         emitted += 1
         if mode == "raw":
             values = decode_unicorn_udp_scan(datagram.payload, byte_order=byte_order)
             counters.append(int(round(float(values[15]))))
     return {
-        "schema": "neuros.unicorn_udp_simulator.dry_run.v1",
+        "schema": "neuros.unicorn_udp_simulator.dry_run.v2",
         "mode": mode,
         "source_updates": source_updates,
         "emitted_datagrams": emitted,
+        "initial_delay_s": stream.initial_delay_s,
+        "first_nominal_time_s": first_nominal_time_s,
         "dropped_or_held_updates": source_updates - len(set(counters)) if mode == "raw" else None,
         "duplicates": duplicates,
         "reordered_datagrams": reordered,
@@ -92,7 +100,7 @@ def _run_live(stream, *, host: str, port: int, duration_s: float) -> None:
     destination = (host, port)
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     start = time.perf_counter()
-    next_source_deadline = start
+    next_source_deadline = start + stream.initial_delay_s
     pending: list[tuple[float, int, bytes]] = []
     insertion_order = 0
     sent = 0
@@ -109,7 +117,9 @@ def _run_live(stream, *, host: str, port: int, duration_s: float) -> None:
                     heapq.heappush(pending, (release_abs, insertion_order, datagram.payload))
                     insertion_order += 1
                 source_updates += 1
-                next_source_deadline = start + source_updates * stream.interval_s
+                next_source_deadline = (
+                    start + stream.initial_delay_s + source_updates * stream.interval_s
+                )
 
             now = time.perf_counter()
             while pending and pending[0][0] <= now:
@@ -126,7 +136,8 @@ def _run_live(stream, *, host: str, port: int, duration_s: float) -> None:
     except KeyboardInterrupt:
         pass
     finally:
-        # Flush a packet held only because the process stopped between a reorder pair.
+        # Flush is a shutdown cleanup operation, not timing evidence. A packet
+        # held solely for a synthetic reorder pair is emitted immediately here.
         for datagram in stream.flush():
             sock.sendto(datagram.payload, destination)
             sent += 1
@@ -135,6 +146,7 @@ def _run_live(stream, *, host: str, port: int, duration_s: float) -> None:
             "source_updates": source_updates,
             "sent_datagrams": sent,
             "destination": f"{host}:{port}",
+            "initial_delay_s": stream.initial_delay_s,
             "synthetic": True,
         }, sort_keys=True))
 
@@ -163,6 +175,7 @@ def main() -> None:
     print(json.dumps({
         "mode": args.mode,
         "nominal_cadence_hz": cadence_hz,
+        "initial_delay_s": stream.initial_delay_s,
         "fault_profile": args.fault_profile,
         "synthetic": True,
         "transport_evidence_class": "synthetic_assumption",

--- a/packages/neuros-drivers/src/neuros/drivers/__init__.py
+++ b/packages/neuros-drivers/src/neuros/drivers/__init__.py
@@ -60,6 +60,7 @@ from neuros.drivers.unicorn_network_sim import (  # noqa: F401
     raw_udp_scan_to_api17_order,
 )
 from neuros.drivers.unicorn_receiver_guard import (  # noqa: F401
+    FLOAT32_EXACT_INTEGER_MAX,
     UnicornRawUdpGuard,
     UnicornRawUdpGuardConfig,
     UnicornRawUdpGuardState,
@@ -68,7 +69,9 @@ from neuros.drivers.unicorn_receiver_guard import (  # noqa: F401
 from neuros.drivers.unicorn_trace import (  # noqa: F401
     UnicornRawUdpTraceSummary,
     UnicornTraceContractComparison,
+    UnicornTraceDeltaReport,
     analyze_unicorn_raw_udp_trace,
+    compare_unicorn_trace_summaries,
     compare_unicorn_trace_to_nominal_contract,
 )
 from neuros.drivers.unicorn_transport_sim import (  # noqa: F401

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
@@ -2,12 +2,19 @@
 
 The device simulator answers what a source can emit. This module answers the
 other half of the contract: what a consumer should do when packets are malformed,
-invalid, missing, duplicated, reordered, or stale.
+invalid, missing, duplicated, reordered, stale, or no longer permit exact counter
+step inference.
 
-The guard deliberately treats transport health as *control authority*. A game may
-continue rendering during faults, but neural data should not continue changing
-state until the stream has recovered for a configurable number of consecutive
-packets.
+Four concepts are deliberately kept separate:
+
+* packet decodability: can the 68-byte payload be interpreted safely?
+* sequence continuity: what does CNT say about ordering and missing samples?
+* validation: is the device VALID field asserted?
+* control authority: may neural data currently alter gameplay?
+
+``health`` remains as a compact backward-compatible summary for simple game
+integrations. Consumers that need diagnostics should inspect the orthogonal
+fields instead.
 """
 from __future__ import annotations
 
@@ -18,6 +25,12 @@ import numpy as np
 
 from .unicorn_network_sim import RAW_UDP_PAYLOAD_BYTES, decode_unicorn_udp_scan
 
+# IEEE-754 float32 represents every integer exactly only through 2**24. The
+# public Unicorn raw-UDP contract documents CNT as a float but does not document
+# wrap/reset behavior. Above this bound, exact +1 packet-continuity inference is
+# therefore unsafe and the default game guard fails closed.
+FLOAT32_EXACT_INTEGER_MAX = 2**24
+
 RawUdpHealth = Literal[
     "healthy",
     "malformed",
@@ -25,7 +38,18 @@ RawUdpHealth = Literal[
     "gap",
     "duplicate",
     "out_of_order",
+    "counter_ambiguous",
     "stale",
+]
+RawUdpPacketStatus = Literal["decodable", "malformed"]
+RawUdpSequenceStatus = Literal[
+    "unknown",
+    "first",
+    "sequential",
+    "gap",
+    "duplicate",
+    "out_of_order",
+    "precision_ambiguous",
 ]
 
 
@@ -36,6 +60,7 @@ class UnicornRawUdpGuardConfig:
     stale_after_s: float = 0.100
     recovery_packets: int = 3
     require_validation: bool = True
+    require_exact_counter_steps: bool = True
     byte_order: str = "<"
 
     def validate(self) -> None:
@@ -58,6 +83,10 @@ class UnicornRawUdpObservation:
     healthy_streak: int = 0
     authority_allowed: bool = False
     reason: str = ""
+    packet_status: RawUdpPacketStatus = "decodable"
+    sequence_status: RawUdpSequenceStatus = "unknown"
+    validation_asserted: bool | None = None
+    counter_step_exact: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -67,6 +96,9 @@ class UnicornRawUdpGuardState:
     healthy_streak: int
     last_counter: int | None
     age_s: float | None
+    stream_live: bool = False
+    sequence_status: RawUdpSequenceStatus = "unknown"
+    validation_asserted: bool | None = None
 
 
 class UnicornRawUdpGuard:
@@ -75,45 +107,91 @@ class UnicornRawUdpGuard:
     def __init__(self, config: UnicornRawUdpGuardConfig | None = None) -> None:
         self.config = config or UnicornRawUdpGuardConfig()
         self.config.validate()
-        self._last_counter: int | None = None
-        # Most recent structurally decodable packet, even if VALID=0. Stream
-        # liveness and gameplay authority are intentionally separate concepts.
-        self._last_valid_receive_s: float | None = None
+        self._counter_high_water: int | None = None
+        self._last_decodable_receive_s: float | None = None
         self._healthy_streak = 0
         self._last_health: RawUdpHealth = "stale"
+        self._last_sequence_status: RawUdpSequenceStatus = "unknown"
+        self._last_validation_asserted: bool | None = None
 
     @property
     def last_counter(self) -> int | None:
-        return self._last_counter
+        """Highest observed counter in the current undocumented counter epoch."""
+
+        return self._counter_high_water
 
     @property
     def healthy_streak(self) -> int:
         return self._healthy_streak
 
-    def _fault(
-        self,
-        health: RawUdpHealth,
-        received_s: float,
-        *,
-        counter: int | None = None,
-        battery: float | None = None,
-        validation: int | None = None,
-        missed: int = 0,
-        reason: str,
-    ) -> UnicornRawUdpObservation:
+    def _malformed(self, received_s: float, *, reason: str) -> UnicornRawUdpObservation:
         self._healthy_streak = 0
-        self._last_health = health
+        self._last_health = "malformed"
+        self._last_sequence_status = "unknown"
+        self._last_validation_asserted = None
         return UnicornRawUdpObservation(
-            health=health,
-            received_monotonic_s=float(received_s),
-            counter=counter,
-            battery_level=battery,
-            validation=validation,
-            missed_packets=missed,
-            healthy_streak=0,
+            health="malformed",
+            received_monotonic_s=received_s,
+            counter=None,
+            battery_level=None,
+            validation=None,
             authority_allowed=False,
             reason=reason,
+            packet_status="malformed",
+            sequence_status="unknown",
+            validation_asserted=None,
+            counter_step_exact=None,
         )
+
+    def _sequence(
+        self,
+        *,
+        counter: int,
+        counter_float: float,
+    ) -> tuple[RawUdpSequenceStatus, int, bool]:
+        exact = abs(counter_float) <= FLOAT32_EXACT_INTEGER_MAX
+        if self._counter_high_water is not None:
+            exact = exact and abs(self._counter_high_water) <= FLOAT32_EXACT_INTEGER_MAX
+        if not exact:
+            if self._counter_high_water is None or counter > self._counter_high_water:
+                self._counter_high_water = counter
+            return "precision_ambiguous", 0, False
+
+        if self._counter_high_water is None:
+            self._counter_high_water = counter
+            return "first", 0, True
+
+        delta = counter - self._counter_high_water
+        if delta == 0:
+            return "duplicate", 0, True
+        if delta < 0:
+            return "out_of_order", 0, True
+
+        self._counter_high_water = counter
+        if delta == 1:
+            return "sequential", 0, True
+        return "gap", delta - 1, True
+
+    @staticmethod
+    def _health_summary(
+        *,
+        validation_asserted: bool,
+        sequence_status: RawUdpSequenceStatus,
+        require_validation: bool,
+    ) -> RawUdpHealth:
+        # Preserve the old compact behavior for VALID=0 while exposing sequence
+        # anomalies independently through sequence_status.
+        if require_validation and not validation_asserted:
+            return "invalid"
+        return {
+            "first": "healthy",
+            "sequential": "healthy",
+            "gap": "gap",
+            "duplicate": "duplicate",
+            "out_of_order": "out_of_order",
+            "precision_ambiguous": "counter_ambiguous",
+            "unknown": "malformed",
+        }[sequence_status]
 
     def ingest(self, payload: bytes, *, received_monotonic_s: float) -> UnicornRawUdpObservation:
         """Consume one datagram and update control-authority state."""
@@ -121,135 +199,131 @@ class UnicornRawUdpGuard:
         received_s = float(received_monotonic_s)
         if not np.isfinite(received_s):
             raise ValueError("received_monotonic_s must be finite")
-        if self._last_valid_receive_s is not None:
-            age_before_packet = max(0.0, received_s - self._last_valid_receive_s)
+
+        if self._last_decodable_receive_s is not None:
+            age_before_packet = max(0.0, received_s - self._last_decodable_receive_s)
             if age_before_packet > self.config.stale_after_s:
-                # Fresh traffic re-establishes liveness but cannot inherit neural
-                # authority accumulated before a stale interval.
+                # Fresh traffic may re-establish liveness, but cannot inherit
+                # gameplay authority accumulated before a stale interval.
                 self._healthy_streak = 0
                 self._last_health = "stale"
+
         if len(payload) != RAW_UDP_PAYLOAD_BYTES:
-            return self._fault(
-                "malformed",
+            return self._malformed(
                 received_s,
                 reason=f"expected {RAW_UDP_PAYLOAD_BYTES} bytes, received {len(payload)}",
             )
         try:
             values = decode_unicorn_udp_scan(payload, byte_order=self.config.byte_order)
         except (ValueError, TypeError) as exc:
-            return self._fault("malformed", received_s, reason=str(exc))
+            return self._malformed(received_s, reason=str(exc))
         if values.shape != (17,) or not np.all(np.isfinite(values)):
-            return self._fault("malformed", received_s, reason="packet contains non-finite or malformed values")
+            return self._malformed(received_s, reason="packet contains non-finite or malformed values")
 
-        # Standalone raw UDP order is ... GYR, BAT, CNT, VALID.
         battery = float(values[14])
         counter_float = float(values[15])
         validation_float = float(values[16])
         counter = int(round(counter_float))
         validation = int(round(validation_float))
         if abs(counter_float - counter) > 0.25:
-            return self._fault(
-                "malformed",
-                received_s,
-                battery=battery,
-                validation=validation,
-                reason="counter is not sufficiently integer-like",
-            )
+            return self._malformed(received_s, reason="counter is not sufficiently integer-like")
         if validation not in {0, 1}:
-            return self._fault(
-                "malformed",
-                received_s,
-                counter=counter,
-                battery=battery,
-                validation=validation,
-                reason="validation indicator is not binary",
-            )
-        if self.config.require_validation and validation != 1:
-            # The packet is structurally observable and advances the device
-            # counter, but its neural payload cannot grant gameplay authority.
-            self._last_counter = counter
-            self._last_valid_receive_s = received_s
-            return self._fault(
-                "invalid",
-                received_s,
-                counter=counter,
-                battery=battery,
-                validation=validation,
-                reason="validation indicator is not asserted",
-            )
+            return self._malformed(received_s, reason="validation indicator is not binary")
 
-        if self._last_counter is not None:
-            delta = counter - self._last_counter
-            if delta == 0:
-                self._last_valid_receive_s = received_s
-                return self._fault(
-                    "duplicate",
-                    received_s,
-                    counter=counter,
-                    battery=battery,
-                    validation=validation,
-                    reason="counter repeated",
-                )
-            if delta < 0:
-                self._last_valid_receive_s = received_s
-                return self._fault(
-                    "out_of_order",
-                    received_s,
-                    counter=counter,
-                    battery=battery,
-                    validation=validation,
-                    reason="counter moved backwards",
-                )
-            if delta > 1:
-                missed = delta - 1
-                self._last_counter = counter
-                self._last_valid_receive_s = received_s
-                return self._fault(
-                    "gap",
-                    received_s,
-                    counter=counter,
-                    battery=battery,
-                    validation=validation,
-                    missed=missed,
-                    reason=f"counter advanced by {delta}; {missed} packet(s) missing",
-                )
+        # Any structurally decodable packet refreshes stream liveness. Sequence
+        # continuity is classified before VALID so an invalid packet cannot hide
+        # a simultaneous transport gap, duplicate, or reorder condition.
+        self._last_decodable_receive_s = received_s
+        sequence_status, missed, counter_step_exact = self._sequence(
+            counter=counter,
+            counter_float=counter_float,
+        )
+        validation_asserted = validation == 1
+        self._last_sequence_status = sequence_status
+        self._last_validation_asserted = validation_asserted
+        health = self._health_summary(
+            validation_asserted=validation_asserted,
+            sequence_status=sequence_status,
+            require_validation=self.config.require_validation,
+        )
 
-        self._last_counter = counter
-        self._last_valid_receive_s = received_s
-        self._healthy_streak += 1
-        self._last_health = "healthy"
-        allowed = self._healthy_streak >= self.config.recovery_packets
+        sequence_ok = sequence_status in {"first", "sequential"}
+        validity_ok = validation_asserted or not self.config.require_validation
+        exactness_ok = counter_step_exact or not self.config.require_exact_counter_steps
+        if sequence_ok and validity_ok and exactness_ok:
+            self._healthy_streak += 1
+        else:
+            self._healthy_streak = 0
+
+        self._last_health = health
+        allowed = (
+            health == "healthy"
+            and self._healthy_streak >= self.config.recovery_packets
+            and sequence_ok
+            and validity_ok
+            and exactness_ok
+        )
+
+        reasons: list[str] = []
+        if not validation_asserted:
+            reasons.append("validation indicator is not asserted")
+        if sequence_status == "gap":
+            reasons.append(f"counter gap implies {missed} missing packet(s)")
+        elif sequence_status == "duplicate":
+            reasons.append("counter repeated")
+        elif sequence_status == "out_of_order":
+            reasons.append("counter arrived below the observed high-water mark")
+        elif sequence_status == "precision_ambiguous":
+            reasons.append(
+                "counter exceeds float32 unit-step exactness; wrap/reset semantics are undocumented"
+            )
+        elif sequence_status in {"first", "sequential"} and validation_asserted:
+            reasons.append("healthy sequential validated packet")
+        elif sequence_status in {"first", "sequential"}:
+            reasons.append("sequence is continuous")
+
         return UnicornRawUdpObservation(
-            health="healthy",
+            health=health,
             received_monotonic_s=received_s,
             counter=counter,
             battery_level=battery,
             validation=validation,
+            missed_packets=missed,
             healthy_streak=self._healthy_streak,
             authority_allowed=allowed,
-            reason="healthy sequential validated packet",
+            reason="; ".join(reasons),
+            packet_status="decodable",
+            sequence_status=sequence_status,
+            validation_asserted=validation_asserted,
+            counter_step_exact=counter_step_exact,
         )
 
     def state(self, *, now_monotonic_s: float) -> UnicornRawUdpGuardState:
         now = float(now_monotonic_s)
         if not np.isfinite(now):
             raise ValueError("now_monotonic_s must be finite")
-        if self._last_valid_receive_s is None:
+        if self._last_decodable_receive_s is None:
             return UnicornRawUdpGuardState(
                 health="stale",
                 authority_allowed=False,
                 healthy_streak=self._healthy_streak,
-                last_counter=self._last_counter,
+                last_counter=self._counter_high_water,
                 age_s=None,
+                stream_live=False,
+                sequence_status=self._last_sequence_status,
+                validation_asserted=self._last_validation_asserted,
             )
-        age = max(0.0, now - self._last_valid_receive_s)
+        age = max(0.0, now - self._last_decodable_receive_s)
         if age > self.config.stale_after_s:
             return UnicornRawUdpGuardState(
                 health="stale",
                 authority_allowed=False,
                 healthy_streak=0,
-                last_counter=self._last_counter,
+                last_counter=self._counter_high_water,
                 age_s=age,
+                stream_live=False,
+                sequence_status=self._last_sequence_status,
+                validation_asserted=self._last_validation_asserted,
             )
         return UnicornRawUdpGuardState(
             health=self._last_health,
@@ -258,6 +332,9 @@ class UnicornRawUdpGuard:
                 and self._healthy_streak >= self.config.recovery_packets
             ),
             healthy_streak=self._healthy_streak,
-            last_counter=self._last_counter,
+            last_counter=self._counter_high_water,
             age_s=age,
+            stream_live=True,
+            sequence_status=self._last_sequence_status,
+            validation_asserted=self._last_validation_asserted,
         )

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
@@ -123,6 +123,24 @@ class UnicornRawUdpGuard:
     def healthy_streak(self) -> int:
         return self._healthy_streak
 
+    def begin_new_epoch(self) -> None:
+        """Explicitly start a new acquisition/counter epoch.
+
+        The public raw-UDP interface does not document counter wrap/reset
+        semantics, so the guard never infers an epoch transition from packet
+        values. Applications should call this only when their own transport or
+        device lifecycle knows that a new acquisition session has begun, for
+        example after an intentional reconnect/restart. The operation revokes
+        liveness and authority and requires the normal recovery streak again.
+        """
+
+        self._counter_high_water = None
+        self._last_decodable_receive_s = None
+        self._healthy_streak = 0
+        self._last_health = "stale"
+        self._last_sequence_status = "unknown"
+        self._last_validation_asserted = None
+
     def _malformed(self, received_s: float, *, reason: str) -> UnicornRawUdpObservation:
         self._healthy_streak = 0
         self._last_health = "malformed"

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_receiver_guard.py
@@ -28,7 +28,7 @@ from .unicorn_network_sim import RAW_UDP_PAYLOAD_BYTES, decode_unicorn_udp_scan
 # IEEE-754 float32 represents every integer exactly only through 2**24. The
 # public Unicorn raw-UDP contract documents CNT as a float but does not document
 # wrap/reset behavior. Above this bound, exact +1 packet-continuity inference is
-# therefore unsafe and the default game guard fails closed.
+# unsafe and the game guard deliberately fails closed.
 FLOAT32_EXACT_INTEGER_MAX = 2**24
 
 RawUdpHealth = Literal[
@@ -60,7 +60,6 @@ class UnicornRawUdpGuardConfig:
     stale_after_s: float = 0.100
     recovery_packets: int = 3
     require_validation: bool = True
-    require_exact_counter_steps: bool = True
     byte_order: str = "<"
 
     def validate(self) -> None:
@@ -203,8 +202,6 @@ class UnicornRawUdpGuard:
         if self._last_decodable_receive_s is not None:
             age_before_packet = max(0.0, received_s - self._last_decodable_receive_s)
             if age_before_packet > self.config.stale_after_s:
-                # Fresh traffic may re-establish liveness, but cannot inherit
-                # gameplay authority accumulated before a stale interval.
                 self._healthy_streak = 0
                 self._last_health = "stale"
 
@@ -249,8 +246,7 @@ class UnicornRawUdpGuard:
 
         sequence_ok = sequence_status in {"first", "sequential"}
         validity_ok = validation_asserted or not self.config.require_validation
-        exactness_ok = counter_step_exact or not self.config.require_exact_counter_steps
-        if sequence_ok and validity_ok and exactness_ok:
+        if sequence_ok and validity_ok and counter_step_exact:
             self._healthy_streak += 1
         else:
             self._healthy_streak = 0
@@ -261,7 +257,7 @@ class UnicornRawUdpGuard:
             and self._healthy_streak >= self.config.recovery_packets
             and sequence_ok
             and validity_ok
-            and exactness_ok
+            and counter_step_exact
         )
 
         reasons: list[str] = []

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_trace.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_trace.py
@@ -365,6 +365,18 @@ def _safe_fraction(numerator: int, denominator: int) -> float | None:
     return None if denominator <= 0 else float(numerator) / float(denominator)
 
 
+def _missing_fraction(summary: UnicornRawUdpTraceSummary) -> float | None:
+    """Fraction of unique packet opportunities that remain unresolved missing."""
+
+    if summary.inferred_missing_packets is None:
+        return None
+    unique_decoded = max(0, summary.decoded_packet_count - summary.duplicate_packets)
+    return _safe_fraction(
+        summary.inferred_missing_packets,
+        unique_decoded + summary.inferred_missing_packets,
+    )
+
+
 def _delta(candidate: float | None, reference: float | None) -> float | None:
     if candidate is None or reference is None:
         return None
@@ -383,28 +395,32 @@ def compare_unicorn_trace_summaries(
     hardware defect.
     """
 
-    reference_missing_fraction = (
-        None
-        if reference.inferred_missing_packets is None
-        else _safe_fraction(
-            reference.inferred_missing_packets,
-            reference.decoded_packet_count + reference.inferred_missing_packets,
-        )
+    reference_missing_fraction = _missing_fraction(reference)
+    candidate_missing_fraction = _missing_fraction(candidate)
+    reference_malformed = _safe_fraction(
+        reference.malformed_packet_count,
+        reference.packet_count,
     )
-    candidate_missing_fraction = (
-        None
-        if candidate.inferred_missing_packets is None
-        else _safe_fraction(
-            candidate.inferred_missing_packets,
-            candidate.decoded_packet_count + candidate.inferred_missing_packets,
-        )
+    candidate_malformed = _safe_fraction(
+        candidate.malformed_packet_count,
+        candidate.packet_count,
     )
-    reference_malformed = _safe_fraction(reference.malformed_packet_count, reference.packet_count)
-    candidate_malformed = _safe_fraction(candidate.malformed_packet_count, candidate.packet_count)
-    reference_invalid = _safe_fraction(reference.validation_zero_packets, reference.decoded_packet_count)
-    candidate_invalid = _safe_fraction(candidate.validation_zero_packets, candidate.decoded_packet_count)
-    reference_reorder = _safe_fraction(reference.out_of_order_packets, reference.decoded_packet_count)
-    candidate_reorder = _safe_fraction(candidate.out_of_order_packets, candidate.decoded_packet_count)
+    reference_invalid = _safe_fraction(
+        reference.validation_zero_packets,
+        reference.decoded_packet_count,
+    )
+    candidate_invalid = _safe_fraction(
+        candidate.validation_zero_packets,
+        candidate.decoded_packet_count,
+    )
+    reference_reorder = _safe_fraction(
+        reference.out_of_order_packets,
+        reference.decoded_packet_count,
+    )
+    candidate_reorder = _safe_fraction(
+        candidate.out_of_order_packets,
+        candidate.decoded_packet_count,
+    )
 
     return UnicornTraceDeltaReport(
         reference_source_kind=reference.source_kind,
@@ -424,9 +440,18 @@ def compare_unicorn_trace_summaries(
                 candidate.p95_interarrival_ms,
                 reference.p95_interarrival_ms,
             ),
-            "malformed_fraction_delta": _delta(candidate_malformed, reference_malformed),
-            "validation_zero_fraction_delta": _delta(candidate_invalid, reference_invalid),
-            "reorder_fraction_delta": _delta(candidate_reorder, reference_reorder),
+            "malformed_fraction_delta": _delta(
+                candidate_malformed,
+                reference_malformed,
+            ),
+            "validation_zero_fraction_delta": _delta(
+                candidate_invalid,
+                reference_invalid,
+            ),
+            "reorder_fraction_delta": _delta(
+                candidate_reorder,
+                reference_reorder,
+            ),
             "unresolved_missing_fraction_delta": _delta(
                 candidate_missing_fraction,
                 reference_missing_fraction,

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_trace.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_trace.py
@@ -5,6 +5,12 @@ of received 68-byte datagrams to interface/timing diagnostics that hardware owne
 can share when validating the simulator: packet shape, arrival cadence, counter
 gaps, duplicates, reordering, validation state, and battery range.
 
+Counter-loss inference is conservative. A forward gap creates an unresolved
+missing interval; a late packet inside that interval reconciles the loss instead
+of being counted as permanently missing. If a backward counter cannot be
+explained by a previously observed gap, the counter epoch is marked ambiguous
+because the public interface does not document reset/wrap semantics.
+
 A source label is user-declared provenance. neurOS cannot cryptographically prove
 that a trace came from physical hardware merely because the caller says so.
 """
@@ -16,6 +22,7 @@ from typing import Iterable, Literal
 import numpy as np
 
 from .unicorn_network_sim import RAW_UDP_PAYLOAD_BYTES, decode_unicorn_udp_scan
+from .unicorn_receiver_guard import FLOAT32_EXACT_INTEGER_MAX
 
 TraceSourceKind = Literal["unknown", "synthetic", "user_declared_physical"]
 
@@ -32,18 +39,21 @@ class UnicornRawUdpTraceSummary:
     first_counter: int | None
     last_counter: int | None
     counter_gap_events: int
-    inferred_missing_packets: int
+    inferred_missing_packets: int | None
     duplicate_packets: int
     out_of_order_packets: int
     validation_zero_packets: int
     battery_min: float | None
     battery_max: float | None
+    recovered_reordered_packets: int = 0
+    counter_precision_ambiguous: bool = False
+    counter_epoch_ambiguous: bool = False
     source_kind: TraceSourceKind = "unknown"
     source_label: str = ""
 
     def to_dict(self) -> dict:
         return {
-            "schema": "neuros.unicorn_raw_udp_trace_summary.v1",
+            "schema": "neuros.unicorn_raw_udp_trace_summary.v2",
             "packet_count": self.packet_count,
             "decoded_packet_count": self.decoded_packet_count,
             "malformed_packet_count": self.malformed_packet_count,
@@ -57,14 +67,19 @@ class UnicornRawUdpTraceSummary:
             "inferred_missing_packets": self.inferred_missing_packets,
             "duplicate_packets": self.duplicate_packets,
             "out_of_order_packets": self.out_of_order_packets,
+            "recovered_reordered_packets": self.recovered_reordered_packets,
+            "counter_precision_ambiguous": self.counter_precision_ambiguous,
+            "counter_epoch_ambiguous": self.counter_epoch_ambiguous,
             "validation_zero_packets": self.validation_zero_packets,
             "battery_min": self.battery_min,
             "battery_max": self.battery_max,
             "source_kind": self.source_kind,
             "source_label": self.source_label,
             "contains_raw_eeg": False,
+            "raw_packets_persisted": False,
             "evidence_boundary": (
-                "Wire/timing diagnostics only. Source provenance is user-declared; "
+                "Wire/timing diagnostics only. Counter-loss inference assumes one observable "
+                "counter epoch unless marked ambiguous. Source provenance is user-declared; "
                 "this summary is not a hardware certification or a human-EEG record."
             ),
         }
@@ -77,21 +92,36 @@ class UnicornTraceContractComparison:
     packet_shape_clean: bool
     arrival_rate_near_250hz: bool | None
     counter_monotonic_without_duplicates: bool
+    counter_gap_free: bool | None
+    counter_precision_unambiguous: bool
+    counter_epoch_unambiguous: bool
     observations: dict[str, object]
 
     @property
     def passed_diagnostic_checks(self) -> bool:
-        rate_ok = True if self.arrival_rate_near_250hz is None else self.arrival_rate_near_250hz
-        return self.packet_shape_clean and rate_ok and self.counter_monotonic_without_duplicates
+        # Unknown cadence or gap state is not evidence of passing. This is a
+        # diagnostic qualification result, so every required check must be known
+        # and true rather than treating missing evidence as success.
+        return (
+            self.packet_shape_clean
+            and self.arrival_rate_near_250hz is True
+            and self.counter_monotonic_without_duplicates
+            and self.counter_gap_free is True
+            and self.counter_precision_unambiguous
+            and self.counter_epoch_unambiguous
+        )
 
     def to_dict(self) -> dict:
         return {
-            "schema": "neuros.unicorn_raw_udp_trace_contract_comparison.v1",
+            "schema": "neuros.unicorn_raw_udp_trace_contract_comparison.v2",
             "passed_diagnostic_checks": self.passed_diagnostic_checks,
             "checks": {
                 "packet_shape_clean": self.packet_shape_clean,
                 "arrival_rate_near_250hz": self.arrival_rate_near_250hz,
                 "counter_monotonic_without_duplicates": self.counter_monotonic_without_duplicates,
+                "counter_gap_free": self.counter_gap_free,
+                "counter_precision_unambiguous": self.counter_precision_unambiguous,
+                "counter_epoch_unambiguous": self.counter_epoch_unambiguous,
             },
             "observations": dict(self.observations),
             "evidence_boundary": (
@@ -99,6 +129,61 @@ class UnicornTraceContractComparison:
                 "not certification of physical hardware, Bluetooth, or EEG quality."
             ),
         }
+
+
+@dataclass(frozen=True)
+class UnicornTraceDeltaReport:
+    """Descriptive differences between two trace summaries, with no pass/fail claim."""
+
+    reference_source_kind: TraceSourceKind
+    reference_source_label: str
+    candidate_source_kind: TraceSourceKind
+    candidate_source_label: str
+    metrics: dict[str, float | None]
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "neuros.unicorn_raw_udp_trace_delta.v1",
+            "reference": {
+                "source_kind": self.reference_source_kind,
+                "source_label": self.reference_source_label,
+            },
+            "candidate": {
+                "source_kind": self.candidate_source_kind,
+                "source_label": self.candidate_source_label,
+            },
+            "metrics": dict(self.metrics),
+            "passed": None,
+            "evidence_boundary": (
+                "Descriptive trace deltas only. No default tolerance is promoted to a "
+                "manufacturer specification or physical-hardware equivalence claim."
+            ),
+        }
+
+
+def _consume_missing_counter(intervals: list[tuple[int, int]], counter: int) -> bool:
+    """Remove one late counter from sorted disjoint inclusive missing intervals."""
+
+    for index, (start, end) in enumerate(intervals):
+        if counter < start:
+            return False
+        if counter > end:
+            continue
+        if start == end:
+            intervals.pop(index)
+        elif counter == start:
+            intervals[index] = (start + 1, end)
+        elif counter == end:
+            intervals[index] = (start, end - 1)
+        else:
+            intervals[index] = (start, counter - 1)
+            intervals.insert(index + 1, (counter + 1, end))
+        return True
+    return False
+
+
+def _missing_count(intervals: list[tuple[int, int]]) -> int:
+    return sum(end - start + 1 for start, end in intervals)
 
 
 def analyze_unicorn_raw_udp_trace(
@@ -123,12 +208,17 @@ def analyze_unicorn_raw_udp_trace(
     decoded = 0
     first_counter: int | None = None
     last_counter: int | None = None
+    high_water: int | None = None
     gap_events = 0
-    missing = 0
     duplicates = 0
     out_of_order = 0
+    recovered_reordered = 0
     validation_zero = 0
+    precision_ambiguous = False
+    epoch_ambiguous = False
     batteries: list[float] = []
+    seen_counters: set[int] = set()
+    unresolved_missing: list[tuple[int, int]] = []
 
     for _, payload in rows:
         if len(payload) != RAW_UDP_PAYLOAD_BYTES:
@@ -142,6 +232,7 @@ def analyze_unicorn_raw_udp_trace(
         if values.shape != (17,) or not np.all(np.isfinite(values)):
             malformed += 1
             continue
+
         counter_float = float(values[15])
         validation_float = float(values[16])
         counter = int(round(counter_float))
@@ -155,19 +246,35 @@ def analyze_unicorn_raw_udp_trace(
         validation_zero += int(validation == 0)
         if first_counter is None:
             first_counter = counter
-            last_counter = counter
+        last_counter = counter
+
+        if abs(counter_float) > FLOAT32_EXACT_INTEGER_MAX:
+            precision_ambiguous = True
             continue
-        assert last_counter is not None
-        delta = counter - last_counter
-        if delta == 0:
+
+        if counter in seen_counters:
             duplicates += 1
-        elif delta < 0:
-            out_of_order += 1
-        else:
-            if delta > 1:
+            continue
+        seen_counters.add(counter)
+
+        if high_water is None:
+            high_water = counter
+            continue
+        if counter > high_water:
+            if counter > high_water + 1:
                 gap_events += 1
-                missing += delta - 1
-            last_counter = counter
+                unresolved_missing.append((high_water + 1, counter - 1))
+            high_water = counter
+            continue
+
+        # A lower unseen counter is either a late packet that repairs a known
+        # gap, or an unexplained counter-epoch discontinuity. We can distinguish
+        # the first case without inventing device reset/wrap semantics.
+        out_of_order += 1
+        if _consume_missing_counter(unresolved_missing, counter):
+            recovered_reordered += 1
+        else:
+            epoch_ambiguous = True
 
     if timestamps.size >= 2:
         interarrival = np.diff(timestamps)
@@ -180,6 +287,12 @@ def analyze_unicorn_raw_udp_trace(
         rate = None
         mean_ms = None
         p95_ms = None
+
+    missing: int | None
+    if precision_ambiguous or epoch_ambiguous:
+        missing = None
+    else:
+        missing = _missing_count(unresolved_missing)
 
     return UnicornRawUdpTraceSummary(
         packet_count=len(rows),
@@ -198,6 +311,9 @@ def analyze_unicorn_raw_udp_trace(
         validation_zero_packets=validation_zero,
         battery_min=min(batteries) if batteries else None,
         battery_max=max(batteries) if batteries else None,
+        recovered_reordered_packets=recovered_reordered,
+        counter_precision_ambiguous=precision_ambiguous,
+        counter_epoch_ambiguous=epoch_ambiguous,
         source_kind=source_kind,
         source_label=str(source_label),
     )
@@ -220,17 +336,100 @@ def compare_unicorn_trace_to_nominal_contract(
     rate = summary.estimated_arrival_rate_hz
     rate_ok = None if rate is None else abs(rate - 250.0) <= rate_tolerance_hz
     counter_clean = summary.duplicate_packets == 0 and summary.out_of_order_packets == 0
+    gap_free = (
+        None
+        if summary.inferred_missing_packets is None
+        else summary.inferred_missing_packets == 0
+    )
     return UnicornTraceContractComparison(
         packet_shape_clean=summary.malformed_packet_count == 0,
         arrival_rate_near_250hz=rate_ok,
         counter_monotonic_without_duplicates=counter_clean,
+        counter_gap_free=gap_free,
+        counter_precision_unambiguous=not summary.counter_precision_ambiguous,
+        counter_epoch_unambiguous=not summary.counter_epoch_ambiguous,
         observations={
             "estimated_arrival_rate_hz": rate,
             "rate_tolerance_hz": float(rate_tolerance_hz),
             "counter_gap_events": summary.counter_gap_events,
             "inferred_missing_packets": summary.inferred_missing_packets,
+            "recovered_reordered_packets": summary.recovered_reordered_packets,
             "validation_zero_packets": summary.validation_zero_packets,
             "source_kind": summary.source_kind,
             "source_label": summary.source_label,
+        },
+    )
+
+
+def _safe_fraction(numerator: int, denominator: int) -> float | None:
+    return None if denominator <= 0 else float(numerator) / float(denominator)
+
+
+def _delta(candidate: float | None, reference: float | None) -> float | None:
+    if candidate is None or reference is None:
+        return None
+    return float(candidate - reference)
+
+
+def compare_unicorn_trace_summaries(
+    reference: UnicornRawUdpTraceSummary,
+    candidate: UnicornRawUdpTraceSummary,
+) -> UnicornTraceDeltaReport:
+    """Describe how two traces differ without declaring either one ground truth.
+
+    This is the calibration bridge between the synthetic endpoint and a short
+    user-declared physical trace. It deliberately has no default pass threshold:
+    a measured discrepancy is evidence to inspect, not proof of equivalence or a
+    hardware defect.
+    """
+
+    reference_missing_fraction = (
+        None
+        if reference.inferred_missing_packets is None
+        else _safe_fraction(
+            reference.inferred_missing_packets,
+            reference.decoded_packet_count + reference.inferred_missing_packets,
+        )
+    )
+    candidate_missing_fraction = (
+        None
+        if candidate.inferred_missing_packets is None
+        else _safe_fraction(
+            candidate.inferred_missing_packets,
+            candidate.decoded_packet_count + candidate.inferred_missing_packets,
+        )
+    )
+    reference_malformed = _safe_fraction(reference.malformed_packet_count, reference.packet_count)
+    candidate_malformed = _safe_fraction(candidate.malformed_packet_count, candidate.packet_count)
+    reference_invalid = _safe_fraction(reference.validation_zero_packets, reference.decoded_packet_count)
+    candidate_invalid = _safe_fraction(candidate.validation_zero_packets, candidate.decoded_packet_count)
+    reference_reorder = _safe_fraction(reference.out_of_order_packets, reference.decoded_packet_count)
+    candidate_reorder = _safe_fraction(candidate.out_of_order_packets, candidate.decoded_packet_count)
+
+    return UnicornTraceDeltaReport(
+        reference_source_kind=reference.source_kind,
+        reference_source_label=reference.source_label,
+        candidate_source_kind=candidate.source_kind,
+        candidate_source_label=candidate.source_label,
+        metrics={
+            "arrival_rate_delta_hz": _delta(
+                candidate.estimated_arrival_rate_hz,
+                reference.estimated_arrival_rate_hz,
+            ),
+            "mean_interarrival_delta_ms": _delta(
+                candidate.mean_interarrival_ms,
+                reference.mean_interarrival_ms,
+            ),
+            "p95_interarrival_delta_ms": _delta(
+                candidate.p95_interarrival_ms,
+                reference.p95_interarrival_ms,
+            ),
+            "malformed_fraction_delta": _delta(candidate_malformed, reference_malformed),
+            "validation_zero_fraction_delta": _delta(candidate_invalid, reference_invalid),
+            "reorder_fraction_delta": _delta(candidate_reorder, reference_reorder),
+            "unresolved_missing_fraction_delta": _delta(
+                candidate_missing_fraction,
+                reference_missing_fraction,
+            ),
         },
     )

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_transport_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_transport_sim.py
@@ -5,6 +5,15 @@ physiology or manufacturer telemetry semantics. Instead it turns already-encoded
 raw-UDP or Bandpower payloads into a reproducible delivery schedule with explicit
 loss, duplication, delay, and reordering probes.
 
+Two source-clock quantities are kept separate:
+
+``initial_delay_s``
+    Time from stream start until the first source update can exist. Raw EEG has
+    no synthetic warm-up delay. Bandpower requires its complete analysis window.
+
+``interval_s``
+    Cadence between subsequent source updates.
+
 The fault profiles are synthetic test policies. They are not claimed to describe
 measured Unicorn Bluetooth or operating-system network statistics.
 """
@@ -189,9 +198,6 @@ class DeterministicPacketFaultEngine:
             release_time_s=float(nominal_time_s),
         )
 
-        # If the previous packet was held for a reordering probe, release the
-        # current packet first and the held packet second. Dropping the current
-        # packet still releases the held packet so the engine cannot deadlock.
         if self._held_for_reorder is not None:
             held = self._held_for_reorder
             self._held_for_reorder = None
@@ -246,6 +252,7 @@ class UnicornRawUdpStreamSimulator:
         )
         self.byte_order = byte_order
         self.sequence = 0
+        self.initial_delay_s = 0.0
         self.interval_s = 1.0 / self.device.spec.sampling_rate_hz
         self.faults = DeterministicPacketFaultEngine(
             fault_profile or FAULT_PROFILES["pristine"],
@@ -260,7 +267,7 @@ class UnicornRawUdpStreamSimulator:
         return self.faults.process(
             payload,
             source_sequence=sequence,
-            nominal_time_s=sequence * self.interval_s,
+            nominal_time_s=self.initial_delay_s + sequence * self.interval_s,
         )
 
     def flush(self) -> tuple[ScheduledDatagram, ...]:
@@ -268,7 +275,14 @@ class UnicornRawUdpStreamSimulator:
 
 
 class UnicornBandpowerUdpStreamSimulator:
-    """Generate 70-value Bandpower reference datagrams at the documented cadence."""
+    """Generate 70-value Bandpower reference datagrams at the documented cadence.
+
+    The public Bandpower interface uses a 250-sample analysis buffer and a
+    10-sample hop. At 250 Hz, a stream starting with no history therefore needs
+    one second of source acquisition before its first complete feature window can
+    exist. ``initial_delay_s`` models that warm-up independently of the later
+    25 Hz update cadence.
+    """
 
     def __init__(
         self,
@@ -283,6 +297,7 @@ class UnicornBandpowerUdpStreamSimulator:
             sampling_rate_hz=self.device.spec.sampling_rate_hz
         )
         self.sequence = 0
+        self.initial_delay_s = self.bandpower.buffer_size / self.bandpower.sampling_rate_hz
         self.interval_s = 1.0 / self.bandpower.update_rate_hz
         self.faults = DeterministicPacketFaultEngine(
             fault_profile or FAULT_PROFILES["pristine"],
@@ -303,7 +318,7 @@ class UnicornBandpowerUdpStreamSimulator:
         return self.faults.process(
             payload,
             source_sequence=sequence,
-            nominal_time_s=sequence * self.interval_s,
+            nominal_time_s=self.initial_delay_s + sequence * self.interval_s,
         )
 
     def flush(self) -> tuple[ScheduledDatagram, ...]:

--- a/tests/test_unicorn_receiver_guard.py
+++ b/tests/test_unicorn_receiver_guard.py
@@ -5,7 +5,11 @@ import struct
 import pytest
 
 from neuros.drivers.unicorn_network_sim import decode_unicorn_udp_scan
-from neuros.drivers.unicorn_receiver_guard import UnicornRawUdpGuard, UnicornRawUdpGuardConfig
+from neuros.drivers.unicorn_receiver_guard import (
+    FLOAT32_EXACT_INTEGER_MAX,
+    UnicornRawUdpGuard,
+    UnicornRawUdpGuardConfig,
+)
 from neuros.drivers.unicorn_transport_sim import UnicornRawUdpStreamSimulator, UnicornUdpFaultProfile
 
 
@@ -15,10 +19,18 @@ def _packet(stream: UnicornRawUdpStreamSimulator) -> bytes:
     return datagrams[0].payload
 
 
-def _set_validation(payload: bytes, value: float) -> bytes:
+def _replace_field(payload: bytes, index: int, value: float) -> bytes:
     values = decode_unicorn_udp_scan(payload).astype(float)
-    values[16] = value
+    values[index] = value
     return struct.pack("<17f", *values.tolist())
+
+
+def _set_validation(payload: bytes, value: float) -> bytes:
+    return _replace_field(payload, 16, value)
+
+
+def _set_counter(payload: bytes, value: float) -> bytes:
+    return _replace_field(payload, 15, value)
 
 
 def test_authority_requires_consecutive_valid_sequential_packets():
@@ -27,8 +39,13 @@ def test_authority_requires_consecutive_valid_sequential_packets():
     first = guard.ingest(_packet(stream), received_monotonic_s=0.000)
     second = guard.ingest(_packet(stream), received_monotonic_s=0.004)
     third = guard.ingest(_packet(stream), received_monotonic_s=0.008)
+    assert [first.sequence_status, second.sequence_status, third.sequence_status] == [
+        "first", "sequential", "sequential"
+    ]
     assert [first.authority_allowed, second.authority_allowed, third.authority_allowed] == [False, False, True]
-    assert guard.state(now_monotonic_s=0.009).authority_allowed is True
+    state = guard.state(now_monotonic_s=0.009)
+    assert state.authority_allowed is True
+    assert state.stream_live is True
 
 
 def test_counter_gap_revokes_authority_and_requires_recovery_streak():
@@ -41,6 +58,7 @@ def test_counter_gap_revokes_authority_and_requires_recovery_streak():
     assert stream.next_datagrams() == ()  # counter 3 lost in transport
     gap = guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.016)
     assert gap.health == "gap"
+    assert gap.sequence_status == "gap"
     assert gap.missed_packets == 1
     assert gap.authority_allowed is False
     assert guard.ingest(stream.next_datagrams()[0].payload, received_monotonic_s=0.020).authority_allowed is False
@@ -55,10 +73,12 @@ def test_validation_zero_preserves_liveness_and_counter_but_revokes_authority():
     invalid_payload = _set_validation(_packet(stream), 0.0)
     invalid = guard.ingest(invalid_payload, received_monotonic_s=0.008)
     assert invalid.health == "invalid"
+    assert invalid.packet_status == "decodable"
+    assert invalid.sequence_status == "sequential"
+    assert invalid.validation_asserted is False
     assert invalid.counter == 2
     assert invalid.authority_allowed is False
-    # Counter 3 follows the observed invalid packet sequentially; liveness is
-    # continuous but authority still has to rebuild from a fresh healthy streak.
+    assert guard.state(now_monotonic_s=0.009).stream_live is True
     recovered_one = guard.ingest(_packet(stream), received_monotonic_s=0.012)
     recovered_two = guard.ingest(_packet(stream), received_monotonic_s=0.016)
     assert recovered_one.health == recovered_two.health == "healthy"
@@ -66,9 +86,49 @@ def test_validation_zero_preserves_liveness_and_counter_but_revokes_authority():
     assert recovered_two.authority_allowed is True
 
 
+def test_invalid_packet_cannot_hide_a_simultaneous_counter_gap():
+    stream = UnicornRawUdpStreamSimulator(seed=108)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=2))
+    guard.ingest(_packet(stream), received_monotonic_s=0.000)  # counter 0
+    guard.ingest(_packet(stream), received_monotonic_s=0.004)  # counter 1
+    _packet(stream)  # counter 2 never reaches the receiver
+    invalid_gap = guard.ingest(
+        _set_validation(_packet(stream), 0.0),  # counter 3
+        received_monotonic_s=0.012,
+    )
+    assert invalid_gap.health == "invalid"  # compact backward-compatible summary
+    assert invalid_gap.validation_asserted is False
+    assert invalid_gap.sequence_status == "gap"
+    assert invalid_gap.missed_packets == 1
+    assert guard.last_counter == 3
+    first_recovery = guard.ingest(_packet(stream), received_monotonic_s=0.016)
+    second_recovery = guard.ingest(_packet(stream), received_monotonic_s=0.020)
+    assert first_recovery.sequence_status == second_recovery.sequence_status == "sequential"
+    assert first_recovery.authority_allowed is False
+    assert second_recovery.authority_allowed is True
+
+
+def test_late_invalid_packet_does_not_rewind_counter_high_water():
+    stream = UnicornRawUdpStreamSimulator(seed=109)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=1))
+    first = _packet(stream)   # 0
+    old = _packet(stream)     # 1
+    latest = _packet(stream)  # 2
+    guard.ingest(first, received_monotonic_s=0.000)
+    guard.ingest(old, received_monotonic_s=0.004)
+    guard.ingest(latest, received_monotonic_s=0.008)
+    late = guard.ingest(_set_validation(old, 0.0), received_monotonic_s=0.009)
+    assert late.health == "invalid"
+    assert late.sequence_status == "out_of_order"
+    assert guard.last_counter == 2
+    next_packet = guard.ingest(_packet(stream), received_monotonic_s=0.012)
+    assert next_packet.sequence_status == "sequential"
+    assert next_packet.counter == 3
+
+
 def test_duplicate_and_reordered_packets_fail_closed():
     duplicate_stream = UnicornRawUdpStreamSimulator(
-        seed=109,
+        seed=110,
         fault_profile=UnicornUdpFaultProfile(name="dup-third", duplicate_every=3),
     )
     guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=1))
@@ -79,6 +139,7 @@ def test_duplicate_and_reordered_packets_fail_closed():
     assert guard.ingest(pair[0].payload, received_monotonic_s=0.008).authority_allowed is True
     duplicate = guard.ingest(pair[1].payload, received_monotonic_s=0.0081)
     assert duplicate.health == "duplicate"
+    assert duplicate.sequence_status == "duplicate"
     assert duplicate.authority_allowed is False
 
     reorder_stream = UnicornRawUdpStreamSimulator(
@@ -93,8 +154,23 @@ def test_duplicate_and_reordered_packets_fail_closed():
     newer = reorder_guard.ingest(pair[0].payload, received_monotonic_s=0.012)
     older = reorder_guard.ingest(pair[1].payload, received_monotonic_s=0.013)
     assert newer.health == "gap"
+    assert newer.sequence_status == "gap"
     assert older.health == "out_of_order"
+    assert older.sequence_status == "out_of_order"
     assert newer.authority_allowed is older.authority_allowed is False
+    assert reorder_guard.last_counter == 3
+
+
+def test_counter_above_float32_unit_step_exactness_fails_closed():
+    stream = UnicornRawUdpStreamSimulator(seed=119)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=1))
+    payload = _set_counter(_packet(stream), float(FLOAT32_EXACT_INTEGER_MAX + 2))
+    observation = guard.ingest(payload, received_monotonic_s=0.0)
+    assert observation.packet_status == "decodable"
+    assert observation.sequence_status == "precision_ambiguous"
+    assert observation.counter_step_exact is False
+    assert observation.health == "counter_ambiguous"
+    assert observation.authority_allowed is False
 
 
 def test_stale_interval_revokes_authority_and_fresh_packet_cannot_inherit_old_streak():
@@ -106,6 +182,7 @@ def test_stale_interval_revokes_authority_and_fresh_packet_cannot_inherit_old_st
     assert guard.ingest(_packet(stream), received_monotonic_s=0.004).authority_allowed is True
     stale = guard.state(now_monotonic_s=0.100)
     assert stale.health == "stale"
+    assert stale.stream_live is False
     assert stale.authority_allowed is False
     fresh_one = guard.ingest(_packet(stream), received_monotonic_s=0.104)
     fresh_two = guard.ingest(_packet(stream), received_monotonic_s=0.108)
@@ -113,12 +190,15 @@ def test_stale_interval_revokes_authority_and_fresh_packet_cannot_inherit_old_st
     assert fresh_two.authority_allowed is True
 
 
-def test_malformed_packet_never_updates_authority():
+def test_malformed_packet_never_refreshes_stream_liveness():
     guard = UnicornRawUdpGuard()
     malformed = guard.ingest(b"too short", received_monotonic_s=1.0)
     assert malformed.health == "malformed"
+    assert malformed.packet_status == "malformed"
     assert malformed.authority_allowed is False
-    assert guard.state(now_monotonic_s=1.01).health == "stale"
+    state = guard.state(now_monotonic_s=1.01)
+    assert state.health == "stale"
+    assert state.stream_live is False
 
 
 def test_guard_config_rejects_invalid_policies():

--- a/tests/test_unicorn_receiver_guard.py
+++ b/tests/test_unicorn_receiver_guard.py
@@ -173,6 +173,39 @@ def test_counter_above_float32_unit_step_exactness_fails_closed():
     assert observation.authority_allowed is False
 
 
+def test_counter_reset_requires_explicit_new_epoch_before_authority_can_recover():
+    stream = UnicornRawUdpStreamSimulator(seed=121)
+    guard = UnicornRawUdpGuard(UnicornRawUdpGuardConfig(recovery_packets=2))
+    packet = _packet(stream)
+
+    first = guard.ingest(_set_counter(packet, 100.0), received_monotonic_s=0.000)
+    second = guard.ingest(_set_counter(packet, 101.0), received_monotonic_s=0.004)
+    assert first.sequence_status == "first"
+    assert second.authority_allowed is True
+
+    reset_without_lifecycle = guard.ingest(
+        _set_counter(packet, 0.0),
+        received_monotonic_s=0.008,
+    )
+    assert reset_without_lifecycle.sequence_status == "out_of_order"
+    assert reset_without_lifecycle.authority_allowed is False
+    assert guard.last_counter == 101
+
+    guard.begin_new_epoch()
+    reset_state = guard.state(now_monotonic_s=0.009)
+    assert reset_state.health == "stale"
+    assert reset_state.stream_live is False
+    assert reset_state.authority_allowed is False
+    assert reset_state.last_counter is None
+
+    new_first = guard.ingest(_set_counter(packet, 0.0), received_monotonic_s=0.012)
+    new_second = guard.ingest(_set_counter(packet, 1.0), received_monotonic_s=0.016)
+    assert new_first.sequence_status == "first"
+    assert new_first.authority_allowed is False
+    assert new_second.sequence_status == "sequential"
+    assert new_second.authority_allowed is True
+
+
 def test_stale_interval_revokes_authority_and_fresh_packet_cannot_inherit_old_streak():
     stream = UnicornRawUdpStreamSimulator(seed=127)
     guard = UnicornRawUdpGuard(

--- a/tests/test_unicorn_trace.py
+++ b/tests/test_unicorn_trace.py
@@ -7,6 +7,7 @@ import pytest
 from neuros.drivers.unicorn_network_sim import decode_unicorn_udp_scan
 from neuros.drivers.unicorn_receiver_guard import FLOAT32_EXACT_INTEGER_MAX
 from neuros.drivers.unicorn_trace import (
+    UnicornRawUdpTraceSummary,
     analyze_unicorn_raw_udp_trace,
     compare_unicorn_trace_summaries,
     compare_unicorn_trace_to_nominal_contract,
@@ -29,6 +30,29 @@ def _set_counter(payload: bytes, counter: float) -> bytes:
     values = decode_unicorn_udp_scan(payload).astype(float)
     values[15] = counter
     return struct.pack("<17f", *values.tolist())
+
+
+def _summary(**overrides) -> UnicornRawUdpTraceSummary:
+    values = dict(
+        packet_count=10,
+        decoded_packet_count=10,
+        malformed_packet_count=0,
+        duration_s=0.036,
+        estimated_arrival_rate_hz=250.0,
+        mean_interarrival_ms=4.0,
+        p95_interarrival_ms=4.0,
+        first_counter=0,
+        last_counter=9,
+        counter_gap_events=0,
+        inferred_missing_packets=0,
+        duplicate_packets=0,
+        out_of_order_packets=0,
+        validation_zero_packets=0,
+        battery_min=90.0,
+        battery_max=90.0,
+    )
+    values.update(overrides)
+    return UnicornRawUdpTraceSummary(**values)
 
 
 def test_pristine_trace_reduces_to_shareable_metadata_without_raw_eeg():
@@ -91,7 +115,6 @@ def test_reordered_packet_repairs_transient_gap_instead_of_becoming_false_loss()
     assert summary.recovered_reordered_packets == summary.out_of_order_packets
     assert summary.inferred_missing_packets == 0
     assert summary.counter_epoch_ambiguous is False
-    # The strict nominal comparison still reports reordering rather than hiding it.
     assert compare_unicorn_trace_to_nominal_contract(summary).passed_diagnostic_checks is False
 
 
@@ -155,6 +178,21 @@ def test_trace_delta_report_is_descriptive_and_has_no_default_equivalence_thresh
     assert report["reference"]["source_kind"] == "synthetic"
     assert report["candidate"]["source_kind"] == "user_declared_physical"
     assert "No default tolerance" in report["evidence_boundary"]
+
+
+def test_trace_missing_fraction_uses_unique_packet_opportunities_not_duplicate_datagrams():
+    reference = _summary()
+    candidate = _summary(
+        packet_count=10,
+        decoded_packet_count=10,
+        duplicate_packets=2,
+        inferred_missing_packets=2,
+        counter_gap_events=1,
+    )
+    report = compare_unicorn_trace_summaries(reference, candidate).to_dict()
+    # 10 decoded datagrams - 2 duplicates + 2 unresolved counters = 10 unique
+    # packet opportunities, so unresolved loss is 2 / 10 rather than 2 / 12.
+    assert report["metrics"]["unresolved_missing_fraction_delta"] == pytest.approx(0.2)
 
 
 def test_malformed_payload_is_counted_but_never_persisted():

--- a/tests/test_unicorn_trace.py
+++ b/tests/test_unicorn_trace.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import struct
+
 import pytest
 
+from neuros.drivers.unicorn_network_sim import decode_unicorn_udp_scan
+from neuros.drivers.unicorn_receiver_guard import FLOAT32_EXACT_INTEGER_MAX
 from neuros.drivers.unicorn_trace import (
     analyze_unicorn_raw_udp_trace,
+    compare_unicorn_trace_summaries,
     compare_unicorn_trace_to_nominal_contract,
 )
 from neuros.drivers.unicorn_transport_sim import UnicornRawUdpStreamSimulator, UnicornUdpFaultProfile
@@ -20,6 +25,12 @@ def _collect(stream: UnicornRawUdpStreamSimulator, updates: int):
     return records
 
 
+def _set_counter(payload: bytes, counter: float) -> bytes:
+    values = decode_unicorn_udp_scan(payload).astype(float)
+    values[15] = counter
+    return struct.pack("<17f", *values.tolist())
+
+
 def test_pristine_trace_reduces_to_shareable_metadata_without_raw_eeg():
     stream = UnicornRawUdpStreamSimulator(seed=151)
     summary = analyze_unicorn_raw_udp_trace(
@@ -28,6 +39,7 @@ def test_pristine_trace_reduces_to_shareable_metadata_without_raw_eeg():
         source_label="ci-pristine",
     )
     payload = summary.to_dict()
+    assert payload["schema"] == "neuros.unicorn_raw_udp_trace_summary.v2"
     assert payload["packet_count"] == 251
     assert payload["decoded_packet_count"] == 251
     assert payload["malformed_packet_count"] == 0
@@ -36,16 +48,20 @@ def test_pristine_trace_reduces_to_shareable_metadata_without_raw_eeg():
     assert payload["first_counter"] == 0
     assert payload["last_counter"] == 250
     assert payload["counter_gap_events"] == 0
+    assert payload["inferred_missing_packets"] == 0
     assert payload["duplicate_packets"] == 0
     assert payload["out_of_order_packets"] == 0
+    assert payload["counter_precision_ambiguous"] is False
+    assert payload["counter_epoch_ambiguous"] is False
     assert payload["contains_raw_eeg"] is False
-    assert "eeg" not in payload or payload["contains_raw_eeg"] is False
+    assert payload["raw_packets_persisted"] is False
 
     comparison = compare_unicorn_trace_to_nominal_contract(summary)
+    assert comparison.counter_gap_free is True
     assert comparison.passed_diagnostic_checks is True
 
 
-def test_periodic_loss_is_visible_as_counter_gaps_without_malformed_packets():
+def test_periodic_loss_is_visible_as_unresolved_counter_gaps():
     stream = UnicornRawUdpStreamSimulator(
         seed=157,
         fault_profile=UnicornUdpFaultProfile(name="drop-10", drop_every=10),
@@ -57,28 +73,88 @@ def test_periodic_loss_is_visible_as_counter_gaps_without_malformed_packets():
     assert summary.inferred_missing_packets == 4
     assert summary.duplicate_packets == 0
     assert summary.out_of_order_packets == 0
-    # The arrival rate is lower because the test records transport delivery
-    # times rather than pretending dropped packets arrived.
     assert summary.estimated_arrival_rate_hz is not None
     assert summary.estimated_arrival_rate_hz < 250.0
+    comparison = compare_unicorn_trace_to_nominal_contract(summary)
+    assert comparison.counter_gap_free is False
+    assert comparison.passed_diagnostic_checks is False
 
 
-def test_duplicate_and_reorder_probe_are_distinguished():
-    duplicate_stream = UnicornRawUdpStreamSimulator(
-        seed=163,
-        fault_profile=UnicornUdpFaultProfile(name="dup-five", duplicate_every=5),
-    )
-    duplicate_summary = analyze_unicorn_raw_udp_trace(_collect(duplicate_stream, 20))
-    assert duplicate_summary.duplicate_packets == 4
-    assert duplicate_summary.out_of_order_packets == 0
-
+def test_reordered_packet_repairs_transient_gap_instead_of_becoming_false_loss():
     reorder_stream = UnicornRawUdpStreamSimulator(
         seed=167,
         fault_profile=UnicornUdpFaultProfile(name="reorder-five", reorder_every=5),
     )
-    reorder_summary = analyze_unicorn_raw_udp_trace(_collect(reorder_stream, 20))
-    assert reorder_summary.out_of_order_packets > 0
-    assert reorder_summary.counter_gap_events > 0
+    summary = analyze_unicorn_raw_udp_trace(_collect(reorder_stream, 20))
+    assert summary.out_of_order_packets > 0
+    assert summary.counter_gap_events > 0
+    assert summary.recovered_reordered_packets == summary.out_of_order_packets
+    assert summary.inferred_missing_packets == 0
+    assert summary.counter_epoch_ambiguous is False
+    # The strict nominal comparison still reports reordering rather than hiding it.
+    assert compare_unicorn_trace_to_nominal_contract(summary).passed_diagnostic_checks is False
+
+
+def test_duplicate_probe_is_distinguished_from_reordering():
+    duplicate_stream = UnicornRawUdpStreamSimulator(
+        seed=163,
+        fault_profile=UnicornUdpFaultProfile(name="dup-five", duplicate_every=5),
+    )
+    summary = analyze_unicorn_raw_udp_trace(_collect(duplicate_stream, 20))
+    assert summary.duplicate_packets == 4
+    assert summary.out_of_order_packets == 0
+    assert summary.inferred_missing_packets == 0
+
+
+def test_unexplained_backward_counter_marks_epoch_ambiguous_instead_of_inventing_loss():
+    stream = UnicornRawUdpStreamSimulator(seed=169)
+    packets = [_collect(stream, 1)[0][1] for _ in range(3)]
+    records = [
+        (0.000, _set_counter(packets[0], 100.0)),
+        (0.004, _set_counter(packets[1], 101.0)),
+        (0.008, _set_counter(packets[2], 0.0)),
+    ]
+    summary = analyze_unicorn_raw_udp_trace(records)
+    assert summary.out_of_order_packets == 1
+    assert summary.counter_epoch_ambiguous is True
+    assert summary.inferred_missing_packets is None
+    comparison = compare_unicorn_trace_to_nominal_contract(summary)
+    assert comparison.counter_epoch_unambiguous is False
+    assert comparison.counter_gap_free is None
+    assert comparison.passed_diagnostic_checks is False
+
+
+def test_counter_precision_boundary_suppresses_exact_loss_claims():
+    stream = UnicornRawUdpStreamSimulator(seed=171)
+    packet = _collect(stream, 1)[0][1]
+    summary = analyze_unicorn_raw_udp_trace([
+        (0.0, _set_counter(packet, float(FLOAT32_EXACT_INTEGER_MAX + 2)))
+    ])
+    assert summary.counter_precision_ambiguous is True
+    assert summary.inferred_missing_packets is None
+    comparison = compare_unicorn_trace_to_nominal_contract(summary)
+    assert comparison.counter_precision_unambiguous is False
+    assert comparison.passed_diagnostic_checks is False
+
+
+def test_trace_delta_report_is_descriptive_and_has_no_default_equivalence_threshold():
+    reference_stream = UnicornRawUdpStreamSimulator(seed=181)
+    candidate_stream = UnicornRawUdpStreamSimulator(seed=181)
+    reference = analyze_unicorn_raw_udp_trace(
+        _collect(reference_stream, 251), source_kind="synthetic", source_label="reference"
+    )
+    candidate = analyze_unicorn_raw_udp_trace(
+        _collect(candidate_stream, 251),
+        source_kind="user_declared_physical",
+        source_label="candidate",
+    )
+    report = compare_unicorn_trace_summaries(reference, candidate).to_dict()
+    assert report["passed"] is None
+    assert report["metrics"]["arrival_rate_delta_hz"] == pytest.approx(0.0)
+    assert report["metrics"]["mean_interarrival_delta_ms"] == pytest.approx(0.0)
+    assert report["reference"]["source_kind"] == "synthetic"
+    assert report["candidate"]["source_kind"] == "user_declared_physical"
+    assert "No default tolerance" in report["evidence_boundary"]
 
 
 def test_malformed_payload_is_counted_but_never_persisted():
@@ -91,6 +167,7 @@ def test_malformed_payload_is_counted_but_never_persisted():
     assert summary.decoded_packet_count == 3
     assert summary.malformed_packet_count == 1
     assert summary.to_dict()["contains_raw_eeg"] is False
+    assert summary.to_dict()["raw_packets_persisted"] is False
 
 
 def test_user_declared_physical_is_explicitly_not_cryptographic_provenance():
@@ -103,6 +180,7 @@ def test_user_declared_physical_is_explicitly_not_cryptographic_provenance():
     assert payload["source_kind"] == "user_declared_physical"
     assert payload["source_label"] == "lab-headset-a"
     assert "user-declared" in payload["evidence_boundary"]
+    assert compare_unicorn_trace_to_nominal_contract(summary).passed_diagnostic_checks is False
 
 
 def test_trace_requires_monotonic_receive_timestamps():

--- a/tests/test_unicorn_transport_sim.py
+++ b/tests/test_unicorn_transport_sim.py
@@ -22,14 +22,18 @@ def _counter(datagram) -> int:
     return int(round(float(decode_unicorn_udp_scan(datagram.payload)[15])))
 
 
-def test_pristine_raw_stream_preserves_68_byte_packets_and_counter_continuity():
+def test_pristine_raw_stream_preserves_68_byte_packets_counter_and_clock():
     stream = UnicornRawUdpStreamSimulator(seed=3)
     packets = [stream.next_datagrams() for _ in range(4)]
     assert all(len(item) == 1 for item in packets)
     flattened = [item[0] for item in packets]
+    assert stream.initial_delay_s == 0.0
     assert all(len(packet.payload) == RAW_UDP_PAYLOAD_BYTES for packet in flattened)
     assert [_counter(packet) for packet in flattened] == [0, 1, 2, 3]
     assert [packet.source_sequence for packet in flattened] == [0, 1, 2, 3]
+    assert [packet.nominal_time_s for packet in flattened] == pytest.approx(
+        [0.0, 0.004, 0.008, 0.012]
+    )
 
 
 def test_transport_drop_does_not_rewind_device_counter():
@@ -92,13 +96,14 @@ def test_named_fault_profiles_are_explicit_synthetic_assumptions():
         get_unicorn_udp_fault_profile("real-bluetooth-statistics")
 
 
-def test_bandpower_udp_stream_emits_one_70_value_frame_per_25hz_update():
+def test_bandpower_udp_stream_waits_for_analysis_window_then_updates_at_25hz():
     stream = UnicornBandpowerUdpStreamSimulator(seed=13)
     first = stream.next_datagrams()
     second = stream.next_datagrams()
     assert len(first) == len(second) == 1
-    assert first[0].nominal_time_s == pytest.approx(0.0)
-    assert second[0].nominal_time_s == pytest.approx(1.0 / 25.0)
+    assert stream.initial_delay_s == pytest.approx(1.0)
+    assert first[0].nominal_time_s == pytest.approx(1.0)
+    assert second[0].nominal_time_s == pytest.approx(1.0 + 1.0 / 25.0)
     values = decode_unicorn_bandpower_ascii(first[0].payload)
     assert values.shape == (70,)
     assert np.all(np.isfinite(values))


### PR DESCRIPTION
## Why

PR #48 established a broad Unicorn Hybrid Black substitution surface. This follow-up attacks the places where our own abstractions were too convenient, could overstate evidence, or could fail closed without a legitimate lifecycle recovery path.

## Interface and timing corrections

- Model source startup latency independently from update cadence. Raw UDP remains immediate at nominal 250 Hz; the Bandpower reference stream waits for its complete 250-sample analysis window before its first nominal feature update, then advances on the 10-sample / 40 ms hop.
- Separate packet decodability, CNT sequence continuity, VALID state, liveness, and gameplay authority while retaining `health` as a compact compatibility summary.
- Use a counter high-water mark so late packets cannot rewind receiver continuity state.
- Fail gameplay authority closed once float32 CNT no longer permits guaranteed unit-step inference at the `2^24` precision boundary. Vendor reset/wrap behavior remains undocumented rather than invented.

## Explicit acquisition epochs

A deeper lifecycle review found an important gap after the high-water policy was introduced: a known device/acquisition restart could legitimately reset CNT, but a long-lived receiver had no explicit way to establish a new counter epoch. Automatically treating a backward counter as a restart would be unsafe because it is indistinguishable from reorder/late traffic under the public wire contract.

This PR now adds an application-authoritative epoch transition instead:

- Python: `UnicornRawUdpGuard.begin_new_epoch()`
- C#: `UnicornRawUdpClient.BeginNewEpoch()`

The operation is never inferred from CNT or stale traffic. It must be called when the application/device lifecycle independently knows that a new acquisition has begun. It clears counter/precision continuity, revokes liveness and BCI authority, and requires the configured healthy recovery streak again.

Regression coverage proves CNT `100 -> 101 -> 0` remains fail-closed without an epoch declaration, then recovers only after `begin_new_epoch()` followed by fresh `0 -> 1` packets.

## Trace/evidence corrections

- Raw-UDP trace loss inference is reorder-aware. A forward gap creates an unresolved interval; late packets reconcile known missing counters rather than becoming permanent false loss.
- Unexplained backward counters mark the counter epoch ambiguous instead of manufacturing a reset/wrap interpretation.
- Trace qualification is strict about unknown cadence, unresolved loss, counter precision, and counter-epoch ambiguity.
- Trace summary/contract receipts move to v2 and explicitly record `contains_raw_eeg=false` and `raw_packets_persisted=false`.
- Simulator-vs-trace comparison is descriptive only and deliberately returns no default equivalence threshold (`passed=null`). A measured delta is something to inspect, not a manufacturer-specification claim.
- The dependency-free C# game receiver mirrors the Python diagnostic and authority semantics.

## Production-base integration

This branch was originally created before the Developer Preview journey merged. It was non-destructively integrated with production `main` using a true two-parent commit:

- Developer Preview main parent: `14f35e1a72cfc31875549840b434c9b64b7986d0`
- feature lineage preserved intact

The current PR merge base is the Developer Preview production revision, so qualification includes the installed-wheel newcomer contract rather than only the older simulation baseline.

## Exact-head qualification

Exact head: `d2622c663958165425aefd982781342e0a4d790b`

All triggered exact-head gates are green:

- **neurOS driver contracts**
  - Unicorn device/API/UDP/Bandpower/transport/receiver/trace/compatibility tests
  - machine-readable compatibility receipt
  - deterministic UDP dry runs
  - dependency-free C# receiver compilation
  - substitution/trace endpoint syntax checks
- **Synthetic BCI Arena**
- **Developer Preview Journey**
- **Public Trust Contracts**
- **Ecosystem Compatibility**
- **neurOS CI**
  - kernel contracts on Python 3.10 / 3.11 / 3.12
  - workspace wheel builds
  - BCI record/replay smoke
  - scientific/latency gates
  - recording interoperability
  - model/mech-int contracts
  - Foundation interoperability
  - SourceWeigher 3.10 / 3.11 / 3.12
  - ORION contracts/tokenization
  - repository hygiene

## Evidence boundary

This establishes stronger **software interface, deterministic fault, receiver-authority, and privacy-safe trace semantics**. It does **not** establish measured Bluetooth jitter, proprietary Bandpower numerical equivalence, undocumented physical CNT wrap/reset behavior, physical-headset qualification, physiological realism, participant decoding performance, closed-loop efficacy, or clinical validity.

Physical discrepancies should update the lowest incorrect simulator/interface layer rather than being hidden by tuning game logic around a synthetic assumption.