### PR TITLE
Synthetic EEG rigor: chunk-invariant replay and sample-exact artifacts

### DIFF
--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -7,6 +7,7 @@ on:
       - "packages/neuros-drivers/**"
       - "tests/test_brainflow_driver.py"
       - "tests/test_lsl_driver.py"
+      - "tests/test_synthetic_eeg_driver.py"
       - "tests/test_unicorn_*.py"
       - "examples/unicorn_*.py"
       - "examples/game_engines/csharp/**"
@@ -20,6 +21,7 @@ on:
       - "packages/neuros-drivers/**"
       - "tests/test_brainflow_driver.py"
       - "tests/test_lsl_driver.py"
+      - "tests/test_synthetic_eeg_driver.py"
       - "tests/test_unicorn_*.py"
       - "examples/unicorn_*.py"
       - "examples/game_engines/csharp/**"
@@ -80,9 +82,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e packages/neuros-core
           python -m pip install -e "packages/neuros-drivers[test]"
-      - name: Verify device, API, UDP, Bandpower, transport, receiver, trace, and compatibility contracts
+      - name: Verify synthetic-world replay plus Unicorn device/interface contracts
         run: |
           pytest -q \
+            tests/test_synthetic_eeg_driver.py \
             tests/test_unicorn_hybrid_black_sim.py \
             tests/test_unicorn_api_sim.py \
             tests/test_unicorn_network_sim.py \

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
@@ -1,9 +1,14 @@
 """Protocol-grade synthetic EEG generator for acquisition and BCI stress tests.
 
 The generator is deliberately not a physiological digital twin. It creates a
-controlled signal with realistic nuisance structure so downstream systems can
-be tested against weak SSVEPs, endogenous alpha, contact loss, movement and EMG
+controlled signal with useful nuisance structure so downstream systems can be
+tested against weak SSVEPs, endogenous alpha, contact loss, movement and EMG
 without requiring physical hardware for every iteration.
+
+Determinism is a contract: for a fixed seed and unchanged controls, the generated
+sample sequence must not depend on how callers partition the same duration across
+``render()`` calls. Independent random streams and time-major draws enforce that
+property for background, white-noise and artifact processes.
 """
 from __future__ import annotations
 
@@ -61,14 +66,21 @@ class SyntheticEEGGenerator:
     def __init__(self, config: SyntheticEEGConfig | None = None) -> None:
         self.config = config or SyntheticEEGConfig()
         self.config.validate()
-        self.rng = np.random.default_rng(self.config.seed)
+        seed_sequence = np.random.SeedSequence(self.config.seed)
+        phase_seed, colored_seed, white_seed, artifact_seed = seed_sequence.spawn(4)
+        self._phase_rng = np.random.default_rng(phase_seed)
+        self._colored_rng = np.random.default_rng(colored_seed)
+        self._white_rng = np.random.default_rng(white_seed)
+        self._artifact_rng = np.random.default_rng(artifact_seed)
         self.sample_index = 0
         self.target_frequency_hz: float | None = None
         self.attention_gain = 0.0
         self.channel_gain = np.ones(8, dtype=float)
-        self._colored_state = np.zeros((8, 4), dtype=float)
-        self._phase = self.rng.uniform(0, 2 * np.pi, 8)
-        self._alpha_phase = self.rng.uniform(0, 2 * np.pi, 8)
+        # Start the AR components in their stationary N(0,1) marginal rather
+        # than introducing a seed-dependent warm-up transient from zero.
+        self._colored_state = self._colored_rng.normal(size=(8, 4))
+        self._phase = self._phase_rng.uniform(0, 2 * np.pi, 8)
+        self._alpha_phase = self._phase_rng.uniform(0, 2 * np.pi, 8)
         self._artifact_kind: str | None = None
         self._artifact_remaining = 0
         self._artifact_total = 0
@@ -99,13 +111,26 @@ class SyntheticEEGGenerator:
     def _colored_noise(self, samples: int) -> np.ndarray:
         alphas = np.asarray([0.70, 0.90, 0.975, 0.995])
         weights = np.asarray([0.55, 0.42, 0.30, 0.20])
+        # Each AR component has stationary unit variance, so this fixed scale is
+        # the theoretical marginal SD of their weighted sum. Unlike per-block
+        # normalization it does not make the signal depend on render boundaries.
+        normalizer = float(np.sqrt(np.sum(weights**2)))
         out = np.empty((8, samples), dtype=float)
+        innovation_scale = np.sqrt(1.0 - alphas**2)
         for index in range(samples):
-            innovation = self.rng.normal(size=(8, 4))
-            self._colored_state = alphas * self._colored_state + np.sqrt(1.0 - alphas**2) * innovation
+            innovation = self._colored_rng.normal(size=(8, 4))
+            self._colored_state = alphas * self._colored_state + innovation_scale * innovation
             out[:, index] = (self._colored_state * weights).sum(axis=1)
-        out /= max(float(np.std(out)), 1e-8)
-        return out * self.config.colored_noise_uv
+        return out * (self.config.colored_noise_uv / normalizer)
+
+    def _white_noise(self, samples: int) -> np.ndarray:
+        # Draw time-major so one render of N samples and multiple renders whose
+        # lengths sum to N assign the same random values to channel/time pairs.
+        return self._white_rng.normal(
+            0.0,
+            self.config.white_noise_uv,
+            size=(samples, 8),
+        ).T
 
     def _render_artifact(self, samples: int, time_s: np.ndarray) -> np.ndarray:
         if self._artifact_kind is None or self._artifact_remaining <= 0:
@@ -121,17 +146,36 @@ class SyntheticEEGGenerator:
             output[:, :count] += self.frontal_weights[:, None] * (120 * severity * pulse)
         elif kind == "jaw":
             t = time_s[:count]
