### PR TITLE
Packaging: enforce unique wheel ownership across the neurOS namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,37 @@ jobs:
             python -m build --wheel --outdir "${DIST}" "${package}"
           done
           test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq "${#PACKAGES[@]}"
+      - name: Enforce wheel ownership and component namespace
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/neuros-wheels"
+          python scripts/check_wheel_ownership.py "${DIST}" \
+            --output "${RUNNER_TEMP}/wheel-ownership.json"
+
+          ENV="${RUNNER_TEMP}/component-namespace-ci"
+          python -m venv "${ENV}"
+          PY="${ENV}/bin/python"
+          "${PY}" -m pip install --upgrade pip
+          CORE_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_core-*.whl' -print -quit)"
+          DRIVERS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_drivers-*.whl' -print -quit)"
+          MODELS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_models-*.whl' -print -quit)"
+          test -n "${CORE_WHEEL}"
+          test -n "${DRIVERS_WHEEL}"
+          test -n "${MODELS_WHEEL}"
+          "${PY}" -m pip install "${CORE_WHEEL}" "${DRIVERS_WHEEL}" "${MODELS_WHEEL}"
+          "${PY}" -m pip check
+          "${PY}" - <<'PY'
+          import neuros
+          import neuros.contracts
+          import neuros.drivers
+          import neuros.models
+          import neuros.runtime
+
+          if getattr(neuros, "__file__", None) is not None:
+              raise SystemExit(
+                  f"component-only neuros must be an implicit namespace; got {neuros.__file__}"
+              )
+          PY
 
   kernel-contracts:
     name: Kernel contracts / Python ${{ matrix.python-version }}

--- a/.github/workflows/packaging-contracts.yml
+++ b/.github/workflows/packaging-contracts.yml
@@ -1,0 +1,47 @@
+name: Packaging Contracts
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/packaging-contracts.yml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/release-candidate.yml"
+      - "scripts/check_wheel_ownership.py"
+      - "tests/test_wheel_ownership.py"
+      - "packages/*/src/neuros/__init__.py"
+      - "packages/*/pyproject.toml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/packaging-contracts.yml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/release-candidate.yml"
+      - "scripts/check_wheel_ownership.py"
+      - "tests/test_wheel_ownership.py"
+      - "packages/*/src/neuros/__init__.py"
+      - "packages/*/pyproject.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: packaging-contracts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wheel-ownership-unit-contracts:
+    name: Wheel ownership unit contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install test tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-asyncio
+      - name: Exercise ownership normalization and fail-closed cases
+        run: pytest -q tests/test_wheel_ownership.py