-            high_frequency = np.sin(2 * np.pi * 38 * t) + 0.8 * np.sin(2 * np.pi * 53 * t + 0.7) + 0.55 * np.sin(2 * np.pi * 71 * t + 1.1)
-            output[:, :count] += (0.55 * self.central_weights + 0.35)[:, None] * (48 * severity * high_frequency)
+            high_frequency = (
+                np.sin(2 * np.pi * 38 * t)
+                + 0.8 * np.sin(2 * np.pi * 53 * t + 0.7)
+                + 0.55 * np.sin(2 * np.pi * 71 * t + 1.1)
+            )
+            output[:, :count] += (
+                (0.55 * self.central_weights + 0.35)[:, None]
+                * (48 * severity * high_frequency)
+            )
         elif kind == "controller":
             t = time_s[:count]
-            controller_emg = np.sin(2 * np.pi * 31 * t) + 0.55 * np.sin(2 * np.pi * 46 * t + 0.4) + 0.30 * self.rng.normal(size=count)
+            controller_emg = (
+                np.sin(2 * np.pi * 31 * t)
+                + 0.55 * np.sin(2 * np.pi * 46 * t + 0.4)
+                + 0.30 * self._artifact_rng.normal(size=count)
+            )
             output[:, :count] += self.central_weights[:, None] * (24 * severity * controller_emg)
         elif kind == "motion":
-            drift = np.sin(np.pi * np.clip(phase, 0, 1)) * np.sign(np.sin(2 * np.pi * 2.2 * time_s[:count]))
-            output[:, :count] += (0.60 + 0.40 * self.frontal_weights)[:, None] * (55 * severity * drift)
+            drift = np.sin(np.pi * np.clip(phase, 0, 1)) * np.sign(
+                np.sin(2 * np.pi * 2.2 * time_s[:count])
+            )
+            output[:, :count] += (
+                (0.60 + 0.40 * self.frontal_weights)[:, None]
+                * (55 * severity * drift)
+            )
         elif kind == "saturation":
             output[6, :count] += 480 * severity
+        elif kind == "dropout":
+            # Dropout is multiplicative and is applied after channel gain below.
+            pass
         self._artifact_remaining -= count
         if self._artifact_remaining <= 0:
             self._artifact_kind = None
@@ -144,19 +188,45 @@ class SyntheticEEGGenerator:
         sample_index = self.sample_index + np.arange(samples)
         time_s = sample_index / fs
         data = self._colored_noise(samples)
-        data += self.rng.normal(0, self.config.white_noise_uv, size=(8, samples))
-        alpha = np.sin(2 * np.pi * self.config.alpha_frequency_hz * time_s[None, :] + self._alpha_phase[:, None])
+        data += self._white_noise(samples)
+        alpha = np.sin(
+            2 * np.pi * self.config.alpha_frequency_hz * time_s[None, :]
+            + self._alpha_phase[:, None]
+        )
         data += self.posterior_weights[:, None] * self.config.alpha_amplitude_uv * alpha
         if self.target_frequency_hz is not None and self.attention_gain > 0:
             frequency = self.target_frequency_hz
-            fundamental = np.sin(2 * np.pi * frequency * time_s[None, :] + self._phase[:, None])
-            harmonic = np.sin(2 * np.pi * 2 * frequency * time_s[None, :] + 0.5 * self._phase[:, None])
+            fundamental = np.sin(
+                2 * np.pi * frequency * time_s[None, :] + self._phase[:, None]
+            )
+            harmonic = np.sin(
+                2 * np.pi * 2 * frequency * time_s[None, :]
+                + 0.5 * self._phase[:, None]
+            )
             ssvep = fundamental + self.config.first_harmonic_ratio * harmonic
-            data += self.posterior_weights[:, None] * self.config.ssvep_amplitude_uv * self.attention_gain * ssvep
+            data += (
+                self.posterior_weights[:, None]
+                * self.config.ssvep_amplitude_uv
+                * self.attention_gain
+                * ssvep
+            )
+
         active_artifact = self._artifact_kind
+        dropout_samples = (
+            min(samples, self._artifact_remaining)
+            if active_artifact == "dropout" and self._artifact_remaining > 0
+            else 0
+        )
         data += self._render_artifact(samples, time_s)
         data *= self.channel_gain[:, None]
-        if active_artifact == "dropout":
-            data[6, :] = 0.0
+        if dropout_samples:
+            data[6, :dropout_samples] = 0.0
+
         self.sample_index += samples
-        return SyntheticEEGBlock(data.astype(np.float32), time_s.astype(float), self.target_frequency_hz, self.attention_gain, active_artifact)
+        return SyntheticEEGBlock(
+            data.astype(np.float32),
+            time_s.astype(float),
+            self.target_frequency_hz,
+            self.attention_gain,
+            active_artifact,
+        )

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py
@@ -11,32 +11,70 @@ from neuros.contracts import ClockDomain, StreamDescriptor
 from neuros.drivers.base_driver import BaseDriver
 from neuros.drivers.synthetic_eeg import ArtifactKind, SyntheticEEGConfig, SyntheticEEGGenerator
 
+SYNTHETIC_EEG_GENERATOR_CONTRACT = "neuros.synthetic_eeg.v2"
+
 
 class SyntheticEEGDriver(BaseDriver):
     """Stream controllable synthetic EEG through the canonical driver interface."""
 
-    def __init__(self, config: SyntheticEEGConfig | None = None, *, realtime: bool = True, stream_id: str = "synthetic-eeg") -> None:
+    def __init__(
+        self,
+        config: SyntheticEEGConfig | None = None,
+        *,
+        realtime: bool = True,
+        stream_id: str = "synthetic-eeg",
+    ) -> None:
         self.generator = SyntheticEEGGenerator(config)
         self.realtime = bool(realtime)
-        super().__init__(sampling_rate=self.generator.config.sampling_rate_hz, channels=len(self.generator.config.channel_names), stream_id=stream_id, modality="eeg")
+        super().__init__(
+            sampling_rate=self.generator.config.sampling_rate_hz,
+            channels=len(self.generator.config.channel_names),
+            stream_id=stream_id,
+            modality="eeg",
+        )
 
     @property
     def descriptor(self) -> StreamDescriptor:
+        config = self.generator.config
         return StreamDescriptor(
             stream_id=self.stream_id,
             modality="eeg",
             sample_rate_hz=self.sampling_rate,
-            channel_names=self.generator.config.channel_names,
+            channel_names=config.channel_names,
             channel_types=tuple("eeg" for _ in range(self.channels)),
             clock_domain=ClockDomain.HOST_MONOTONIC,
             device="SyntheticEEGGenerator",
-            metadata={"synthetic": True, "units": "microvolts", "generator": "neuros.synthetic_eeg.v1"},
+            metadata={
+                "synthetic": True,
+                "units": "microvolts",
+                "generator": SYNTHETIC_EEG_GENERATOR_CONTRACT,
+                # Persist the stochastic-world inputs beside the stream identity.
+                # Recorded samples remain the replay authority, but a seed without
+                # these parameters or a generator contract is not sufficient to
+                # reconstruct the same synthetic world across software revisions.
+                "generator_config": {
+                    "sampling_rate_hz": float(config.sampling_rate_hz),
+                    "channel_names": list(config.channel_names),
+                    "colored_noise_uv": float(config.colored_noise_uv),
+                    "white_noise_uv": float(config.white_noise_uv),
+                    "alpha_frequency_hz": float(config.alpha_frequency_hz),
+                    "alpha_amplitude_uv": float(config.alpha_amplitude_uv),
+                    "ssvep_amplitude_uv": float(config.ssvep_amplitude_uv),
+                    "first_harmonic_ratio": float(config.first_harmonic_ratio),
+                    "seed": int(config.seed),
+                },
+            },
         )
 
     def set_attention(self, frequency_hz: float | None, gain: float = 1.0) -> None:
         self.generator.set_attention(frequency_hz, gain)
 
-    def inject_artifact(self, kind: ArtifactKind, duration_seconds: float = 0.35, severity: float = 1.0) -> None:
+    def inject_artifact(
+        self,
+        kind: ArtifactKind,
+        duration_seconds: float = 0.35,
+        severity: float = 1.0,
+    ) -> None:
         self.generator.inject_artifact(kind, duration_seconds, severity)
 
     def set_channel_gain(self, channel: str | int, gain: float) -> None:

--- a/packages/neuros-drivers/src/neuros/drivers/unicorn_hybrid_black_sim.py
+++ b/packages/neuros-drivers/src/neuros/drivers/unicorn_hybrid_black_sim.py
@@ -1,8 +1,8 @@
 """Device-faithful Unicorn Hybrid Black simulation contracts.
 
 This module models the *acquisition/interface behavior* of the Unicorn Hybrid
-Black around an EEG source.  It deliberately does not claim to be a human
-physiology simulator.  Neural voltages come from ``SyntheticEEGGenerator`` (or,
+Black around an EEG source. It deliberately does not claim to be a human
+physiology simulator. Neural voltages come from ``SyntheticEEGGenerator`` (or,
 in higher-level Arena integrations, another world model); this layer adds the
 hardware-facing channel schemas, quantization/clipping envelope, motion/auxiliary
 telemetry, counter continuity, battery state, validation state, and acquisition
@@ -22,8 +22,12 @@ current g.tec/Unicorn documentation:
 * about 40 ms device-delay compensation in g.Pype's HybridBlack source.
 
 The Recorder/network 19-field view additionally exposes delta-time and status /
-trigger fields.  Those two fields are application/interface products rather than
+trigger fields. Those two fields are application/interface products rather than
 extra amplifier electrodes.
+
+Random stress processes use independent seeded streams and time-major draws so
+replay does not depend on how a caller partitions an otherwise identical sample
+sequence across ``render()`` calls.
 """
 from __future__ import annotations
 
@@ -41,7 +45,12 @@ UNICORN_SCALP_LABELS = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
 UNICORN_ACCEL_NAMES = ("Accelerometer X", "Accelerometer Y", "Accelerometer Z")
 UNICORN_GYRO_NAMES = ("Gyroscope X", "Gyroscope Y", "Gyroscope Z")
 UNICORN_AUX_NAMES = ("Counter", "Battery Level", "Validation Indicator")