--- a/.github/workflows/packaging-uninstall.yml
+++ b/.github/workflows/packaging-uninstall.yml
@@ -1,0 +1,136 @@
+name: Packaging Uninstall Contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/packaging-uninstall.yml"
+      - ".github/workflows/release-candidate.yml"
+      - "packages/neuros/pyproject.toml"
+      - "packages/neuros-core/pyproject.toml"
+      - "packages/neuros-drivers/pyproject.toml"
+      - "packages/neuros-models/pyproject.toml"
+      - "packages/neuros-cloud/pyproject.toml"
+      - "packages/*/src/neuros/__init__.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/packaging-uninstall.yml"
+      - ".github/workflows/release-candidate.yml"
+      - "packages/neuros/pyproject.toml"
+      - "packages/neuros-core/pyproject.toml"
+      - "packages/neuros-drivers/pyproject.toml"
+      - "packages/neuros-models/pyproject.toml"
+      - "packages/neuros-cloud/pyproject.toml"
+      - "packages/*/src/neuros/__init__.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: packaging-uninstall-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  optional-leaf-uninstall-survival:
+    name: Optional leaf uninstall preserves SDK root
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Build exact wheel set
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build
+          DIST="${RUNNER_TEMP}/uninstall-wheels"
+          mkdir -p "${DIST}"
+          for package in \
+            packages/neuros-core \
+            packages/neuros-drivers \
+            packages/neuros-models \
+            packages/neuros \
+            packages/neuros-cloud
+          do
+            python -m build --wheel --outdir "${DIST}" "${package}"
+          done
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq 5
+      - name: Install SDK from exact local wheels
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/uninstall-wheels"
+          ENV="${RUNNER_TEMP}/uninstall-smoke"
+          python -m venv "${ENV}"
+          PY="${ENV}/bin/python"
+          "${PY}" -m pip install --upgrade pip
+
+          CORE_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_core-*.whl' -print -quit)"
+          DRIVERS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_drivers-*.whl' -print -quit)"
+          MODELS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_models-*.whl' -print -quit)"
+          SDK_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros-[0-9]*.whl' -print -quit)"
+          test -n "${CORE_WHEEL}"
+          test -n "${DRIVERS_WHEEL}"
+          test -n "${MODELS_WHEEL}"
+          test -n "${SDK_WHEEL}"
+
+          "${PY}" -m pip install \
+            "${CORE_WHEEL}" \
+            "${DRIVERS_WHEEL}" \
+            "${MODELS_WHEEL}" \
+            "${SDK_WHEEL}"
+          "${PY}" -m pip check
+      - name: Prove optional leaf uninstall cannot delete SDK-owned files
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/uninstall-wheels"
+          PY="${RUNNER_TEMP}/uninstall-smoke/bin/python"
+          CLOUD_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_cloud-*.whl' -print -quit)"
+          test -n "${CLOUD_WHEEL}"
+
+          SDK_ROOT="$("${PY}" -c 'import pathlib, neuros; print(pathlib.Path(neuros.__file__).resolve())')"
+          test -f "${SDK_ROOT}"
+          BEFORE="$(sha256sum "${SDK_ROOT}" | awk '{print $1}')"
+
+          "${PY}" -m pip install --no-deps "${CLOUD_WHEEL}"
+          "${PY}" -m pip show neuros-cloud >/dev/null
+          test "$(sha256sum "${SDK_ROOT}" | awk '{print $1}')" = "${BEFORE}"
+          "${PY}" - <<'PY'
+          import neuros
+          import neuros.cloud
+
+          required = {"SignalFrame", "Pipeline", "BaseDriver", "BaseModel", "load_plugin"}
+          missing = sorted(name for name in required if not hasattr(neuros, name))
+          if missing:
+              raise SystemExit(f"SDK root lost exports after optional leaf install: {missing}")
+          PY
+
+          "${PY}" -m pip uninstall -y neuros-cloud
+          if "${PY}" -m pip show neuros-cloud >/dev/null 2>&1; then
+              echo "neuros-cloud still registered after uninstall" >&2
+              exit 1
+          fi
+
+          test -f "${SDK_ROOT}"
+          AFTER="$(sha256sum "${SDK_ROOT}" | awk '{print $1}')"
+          test "${AFTER}" = "${BEFORE}"
+          "${PY}" -m pip check
+          "${PY}" - <<'PY'
+          import importlib.util
+          import pathlib
+          import neuros
+          import neuros.contracts
+          import neuros.drivers
+          import neuros.models
+          import neuros.runtime
+
+          required = {"SignalFrame", "Pipeline", "BaseDriver", "BaseModel", "load_plugin"}
+          missing = sorted(name for name in required if not hasattr(neuros, name))
+          if missing:
+              raise SystemExit(f"SDK root lost exports after optional leaf uninstall: {missing}")
+          if not neuros.__file__ or not pathlib.Path(neuros.__file__).is_file():
+              raise SystemExit("SDK root initializer disappeared after optional leaf uninstall")
+          if importlib.util.find_spec("neuros.cloud") is not None:
+              raise SystemExit("neuros.cloud remains importable after neuros-cloud uninstall")
+          PY

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - ".github/workflows/release-candidate.yml"
       - "packages/*/pyproject.toml"
+      - "packages/*/src/neuros/__init__.py"
       - "CITATION.cff"
       - "docs/RELEASE_POLICY.md"
       - "docs/SCIENTIFIC_CLAIMS.md"
       - "scripts/check_public_contracts.py"
+      - "scripts/check_wheel_ownership.py"
       - "scripts/list_workspace_packages.py"
       - "mkdocs.yml"
   workflow_dispatch:
@@ -56,6 +58,38 @@ jobs:
           done
           test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq "${#PACKAGES[@]}"
           python -m twine check "${DIST}"/*.whl
+          python scripts/check_wheel_ownership.py "${DIST}" \
+            --output "${DIST}/wheel-ownership.json"
+      - name: Prove component namespace without the SDK
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/neuros-release"
+          ENV="${RUNNER_TEMP}/component-namespace-smoke"
+          python -m venv "${ENV}"
+          PY="${ENV}/bin/python"
+          "${PY}" -m pip install --upgrade pip
+          CORE_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_core-*.whl' -print -quit)"
+          DRIVERS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_drivers-*.whl' -print -quit)"
+          MODELS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_models-*.whl' -print -quit)"
+          test -n "${CORE_WHEEL}"
+          test -n "${DRIVERS_WHEEL}"
+          test -n "${MODELS_WHEEL}"
+          "${PY}" -m pip install "${CORE_WHEEL}" "${DRIVERS_WHEEL}" "${MODELS_WHEEL}"
+          "${PY}" -m pip check
+          "${PY}" - <<'PY'
+          import neuros
+          import neuros.contracts
+          import neuros.drivers
+          import neuros.models
+          import neuros.runtime
+
+          if getattr(neuros, "__file__", None) is not None:
+              raise SystemExit(
+                  f"component-only neuros must be an implicit namespace; got {neuros.__file__}"
+              )
+          if not neuros.__spec__ or not neuros.__spec__.submodule_search_locations:
+              raise SystemExit("component-only neuros namespace has no search locations")
+          PY
       - name: Generate component and checksum manifests
         run: |
           set -euo pipefail
@@ -99,19 +133,36 @@ jobs:
               raise SystemExit(f"expected {expected_count} wheels, found {len(artifacts)}")
           if len({item["name"] for item in artifacts}) != expected_count:
               raise SystemExit("release contains duplicate distribution names")
+
+          ownership_path = dist / "wheel-ownership.json"
+          if not ownership_path.is_file():
+              raise SystemExit("wheel ownership manifest is missing")
+          ownership_payload = json.loads(ownership_path.read_text(encoding="utf-8"))
+          if ownership_payload.get("schema") != "neuros.wheel_ownership.v1":
+              raise SystemExit("unexpected wheel ownership schema")
+          if ownership_payload.get("status") != "pass":
+              raise SystemExit("wheel ownership manifest is not passing")
+          ownership_sha = hashlib.sha256(ownership_path.read_bytes()).hexdigest()
+
           manifest = {
               "schema_version": 1,
               "git_sha": os.environ["GITHUB_SHA"],
               "git_ref": os.environ["GITHUB_REF"],
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
+              "wheel_ownership": {
+                  "file": ownership_path.name,
+                  "sha256": ownership_sha,
+                  "schema": ownership_payload["schema"],
+              },
           }
           (dist / "release-manifest.json").write_text(
               json.dumps(manifest, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
           (dist / "SHA256SUMS").write_text(
-              "".join(f"{a['sha256']}  {a['file']}\n" for a in artifacts),
+              "".join(f"{a['sha256']}  {a['file']}\n" for a in artifacts)
+              + f"{ownership_sha}  {ownership_path.name}\n",
               encoding="utf-8",
           )
           PY
@@ -152,6 +203,16 @@ jobs:
             "${SDK_WHEEL}" \
             "${ARENA_WHEEL}"
           "${PY}" -m pip check
+          "${PY}" - <<'PY'
+          import neuros
+
+          required = {"SignalFrame", "Pipeline", "BaseDriver", "BaseModel", "load_plugin"}
+          missing = sorted(name for name in required if not hasattr(neuros, name))
+          if missing:
+              raise SystemExit(f"public neuros SDK root is missing exports: {missing}")
+          if not getattr(neuros, "__file__", None):
+              raise SystemExit("public neuros SDK must own the root package initializer")
+          PY
           "${NEUROS}" doctor --json
           "${NEUROS}" compatibility --json
           "${ARENA}" --preset dual-target-smoke --output "${RUNNER_TEMP}/arena-wheel-smoke.json"
@@ -164,6 +225,7 @@ jobs:
             ${{ runner.temp }}/neuros-release/*.whl
             ${{ runner.temp }}/neuros-release/SHA256SUMS
             ${{ runner.temp }}/neuros-release/release-manifest.json
+            ${{ runner.temp }}/neuros-release/wheel-ownership.json
           if-no-files-found: error
           retention-days: 30
 

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -123,6 +123,16 @@ Prefer this order:
 
 Keep vendor SDKs, large ML frameworks, and optional scientific stacks in plugin-specific dependencies or extras. `neuros-core` should never need a new concrete hardware/model dependency merely because one external plugin uses it.
 
+## Namespace and file ownership
+
+An external plugin does **not** need to place its code inside the `neuros` namespace. A normal top-level package such as `my_neuros_plugin` plus neurOS entry points is usually the safest design.
+
+If a package deliberately contributes a `neuros.<submodule>` namespace portion, use PEP 420 implicit namespaces and do not ship `neuros/__init__.py`. The public `neuros` SDK is the sole owner of that root initializer because it defines the documented top-level API.
+
+More generally, two Python distributions must not own the same installed file. Package managers track files per distribution, so an overlapping path can be overwritten by install order and deleted when either distribution is uninstalled. neurOS release qualification scans built wheel payloads and fails on cross-distribution ownership collisions.
+
+Entry points are therefore preferred over placing plugin implementation inside neurOS-owned package paths. They keep implementation ownership obvious while preserving runtime discovery.
+
 ## Compatibility contract
 
 For each release of an external plugin:

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -8,6 +8,16 @@ The repository is a multi-distribution workspace. Individual Python distribution
 
 A platform release must record the exact versions and wheel hashes of every included distribution.
 
+## Distribution and namespace ownership
+
+Multiple distributions may contribute subpackages to the shared `neuros` Python namespace, but **two distributions must never own the same installed file path**.
+
+Component distributions use PEP 420 implicit namespace portions. The user-facing `neuros` SDK is the sole owner of `neuros/__init__.py` because that initializer defines the public top-level SDK API.
+
+Release qualification scans the payload of every built workspace wheel, normalizes wheel `.data/purelib` and `.data/platlib` entries to their real install destinations, and fails if any destination has multiple owners. The resulting `neuros.wheel_ownership.v1` manifest is checksum-bound into the release-candidate bundle.
+
+This is an install-integrity requirement, not a style preference. Package managers track files per distribution; if two wheels record the same path, uninstalling either distribution can delete a file the other still requires.
+
 ## Versioning
 
 Promoted public Python APIs follow semantic-versioning intent:
@@ -35,7 +45,10 @@ Before a public release is published, CI must:
 
 - build every intended workspace wheel from the release source;
 - run package metadata validation (`twine check` or equivalent);
-- generate SHA-256 checksums for release artifacts;
+- prove that built wheels have no overlapping installed-file ownership;
+- prove core/drivers/models work as implicit namespace portions without the SDK initializer;
+- prove the installed SDK owns and exposes the documented top-level `neuros` API;
+- generate SHA-256 checksums for release artifacts and the wheel-ownership manifest;
 - smoke-install the user-facing `neuros` distribution from the built wheel set;
 - execute a minimal `neuros doctor` / compatibility smoke path;
 - build documentation in strict mode;
@@ -50,6 +63,7 @@ Release notes should include:
 - Git tag and commit SHA;
 - component package/version manifest;
 - SHA-256 manifest for built artifacts;
+- wheel-ownership manifest proving unique installed-file ownership;
 - strongest supported evidence tiers and important claim boundaries;
 - breaking/deprecated behavior;
 - known limitations.

--- a/packages/neuros-cloud/src/neuros/__init__.py
+++ b/packages/neuros-cloud/src/neuros/__init__.py
@@ -1,3 +1,0 @@
-# neurOS Cloud - Namespace Package
-# This allows neuros.* to be a namespace package spread across multiple packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/packages/neuros-core/src/neuros/__init__.py
+++ b/packages/neuros-core/src/neuros/__init__.py
@@ -1,3 +1,0 @@
-# neurOS Core - Namespace Package
-# This allows neuros.* to be a namespace package spread across multiple packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/packages/neuros-drivers/src/neuros/__init__.py
+++ b/packages/neuros-drivers/src/neuros/__init__.py
@@ -1,3 +1,0 @@
-# neurOS Drivers - Namespace Package
-# This allows neuros.* to be a namespace package spread across multiple packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/packages/neuros-foundation/src/neuros/__init__.py
+++ b/packages/neuros-foundation/src/neuros/__init__.py
@@ -1,3 +1,0 @@
-# neurOS Foundation Models - Namespace Package
-# This allows neuros.* to be a namespace package spread across multiple packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/packages/neuros-models/src/neuros/__init__.py
+++ b/packages/neuros-models/src/neuros/__init__.py
@@ -1,3 +1,0 @@
-# neurOS Models - Namespace Package
-# This allows neuros.* to be a namespace package spread across multiple packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/packages/neuros-ui/src/neuros/__init__.py
+++ b/packages/neuros-ui/src/neuros/__init__.py
@@ -1,3 +1,0 @@
-# neurOS UI - Namespace Package
-# This allows neuros.* to be a namespace package spread across multiple packages
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/scripts/check_wheel_ownership.py
+++ b/scripts/check_wheel_ownership.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Fail closed when neurOS wheel distributions own ambiguous installed files.
+
+Sharing the ``neuros`` Python namespace is intentional. Sharing ownership of an
+installed file is not: pip records file ownership per distribution, so removing
+one wheel can delete a path another wheel still expects. A single wheel also
+must not encode two archive members that normalize to the same install target.
+This checker inspects built wheel payloads and emits a deterministic ownership
+manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from email.parser import Parser
+from pathlib import Path, PurePosixPath
+from typing import Any
+from zipfile import BadZipFile, ZipFile
+
+SCHEMA = "neuros.wheel_ownership.v1"
+SDK_ROOT = "neuros/__init__.py"
+SDK_DISTRIBUTION = "neuros"
+
+
+def _normalize_name(name: str) -> str:
+    """Canonicalize a distribution name using the packaging-name rule."""
+
+    return re.sub(r"[-_.]+", "-", name.strip()).lower()
+
+
+def _metadata(archive: ZipFile, wheel: Path) -> tuple[str, str]:
+    metadata_names = [
+        name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+    ]
+    if len(metadata_names) != 1:
+        raise ValueError(
+            f"{wheel.name}: expected exactly one .dist-info/METADATA, found {len(metadata_names)}"
+        )
+    text = archive.read(metadata_names[0]).decode("utf-8", errors="strict")
+    message = Parser().parsestr(text)
+    name = message.get("Name")
+    version = message.get("Version")
+    if not name or not version:
+        raise ValueError(f"{wheel.name}: METADATA must contain Name and Version")
+    return str(name), str(version)
+
+
+def _validate_relative_parts(parts: tuple[str, ...], member: str) -> None:
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"unsafe or ambiguous wheel member path: {member}")
+    if member.startswith("/") or member.startswith("\\"):
+        raise ValueError(f"absolute wheel member path is not allowed: {member}")
+
+
+def _installed_path(member: str) -> str | None:
+    """Map a wheel archive member to its logical installed destination.
+
+    dist-info metadata is distribution-private and intentionally excluded.
+    ``.data/purelib`` and ``.data/platlib`` payloads install into the same import
+    root as ordinary wheel files, so they are normalized to that shared path.
+    Other wheel data schemes retain an explicit scheme prefix.
+    """
+
+    if not member or member.endswith("/") or ".dist-info/" in member:
+        return None
+
+    parts = PurePosixPath(member).parts
+    _validate_relative_parts(parts, member)
+    for index, part in enumerate(parts):
+        if not part.endswith(".data"):
+            continue
+        if index + 2 >= len(parts):
+            raise ValueError(f"malformed wheel .data member: {member}")
+        scheme = parts[index + 1]
+        remainder_parts = parts[index + 2 :]
+        _validate_relative_parts(remainder_parts, member)
+        remainder = PurePosixPath(*remainder_parts).as_posix()
+        if scheme in {"purelib", "platlib"}:
+            return remainder
+        return f"@{scheme}/{remainder}"
+
+    return PurePosixPath(*parts).as_posix()
+
+
+def inspect_wheels(wheel_dir: Path) -> dict[str, Any]:
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if not wheels:
+        raise ValueError(f"no wheels found in {wheel_dir}")
+
+    owners: dict[str, set[str]] = defaultdict(set)
+    distributions: dict[str, dict[str, Any]] = {}
+
+    for wheel in wheels:
+        try:
+            with ZipFile(wheel) as archive:
+                display_name, version = _metadata(archive, wheel)
+                distribution = _normalize_name(display_name)
+                if distribution in distributions:
+                    previous = distributions[distribution]["wheel"]
+                    raise ValueError(
+                        f"duplicate distribution name {display_name!r}: {previous} and {wheel.name}"
+                    )
+
+                payload_count = 0
+                installed_members: dict[str, str] = {}
+                for member in archive.namelist():
+                    installed = _installed_path(member)
+                    if installed is None:
+                        continue
+                    previous_member = installed_members.get(installed)
+                    if previous_member is not None:
+                        raise ValueError(
+                            f"{wheel.name}: multiple archive members install to {installed!r}: "
+                            f"{previous_member!r} and {member!r}"
+                        )
+                    installed_members[installed] = member
+                    owners[installed].add(distribution)
+                    payload_count += 1
+
+                distributions[distribution] = {
+                    "name": display_name,
+                    "version": version,
+                    "wheel": wheel.name,
+                    "payload_file_count": payload_count,
+                }
+        except BadZipFile as exc:
+            raise ValueError(f"invalid wheel archive: {wheel}") from exc
+
+    collisions = [
+        {"path": path, "owners": sorted(path_owners)}
+        for path, path_owners in sorted(owners.items())
+        if len(path_owners) > 1
+    ]
+    root_owners = sorted(owners.get(SDK_ROOT, set()))
+    sdk_root_ok = root_owners == [SDK_DISTRIBUTION]
+
+    return {
+        "schema": SCHEMA,
+        "status": "pass" if not collisions and sdk_root_ok else "fail",
+        "wheel_count": len(wheels),
+        "distribution_count": len(distributions),
+        "distributions": dict(sorted(distributions.items())),
+        "ownership": {
+            path: sorted(path_owners) for path, path_owners in sorted(owners.items())
+        },
+        "collisions": collisions,
+        "sdk_root": {
+            "path": SDK_ROOT,
+            "expected_owner": SDK_DISTRIBUTION,
+            "owners": root_owners,
+            "pass": sdk_root_ok,
+        },
+    }
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel_dir", type=Path, help="Directory containing built wheel files")
+    parser.add_argument("--output", type=Path, help="Optional JSON ownership-manifest path")
+    args = parser.parse_args()
+
+    try:
+        report = inspect_wheels(args.wheel_dir.resolve())
+    except (OSError, ValueError) as exc:
+        print(f"wheel ownership: ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.output:
+        _write_report(args.output, report)
+
+    if report["status"] != "pass":
+        for collision in report["collisions"]:
+            print(
+                f"wheel ownership collision: {collision['path']} <- "
+                + ", ".join(collision["owners"]),
+                file=sys.stderr,
+            )
+        if not report["sdk_root"]["pass"]:
+            print(
+                "wheel ownership root error: "
+                f"{SDK_ROOT} must be owned only by {SDK_DISTRIBUTION}; "
+                f"found {report['sdk_root']['owners']}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(
+        "wheel ownership: PASS "
+        f"({report['distribution_count']} distributions, "
+        f"{len(report['ownership'])} installed paths, zero collisions)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_wheel_ownership.py
+++ b/tests/test_wheel_ownership.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from scripts.check_wheel_ownership import inspect_wheels
+
+
+def _write_wheel(
+    directory: Path,
+    filename: str,
+    *,
+    distribution: str,
+    version: str = "1.0.0",
+    payloads: tuple[str, ...] = (),
+) -> Path:
+    wheel = directory / filename
+    dist_info = filename.split("-")[0].replace("-", "_")
+    with ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"{dist_info}-{version}.dist-info/METADATA",
+            "\n".join(
+                [
+                    "Metadata-Version: 2.1",
+                    f"Name: {distribution}",
+                    f"Version: {version}",
+                    "",
+                ]
+            ),
+        )
+        for payload in payloads:
+            archive.writestr(payload, b"fixture")
+    return wheel
+
+
+def _sdk(directory: Path) -> Path:
+    return _write_wheel(
+        directory,
+        "neuros-2.1.0-py3-none-any.whl",
+        distribution="neuros",
+        version="2.1.0",
+        payloads=("neuros/__init__.py", "neuros/cli.py"),
+    )
+
+
+def test_distinct_namespace_portions_have_unique_file_ownership(tmp_path: Path):
+    _sdk(tmp_path)
+    _write_wheel(
+        tmp_path,
+        "neuros_core-2.0.0-py3-none-any.whl",
+        distribution="neuros-core",
+        version="2.0.0",
+        payloads=("neuros/contracts.py", "neuros/runtime/__init__.py"),
+    )
+    _write_wheel(
+        tmp_path,
+        "neuros_drivers-2.0.0-py3-none-any.whl",
+        distribution="neuros-drivers",
+        version="2.0.0",
+        payloads=("neuros/drivers/__init__.py",),
+    )
+
+    report = inspect_wheels(tmp_path)
+
+    assert report["status"] == "pass"
+    assert report["collisions"] == []
+    assert report["sdk_root"] == {
+        "path": "neuros/__init__.py",
+        "expected_owner": "neuros",
+        "owners": ["neuros"],
+        "pass": True,
+    }
+
+
+def test_purelib_payload_is_normalized_to_real_install_destination(tmp_path: Path):
+    _sdk(tmp_path)
+    _write_wheel(
+        tmp_path,
+        "neuros_core-2.0.0-py3-none-any.whl",
+        distribution="neuros-core",
+        version="2.0.0",
+        payloads=("neuros/contracts.py",),
+    )
+    _write_wheel(
+        tmp_path,
+        "external_plugin-1.0.0-py3-none-any.whl",
+        distribution="external-plugin",
+        payloads=("external_plugin-1.0.0.data/purelib/neuros/contracts.py",),
+    )
+
+    report = inspect_wheels(tmp_path)
+
+    assert report["status"] == "fail"
+    assert {
+        "path": "neuros/contracts.py",
+        "owners": ["external-plugin", "neuros-core"],
+    } in report["collisions"]
+
+
+def test_single_wheel_cannot_encode_same_install_target_twice(tmp_path: Path):
+    _write_wheel(
+        tmp_path,
+        "neuros-2.1.0-py3-none-any.whl",
+        distribution="neuros",
+        version="2.1.0",
+        payloads=(
+            "neuros/__init__.py",
+            "neuros/cli.py",
+            "neuros-2.1.0.data/purelib/neuros/cli.py",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="multiple archive members install to 'neuros/cli.py'"):
+        inspect_wheels(tmp_path)
+
+
+def test_component_cannot_coown_sdk_root_initializer(tmp_path: Path):
+    _sdk(tmp_path)
+    _write_wheel(
+        tmp_path,
+        "neuros_models-2.0.0-py3-none-any.whl",
+        distribution="neuros-models",
+        version="2.0.0",
+        payloads=("neuros/__init__.py", "neuros/models/__init__.py"),
+    )
+
+    report = inspect_wheels(tmp_path)
+
+    assert report["status"] == "fail"
+    assert report["sdk_root"]["owners"] == ["neuros", "neuros-models"]
+    assert report["sdk_root"]["pass"] is False
+    assert {
+        "path": "neuros/__init__.py",
+        "owners": ["neuros", "neuros-models"],
+    } in report["collisions"]
+
+
+def test_sdk_root_must_exist_even_when_other_payloads_are_collision_free(tmp_path: Path):
+    _write_wheel(
+        tmp_path,
+        "neuros_core-2.0.0-py3-none-any.whl",
+        distribution="neuros-core",
+        version="2.0.0",
+        payloads=("neuros/contracts.py",),
+    )
+
+    report = inspect_wheels(tmp_path)
+
+    assert report["collisions"] == []
+    assert report["status"] == "fail"
+    assert report["sdk_root"]["owners"] == []
+
+
+def test_distribution_names_are_canonicalized_before_duplicate_detection(tmp_path: Path):
+    _write_wheel(
+        tmp_path,
+        "a-1.0.0-py3-none-any.whl",
+        distribution="NeurOS.Core",
+        payloads=("a.py",),
+    )
+    _write_wheel(
+        tmp_path,
+        "b-1.0.0-py3-none-any.whl",
+        distribution="neuros_core",
+        payloads=("b.py",),
+    )
+
+    with pytest.raises(ValueError, match="duplicate distribution name"):
+        inspect_wheels(tmp_path)
+
+
+def test_unsafe_parent_traversal_member_fails_closed(tmp_path: Path):
+    _sdk(tmp_path)
+    _write_wheel(
+        tmp_path,
+        "bad-1.0.0-py3-none-any.whl",
+        distribution="bad",
+        payloads=("../neuros/contracts.py",),
+    )
+
+    with pytest.raises(ValueError, match="unsafe or ambiguous wheel member path"):
+        inspect_wheels(tmp_path)
+
+
+def test_missing_wheel_directory_content_fails_closed(tmp_path: Path):
+    with pytest.raises(ValueError, match="no wheels found"):
+        inspect_wheels(tmp_path)


### PR DESCRIPTION
## Summary

Fixes #55 by enforcing a hard install-integrity invariant across the neurOS multi-wheel namespace:

> Multiple distributions may share the `neuros` namespace, but two distributions must never own the same installed file.

The final feature head is:

`84bb2eca6cb0dffa70226a67f46cddf698ddfe56`

Its production parent is the merged Synthetic EEG v2 baseline:

`9db43e45208d2af8579c9df99a7cc655423675b2`

## PEP 420 namespace ownership

Namespace-only `neuros/__init__.py` files are removed from:

- `neuros-core`
- `neuros-drivers`
- `neuros-models`
- `neuros-foundation`
- `neuros-ui`
- `neuros-cloud`

Those distributions now contribute PEP 420 implicit namespace portions. The user-facing `neuros` SDK remains the sole owner of `neuros/__init__.py` and therefore the sole owner of the public root API initializer.

## Executable ownership contract

`scripts/check_wheel_ownership.py` emits `neuros.wheel_ownership.v1` and fails closed on:

- cross-distribution installed-path collisions;
- `.data/purelib` / `.data/platlib` aliases that resolve to an already-owned path;
- multiple members inside one wheel that normalize to the same destination;
- duplicate canonicalized distribution identities;
- unsafe/ambiguous archive paths;
- missing or co-owned `neuros/__init__.py` SDK ownership.

Focused scanner regressions live in `tests/test_wheel_ownership.py` and execute through `Packaging Contracts`.

## Explicit uninstall-survival contract

The final acceptance gap from #55 is now executable CI in `.github/workflows/packaging-uninstall.yml`.

It builds exact local wheels for the SDK, core, drivers, models, and cloud package, then:

1. installs the SDK stack from those exact wheels;
2. hashes the installed SDK-owned `neuros/__init__.py`;
3. installs `neuros-cloud` as an optional leaf;
4. verifies the root hash and public API are unchanged;
5. uninstalls `neuros-cloud`;
6. proves the leaf distribution and `neuros.cloud` module are gone;
7. proves the SDK initializer is still byte-identical and all documented root exports/imports remain healthy;
8. runs `pip check` after removal.

This contract is green on exact head `84bb2eca...`.

## Release-candidate evidence

The final exact-head Release Candidate run is green end-to-end:

- public contracts/docs validated;
- all workspace wheels built and `twine check` passed;
- complete wheel set scanned for ownership collisions;
- component-only core/drivers/models environment proved valid PEP 420 semantics without the SDK;
- release manifest and SHA-256 checksums generated and verified;
- public SDK + Arena installed from the exact wheel set and smoke-tested;
- immutable release-candidate bundle uploaded.

Final artifact:

- artifact id: `9630074984`
- artifact digest: `sha256:9e86e4d8aa20e1bc02842a5ae934e60313bce1dc8ec4afb2545ea63fed440cbf`
- 12 distributions / 12 wheels
- 452 logical installed payload paths
- zero collisions
- `neuros/__init__.py` owner: `neuros` only
- all 13 SHA256SUMS entries verified independently.

## Exact-head qualification

All triggered workflows are green on `84bb2eca6cb0dffa70226a67f46cddf698ddfe56`:

- Packaging Contracts
- Packaging Uninstall Contract
- Release Candidate Artifacts
- neurOS CI
- Developer Preview Journey
- External Plugin Contract
- Public Trust Contracts
- neurOS driver contracts
- Synthetic BCI Arena
- Ecosystem Compatibility
- Neural Window Contracts
- neurOS real-world evidence
- Braindecode Compatibility
- Braindecode Longitudinal Evidence

The full CI workspace-wheel job specifically passed `Enforce wheel ownership and component namespace` on this exact head.

## Documentation and ecosystem policy

`RELEASE_POLICY.md` now makes unique installed-file ownership a release requirement.

`PLUGIN_AUTHORING.md` recommends external top-level packages plus neurOS entry points, and requires PEP 420 without a competing `neuros/__init__.py` if a plugin intentionally contributes a `neuros.<submodule>` portion.

## Related follow-up

Legacy setuptools license metadata modernization remains isolated in #59. SPDX/PEP 639 migration is intentionally not mixed into this namespace-safety change.

## Evidence boundary

This PR establishes software packaging, installation, uninstall, and release-integrity evidence only. It does not promote scientific, physiological, physical-hardware, human closed-loop, or clinical evidence claims.