-UNICORN_DEVICE17_NAMES = UNICORN_EEG_API_NAMES + UNICORN_ACCEL_NAMES + UNICORN_GYRO_NAMES + UNICORN_AUX_NAMES
+UNICORN_DEVICE17_NAMES = (
+    UNICORN_EEG_API_NAMES
+    + UNICORN_ACCEL_NAMES
+    + UNICORN_GYRO_NAMES
+    + UNICORN_AUX_NAMES
+)
 UNICORN_RECORDER19_NAMES = (
     UNICORN_EEG_API_NAMES
     + ("ACC X", "ACC Y", "ACC Z")
@@ -54,7 +63,7 @@ UNICORN_RECORDER19_NAMES = (
 class UnicornHybridBlackSpec:
     """Published device constants used by the simulator.
 
-    ``input_impedance_lower_bound_ohm`` is descriptive provenance only.  The
+    ``input_impedance_lower_bound_ohm`` is descriptive provenance only. The
     physical headset specification states >1 GOhm; the simulator does not claim
     to infer or reproduce electrode-skin impedance.
     """
@@ -125,7 +134,7 @@ class UnicornHybridBlackBlock:
 
     ``sample_timestamps_s`` represent causal sample times. ``available_timestamps_s``
     represent when those samples become available to host software after the
-    configured device-delay model.  Keeping these separate prevents a transport
+    configured device-delay model. Keeping these separate prevents a transport
     latency from silently becoming a neural timestamp.
     """
 
@@ -196,7 +205,14 @@ class UnicornHybridBlackSimulator:
         if float(eeg_generator.config.sampling_rate_hz) != self.spec.sampling_rate_hz:
             raise ValueError("Unicorn simulator source must run at 250 Hz")
         self.eeg = eeg_generator
-        self.rng = np.random.default_rng(self.config.seed + 6011)
+
+        timing_seed, accel_seed, gyro_seed = np.random.SeedSequence(
+            self.config.seed + 6011
+        ).spawn(3)
+        self._availability_rng = np.random.default_rng(timing_seed)
+        self._accel_rng = np.random.default_rng(accel_seed)
+        self._gyro_rng = np.random.default_rng(gyro_seed)
+
         self.accel_g = np.asarray([0.0, 0.0, 1.0], dtype=float)
         self.gyro_dps = np.zeros(3, dtype=float)
         self.validation_value = int(self.config.validation_default)
@@ -207,10 +223,19 @@ class UnicornHybridBlackSimulator:
     def schema(self) -> UnicornSchema:
         return self.config.schema
 
-    def set_motion(self, accel_xyz_g: tuple[float, float, float], gyro_xyz_dps: tuple[float, float, float]) -> None:
+    def set_motion(
+        self,
+        accel_xyz_g: tuple[float, float, float],
+        gyro_xyz_dps: tuple[float, float, float],
+    ) -> None:
         accel = np.asarray(accel_xyz_g, dtype=float)
         gyro = np.asarray(gyro_xyz_dps, dtype=float)
-        if accel.shape != (3,) or gyro.shape != (3,) or not np.all(np.isfinite(accel)) or not np.all(np.isfinite(gyro)):
+        if (
+            accel.shape != (3,)
+            or gyro.shape != (3,)
+            or not np.all(np.isfinite(accel))
+            or not np.all(np.isfinite(gyro))
+        ):
             raise ValueError("motion vectors must contain three finite values")
         self.accel_g = accel
         self.gyro_dps = gyro
@@ -235,22 +260,42 @@ class UnicornHybridBlackSimulator:
         runtime_s = self.config.battery_runtime_hours * 3600.0
         elapsed = np.maximum(0.0, np.asarray(sample_times_s, dtype=float))
         fraction = np.clip(elapsed / runtime_s, 0.0, 1.0)
-        return np.maximum(0.0, self.config.battery_start_percent * (1.0 - fraction))
+        return np.maximum(
+            0.0,
+            self.config.battery_start_percent * (1.0 - fraction),
+        )
 
     def _availability(self, sample_times_s: np.ndarray) -> np.ndarray:
-        base = np.asarray(sample_times_s, dtype=float) + self.spec.device_delay_ms / 1000.0
+        base = (
+            np.asarray(sample_times_s, dtype=float)
+            + self.spec.device_delay_ms / 1000.0
+        )
         if self.config.acquisition_delay_jitter_ms <= 0:
             return base
-        jitter = self.rng.normal(0.0, self.config.acquisition_delay_jitter_ms / 1000.0, size=base.size)
+        jitter = self._availability_rng.normal(
+            0.0,
+            self.config.acquisition_delay_jitter_ms / 1000.0,
+            size=base.size,
+        )
         return base + jitter
 
     def _motion(self, samples: int) -> tuple[np.ndarray, np.ndarray]:
         accel = np.repeat(self.accel_g[:, None], samples, axis=1)
         gyro = np.repeat(self.gyro_dps[:, None], samples, axis=1)
         if self.config.accelerometer_noise_g:
-            accel += self.rng.normal(0.0, self.config.accelerometer_noise_g, size=accel.shape)
+            # Time-major draws make one N-sample render equivalent to any
+            # partition of the same N samples.
+            accel += self._accel_rng.normal(
+                0.0,
+                self.config.accelerometer_noise_g,
+                size=(samples, 3),
+            ).T
         if self.config.gyroscope_noise_dps:
-            gyro += self.rng.normal(0.0, self.config.gyroscope_noise_dps, size=gyro.shape)
+            gyro += self._gyro_rng.normal(
+                0.0,
+                self.config.gyroscope_noise_dps,
+                size=(samples, 3),
+            ).T
         return accel.astype(np.float32), gyro.astype(np.float32)
 
     def render(self, samples: int) -> UnicornHybridBlackBlock:
@@ -290,7 +335,11 @@ class UnicornHybridBlackSimulator:
                 + ("count", "percent", "boolean")
             )
         else:
-            delta_ms = np.full(samples, 1000.0 / self.spec.sampling_rate_hz, dtype=np.float32)
+            delta_ms = np.full(
+                samples,
+                1000.0 / self.spec.sampling_rate_hz,
+                dtype=np.float32,
+            )
             data = np.vstack(
                 [
                     eeg_uv,
@@ -344,31 +393,65 @@ def validate_unicorn_block(
     }[block.schema]
     if samples > 1:
         sample_dt = np.diff(block.sample_timestamps_s)
-        available_delay_ms = (block.available_timestamps_s - block.sample_timestamps_s) * 1000.0
+        available_delay_ms = (
+            block.available_timestamps_s - block.sample_timestamps_s
+        ) * 1000.0
         mean_rate = 1.0 / float(np.mean(sample_dt))
         counter_continuity = bool(np.all(np.diff(block.counter) == 1))
         mean_delay = float(np.mean(available_delay_ms))
     else:
         mean_rate = device.sampling_rate_hz
         counter_continuity = True
-        mean_delay = float(np.mean((block.available_timestamps_s - block.sample_timestamps_s) * 1000.0)) if samples else 0.0
+        mean_delay = (
+            float(
+                np.mean(
+                    (block.available_timestamps_s - block.sample_timestamps_s)
+                    * 1000.0
+                )
+            )
+            if samples
+            else 0.0
+        )
     checks = {
         "two_dimensional_samples": block.data.ndim == 2 and samples > 0,
-        "expected_channel_count": block.data.ndim == 2 and block.data.shape[0] == expected_channels,
-        "channel_metadata_count": len(block.channel_names) == expected_channels and len(block.channel_units) == expected_channels,
+        "expected_channel_count": (
+            block.data.ndim == 2 and block.data.shape[0] == expected_channels
+        ),
+        "channel_metadata_count": (
+            len(block.channel_names) == expected_channels
+            and len(block.channel_units) == expected_channels
+        ),
         "250hz_sample_clock": abs(mean_rate - device.sampling_rate_hz) < 1e-6,
         "counter_continuity": counter_continuity,
-        "battery_range": bool(np.all((block.battery_percent >= 0.0) & (block.battery_percent <= 100.0))),
+        "battery_range": bool(
+            np.all(
+                (block.battery_percent >= 0.0)
+                & (block.battery_percent <= 100.0)
+            )
+        ),
         "validation_binary": bool(np.all(np.isin(block.validation, [0.0, 1.0]))),
-        "eeg_within_sensitivity": bool(np.all(np.abs(block.eeg_data_uv) <= device.sensitivity_uv + block.lsb_uv)),
-        "published_quantization_lsb": abs(block.lsb_uv - device.eeg_lsb_uv) < 1e-12,
-        "availability_not_before_sample": bool(np.all(block.available_timestamps_s >= block.sample_timestamps_s)),
+        "eeg_within_sensitivity": bool(
+            np.all(
+                np.abs(block.eeg_data_uv)
+                <= device.sensitivity_uv + block.lsb_uv
+            )
+        ),
+        "published_quantization_lsb": (
+            abs(block.lsb_uv - device.eeg_lsb_uv) < 1e-12
+        ),
+        "availability_not_before_sample": bool(
+            np.all(block.available_timestamps_s >= block.sample_timestamps_s)
+        ),
     }
     if block.schema == "device17_api":
         checks["api_channel_order"] = block.channel_names == UNICORN_DEVICE17_NAMES
     elif block.schema == "recorder19":
-        checks["recorder_channel_order"] = block.channel_names == UNICORN_RECORDER19_NAMES
-        checks["recorder_delta_time"] = bool(np.allclose(block.data[17], 4.0, atol=1e-6))
+        checks["recorder_channel_order"] = (
+            block.channel_names == UNICORN_RECORDER19_NAMES
+        )
+        checks["recorder_delta_time"] = bool(
+            np.allclose(block.data[17], 4.0, atol=1e-6)
+        )
     else:
         checks["anatomical_eeg_order"] = block.channel_names == UNICORN_SCALP_LABELS
     metrics = {
@@ -376,7 +459,15 @@ def validate_unicorn_block(
         "mean_availability_delay_ms": mean_delay,
         "eeg_lsb_uv": float(block.lsb_uv),
         "clipped_fraction": float(block.clipped_fraction),
-        "battery_min_percent": float(np.min(block.battery_percent)) if samples else 0.0,
-        "battery_max_percent": float(np.max(block.battery_percent)) if samples else 0.0,
+        "battery_min_percent": (
+            float(np.min(block.battery_percent)) if samples else 0.0
+        ),
+        "battery_max_percent": (
+            float(np.max(block.battery_percent)) if samples else 0.0
+        ),
     }
-    return UnicornConformanceReport(passed=all(checks.values()), checks=checks, metrics=metrics)
+    return UnicornConformanceReport(
+        passed=all(checks.values()),
+        checks=checks,
+        metrics=metrics,
+    )

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -13,6 +13,10 @@ def spectral_amplitude(signal: np.ndarray, sampling_rate_hz: float, frequency_hz
     return float(np.abs(spectrum[index]))
 
 
+def _render_partitioned(generator: SyntheticEEGGenerator, chunks: tuple[int, ...]) -> np.ndarray:
+    return np.concatenate([generator.render(samples).data_uv for samples in chunks], axis=1)
+
+
 def test_ssvep_strength_is_controllable_and_posterior():
     cfg = SyntheticEEGConfig(seed=11, ssvep_amplitude_uv=8.0)
     strong = SyntheticEEGGenerator(cfg)
@@ -28,6 +32,59 @@ def test_ssvep_strength_is_controllable_and_posterior():
     strong_fz = spectral_amplitude(strong_block[0], cfg.sampling_rate_hz, 12.0)
     assert strong_oz > weak_oz * 2.0
     assert strong_oz > strong_fz * 4.0
+
+
+def test_seeded_world_is_invariant_to_render_partitioning():
+    cfg = SyntheticEEGConfig(seed=23)
+    whole = SyntheticEEGGenerator(cfg)
+    whole.set_attention(12.0, 0.7)
+    expected = whole.render(1000).data_uv
+
+    partitioned = SyntheticEEGGenerator(cfg)
+    partitioned.set_attention(12.0, 0.7)
+    actual = _render_partitioned(partitioned, (1, 7, 92, 250, 13, 637))
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=1e-6)
+    assert partitioned.sample_index == whole.sample_index == 1000
+
+
+def test_seeded_controller_artifact_is_also_partition_invariant():
+    cfg = SyntheticEEGConfig(seed=29)
+    whole = SyntheticEEGGenerator(cfg)
+    whole.set_attention(10.0, 0.5)
+    whole.inject_artifact("controller", duration_seconds=0.2, severity=0.8)
+    expected = whole.render(100).data_uv
+
+    partitioned = SyntheticEEGGenerator(cfg)
+    partitioned.set_attention(10.0, 0.5)
+    partitioned.inject_artifact("controller", duration_seconds=0.2, severity=0.8)
+    actual = _render_partitioned(partitioned, (11, 26, 9, 54))
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=1e-6)
+
+
+def test_dropout_duration_is_sample_exact_when_render_block_outlives_artifact():
+    cfg = SyntheticEEGConfig(seed=31)
+    generator = SyntheticEEGGenerator(cfg)
+    generator.inject_artifact("dropout", duration_seconds=10 / cfg.sampling_rate_hz)
+    block = generator.render(25).data_uv
+    assert np.allclose(block[6, :10], 0.0)
+    assert not np.allclose(block[6, 10:], 0.0)
+
+
+def test_dropout_is_partition_invariant_across_expiration_boundary():
+    cfg = SyntheticEEGConfig(seed=37)
+    whole = SyntheticEEGGenerator(cfg)
+    whole.inject_artifact("dropout", duration_seconds=0.2)
+    expected = whole.render(100).data_uv
+
+    partitioned = SyntheticEEGGenerator(cfg)
+    partitioned.inject_artifact("dropout", duration_seconds=0.2)
+    actual = _render_partitioned(partitioned, (20, 20, 20, 40))
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=1e-6)
+    assert np.allclose(actual[6, :50], 0.0)
+    assert not np.allclose(actual[6, 50:], 0.0)
 
 
 def test_artifacts_and_channel_contact_are_explicit():

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 
 from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
@@ -7,6 +10,7 @@ from neuros.drivers.synthetic_eeg_driver import (
     SYNTHETIC_EEG_GENERATOR_CONTRACT,
     SyntheticEEGDriver,
 )
+from neuros.recording.archive import SessionArchiveWriter
 
 
 def spectral_amplitude(signal: np.ndarray, sampling_rate_hz: float, frequency_hz: float) -> float:
@@ -18,6 +22,32 @@ def spectral_amplitude(signal: np.ndarray, sampling_rate_hz: float, frequency_hz
 
 def _render_partitioned(generator: SyntheticEEGGenerator, chunks: tuple[int, ...]) -> np.ndarray:
     return np.concatenate([generator.render(samples).data_uv for samples in chunks], axis=1)
+
+
+def _provenance_config() -> SyntheticEEGConfig:
+    return SyntheticEEGConfig(
+        seed=41,
+        colored_noise_uv=3.25,
+        white_noise_uv=0.75,
+        alpha_frequency_hz=10.2,
+        alpha_amplitude_uv=1.8,
+        ssvep_amplitude_uv=7.2,
+        first_harmonic_ratio=0.42,
+    )
+
+
+def _expected_generator_config() -> dict[str, object]:
+    return {
+        "sampling_rate_hz": 250.0,
+        "channel_names": ["Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8"],
+        "colored_noise_uv": 3.25,
+        "white_noise_uv": 0.75,
+        "alpha_frequency_hz": 10.2,
+        "alpha_amplitude_uv": 1.8,
+        "ssvep_amplitude_uv": 7.2,
+        "first_harmonic_ratio": 0.42,
+        "seed": 41,
+    }
 
 
 def test_ssvep_strength_is_controllable_and_posterior():
@@ -105,16 +135,7 @@ def test_artifacts_and_channel_contact_are_explicit():
 
 
 def test_driver_exposes_versioned_replay_configuration():
-    config = SyntheticEEGConfig(
-        seed=41,
-        colored_noise_uv=3.25,
-        white_noise_uv=0.75,
-        alpha_frequency_hz=10.2,
-        alpha_amplitude_uv=1.8,
-        ssvep_amplitude_uv=7.2,
-        first_harmonic_ratio=0.42,
-    )
-    driver = SyntheticEEGDriver(config, realtime=False, stream_id="phantom")
+    driver = SyntheticEEGDriver(_provenance_config(), realtime=False, stream_id="phantom")
     descriptor = driver.descriptor
     assert descriptor.stream_id == "phantom"
     assert descriptor.modality == "eeg"
@@ -122,14 +143,15 @@ def test_driver_exposes_versioned_replay_configuration():
     assert descriptor.channel_names == ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
     assert descriptor.metadata["synthetic"] is True
     assert descriptor.metadata["generator"] == SYNTHETIC_EEG_GENERATOR_CONTRACT
-    assert descriptor.metadata["generator_config"] == {
-        "sampling_rate_hz": 250.0,
-        "channel_names": ["Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8"],
-        "colored_noise_uv": 3.25,
-        "white_noise_uv": 0.75,
-        "alpha_frequency_hz": 10.2,
-        "alpha_amplitude_uv": 1.8,
-        "ssvep_amplitude_uv": 7.2,
-        "first_harmonic_ratio": 0.42,
-        "seed": 41,
-    }
+    assert descriptor.metadata["generator_config"] == _expected_generator_config()
+
+
+def test_generator_contract_and_seed_survive_session_archive_serialization(tmp_path: Path):
+    driver = SyntheticEEGDriver(_provenance_config(), realtime=False, stream_id="phantom")
+    archive = SessionArchiveWriter(tmp_path / "session", session_id="synthetic-provenance")
+    archive.register_stream(driver.descriptor)
+
+    manifest = json.loads((tmp_path / "session" / "manifest.json").read_text(encoding="utf-8"))
+    metadata = manifest["streams"]["phantom"]["descriptor"]["metadata"]
+    assert metadata["generator"] == SYNTHETIC_EEG_GENERATOR_CONTRACT
+    assert metadata["generator_config"] == _expected_generator_config()

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import numpy as np
 
 from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
-from neuros.drivers.synthetic_eeg_driver import SyntheticEEGDriver
+from neuros.drivers.synthetic_eeg_driver import (
+    SYNTHETIC_EEG_GENERATOR_CONTRACT,
+    SyntheticEEGDriver,
+)
 
 
 def spectral_amplitude(signal: np.ndarray, sampling_rate_hz: float, frequency_hz: float) -> float:
@@ -101,11 +104,32 @@ def test_artifacts_and_channel_contact_are_explicit():
     assert np.allclose(dropout.data_uv[6], 0.0)
 
 
-def test_driver_exposes_unicorn_like_descriptor():
-    driver = SyntheticEEGDriver(SyntheticEEGConfig(seed=1), realtime=False, stream_id="phantom")
+def test_driver_exposes_versioned_replay_configuration():
+    config = SyntheticEEGConfig(
+        seed=41,
+        colored_noise_uv=3.25,
+        white_noise_uv=0.75,
+        alpha_frequency_hz=10.2,
+        alpha_amplitude_uv=1.8,
+        ssvep_amplitude_uv=7.2,
+        first_harmonic_ratio=0.42,
+    )
+    driver = SyntheticEEGDriver(config, realtime=False, stream_id="phantom")
     descriptor = driver.descriptor
     assert descriptor.stream_id == "phantom"
     assert descriptor.modality == "eeg"
     assert descriptor.sample_rate_hz == 250.0
     assert descriptor.channel_names == ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
     assert descriptor.metadata["synthetic"] is True
+    assert descriptor.metadata["generator"] == SYNTHETIC_EEG_GENERATOR_CONTRACT
+    assert descriptor.metadata["generator_config"] == {
+        "sampling_rate_hz": 250.0,
+        "channel_names": ["Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8"],
+        "colored_noise_uv": 3.25,
+        "white_noise_uv": 0.75,
+        "alpha_frequency_hz": 10.2,
+        "alpha_amplitude_uv": 1.8,
+        "ssvep_amplitude_uv": 7.2,
+        "first_harmonic_ratio": 0.42,
+        "seed": 41,
+    }

--- a/tests/test_unicorn_hybrid_black_sim.py
+++ b/tests/test_unicorn_hybrid_black_sim.py
@@ -14,6 +14,22 @@ from neuros.drivers.unicorn_hybrid_black_sim import (
 )
 
 
+def _render_device_partitioned(
+    simulator: UnicornHybridBlackSimulator,
+    chunks: tuple[int, ...],
+) -> dict[str, np.ndarray]:
+    blocks = [simulator.render(samples) for samples in chunks]
+    return {
+        "data": np.concatenate([block.data for block in blocks], axis=1),
+        "eeg": np.concatenate([block.eeg_data_uv for block in blocks], axis=1),
+        "sample_time": np.concatenate([block.sample_timestamps_s for block in blocks]),
+        "available_time": np.concatenate([block.available_timestamps_s for block in blocks]),
+        "counter": np.concatenate([block.counter for block in blocks]),
+        "battery": np.concatenate([block.battery_percent for block in blocks]),
+        "validation": np.concatenate([block.validation for block in blocks]),
+    }
+
+
 def test_published_device_constants_and_quantization_are_explicit():
     spec = UnicornHybridBlackSpec()
     spec.validate()
@@ -42,6 +58,43 @@ def test_full_device_scan_matches_17_channel_api_order_and_units():
     assert np.all(block.validation == 1)
     report = validate_unicorn_block(block)
     assert report.passed, report.to_dict()
+
+
+def test_full_device_world_is_invariant_to_render_partitioning():
+    config = UnicornHybridBlackSimulationConfig(
+        schema="device17_api",
+        seed=13,
+        accelerometer_noise_g=0.003,
+        gyroscope_noise_dps=0.08,
+        acquisition_delay_jitter_ms=0.5,
+        counter_start=500,
+    )
+
+    whole = UnicornHybridBlackSimulator(config=config)
+    whole.eeg.set_attention(12.0, 0.65)
+    expected_block = whole.render(500)
+    expected = {
+        "data": expected_block.data,
+        "eeg": expected_block.eeg_data_uv,
+        "sample_time": expected_block.sample_timestamps_s,
+        "available_time": expected_block.available_timestamps_s,
+        "counter": expected_block.counter,
+        "battery": expected_block.battery_percent,
+        "validation": expected_block.validation,
+    }
+
+    partitioned = UnicornHybridBlackSimulator(config=config)
+    partitioned.eeg.set_attention(12.0, 0.65)
+    actual = _render_device_partitioned(
+        partitioned,
+        (1, 7, 42, 100, 3, 97, 250),
+    )
+
+    for key in ("data", "eeg", "sample_time", "available_time", "battery"):
+        np.testing.assert_allclose(actual[key], expected[key], rtol=0.0, atol=1e-6)
+    np.testing.assert_array_equal(actual["counter"], expected["counter"])
+    np.testing.assert_array_equal(actual["validation"], expected["validation"])
+    assert partitioned.counter_value == whole.counter_value == 1000
 
 
 def test_recorder_view_adds_delta_time_and_status_without_inventing_eeg_channels():
@@ -81,14 +134,18 @@ def test_motion_aux_channels_do_not_silently_change_eeg_physiology():
     block = sim.render(12)
     assert np.allclose(block.data[8:11], np.asarray([[0.25], [-0.50], [0.90]]))
     assert np.allclose(block.data[11:14], np.asarray([[25.0], [-10.0], [4.0]]))
-    # Motion telemetry is a device observable.  Motion-to-EEG contamination must
+    # Motion telemetry is a device observable. Motion-to-EEG contamination must
     # be injected explicitly in the neural/world layer rather than hidden here.
     assert np.all(np.isfinite(block.eeg_data_uv))
 
 
 def test_validation_and_counter_can_exercise_fail_closed_consumers():
     sim = UnicornHybridBlackSimulator(
-        config=UnicornHybridBlackSimulationConfig(schema="device17_api", seed=29, counter_start=100)
+        config=UnicornHybridBlackSimulationConfig(
+            schema="device17_api",
+            seed=29,
+            counter_start=100,
+        )
     )
     first = sim.render(5)
     sim.set_validation(0)
@@ -108,7 +165,9 @@ def test_acquisition_availability_delay_is_separate_from_neural_sample_time():
         )
     )
     block = sim.render(50)
-    delay_ms = (block.available_timestamps_s - block.sample_timestamps_s) * 1000.0
+    delay_ms = (
+        block.available_timestamps_s - block.sample_timestamps_s
+    ) * 1000.0
     assert np.allclose(delay_ms, 40.0)
     assert np.allclose(np.diff(block.sample_timestamps_s), 1.0 / 250.0)
 
@@ -128,7 +187,10 @@ def test_24_bit_clipping_and_quantization_are_applied_at_device_boundary():
     generator.inject_artifact("saturation", duration_seconds=0.1, severity=3000.0)
     sim = UnicornHybridBlackSimulator(
         generator,
-        config=UnicornHybridBlackSimulationConfig(schema="eeg8_anatomical", seed=37),
+        config=UnicornHybridBlackSimulationConfig(
+            schema="eeg8_anatomical",
+            seed=37,
+        ),
     )
     block = sim.render(10)
     spec = UnicornHybridBlackSpec()
@@ -136,5 +198,7 @@ def test_24_bit_clipping_and_quantization_are_applied_at_device_boundary():
     assert np.max(np.abs(block.eeg_data_uv)) <= spec.sensitivity_uv + spec.eeg_lsb_uv
     # Quantized values should sit on the advertised 24-bit grid to floating
     # precision, after subtracting the negative full-scale origin.
-    grid = (block.eeg_data_uv.astype(float) + spec.sensitivity_uv) / spec.eeg_lsb_uv
+    grid = (
+        block.eeg_data_uv.astype(float) + spec.sensitivity_uv
+    ) / spec.eeg_lsb_uv
     assert np.max(np.abs(grid - np.round(grid))) < 0.25


### PR DESCRIPTION
## Why

The Unicorn substitution stack depends on `SyntheticEEGGenerator` for several hardware-free neural worlds. A deterministic audit found two correctness defects that matter before adding more physiological complexity:

1. background/white randomness depended on how callers partitioned a fixed duration across `render()` calls;
2. a dropout artifact could zero an entire returned block even when the artifact expired partway through that block.

This PR is the clean post-#56 reconstruction of superseded stacked PR #57. Its merge base is the exact merged Unicorn rigor v2 production revision:

`e07f7df2d65a53c2f45d25e00c57fa41ec752980`

## Determinism contract

For a fixed generator contract, full configuration, controls, and total sample sequence, output must not change merely because a caller requests `1000` samples in one render versus partitions such as `1 + 7 + 92 + ...`.

The implementation now:

- splits phase, colored-background, white-noise, and artifact randomness into independent `SeedSequence` child streams;
- draws white noise time-major so RNG assignment to channel/time pairs is invariant to render partitioning;
- initializes colored AR components from their stationary unit-variance marginals instead of a block-dependent zero warm-up;
- replaces per-render colored-noise standardization with the fixed theoretical marginal scale `sqrt(sum(weights**2))`;
- gives device availability jitter, accelerometer noise, and gyroscope noise independent seeded streams;
- draws IMU noise time-major for the same partition-invariance reason.

This deliberately changes the historical pseudo-random sequence produced by a given seed. A seed by itself is therefore not treated as a durable replay identity across simulator revisions.

## Versioned synthetic-world provenance

The corrected stochastic contract is now explicitly identified as:

`neuros.synthetic_eeg.v2`

`SyntheticEEGDriver.descriptor` records the complete generator configuration beside that contract identity:

- sampling rate and channel names;
- colored/white noise amplitudes;
- alpha frequency/amplitude;
- SSVEP amplitude;
- harmonic ratio;
- seed.

A regression test registers that descriptor with the canonical `SessionArchiveWriter` and verifies the generator contract plus complete configuration survive into `manifest.json`.

Recorded sample arrays remain the exact replay authority. The generator contract/config makes intentional world regeneration interpretable; it does not replace recorded evidence.

## Sample-exact artifacts

Dropout is now applied only to the samples for which the artifact is active. A 10-sample dropout followed by a 25-sample render zeros exactly the first 10 Oz samples rather than the whole block.

Controller-artifact stochasticity uses the independent artifact RNG, so unrelated background rendering cannot steal random draws and alter the artifact waveform.

## Device-level replay

The Unicorn Hybrid Black simulator preserves the same partition-invariance property across:

- EEG payloads;
- quantized device data;
- sample timestamps;
- availability timestamps with configured synthetic jitter;
- accelerometer/gyroscope noise;
- CNT, battery, and VALID telemetry.

## Regression coverage

The driver contract includes `tests/test_synthetic_eeg_driver.py` alongside the merged #56 receiver/trace/C# suite.

The exact-head targeted lane exercises:

- whole-vs-partitioned attended SSVEP worlds;
- stochastic controller artifacts;
- sample-exact dropout and expiration-boundary partitioning;
- full 17-channel device-world partition invariance;
- v2 generator/config descriptor provenance;
- canonical session-manifest serialization of that provenance;
- all merged #56 receiver/trace/compatibility tests;
- dependency-free C# receiver compilation.

## Clean delta

Compared with production `main`, this PR changes exactly six files:

- `.github/workflows/drivers-ci.yml`
- `packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py`
- `packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py`
- `packages/neuros-drivers/src/neuros/drivers/unicorn_hybrid_black_sim.py`
- `tests/test_synthetic_eeg_driver.py`
- `tests/test_unicorn_hybrid_black_sim.py`

The original deterministic implementation/test work was reconstructed from stacked #57 onto merged #56 `main`; the workflow was reconciled against current production so none of #56's newer receiver/trace/C# qualification was regressed. The v2 provenance addition was then reviewed and tested on this clean branch.

## Exact-head qualification

Exact head: `2a03b72c4a45de5d1eb5b339aaf07a3f1ff585b6`

All triggered exact-head gates are green:

- neurOS driver contracts, including the synthetic-world/provenance tests and C# receiver compilation;
- Developer Preview Journey;
- Ecosystem Compatibility;
- Synthetic BCI Arena across Python 3.10/3.11/3.12, wheel build, and real-domain anchoring;
- full neurOS CI, including kernel contracts on Python 3.10/3.11/3.12, workspace wheel builds, BCI persistent replay, recording interoperability, scientific/latency gates, ORION tokenization, Foundation, SourceWeigher, model/mech-int contracts, and repository hygiene.

The model/mech-int lane completed 7/7 tests and exercised the EEG-Conformer interpretability manifest on this same exact head.

## Evidence boundary

This is **deterministic software semantics, provenance, and simulator testability evidence**. It does not establish that synthetic covariance, alpha morphology, SSVEP amplitudes, artifact magnitudes, IMU noise, timing jitter, or participant responsiveness match physical Unicorn recordings or human physiology.