### PR TITLE
Synthetic EEG v3: composable sample-indexed artifact worlds

### DIFF
--- a/.github/workflows/drivers-ci.yml
+++ b/.github/workflows/drivers-ci.yml
@@ -8,7 +8,9 @@ on:
       - "tests/test_brainflow_driver.py"
       - "tests/test_lsl_driver.py"
       - "tests/test_synthetic_eeg_driver.py"
+      - "tests/test_synthetic_eeg_control_contracts.py"
       - "tests/test_unicorn_*.py"
+      - "examples/mindforge_phantom_unicorn.py"
       - "examples/unicorn_*.py"
       - "examples/game_engines/csharp/**"
       - ".github/workflows/drivers-ci.yml"
@@ -22,7 +24,9 @@ on:
       - "tests/test_brainflow_driver.py"
       - "tests/test_lsl_driver.py"
       - "tests/test_synthetic_eeg_driver.py"
+      - "tests/test_synthetic_eeg_control_contracts.py"
       - "tests/test_unicorn_*.py"
+      - "examples/mindforge_phantom_unicorn.py"
       - "examples/unicorn_*.py"
       - "examples/game_engines/csharp/**"
       - ".github/workflows/drivers-ci.yml"
@@ -86,6 +90,7 @@ jobs:
         run: |
           pytest -q \
             tests/test_synthetic_eeg_driver.py \
+            tests/test_synthetic_eeg_control_contracts.py \
             tests/test_unicorn_hybrid_black_sim.py \
             tests/test_unicorn_api_sim.py \
             tests/test_unicorn_network_sim.py \
@@ -113,6 +118,7 @@ jobs:
       - name: Syntax-check real-time substitution and trace endpoints
         run: |
           python -m py_compile \
+            examples/mindforge_phantom_unicorn.py \
             examples/unicorn_hybrid_black_simulator.py \
             examples/unicorn_udp_simulator.py \
             examples/unicorn_raw_udp_trace_capture.py \

--- a/docs/MINDFORGE_PHANTOM_UNICORN.md
+++ b/docs/MINDFORGE_PHANTOM_UNICORN.md
@@ -23,10 +23,14 @@ Defaults:
 - source ID: `mindforge-phantom-unicorn`
 - 8 channels / 250 Hz / microvolts
 - localhost control: UDP `127.0.0.1:19744`
+- generator contract: `neuros.synthetic_eeg.v3`
+- artifact scheduler: `neuros.synthetic_eeg.artifact_schedule.v1`
+
+The two synthetic contract identifiers are also emitted in the LSL stream metadata. They identify the software world only; a physical Unicorn stream is not required or expected to advertise them.
 
 Interactive stdin remains available if `--no-stdin` is omitted.
 
-## Deterministic control commands
+## Manual convenience commands
 
 Send one UTF-8 datagram to port 19744:
 
@@ -34,13 +38,15 @@ Send one UTF-8 datagram to port 19744:
 0            no attended target / resting baseline
 1            attend 10 Hz / Sight
 2            attend 12 Hz / Guard
-b            blink transient
-j            jaw contamination
-c            controller/hand contamination
-m            movement artifact
-s            saturation
-d            drop Oz
-r            restore Oz
+b            immediate blink transient
+j            immediate jaw contamination
+c            immediate controller/hand contamination
+m            immediate movement contamination
+s            immediate source-offset stressor
+
+d            persistently mask Oz at the synthetic-source layer
+r            restore Oz source gain
+
 x            2 s source silence
 silence:2.5  explicit source-silence duration
 gain:0.65    set SSVEP response gain
@@ -48,10 +54,90 @@ gain:0.65    set SSVEP response gain
 q            stop source
 ```
 
-The control channel changes only the simulator state/fault schedule. LSL samples and metadata retain the same external contract used by Mindforge acquisition. This lets the Unity/Python calibration ritual drive Phantom automatically while preserving the eventual physical-source substitution boundary.
+The single-letter artifact commands deliberately preserve the historical **single-slot replacement** behavior for fast manual rehearsals. If `b` is followed immediately by `c`, the controller artifact replaces the blink. Use the explicit scheduler below when overlap is part of the experiment.
+
+## Exact composable artifact schedule
+
+For reproducible multi-artifact scenarios, schedule events on the synthetic sample clock:
+
+```text
+artifact:ID:KIND:START_SAMPLE:DURATION_SECONDS:SEVERITY[:CHANNELS][:SEED]
+```
+
+Examples:
+
+```text
+artifact:blink-a:blink:500:0.30:0.7:*:101
+artifact:controller-a:controller:480:0.40:0.9:*:202
+artifact:posterior-loss:dropout:525:0.10:1.0:PO7,Oz:303
+```
+
+Those three events overlap in sample time. The generator renders them compositionally rather than replacing one with another.
+
+Fields:
+
+- `ID` is the stable event identity. The interactive/UDP reader normalizes commands to lowercase, so use lowercase IDs when external scripts need to cancel them later.
+- `KIND` is one of `blink`, `jaw`, `controller`, `motion`, `saturation`, or `dropout`.
+- `START_SAMPLE` is an absolute integer sample index on this generator run. A command that arrives after that sample has already been rendered is rejected rather than moved to the present.
+- `DURATION_SECONDS` must be positive and finite.
+- `SEVERITY` must be non-negative and finite.
+- `CHANNELS` is optional. Use `*` for the artifact's default spatial support or a comma-separated scalp list such as `PO7,Oz`. Channel labels from the lowercased control path are resolved back to the canonical montage names.
+- `SEED` is optional. When supplied it must be a non-negative integer. When omitted, the generator derives an event-local deterministic seed from generator seed + event identity + event support.
+
+Cancel a scheduled event with:
+
+```text
+cancel:posterior-loss
+```
+
+A completed event cannot be retroactively cancelled. A rejected malformed/late command is printed and does not kill the source.
+
+## Why sample-indexed scheduling matters
+
+Wall-clock arrival is convenient for a person pressing a key, but it is a weak replay identity. A sample-indexed schedule lets a scripted rehearsal state the intended synthetic world directly:
+
+```text
+same generator contract
++ same generator configuration
++ same attention/control history
++ same sample-indexed artifact schedule
+= same source sample sequence
+```
+
+That equality is a **software determinism claim**. It is not a claim that the generated artifacts have the same distribution as human EEG.
+
+The current Phantom still changes attention through immediate commands (`0/1/2/gain:*`). Exact regeneration of a complete experiment therefore also requires preserving that dynamic attention/control history. A first-class scenario manifest is a logical follow-up; recorded EEG remains the canonical replay authority today.
+
+## Keep causal layers distinct
+
+Several stress mechanisms can look superficially similar but belong to different layers:
+
+| control/model | layer | meaning |
+|---|---|---|
+| `dropout` artifact / `d` | synthetic source/contact stress | masks selected synthetic EEG channels |
+| `saturation` / `s` | synthetic source stress | large source offset used to test downstream artifact handling |
+| Unicorn `_quantize_eeg()` clipping | device model | sensitivity-envelope clipping + 24-bit quantization |
+| `--drop-probability` | LSL delivery stress | synthetic chunk delivery loss |
+| `--jitter-ms` | LSL delivery stress | synthetic extra delivery delay |
+| `silence:*` | source/transport availability rehearsal | emits no LSL chunks during the interval |
+
+In particular, the `saturation` artifact is **not** a measured Unicorn amplifier-saturation model. Physical clipping/contact behavior must be measured and qualified separately.
 
 ## Transport stress
 
 Use `--drop-probability` and `--jitter-ms` for continuous delivery stress. Use `silence:SECONDS` for a coherent source-death/recovery rehearsal.
 
+This is intentionally separate from EEG artifact scheduling. A controller EMG artifact should not manufacture packet loss, and an LSL dropout should not mutate the underlying synthetic participant waveform.
+
+## Qualification boundary
+
 Synthetic success must never be reported as physical Unicorn or human SSVEP performance.
+
+The Phantom can establish that software reacts correctly to known synthetic worlds and transport failures. It cannot establish:
+
+- physical Bluetooth latency or loss distributions;
+- physical channel order/units without observation;
+- human SSVEP response magnitude or morphology;
+- false-switch/abstention performance in participants;
+- comfort or photosensitivity;
+- full closed-loop gameplay efficacy.

--- a/docs/UNICORN_SIMULATOR_RIGOR.md
+++ b/docs/UNICORN_SIMULATOR_RIGOR.md
@@ -48,9 +48,29 @@ The receiver guard fails neural gameplay authority closed on:
 
 Packet decodability, sequence continuity, validation and gameplay authority are separate diagnostics. A packet can therefore be both `VALID=0` and part of a counter gap without one condition hiding the other.
 
+### Green/yellow: deterministic synthetic-world semantics
+
+`SyntheticEEGGenerator` is now explicitly versioned and replay-oriented. The software contract establishes that a fixed generator configuration, control sequence and sample-indexed nuisance schedule produce the same sample sequence regardless of ordinary `render()` partitioning.
+
+Implemented invariants include:
+
+- independent seeded streams for phase, colored background and white noise;
+- stationary initialization for the colored AR components;
+- fixed theoretical colored-noise scaling rather than per-block normalization;
+- time-major stochastic draws where stream state is consumed sequentially;
+- sample-exact artifact expiration across render boundaries;
+- a sample-indexed artifact scheduler that can represent overlapping blink, jaw, controller, motion and source-level masking/offset stressors;
+- independent deterministic seeds for stochastic artifact events;
+- canonical event rendering order so schedule insertion order cannot change floating-point summation order;
+- explicit event IDs, start/end samples, severity, channel support, seed and `synthetic_assumption` evidence class in returned block provenance;
+- legacy `inject_artifact()` replacement semantics preserved for existing consumers;
+- completed event/noise state pruned rather than accumulated indefinitely.
+
+The static stream descriptor identifies the generator and artifact-scheduler contracts, but does **not** pretend to contain the dynamic experiment schedule. Recorded sample arrays remain replay authority. A scenario that must be regenerated rather than replayed must persist its dynamic control/artifact schedule separately.
+
 ### Yellow: timing
 
-Raw source cadence and Bandpower feature cadence are explicit. Bandpower now models the initial 250-sample analysis-window warm-up separately from its later 25 Hz feature updates.
+Raw source cadence and Bandpower feature cadence are explicit. Bandpower models the initial 250-sample analysis-window warm-up separately from its later 25 Hz feature updates.
 
 Still unknown until measurement:
 
@@ -75,22 +95,47 @@ Loss accounting is reorder-aware:
 
 Synthetic and user-declared physical trace summaries can be compared descriptively. neurOS intentionally ships no default “close enough to hardware” threshold.
 
-### Red/yellow: physiological digital-twin realism
+### Red/yellow: empirical physiology realism
 
-`SyntheticEEGGenerator` is a controlled nuisance generator, **not a validated human or Unicorn physiological twin**.
+`SyntheticEEGGenerator` remains a controlled nuisance generator, **not a validated human or Unicorn physiological twin**.
 
-Known issues that must be resolved before promoting its replay/realism claims:
+Important remaining limitations are deliberate and visible:
 
-1. **Chunk-dependent colored-noise normalization.** Colored noise is currently normalized using statistics from each render call. The same seed can therefore produce different scaled data when the same duration is requested with different chunk boundaries. This violates partition-invariant replay.
-2. **Dropout duration leak.** A dropout active at the start of a render call can zero the selected channel for the entire returned block even when the requested artifact expires partway through that block.
-3. **Single-artifact state.** Artifact injection currently permits one active artifact at a time, while real gameplay can combine eye, jaw, controller and head-motion contamination.
-4. **Stationary alpha.** Alpha frequency/amplitude are fixed rather than slowly varying across a session.
-5. **No explicit line-noise process in the base generator.** Arena can add environmental line noise, but the low-level generator itself does not yet exercise it.
-6. **Simplified spatial covariance.** Channel weighting is hand-authored and useful for stress tests, but not fitted to measured Unicorn covariance.
-7. **Simplified SSVEP morphology.** Fundamental/harmonic weights are controlled synthetic parameters, not a population model learned from Unicorn participants.
-8. **“Saturation” is a stress label, not yet a calibrated amplifier-clipping model.** It must not be described as measured ADC saturation behavior.
+1. **Stationary alpha.** Alpha frequency/amplitude are fixed rather than slowly varying across a session.
+2. **No explicit line-noise process in the base generator.** Arena can add environmental line noise, but the low-level generator itself does not yet exercise it.
+3. **Simplified spatial covariance.** Channel weighting and independent colored backgrounds are hand-authored stress assumptions, not fits to measured Unicorn covariance.
+4. **Simplified SSVEP morphology.** Fundamental/harmonic weights and posterior topography are controlled parameters, not a participant population model.
+5. **Instantaneous attention control.** `set_attention()` changes the synthetic response immediately at a render boundary. It does not model attentional acquisition latency, fatigue or hysteresis.
+6. **Persistent channel gain is not yet sample-scheduled.** Contact degradation can be represented, but its temporal transitions are currently caller-controlled rather than part of the same event timeline.
+7. **Source-level `saturation` is only a compatibility stress label.** It adds a large source offset and is not physical amplifier clipping. Actual Unicorn sensitivity clipping/quantization is modeled in the device layer.
+8. **Source-level `dropout` is a masking stressor, not a claim about electrode physics or transport packet loss.** Those failure mechanisms belong to separate causal layers.
+9. **Artifact magnitudes and spatial patterns are not measured population distributions.** They are useful adversarial assumptions until physical recordings provide an empirical basis.
+10. **Dynamic scenario provenance is not yet a first-class archive artifact.** Recorded data can be replayed exactly, but exact regeneration of a complex synthetic world still requires the caller to persist the schedule separately.
 
-These are not reasons to discard the generator. They define the next implementation gates.
+These are not reasons to discard the generator. They define the next implementation and measurement gates.
+
+## Causal-layer rule
+
+Keep failure mechanisms in the lowest layer that actually owns them:
+
+```text
+participant/source world
+  background EEG, alpha, SSVEP, blink, jaw, movement/EMG contamination
+        ↓
+sensor/contact world
+  channel gain/contact quality/electrode-specific nuisance assumptions
+        ↓
+device world
+  sensitivity envelope, quantization, VALID, battery, counter, IMU
+        ↓
+transport world
+  delay, jitter, packet loss, duplicate, reorder, silence/recovery
+        ↓
+consumer world
+  decoding, quality gates, abstention, gameplay authority
+```
+
+Do not fix a transport discrepancy by retuning synthetic physiology. Do not call a source offset “hardware saturation” when the device layer owns clipping. Do not tune game logic around a simulator mismatch that should instead correct the simulator.
 
 ## Counter precision boundary
 
@@ -110,9 +155,12 @@ This arithmetic does **not** prove the physical device counts continuously for 1
 
 Required:
 
-- same seed and same scenario produce the same data;
+- same generator contract, configuration, controls and scenario produce the same data;
 - replay is invariant to reasonable render chunk partitioning;
-- artifact durations are sample-exact across chunk boundaries;
+- overlapping event output is invariant to schedule insertion order;
+- stochastic events own independent seeds so unrelated events cannot steal random draws;
+- artifact durations and channel support are sample-exact across chunk boundaries;
+- completed artifact state is bounded/pruned;
 - transport fault schedule is deterministic;
 - Python and C# receiver authority decisions agree on shared fixtures.
 
@@ -132,7 +180,8 @@ Required:
 - stale/invalid/gap/duplicate/reorder all fail closed;
 - recovery requires a fresh healthy streak;
 - game telemetry records synthetic versus user-declared physical source out of band;
-- no raw EEG crosses a gameplay boundary unless the application intentionally owns raw decoding.
+- no raw EEG crosses a gameplay boundary unless the application intentionally owns raw decoding;
+- combined neural/source, sensor/contact, device and transport faults can be exercised without collapsing them into one ambiguous artifact label.
 
 ### R3: physical interface observation
 
@@ -141,6 +190,7 @@ Required before claiming hardware-observed compatibility:
 - trace at least one identified Unicorn Hybrid Black configuration;
 - record OS, vendor software version, transport path and capture conditions;
 - compare cadence/counter/validation behavior against the simulator;
+- measure the actual clipping/contact/failure behavior before calibrating those synthetic policies;
 - turn differences into versioned simulator corrections rather than game-specific workarounds.
 
 ### R4: human closed-loop qualification

--- a/examples/mindforge_phantom_unicorn.py
+++ b/examples/mindforge_phantom_unicorn.py
@@ -4,14 +4,22 @@
 Keyboard or localhost UDP commands:
   1 = attend 10 Hz, 2 = attend 12 Hz, 0 = no target
   b = blink, j = jaw EMG, c = controller EMG, m = motion
-  s = saturation, d = Oz dropout, r = restore Oz
+  s = source-offset stressor, d = persistent Oz mask, r = restore Oz
+  artifact:ID:KIND:START_SAMPLE:DURATION:SEVERITY[:CHANNELS][:SEED]
+      = schedule an exact future artifact; CHANNELS is comma-separated or '*'
+  cancel:ID = cancel a scheduled artifact that has not completed
   x = two-second stream silence, silence:2.5 = explicit silence duration
   + / - = SSVEP gain step, gain:0.65 = explicit response gain
   q = quit
 
-The UDP control path is intentionally localhost-only by default. It makes Mindforge
-calibration/torture rehearsals reproducible without changing the generated EEG or LSL
-contract used by the physical-source path.
+The UDP control path is intentionally localhost-only by default. Immediate
+single-key artifact commands preserve the historical replacement behavior for
+manual rehearsals. Explicit ``artifact:...`` commands use the v3 sample-indexed
+scheduler so multiple future nuisances can overlap reproducibly.
+
+Source-level ``s``/``saturation`` is a synthetic source-offset stressor, not a
+claim about physical Unicorn amplifier saturation. Physical sensitivity clipping
+and quantization belong to the Unicorn device simulation layer.
 """
 from __future__ import annotations
 
@@ -23,7 +31,16 @@ import time
 
 import numpy as np
 
-from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+from neuros.drivers.synthetic_eeg import (
+    SUPPORTED_ARTIFACTS,
+    ArtifactEvent,
+    SyntheticEEGConfig,
+    SyntheticEEGGenerator,
+)
+from neuros.drivers.synthetic_eeg_driver import (
+    SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT,
+    SYNTHETIC_EEG_GENERATOR_CONTRACT,
+)
 
 
 def command_reader(commands: queue.Queue[str]) -> None:
@@ -61,9 +78,111 @@ def parse_duration(command: str, prefix: str, default: float) -> float:
     if not command.startswith(prefix + ":"):
         return default
     try:
-        return float(command.split(":", 1)[1])
+        value = float(command.split(":", 1)[1])
     except ValueError:
         return default
+    return value if np.isfinite(value) else default
+
+
+def parse_artifact_schedule_command(command: str) -> dict[str, object]:
+    """Parse one exact sample-indexed Phantom artifact command.
+
+    Syntax:
+
+    ``artifact:ID:KIND:START_SAMPLE:DURATION_SECONDS:SEVERITY[:CHANNELS][:SEED]``
+
+    ``CHANNELS`` is a comma-separated scalp-label list or ``*`` for the
+    artifact's default support. Parsing is deliberately strict: sample indices
+    and seeds are integers, and floating controls must be finite. The generator
+    remains authoritative for channel-name and already-rendered-past checks.
+    """
+
+    parts = command.strip().split(":")
+    if not 6 <= len(parts) <= 8 or parts[0].lower() != "artifact":
+        raise ValueError(
+            "artifact command must be artifact:ID:KIND:START_SAMPLE:DURATION:SEVERITY"
+            "[:CHANNELS][:SEED]"
+        )
+    _, event_id, kind_text, start_text, duration_text, severity_text, *optional = parts
+    event_id = event_id.strip()
+    kind = kind_text.strip().lower()
+    if not event_id:
+        raise ValueError("artifact event ID must be non-empty")
+    if kind not in SUPPORTED_ARTIFACTS:
+        raise ValueError(f"unsupported artifact kind: {kind}")
+    try:
+        start_sample = int(start_text)
+    except ValueError as exc:
+        raise ValueError("artifact START_SAMPLE must be an integer") from exc
+    if start_sample < 0:
+        raise ValueError("artifact START_SAMPLE must be non-negative")
+    try:
+        duration_seconds = float(duration_text)
+        severity = float(severity_text)
+    except ValueError as exc:
+        raise ValueError("artifact duration/severity must be numeric") from exc
+    if not np.isfinite(duration_seconds) or duration_seconds <= 0:
+        raise ValueError("artifact duration must be positive and finite")
+    if not np.isfinite(severity) or severity < 0:
+        raise ValueError("artifact severity must be non-negative and finite")
+
+    channels: tuple[str, ...] | None = None
+    if optional:
+        channel_text = optional[0].strip()
+        if channel_text and channel_text != "*":
+            channels = tuple(
+                channel.strip() for channel in channel_text.split(",") if channel.strip()
+            )
+            if not channels:
+                raise ValueError("artifact channel list must not be empty")
+
+    seed: int | None = None
+    if len(optional) == 2:
+        seed_text = optional[1].strip()
+        if not seed_text:
+            raise ValueError("artifact seed must not be empty")
+        try:
+            seed = int(seed_text)
+        except ValueError as exc:
+            raise ValueError("artifact seed must be an integer") from exc
+        if seed < 0:
+            raise ValueError("artifact seed must be non-negative")
+
+    return {
+        "kind": kind,
+        "event_id": event_id,
+        "start_sample": start_sample,
+        "duration_seconds": duration_seconds,
+        "severity": severity,
+        "channels": channels,
+        "seed": seed,
+    }
+
+
+def schedule_artifact_command(
+    generator: SyntheticEEGGenerator,
+    command: str,
+) -> ArtifactEvent:
+    """Parse and apply one exact Phantom artifact schedule command.
+
+    The historical command readers normalize input to lowercase. Resolve channel
+    labels case-insensitively back to the generator's canonical montage names so
+    `PO7,Oz` and the normalized `po7,oz` address the same channels without making
+    the core generator itself case-insensitive.
+    """
+
+    parsed = parse_artifact_schedule_command(command)
+    channels = parsed["channels"]
+    if channels is not None:
+        lookup = {name.casefold(): name for name in generator.config.channel_names}
+        canonical: list[str] = []
+        for channel in channels:
+            resolved = lookup.get(str(channel).casefold())
+            if resolved is None:
+                raise ValueError(f"unknown channel: {channel!r}")
+            canonical.append(resolved)
+        parsed["channels"] = tuple(canonical)
+    return generator.schedule_artifact(**parsed)
 
 
 def main() -> None:
@@ -80,10 +199,12 @@ def main() -> None:
     parser.add_argument("--no-stdin", action="store_true",
                         help="disable interactive stdin; use UDP control only")
     args = parser.parse_args()
-    if not 0.0 <= args.drop_probability < 1.0:
-        raise SystemExit("--drop-probability must be in [0, 1)")
-    if args.jitter_ms < 0:
-        raise SystemExit("--jitter-ms must be non-negative")
+    if not 0.0 <= args.drop_probability < 1.0 or not np.isfinite(args.drop_probability):
+        raise SystemExit("--drop-probability must be finite and in [0, 1)")
+    if args.jitter_ms < 0 or not np.isfinite(args.jitter_ms):
+        raise SystemExit("--jitter-ms must be non-negative and finite")
+    if args.block <= 0:
+        raise SystemExit("--block must be positive")
     if not 1 <= args.control_port <= 65535:
         raise SystemExit("--control-port must be a valid UDP port")
 
@@ -105,6 +226,11 @@ def main() -> None:
         channel.append_child_value("type", "EEG")
     info.desc().append_child_value("manufacturer", "neurOS synthetic source")
     info.desc().append_child_value("synthetic", "true")
+    info.desc().append_child_value("generator_contract", SYNTHETIC_EEG_GENERATOR_CONTRACT)
+    info.desc().append_child_value(
+        "artifact_scheduler_contract",
+        SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT,
+    )
     info.desc().append_child_value("transport_drop_probability", str(args.drop_probability))
     info.desc().append_child_value("transport_jitter_ms", str(args.jitter_ms))
     info.desc().append_child_value("control_port", str(args.control_port))
@@ -126,7 +252,10 @@ def main() -> None:
         f"drop={args.drop_probability:.3f}, jitter<= {args.jitter_ms:g} ms; "
         f"control=udp://{args.control_host}:{args.control_port}."
     )
-    print("Commands: 1/2/0/b/j/c/m/s/d/r/x/silence:SECONDS/+/-/gain:VALUE/q")
+    print(
+        "Commands: 1/2/0/b/j/c/m/s/d/r/artifact:.../cancel:ID/"
+        "x/silence:SECONDS/+/-/gain:VALUE/q"
+    )
     deadline = time.monotonic()
 
     while running:
@@ -136,43 +265,67 @@ def main() -> None:
             except queue.Empty:
                 break
 
-            if command == "1":
-                generator.set_attention(10.0, attention_gain)
-            elif command == "2":
-                generator.set_attention(12.0, attention_gain)
-            elif command == "0":
-                generator.set_attention(None)
-            elif command == "b":
-                generator.inject_artifact("blink", 0.35, 1.0)
-            elif command == "j":
-                generator.inject_artifact("jaw", 0.45, 1.0)
-            elif command == "c":
-                generator.inject_artifact("controller", 0.50, 1.0)
-            elif command == "m":
-                generator.inject_artifact("motion", 0.50, 1.0)
-            elif command == "s":
-                generator.inject_artifact("saturation", 0.40, 1.0)
-            elif command == "d":
-                generator.set_channel_gain("Oz", 0.0)
-            elif command == "r":
-                generator.set_channel_gain("Oz", 1.0)
-            elif command == "x" or command.startswith("silence:"):
-                duration = float(np.clip(parse_duration(command, "silence", 2.0), 0.1, 10.0))
-                silence_until = max(silence_until, time.monotonic() + duration)
-            elif command == "+":
-                attention_gain = min(1.5, attention_gain + 0.1)
-                if generator.target_frequency_hz is not None:
-                    generator.set_attention(generator.target_frequency_hz, attention_gain)
-            elif command == "-":
-                attention_gain = max(0.0, attention_gain - 0.1)
-                if generator.target_frequency_hz is not None:
-                    generator.set_attention(generator.target_frequency_hz, attention_gain)
-            elif command.startswith("gain:"):
-                attention_gain = float(np.clip(parse_duration(command, "gain", attention_gain), 0.0, 1.5))
-                if generator.target_frequency_hz is not None:
-                    generator.set_attention(generator.target_frequency_hz, attention_gain)
-            elif command == "q":
-                running = False
+            try:
+                if command == "1":
+                    generator.set_attention(10.0, attention_gain)
+                elif command == "2":
+                    generator.set_attention(12.0, attention_gain)
+                elif command == "0":
+                    generator.set_attention(None)
+                elif command == "b":
+                    generator.inject_artifact("blink", 0.35, 1.0)
+                elif command == "j":
+                    generator.inject_artifact("jaw", 0.45, 1.0)
+                elif command == "c":
+                    generator.inject_artifact("controller", 0.50, 1.0)
+                elif command == "m":
+                    generator.inject_artifact("motion", 0.50, 1.0)
+                elif command == "s":
+                    generator.inject_artifact("saturation", 0.40, 1.0)
+                elif command == "d":
+                    generator.set_channel_gain("Oz", 0.0)
+                elif command == "r":
+                    generator.set_channel_gain("Oz", 1.0)
+                elif command.startswith("artifact:"):
+                    event = schedule_artifact_command(generator, command)
+                    print(
+                        "scheduled artifact "
+                        f"{event.event_id!r} kind={event.kind} "
+                        f"samples=[{event.start_sample},{event.end_sample})"
+                    )
+                elif command.startswith("cancel:"):
+                    event_id = command.split(":", 1)[1].strip()
+                    if not event_id:
+                        raise ValueError("cancel event ID must be non-empty")
+                    print(
+                        f"cancel artifact {event_id!r}: "
+                        f"{'removed' if generator.cancel_artifact(event_id) else 'not-found'}"
+                    )
+                elif command == "x" or command.startswith("silence:"):
+                    duration = float(np.clip(parse_duration(command, "silence", 2.0), 0.1, 10.0))
+                    silence_until = max(silence_until, time.monotonic() + duration)
+                elif command == "+":
+                    attention_gain = min(1.5, attention_gain + 0.1)
+                    if generator.target_frequency_hz is not None:
+                        generator.set_attention(generator.target_frequency_hz, attention_gain)
+                elif command == "-":
+                    attention_gain = max(0.0, attention_gain - 0.1)
+                    if generator.target_frequency_hz is not None:
+                        generator.set_attention(generator.target_frequency_hz, attention_gain)
+                elif command.startswith("gain:"):
+                    attention_gain = float(
+                        np.clip(parse_duration(command, "gain", attention_gain), 0.0, 1.5)
+                    )
+                    if generator.target_frequency_hz is not None:
+                        generator.set_attention(generator.target_frequency_hz, attention_gain)
+                elif command == "q":
+                    running = False
+                else:
+                    print(f"ignored unknown command: {command!r}")
+            except (IndexError, TypeError, ValueError) as exc:
+                # A malformed control command must not kill the source or mutate
+                # itself into a different scenario. Reject it visibly instead.
+                print(f"rejected control command {command!r}: {exc}")
 
         block = generator.render(args.block)
         generated_timestamp = local_clock()

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
@@ -5,19 +5,29 @@ controlled signal with useful nuisance structure so downstream systems can be
 tested against weak SSVEPs, endogenous alpha, contact loss, movement and EMG
 without requiring physical hardware for every iteration.
 
-Determinism is a contract: for a fixed seed and unchanged controls, the generated
-sample sequence must not depend on how callers partition the same duration across
-``render()`` calls. Independent random streams and time-major draws enforce that
-property for background, white-noise and artifact processes.
+Determinism is a contract: for a fixed seed, controls, and sample-indexed event
+schedule, the generated sample sequence must not depend on how callers partition
+the same duration across ``render()`` calls. Artifact events are independently
+seeded and rendered in canonical order, so adding or reordering an unrelated
+event cannot steal random draws from another event.
+
+The source-level ``saturation`` and ``dropout`` artifact names are retained for
+backward compatibility as synthetic stress conveniences. They are not claims
+about physical Unicorn amplifier saturation or transport loss; device clipping
+and transport semantics belong to the Unicorn/device layer.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+import hashlib
+from typing import Literal, Sequence
 
 import numpy as np
 
 ArtifactKind = Literal["blink", "jaw", "controller", "motion", "saturation", "dropout"]
+SUPPORTED_ARTIFACTS = frozenset(
+    {"blink", "jaw", "controller", "motion", "saturation", "dropout"}
+)
 
 
 @dataclass(frozen=True)
@@ -33,10 +43,26 @@ class SyntheticEEGConfig:
     seed: int = 7
 
     def validate(self) -> None:
+        numeric = {
+            "sampling_rate_hz": self.sampling_rate_hz,
+            "colored_noise_uv": self.colored_noise_uv,
+            "white_noise_uv": self.white_noise_uv,
+            "alpha_frequency_hz": self.alpha_frequency_hz,
+            "alpha_amplitude_uv": self.alpha_amplitude_uv,
+            "ssvep_amplitude_uv": self.ssvep_amplitude_uv,
+            "first_harmonic_ratio": self.first_harmonic_ratio,
+        }
+        for name, value in numeric.items():
+            if not np.isfinite(value):
+                raise ValueError(f"{name} must be finite")
         if self.sampling_rate_hz <= 0:
             raise ValueError("sampling_rate_hz must be positive")
         if len(self.channel_names) != 8:
             raise ValueError("the default synthetic EEG profile expects exactly 8 channels")
+        if any(not isinstance(name, str) or not name for name in self.channel_names):
+            raise ValueError("channel_names must contain eight non-empty strings")
+        if len(set(self.channel_names)) != len(self.channel_names):
+            raise ValueError("channel_names must be unique")
         if self.colored_noise_uv < 0 or self.white_noise_uv < 0:
             raise ValueError("noise amplitudes must be non-negative")
         if self.alpha_frequency_hz <= 0 or self.alpha_amplitude_uv < 0:
@@ -45,6 +71,48 @@ class SyntheticEEGConfig:
             raise ValueError("ssvep_amplitude_uv must be non-negative")
         if not 0 <= self.first_harmonic_ratio <= 2:
             raise ValueError("first_harmonic_ratio must be in [0, 2]")
+        if isinstance(self.seed, (bool, np.bool_)) or not isinstance(self.seed, (int, np.integer)):
+            raise ValueError("seed must be a non-negative integer")
+        if int(self.seed) < 0:
+            raise ValueError("seed must be a non-negative integer")
+
+
+@dataclass(frozen=True)
+class ArtifactEvent:
+    """One sample-indexed synthetic nuisance event.
+
+    ``end_sample`` is exclusive. ``channel_indices=None`` means the artifact's
+    built-in spatial pattern applies to all channels. For source-level dropout
+    and saturation compatibility events, the scheduler resolves the historical
+    default to Oz explicitly so provenance records the affected channel.
+    """
+
+    event_id: str
+    kind: ArtifactKind
+    start_sample: int
+    end_sample: int
+    severity: float
+    channel_indices: tuple[int, ...] | None
+    seed: int
+    evidence_class: Literal["synthetic_assumption"] = "synthetic_assumption"
+
+    @property
+    def duration_samples(self) -> int:
+        return self.end_sample - self.start_sample
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "event_id": self.event_id,
+            "kind": self.kind,
+            "start_sample": self.start_sample,
+            "end_sample": self.end_sample,
+            "severity": self.severity,
+            "channel_indices": (
+                None if self.channel_indices is None else list(self.channel_indices)
+            ),
+            "seed": self.seed,
+            "evidence_class": self.evidence_class,
+        }
 
 
 @dataclass(frozen=True)
@@ -54,6 +122,11 @@ class SyntheticEEGBlock:
     target_frequency_hz: float | None
     attention_gain: float
     artifact: str | None
+    artifact_events: tuple[ArtifactEvent, ...] = ()
+
+    @property
+    def artifact_ids(self) -> tuple[str, ...]:
+        return tuple(event.event_id for event in self.artifact_events)
 
 
 class SyntheticEEGGenerator:
@@ -67,11 +140,13 @@ class SyntheticEEGGenerator:
         self.config = config or SyntheticEEGConfig()
         self.config.validate()
         seed_sequence = np.random.SeedSequence(self.config.seed)
-        phase_seed, colored_seed, white_seed, artifact_seed = seed_sequence.spawn(4)
+        # Keep four children so the v2 phase/background/white streams retain
+        # their identities even though v3 replaces the shared artifact stream
+        # with event-local deterministic seeds.
+        phase_seed, colored_seed, white_seed, _legacy_artifact_seed = seed_sequence.spawn(4)
         self._phase_rng = np.random.default_rng(phase_seed)
         self._colored_rng = np.random.default_rng(colored_seed)
         self._white_rng = np.random.default_rng(white_seed)
-        self._artifact_rng = np.random.default_rng(artifact_seed)
         self.sample_index = 0
         self.target_frequency_hz: float | None = None
         self.attention_gain = 0.0
@@ -81,32 +156,198 @@ class SyntheticEEGGenerator:
         self._colored_state = self._colored_rng.normal(size=(8, 4))
         self._phase = self._phase_rng.uniform(0, 2 * np.pi, 8)
         self._alpha_phase = self._phase_rng.uniform(0, 2 * np.pi, 8)
-        self._artifact_kind: str | None = None
-        self._artifact_remaining = 0
-        self._artifact_total = 0
-        self._artifact_severity = 1.0
+        self._artifact_events: list[ArtifactEvent] = []
+        self._artifact_noise_cache: dict[str, np.ndarray] = {}
+        self._legacy_artifact_serial = 0
 
-    def set_attention(self, frequency_hz: float | None, gain: float = 1.0) -> None:
-        if frequency_hz is not None and frequency_hz <= 0:
-            raise ValueError("frequency_hz must be positive")
-        self.target_frequency_hz = None if frequency_hz is None else float(frequency_hz)
-        self.attention_gain = float(np.clip(gain, 0.0, 1.5)) if frequency_hz is not None else 0.0
+    @staticmethod
+    def _require_integer(value: object, *, name: str) -> int:
+        if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+            raise ValueError(f"{name} must be an integer")
+        return int(value)
 
-    def set_channel_gain(self, channel: str | int, gain: float) -> None:
-        index = self.config.channel_names.index(channel) if isinstance(channel, str) else int(channel)
+    def _channel_index(self, channel: str | int) -> int:
+        if isinstance(channel, str):
+            try:
+                return self.config.channel_names.index(channel)
+            except ValueError as exc:
+                raise ValueError(f"unknown channel: {channel!r}") from exc
+        index = self._require_integer(channel, name="channel index")
         if not 0 <= index < 8:
             raise IndexError("channel index out of range")
-        self.channel_gain[index] = max(0.0, float(gain))
+        return index
 
-    def inject_artifact(self, kind: ArtifactKind, duration_seconds: float = 0.35, severity: float = 1.0) -> None:
-        if kind not in {"blink", "jaw", "controller", "motion", "saturation", "dropout"}:
+    def set_attention(self, frequency_hz: float | None, gain: float = 1.0) -> None:
+        if frequency_hz is None:
+            self.target_frequency_hz = None
+            self.attention_gain = 0.0
+            return
+        frequency = float(frequency_hz)
+        gain_value = float(gain)
+        if not np.isfinite(frequency) or frequency <= 0:
+            raise ValueError("frequency_hz must be positive and finite")
+        if not np.isfinite(gain_value):
+            raise ValueError("gain must be finite")
+        self.target_frequency_hz = frequency
+        self.attention_gain = float(np.clip(gain_value, 0.0, 1.5))
+
+    def set_channel_gain(self, channel: str | int, gain: float) -> None:
+        index = self._channel_index(channel)
+        gain_value = float(gain)
+        if not np.isfinite(gain_value):
+            raise ValueError("gain must be finite")
+        self.channel_gain[index] = max(0.0, gain_value)
+
+    def _normalize_channels(
+        self,
+        channels: str | int | Sequence[str | int] | None,
+        *,
+        kind: ArtifactKind,
+    ) -> tuple[int, ...] | None:
+        if channels is None:
+            # Preserve the historical Oz-only support of these compatibility
+            # stressors, but make it explicit in the event provenance.
+            return (6,) if kind in {"saturation", "dropout"} else None
+        values: Sequence[str | int]
+        if isinstance(channels, (str, int, np.integer)) and not isinstance(channels, (bool, np.bool_)):
+            values = (channels,)
+        else:
+            values = channels
+        indices = [self._channel_index(channel) for channel in values]
+        if not indices:
+            raise ValueError("channels must contain at least one channel")
+        return tuple(sorted(set(indices)))
+
+    def _derive_event_seed(
+        self,
+        *,
+        event_id: str,
+        kind: ArtifactKind,
+        start_sample: int,
+        end_sample: int,
+        severity: float,
+        channel_indices: tuple[int, ...] | None,
+    ) -> int:
+        payload = (
+            f"{int(self.config.seed)}|{event_id}|{kind}|{start_sample}|{end_sample}|"
+            f"{severity:.17g}|{channel_indices}"
+        ).encode("utf-8")
+        return int.from_bytes(hashlib.sha256(payload).digest()[:8], "little", signed=False)
+
+    @property
+    def scheduled_artifacts(self) -> tuple[ArtifactEvent, ...]:
+        return tuple(
+            sorted(self._artifact_events, key=lambda event: (event.start_sample, event.event_id))
+        )
+
+    def schedule_artifact(
+        self,
+        kind: ArtifactKind,
+        *,
+        event_id: str,
+        duration_seconds: float = 0.35,
+        severity: float = 1.0,
+        start_sample: int | None = None,
+        delay_seconds: float = 0.0,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> ArtifactEvent:
+        """Schedule an independently reproducible nuisance event.
+
+        The event start is expressed on the generator's sample clock. Callers may
+        instead supply ``delay_seconds`` relative to the current sample. Event
+        identity is explicit so stochastic waveforms do not depend on insertion
+        order. A duplicate currently scheduled ``event_id`` is rejected.
+        """
+
+        if kind not in SUPPORTED_ARTIFACTS:
             raise ValueError(f"unsupported artifact kind: {kind}")
-        if duration_seconds <= 0:
-            raise ValueError("duration_seconds must be positive")
-        self._artifact_kind = kind
-        self._artifact_total = max(1, int(round(duration_seconds * self.config.sampling_rate_hz)))
-        self._artifact_remaining = self._artifact_total
-        self._artifact_severity = max(0.0, float(severity))
+        if not isinstance(event_id, str) or not event_id.strip():
+            raise ValueError("event_id must be a non-empty string")
+        if not np.isfinite(duration_seconds) or duration_seconds <= 0:
+            raise ValueError("duration_seconds must be positive and finite")
+        if not np.isfinite(severity) or severity < 0:
+            raise ValueError("severity must be non-negative and finite")
+        if not np.isfinite(delay_seconds) or delay_seconds < 0:
+            raise ValueError("delay_seconds must be non-negative and finite")
+        if start_sample is not None and delay_seconds != 0:
+            raise ValueError("specify either start_sample or delay_seconds, not both")
+        if any(event.event_id == event_id for event in self._artifact_events):
+            raise ValueError(f"artifact event_id already scheduled: {event_id}")
+
+        fs = self.config.sampling_rate_hz
+        if start_sample is None:
+            start = self.sample_index + int(round(delay_seconds * fs))
+        else:
+            start = self._require_integer(start_sample, name="start_sample")
+        if start < self.sample_index:
+            raise ValueError("cannot schedule an artifact in the already-rendered past")
+        duration_samples = max(1, int(round(duration_seconds * fs)))
+        end = start + duration_samples
+        channel_indices = self._normalize_channels(channels, kind=kind)
+        if seed is not None:
+            event_seed = self._require_integer(seed, name="seed")
+            if event_seed < 0:
+                raise ValueError("seed must be non-negative")
+        else:
+            event_seed = self._derive_event_seed(
+                event_id=event_id,
+                kind=kind,
+                start_sample=start,
+                end_sample=end,
+                severity=float(severity),
+                channel_indices=channel_indices,
+            )
+
+        event = ArtifactEvent(
+            event_id=event_id,
+            kind=kind,
+            start_sample=start,
+            end_sample=end,
+            severity=float(severity),
+            channel_indices=channel_indices,
+            seed=event_seed,
+        )
+        self._artifact_events.append(event)
+        if event.kind == "controller":
+            self._artifact_noise_cache[event.event_id] = np.random.default_rng(event.seed).normal(
+                size=event.duration_samples
+            )
+        return event
+
+    def cancel_artifact(self, event_id: str) -> bool:
+        before = len(self._artifact_events)
+        self._artifact_events = [
+            event for event in self._artifact_events if event.event_id != event_id
+        ]
+        removed = len(self._artifact_events) != before
+        if removed:
+            self._artifact_noise_cache.pop(event_id, None)
+        return removed
+
+    def inject_artifact(
+        self,
+        kind: ArtifactKind,
+        duration_seconds: float = 0.35,
+        severity: float = 1.0,
+    ) -> None:
+        """Backward-compatible single-slot artifact injection.
+
+        Historically a new injection replaced any currently active artifact.
+        Keep that behavior here. New multi-artifact scenarios should use
+        ``schedule_artifact`` with stable explicit event IDs.
+        """
+
+        self._artifact_events.clear()
+        self._artifact_noise_cache.clear()
+        self._legacy_artifact_serial += 1
+        self.schedule_artifact(
+            kind,
+            event_id=f"legacy-{self._legacy_artifact_serial}",
+            duration_seconds=duration_seconds,
+            severity=severity,
+            start_sample=self.sample_index,
+        )
 
     def _colored_noise(self, samples: int) -> np.ndarray:
         alphas = np.asarray([0.70, 0.90, 0.975, 0.995])
@@ -132,63 +373,163 @@ class SyntheticEEGGenerator:
             size=(samples, 8),
         ).T
 
-    def _render_artifact(self, samples: int, time_s: np.ndarray) -> np.ndarray:
-        if self._artifact_kind is None or self._artifact_remaining <= 0:
-            return np.zeros((8, samples), dtype=float)
-        count = min(samples, self._artifact_remaining)
-        start = self._artifact_total - self._artifact_remaining
-        phase = (np.arange(count) + start) / max(1, self._artifact_total - 1)
-        output = np.zeros((8, samples), dtype=float)
-        severity = self._artifact_severity
-        kind = self._artifact_kind
-        if kind == "blink":
+    def _event_weights(
+        self,
+        event: ArtifactEvent,
+        weights: np.ndarray,
+    ) -> np.ndarray:
+        if event.channel_indices is None:
+            return weights
+        selected = np.zeros(8, dtype=float)
+        selected[list(event.channel_indices)] = weights[list(event.channel_indices)]
+        return selected
+
+    def _render_event_additive(
+        self,
+        event: ArtifactEvent,
+        *,
+        block_start: int,
+        block_end: int,
+        time_s: np.ndarray,
+    ) -> np.ndarray:
+        output = np.zeros((8, block_end - block_start), dtype=float)
+        overlap_start = max(block_start, event.start_sample)
+        overlap_end = min(block_end, event.end_sample)
+        if overlap_start >= overlap_end or event.kind == "dropout":
+            return output
+
+        block_slice = slice(overlap_start - block_start, overlap_end - block_start)
+        event_offset_start = overlap_start - event.start_sample
+        event_offset_end = overlap_end - event.start_sample
+        event_offsets = np.arange(event_offset_start, event_offset_end)
+        phase = event_offsets / max(1, event.duration_samples - 1)
+        t = time_s[block_slice]
+        severity = event.severity
+
+        if event.kind == "blink":
             pulse = np.sin(np.pi * np.clip(phase, 0, 1)) ** 2
-            output[:, :count] += self.frontal_weights[:, None] * (120 * severity * pulse)
-        elif kind == "jaw":
-            t = time_s[:count]
+            weights = self._event_weights(event, self.frontal_weights)
+            output[:, block_slice] += weights[:, None] * (120 * severity * pulse)
+        elif event.kind == "jaw":
             high_frequency = (
                 np.sin(2 * np.pi * 38 * t)
                 + 0.8 * np.sin(2 * np.pi * 53 * t + 0.7)
                 + 0.55 * np.sin(2 * np.pi * 71 * t + 1.1)
             )
-            output[:, :count] += (
-                (0.55 * self.central_weights + 0.35)[:, None]
-                * (48 * severity * high_frequency)
+            weights = self._event_weights(
+                event,
+                0.55 * self.central_weights + 0.35,
             )
-        elif kind == "controller":
-            t = time_s[:count]
+            output[:, block_slice] += weights[:, None] * (
+                48 * severity * high_frequency
+            )
+        elif event.kind == "controller":
+            # Event-local random samples are cached once from the event seed.
+            # Slicing is therefore random-access stable across render boundaries.
+            random_component = self._artifact_noise_cache[event.event_id][
+                event_offset_start:event_offset_end
+            ]
             controller_emg = (
                 np.sin(2 * np.pi * 31 * t)
                 + 0.55 * np.sin(2 * np.pi * 46 * t + 0.4)
-                + 0.30 * self._artifact_rng.normal(size=count)
+                + 0.30 * random_component
             )
-            output[:, :count] += self.central_weights[:, None] * (24 * severity * controller_emg)
-        elif kind == "motion":
+            weights = self._event_weights(event, self.central_weights)
+            output[:, block_slice] += weights[:, None] * (
+                24 * severity * controller_emg
+            )
+        elif event.kind == "motion":
             drift = np.sin(np.pi * np.clip(phase, 0, 1)) * np.sign(
-                np.sin(2 * np.pi * 2.2 * time_s[:count])
+                np.sin(2 * np.pi * 2.2 * t)
             )
-            output[:, :count] += (
-                (0.60 + 0.40 * self.frontal_weights)[:, None]
-                * (55 * severity * drift)
+            weights = self._event_weights(
+                event,
+                0.60 + 0.40 * self.frontal_weights,
             )
-        elif kind == "saturation":
-            output[6, :count] += 480 * severity
-        elif kind == "dropout":
-            # Dropout is multiplicative and is applied after channel gain below.
-            pass
-        self._artifact_remaining -= count
-        if self._artifact_remaining <= 0:
-            self._artifact_kind = None
+            output[:, block_slice] += weights[:, None] * (55 * severity * drift)
+        elif event.kind == "saturation":
+            # Compatibility source stressor only. True Unicorn clipping is
+            # modeled later by UnicornHybridBlackSimulator._quantize_eeg().
+            channels = event.channel_indices or (6,)
+            output[list(channels), block_slice] += 480 * severity
         return output
 
+    def _overlapping_events(
+        self,
+        block_start: int,
+        block_end: int,
+    ) -> tuple[ArtifactEvent, ...]:
+        # Canonical event-id order makes floating-point summation independent of
+        # scheduling/insertion order.
+        return tuple(
+            sorted(
+                (
+                    event
+                    for event in self._artifact_events
+                    if event.start_sample < block_end and event.end_sample > block_start
+                ),
+                key=lambda event: event.event_id,
+            )
+        )
+
+    def _apply_artifacts(
+        self,
+        data: np.ndarray,
+        *,
+        block_start: int,
+        block_end: int,
+        time_s: np.ndarray,
+    ) -> tuple[np.ndarray, tuple[ArtifactEvent, ...]]:
+        events = self._overlapping_events(block_start, block_end)
+        for event in events:
+            data += self._render_event_additive(
+                event,
+                block_start=block_start,
+                block_end=block_end,
+                time_s=time_s,
+            )
+
+        data *= self.channel_gain[:, None]
+
+        # Multiplicative/masking effects are applied after source/channel gain.
+        # Multiple dropouts compose as the union of their exact sample/channel
+        # supports.
+        for event in events:
+            if event.kind != "dropout":
+                continue
+            overlap_start = max(block_start, event.start_sample)
+            overlap_end = min(block_end, event.end_sample)
+            if overlap_start >= overlap_end:
+                continue
+            channels = event.channel_indices or (6,)
+            data[
+                list(channels),
+                overlap_start - block_start : overlap_end - block_start,
+            ] = 0.0
+
+        # Retain only future or still-active events. Completed event objects are
+        # carried by the returned block, not accumulated indefinitely in state.
+        completed_ids = {
+            event.event_id for event in self._artifact_events if event.end_sample <= block_end
+        }
+        self._artifact_events = [
+            event for event in self._artifact_events if event.end_sample > block_end
+        ]
+        for event_id in completed_ids:
+            self._artifact_noise_cache.pop(event_id, None)
+        return data, events
+
     def render(self, samples: int) -> SyntheticEEGBlock:
-        if samples <= 0:
+        sample_count = self._require_integer(samples, name="samples")
+        if sample_count <= 0:
             raise ValueError("samples must be positive")
         fs = self.config.sampling_rate_hz
-        sample_index = self.sample_index + np.arange(samples)
+        block_start = self.sample_index
+        block_end = block_start + sample_count
+        sample_index = block_start + np.arange(sample_count)
         time_s = sample_index / fs
-        data = self._colored_noise(samples)
-        data += self._white_noise(samples)
+        data = self._colored_noise(sample_count)
+        data += self._white_noise(sample_count)
         alpha = np.sin(
             2 * np.pi * self.config.alpha_frequency_hz * time_s[None, :]
             + self._alpha_phase[:, None]
@@ -211,22 +552,23 @@ class SyntheticEEGGenerator:
                 * ssvep
             )
 
-        active_artifact = self._artifact_kind
-        dropout_samples = (
-            min(samples, self._artifact_remaining)
-            if active_artifact == "dropout" and self._artifact_remaining > 0
-            else 0
+        data, active_events = self._apply_artifacts(
+            data,
+            block_start=block_start,
+            block_end=block_end,
+            time_s=time_s,
         )
-        data += self._render_artifact(samples, time_s)
-        data *= self.channel_gain[:, None]
-        if dropout_samples:
-            data[6, :dropout_samples] = 0.0
 
-        self.sample_index += samples
+        self.sample_index = block_end
+        kinds = tuple(dict.fromkeys(event.kind for event in active_events))
+        legacy_artifact = (
+            None if not kinds else kinds[0] if len(kinds) == 1 else "multiple"
+        )
         return SyntheticEEGBlock(
-            data.astype(np.float32),
-            time_s.astype(float),
-            self.target_frequency_hz,
-            self.attention_gain,
-            active_artifact,
+            data_uv=data.astype(np.float32),
+            timestamps_s=time_s.astype(float),
+            target_frequency_hz=self.target_frequency_hz,
+            attention_gain=self.attention_gain,
+            artifact=legacy_artifact,
+            artifact_events=active_events,
         )

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg.py
@@ -15,6 +15,11 @@ The source-level ``saturation`` and ``dropout`` artifact names are retained for
 backward compatibility as synthetic stress conveniences. They are not claims
 about physical Unicorn amplifier saturation or transport loss; device clipping
 and transport semantics belong to the Unicorn/device layer.
+
+Every declared oscillatory component must also be representable at the configured
+sample rate. The generator fails closed instead of silently aliasing alpha, SSVEP
+fundamental/harmonic, or fixed artifact carrier frequencies into a different
+synthetic cause.
 """
 from __future__ import annotations
 
@@ -28,6 +33,11 @@ ArtifactKind = Literal["blink", "jaw", "controller", "motion", "saturation", "dr
 SUPPORTED_ARTIFACTS = frozenset(
     {"blink", "jaw", "controller", "motion", "saturation", "dropout"}
 )
+_ARTIFACT_MAX_FREQUENCY_HZ: dict[ArtifactKind, float] = {
+    "jaw": 71.0,
+    "controller": 46.0,
+    "motion": 2.2,
+}
 
 
 @dataclass(frozen=True)
@@ -67,6 +77,12 @@ class SyntheticEEGConfig:
             raise ValueError("noise amplitudes must be non-negative")
         if self.alpha_frequency_hz <= 0 or self.alpha_amplitude_uv < 0:
             raise ValueError("alpha parameters must be positive/non-negative")
+        nyquist_hz = 0.5 * float(self.sampling_rate_hz)
+        if self.alpha_frequency_hz >= nyquist_hz:
+            raise ValueError(
+                "alpha_frequency_hz must be strictly below the configured Nyquist frequency "
+                f"({nyquist_hz:g} Hz)"
+            )
         if self.ssvep_amplitude_uv < 0:
             raise ValueError("ssvep_amplitude_uv must be non-negative")
         if not 0 <= self.first_harmonic_ratio <= 2:
@@ -166,6 +182,18 @@ class SyntheticEEGGenerator:
             raise ValueError(f"{name} must be an integer")
         return int(value)
 
+    @property
+    def nyquist_hz(self) -> float:
+        return 0.5 * float(self.config.sampling_rate_hz)
+
+    def _require_representable_frequency(self, frequency_hz: float, *, component: str) -> None:
+        if frequency_hz >= self.nyquist_hz:
+            raise ValueError(
+                f"{component} frequency {frequency_hz:g} Hz must be strictly below the "
+                f"configured Nyquist frequency ({self.nyquist_hz:g} Hz); refusing to "
+                "silently alias the declared synthetic component"
+            )
+
     def _channel_index(self, channel: str | int) -> int:
         if isinstance(channel, str):
             try:
@@ -188,6 +216,12 @@ class SyntheticEEGGenerator:
             raise ValueError("frequency_hz must be positive and finite")
         if not np.isfinite(gain_value):
             raise ValueError("gain must be finite")
+        self._require_representable_frequency(frequency, component="SSVEP fundamental")
+        if self.config.first_harmonic_ratio > 0:
+            self._require_representable_frequency(
+                2.0 * frequency,
+                component="SSVEP first harmonic",
+            )
         self.target_frequency_hz = frequency
         self.attention_gain = float(np.clip(gain_value, 0.0, 1.5))
 
@@ -262,6 +296,12 @@ class SyntheticEEGGenerator:
 
         if kind not in SUPPORTED_ARTIFACTS:
             raise ValueError(f"unsupported artifact kind: {kind}")
+        max_frequency_hz = _ARTIFACT_MAX_FREQUENCY_HZ.get(kind)
+        if max_frequency_hz is not None:
+            self._require_representable_frequency(
+                max_frequency_hz,
+                component=f"{kind} artifact carrier",
+            )
         if not isinstance(event_id, str) or not event_id.strip():
             raise ValueError("event_id must be a non-empty string")
         if not np.isfinite(duration_seconds) or duration_seconds <= 0:
@@ -540,11 +580,14 @@ class SyntheticEEGGenerator:
             fundamental = np.sin(
                 2 * np.pi * frequency * time_s[None, :] + self._phase[:, None]
             )
-            harmonic = np.sin(
-                2 * np.pi * 2 * frequency * time_s[None, :]
-                + 0.5 * self._phase[:, None]
-            )
-            ssvep = fundamental + self.config.first_harmonic_ratio * harmonic
+            if self.config.first_harmonic_ratio > 0:
+                harmonic = np.sin(
+                    2 * np.pi * 2 * frequency * time_s[None, :]
+                    + 0.5 * self._phase[:, None]
+                )
+                ssvep = fundamental + self.config.first_harmonic_ratio * harmonic
+            else:
+                ssvep = fundamental
             data += (
                 self.posterior_weights[:, None]
                 * self.config.ssvep_amplitude_uv

--- a/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py
+++ b/packages/neuros-drivers/src/neuros/drivers/synthetic_eeg_driver.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import AsyncIterator
+from typing import AsyncIterator, Sequence
 
 import numpy as np
 
 from neuros.contracts import ClockDomain, StreamDescriptor
 from neuros.drivers.base_driver import BaseDriver
-from neuros.drivers.synthetic_eeg import ArtifactKind, SyntheticEEGConfig, SyntheticEEGGenerator
+from neuros.drivers.synthetic_eeg import (
+    ArtifactEvent,
+    ArtifactKind,
+    SyntheticEEGConfig,
+    SyntheticEEGGenerator,
+)
 
-SYNTHETIC_EEG_GENERATOR_CONTRACT = "neuros.synthetic_eeg.v2"
+SYNTHETIC_EEG_GENERATOR_CONTRACT = "neuros.synthetic_eeg.v3"
+SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT = "neuros.synthetic_eeg.artifact_schedule.v1"
 
 
 class SyntheticEEGDriver(BaseDriver):
@@ -48,10 +54,16 @@ class SyntheticEEGDriver(BaseDriver):
                 "synthetic": True,
                 "units": "microvolts",
                 "generator": SYNTHETIC_EEG_GENERATOR_CONTRACT,
+                "artifact_scheduler": SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT,
+                # Artifact/control schedules are dynamic experiment inputs and
+                # are intentionally not implied by this static stream descriptor.
+                # Recorded samples remain replay authority; scenario manifests
+                # should persist dynamic schedules separately when regeneration
+                # rather than replay is required.
+                "artifact_schedule_in_descriptor": False,
                 # Persist the stochastic-world inputs beside the stream identity.
-                # Recorded samples remain the replay authority, but a seed without
-                # these parameters or a generator contract is not sufficient to
-                # reconstruct the same synthetic world across software revisions.
+                # A seed without these parameters or a generator contract is not
+                # sufficient to reconstruct the same world across revisions.
                 "generator_config": {
                     "sampling_rate_hz": float(config.sampling_rate_hz),
                     "channel_names": list(config.channel_names),
@@ -76,6 +88,36 @@ class SyntheticEEGDriver(BaseDriver):
         severity: float = 1.0,
     ) -> None:
         self.generator.inject_artifact(kind, duration_seconds, severity)
+
+    def schedule_artifact(
+        self,
+        kind: ArtifactKind,
+        *,
+        event_id: str,
+        duration_seconds: float = 0.35,
+        severity: float = 1.0,
+        start_sample: int | None = None,
+        delay_seconds: float = 0.0,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> ArtifactEvent:
+        return self.generator.schedule_artifact(
+            kind,
+            event_id=event_id,
+            duration_seconds=duration_seconds,
+            severity=severity,
+            start_sample=start_sample,
+            delay_seconds=delay_seconds,
+            channels=channels,
+            seed=seed,
+        )
+
+    def cancel_artifact(self, event_id: str) -> bool:
+        return self.generator.cancel_artifact(event_id)
+
+    @property
+    def scheduled_artifacts(self) -> tuple[ArtifactEvent, ...]:
+        return self.generator.scheduled_artifacts
 
     def set_channel_gain(self, channel: str | int, gain: float) -> None:
         self.generator.set_channel_gain(channel, gain)

--- a/tests/test_synthetic_eeg_control_contracts.py
+++ b/tests/test_synthetic_eeg_control_contracts.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PHANTOM_PATH = ROOT / "examples" / "mindforge_phantom_unicorn.py"
+
+
+def _load_phantom_module():
+    spec = importlib.util.spec_from_file_location("mindforge_phantom_unicorn", PHANTOM_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("sampling_rate_hz", np.nan),
+        ("colored_noise_uv", np.inf),
+        ("white_noise_uv", np.nan),
+        ("alpha_frequency_hz", np.inf),
+        ("alpha_amplitude_uv", np.nan),
+        ("ssvep_amplitude_uv", np.inf),
+        ("first_harmonic_ratio", np.nan),
+    ),
+)
+def test_generator_configuration_rejects_nonfinite_values(field: str, value: float):
+    with pytest.raises(ValueError, match="finite"):
+        SyntheticEEGGenerator(SyntheticEEGConfig(**{field: value}))
+
+
+@pytest.mark.parametrize("seed", (-1, 7.5, True))
+def test_generator_configuration_requires_nonnegative_integer_seed(seed):
+    with pytest.raises(ValueError, match="seed must be a non-negative integer"):
+        SyntheticEEGGenerator(SyntheticEEGConfig(seed=seed))
+
+
+def test_generator_configuration_rejects_ambiguous_channel_names():
+    with pytest.raises(ValueError, match="unique"):
+        SyntheticEEGGenerator(
+            SyntheticEEGConfig(
+                channel_names=("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "Oz")
+            )
+        )
+
+
+def test_runtime_controls_reject_nonfinite_values_before_state_mutates():
+    generator = SyntheticEEGGenerator(SyntheticEEGConfig(seed=131))
+
+    with pytest.raises(ValueError, match="positive and finite"):
+        generator.set_attention(np.nan)
+    assert generator.target_frequency_hz is None
+    assert generator.attention_gain == 0.0
+
+    generator.set_attention(10.0, 0.7)
+    with pytest.raises(ValueError, match="gain must be finite"):
+        generator.set_attention(12.0, np.nan)
+    assert generator.target_frequency_hz == 10.0
+    assert generator.attention_gain == 0.7
+
+    before = generator.channel_gain.copy()
+    with pytest.raises(ValueError, match="gain must be finite"):
+        generator.set_channel_gain("Oz", np.inf)
+    np.testing.assert_array_equal(generator.channel_gain, before)
+
+
+def test_sample_exact_apis_reject_lossy_numeric_coercion():
+    generator = SyntheticEEGGenerator(SyntheticEEGConfig(seed=137))
+
+    with pytest.raises(ValueError, match="start_sample must be an integer"):
+        generator.schedule_artifact(
+            "blink",
+            event_id="fractional-start",
+            start_sample=10.7,
+            duration_seconds=0.1,
+        )
+    with pytest.raises(ValueError, match="seed must be an integer"):
+        generator.schedule_artifact(
+            "controller",
+            event_id="fractional-seed",
+            start_sample=10,
+            duration_seconds=0.1,
+            seed=3.2,
+        )
+    with pytest.raises(ValueError, match="channel index must be an integer"):
+        generator.set_channel_gain(6.2, 1.0)
+    with pytest.raises(ValueError, match="samples must be an integer"):
+        generator.render(10.5)
+
+    event = generator.schedule_artifact(
+        "controller",
+        event_id="numpy-integer-controls",
+        start_sample=np.int64(10),
+        duration_seconds=0.1,
+        seed=np.int64(17),
+        channels=np.int64(6),
+    )
+    assert event.start_sample == 10
+    assert event.seed == 17
+    assert event.channel_indices == (6,)
+
+
+def test_phantom_parser_accepts_explicit_future_schedule_and_channel_list():
+    phantom = _load_phantom_module()
+    parsed = phantom.parse_artifact_schedule_command(
+        "artifact:posterior-loss:dropout:40:0.10:1.0:PO7,Oz:1234"
+    )
+    assert parsed == {
+        "kind": "dropout",
+        "event_id": "posterior-loss",
+        "start_sample": 40,
+        "duration_seconds": 0.10,
+        "severity": 1.0,
+        "channels": ("PO7", "Oz"),
+        "seed": 1234,
+    }
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "artifact::blink:10:0.1:1.0",
+        "artifact:a:not-real:10:0.1:1.0",
+        "artifact:a:blink:10.5:0.1:1.0",
+        "artifact:a:blink:10:nan:1.0",
+        "artifact:a:blink:10:0.1:inf",
+        "artifact:a:blink:10:0.1:1.0:*:-1",
+    ),
+)
+def test_phantom_parser_rejects_ambiguous_or_nonfinite_schedule(command: str):
+    phantom = _load_phantom_module()
+    with pytest.raises(ValueError):
+        phantom.parse_artifact_schedule_command(command)
+
+
+def test_phantom_schedule_resolves_lowercase_channel_labels_from_udp_normalization():
+    phantom = _load_phantom_module()
+    generator = SyntheticEEGGenerator(SyntheticEEGConfig(seed=139))
+
+    event = phantom.schedule_artifact_command(
+        generator,
+        "artifact:posterior-loss:dropout:40:0.10:1.0:po7,oz:1234",
+    )
+    assert event.channel_indices == (5, 6)
+    assert event.seed == 1234
+
+
+def test_phantom_control_surface_can_build_a_true_overlapping_world():
+    phantom = _load_phantom_module()
+    cfg = SyntheticEEGConfig(seed=149)
+    generator = SyntheticEEGGenerator(cfg)
+
+    blink = phantom.schedule_artifact_command(
+        generator,
+        "artifact:blink-a:blink:20:0.30:0.7:*:101",
+    )
+    controller = phantom.schedule_artifact_command(
+        generator,
+        "artifact:controller-a:controller:10:0.40:0.9:*:202",
+    )
+    dropout = phantom.schedule_artifact_command(
+        generator,
+        "artifact:dropout-a:dropout:40:0.10:1.0:PO7,Oz:303",
+    )
+
+    assert tuple(event.event_id for event in generator.scheduled_artifacts) == (
+        "controller-a",
+        "blink-a",
+        "dropout-a",
+    )
+    block = generator.render(150)
+    assert set(block.artifact_ids) == {blink.event_id, controller.event_id, dropout.event_id}
+    assert block.artifact == "multiple"
+    assert np.allclose(block.data_uv[5:7, 40:65], 0.0)
+
+
+def test_phantom_cancel_keeps_scenario_state_explicit():
+    phantom = _load_phantom_module()
+    generator = SyntheticEEGGenerator(SyntheticEEGConfig(seed=151))
+    event = phantom.schedule_artifact_command(
+        generator,
+        "artifact:future-blink:blink:100:0.2:1.0:*:44",
+    )
+    assert generator.cancel_artifact(event.event_id) is True
+    assert generator.scheduled_artifacts == ()
+    assert generator.cancel_artifact(event.event_id) is False

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -87,6 +87,49 @@ def _schedule_overlap_world(generator: SyntheticEEGGenerator, order: tuple[str, 
         generator.schedule_artifact(kind, **kwargs)
 
 
+def test_config_rejects_alpha_at_or_above_nyquist():
+    with pytest.raises(ValueError, match="alpha_frequency_hz.*Nyquist"):
+        SyntheticEEGGenerator(
+            SyntheticEEGConfig(
+                sampling_rate_hz=20.0,
+                alpha_frequency_hz=10.0,
+                first_harmonic_ratio=0.0,
+            )
+        )
+
+
+def test_attention_rejects_unrepresentable_fundamental_and_enabled_harmonic():
+    no_harmonic = SyntheticEEGGenerator(
+        SyntheticEEGConfig(sampling_rate_hz=100.0, first_harmonic_ratio=0.0)
+    )
+    no_harmonic.set_attention(49.0)
+    with pytest.raises(ValueError, match="SSVEP fundamental.*Nyquist"):
+        no_harmonic.set_attention(50.0)
+
+    with_harmonic = SyntheticEEGGenerator(
+        SyntheticEEGConfig(sampling_rate_hz=100.0, first_harmonic_ratio=0.34)
+    )
+    with_harmonic.set_attention(24.0)
+    with pytest.raises(ValueError, match="SSVEP first harmonic.*Nyquist"):
+        with_harmonic.set_attention(25.0)
+
+
+def test_artifact_scheduler_refuses_fixed_carriers_that_would_alias():
+    jaw_world = SyntheticEEGGenerator(
+        SyntheticEEGConfig(sampling_rate_hz=100.0, first_harmonic_ratio=0.0)
+    )
+    with pytest.raises(ValueError, match="jaw artifact carrier.*Nyquist"):
+        jaw_world.schedule_artifact("jaw", event_id="aliased-jaw")
+    # 46 Hz remains representable at a 100 Hz sample rate.
+    jaw_world.schedule_artifact("controller", event_id="controller-ok")
+
+    controller_world = SyntheticEEGGenerator(
+        SyntheticEEGConfig(sampling_rate_hz=80.0, first_harmonic_ratio=0.0)
+    )
+    with pytest.raises(ValueError, match="controller artifact carrier.*Nyquist"):
+        controller_world.schedule_artifact("controller", event_id="aliased-controller")
+
+
 def test_ssvep_strength_is_controllable_and_posterior():
     cfg = SyntheticEEGConfig(seed=11, ssvep_amplitude_uv=8.0)
     strong = SyntheticEEGGenerator(cfg)

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -4,9 +4,11 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
 from neuros.drivers.synthetic_eeg_driver import (
+    SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT,
     SYNTHETIC_EEG_GENERATOR_CONTRACT,
     SyntheticEEGDriver,
 )
@@ -48,6 +50,41 @@ def _expected_generator_config() -> dict[str, object]:
         "first_harmonic_ratio": 0.42,
         "seed": 41,
     }
+
+
+def _schedule_overlap_world(generator: SyntheticEEGGenerator, order: tuple[str, ...]) -> None:
+    specs = {
+        "blink": (
+            "blink",
+            {
+                "event_id": "blink-A",
+                "duration_seconds": 0.30,
+                "start_sample": 20,
+                "severity": 0.7,
+            },
+        ),
+        "controller": (
+            "controller",
+            {
+                "event_id": "controller-A",
+                "duration_seconds": 0.40,
+                "start_sample": 10,
+                "severity": 0.9,
+            },
+        ),
+        "dropout": (
+            "dropout",
+            {
+                "event_id": "dropout-A",
+                "duration_seconds": 0.10,
+                "start_sample": 40,
+                "channels": ("PO7", "Oz"),
+            },
+        ),
+    }
+    for name in order:
+        kind, kwargs = specs[name]
+        generator.schedule_artifact(kind, **kwargs)
 
 
 def test_ssvep_strength_is_controllable_and_posterior():
@@ -94,6 +131,125 @@ def test_seeded_controller_artifact_is_also_partition_invariant():
     actual = _render_partitioned(partitioned, (11, 26, 9, 54))
 
     np.testing.assert_allclose(actual, expected, rtol=0.0, atol=1e-6)
+
+
+def test_overlapping_artifacts_are_insertion_order_and_partition_invariant():
+    cfg = SyntheticEEGConfig(seed=101)
+
+    forward = SyntheticEEGGenerator(cfg)
+    _schedule_overlap_world(forward, ("blink", "controller", "dropout"))
+    expected_block = forward.render(150)
+
+    reversed_world = SyntheticEEGGenerator(cfg)
+    _schedule_overlap_world(reversed_world, ("dropout", "controller", "blink"))
+    reversed_block = reversed_world.render(150)
+
+    partitioned = SyntheticEEGGenerator(cfg)
+    _schedule_overlap_world(partitioned, ("controller", "blink", "dropout"))
+    partitioned_data = _render_partitioned(partitioned, (13, 17, 29, 1, 40, 50))
+
+    np.testing.assert_allclose(reversed_block.data_uv, expected_block.data_uv, rtol=0.0, atol=1e-6)
+    np.testing.assert_allclose(partitioned_data, expected_block.data_uv, rtol=0.0, atol=1e-6)
+    assert expected_block.artifact == "multiple"
+    assert expected_block.artifact_ids == ("blink-A", "controller-A", "dropout-A")
+
+
+def test_scheduled_dropout_has_exact_sample_channel_support_and_provenance():
+    cfg = SyntheticEEGConfig(seed=103)
+    generator = SyntheticEEGGenerator(cfg)
+    event = generator.schedule_artifact(
+        "dropout",
+        event_id="posterior-contact-loss",
+        duration_seconds=10 / cfg.sampling_rate_hz,
+        start_sample=7,
+        channels=("PO7", "Oz"),
+    )
+    block = generator.render(30)
+
+    assert event.start_sample == 7
+    assert event.end_sample == 17
+    assert event.channel_indices == (5, 6)
+    assert event.evidence_class == "synthetic_assumption"
+    assert block.artifact_ids == ("posterior-contact-loss",)
+    assert np.allclose(block.data_uv[5:7, 7:17], 0.0)
+    assert not np.allclose(block.data_uv[5:7, :7], 0.0)
+    assert not np.allclose(block.data_uv[4, 7:17], 0.0)
+    assert generator.scheduled_artifacts == ()
+
+
+def test_future_stochastic_event_does_not_perturb_current_event():
+    cfg = SyntheticEEGConfig(seed=107)
+
+    current_only = SyntheticEEGGenerator(cfg)
+    current_only.schedule_artifact(
+        "controller",
+        event_id="controller-now",
+        start_sample=0,
+        duration_seconds=0.2,
+        seed=123,
+    )
+    expected = current_only.render(50).data_uv
+
+    with_future = SyntheticEEGGenerator(cfg)
+    with_future.schedule_artifact(
+        "controller",
+        event_id="controller-now",
+        start_sample=0,
+        duration_seconds=0.2,
+        seed=123,
+    )
+    with_future.schedule_artifact(
+        "controller",
+        event_id="controller-later",
+        start_sample=100,
+        duration_seconds=0.2,
+        seed=456,
+    )
+    actual = with_future.render(50).data_uv
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=1e-6)
+    assert tuple(event.event_id for event in with_future.scheduled_artifacts) == (
+        "controller-later",
+    )
+
+
+def test_legacy_injection_preserves_single_slot_replacement_semantics():
+    generator = SyntheticEEGGenerator(SyntheticEEGConfig(seed=109))
+    generator.schedule_artifact(
+        "blink",
+        event_id="scheduled-blink",
+        start_sample=0,
+        duration_seconds=0.5,
+    )
+    generator.inject_artifact("controller", duration_seconds=0.2)
+
+    assert len(generator.scheduled_artifacts) == 1
+    assert generator.scheduled_artifacts[0].event_id.startswith("legacy-")
+    assert generator.scheduled_artifacts[0].kind == "controller"
+
+
+def test_scheduler_rejects_ambiguous_duplicate_and_past_events():
+    generator = SyntheticEEGGenerator(SyntheticEEGConfig(seed=113))
+    generator.schedule_artifact("blink", event_id="blink-A", duration_seconds=0.1)
+    with pytest.raises(ValueError, match="already scheduled"):
+        generator.schedule_artifact("motion", event_id="blink-A", duration_seconds=0.1)
+
+    generator.render(10)
+    with pytest.raises(ValueError, match="already-rendered past"):
+        generator.schedule_artifact(
+            "motion",
+            event_id="past-motion",
+            start_sample=0,
+            duration_seconds=0.1,
+        )
+    with pytest.raises(ValueError, match="either start_sample or delay_seconds"):
+        generator.schedule_artifact(
+            "motion",
+            event_id="ambiguous-motion",
+            start_sample=10,
+            delay_seconds=0.1,
+            duration_seconds=0.1,
+        )
 
 
 def test_dropout_duration_is_sample_exact_when_render_block_outlives_artifact():
@@ -143,7 +299,30 @@ def test_driver_exposes_versioned_replay_configuration():
     assert descriptor.channel_names == ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
     assert descriptor.metadata["synthetic"] is True
     assert descriptor.metadata["generator"] == SYNTHETIC_EEG_GENERATOR_CONTRACT
+    assert descriptor.metadata["generator"] == "neuros.synthetic_eeg.v3"
+    assert descriptor.metadata["artifact_scheduler"] == SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT
+    assert descriptor.metadata["artifact_scheduler"] == "neuros.synthetic_eeg.artifact_schedule.v1"
+    assert descriptor.metadata["artifact_schedule_in_descriptor"] is False
     assert descriptor.metadata["generator_config"] == _expected_generator_config()
+
+
+def test_driver_exposes_composable_scheduler_without_bypassing_generator_contract():
+    driver = SyntheticEEGDriver(SyntheticEEGConfig(seed=127), realtime=False)
+    event = driver.schedule_artifact(
+        "controller",
+        event_id="driver-controller",
+        duration_seconds=0.2,
+        delay_seconds=0.1,
+        channels=("C3", "C4"),
+        seed=999,
+    )
+    assert event.start_sample == 25
+    assert event.end_sample == 75
+    assert event.channel_indices == (1, 3)
+    assert driver.scheduled_artifacts == (event,)
+    assert driver.cancel_artifact("driver-controller") is True
+    assert driver.scheduled_artifacts == ()
+    assert driver.cancel_artifact("driver-controller") is False
 
 
 def test_generator_contract_and_seed_survive_session_archive_serialization(tmp_path: Path):
@@ -154,4 +333,6 @@ def test_generator_contract_and_seed_survive_session_archive_serialization(tmp_p
     manifest = json.loads((tmp_path / "session" / "manifest.json").read_text(encoding="utf-8"))
     metadata = manifest["streams"]["phantom"]["descriptor"]["metadata"]
     assert metadata["generator"] == SYNTHETIC_EEG_GENERATOR_CONTRACT
+    assert metadata["artifact_scheduler"] == SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT
+    assert metadata["artifact_schedule_in_descriptor"] is False
     assert metadata["generator_config"] == _expected_generator_config()


### PR DESCRIPTION
## Why

PR #60 made `SyntheticEEGGenerator` deterministic across render partitioning and fixed sample-exact artifact expiration. The next adversarial review found a deeper limitation: artifact state was still a single mutable slot. Real BCI/game stress combines blink, jaw/controller EMG, movement and contact/channel failures, and a shared artifact RNG made future stochastic composition scientifically opaque.

This PR upgrades the synthetic world from one active nuisance to an explicit sample-indexed event schedule while preserving the legacy single-slot API for existing consumers. It also carries that contract through the actual Mindforge Phantom control surface instead of leaving it as a library-only feature.

## Core contract

For a fixed generator contract/configuration, control sequence and artifact schedule:

- output is invariant to render partitioning;
- output is invariant to artifact insertion order;
- each stochastic artifact owns an independent deterministic seed;
- adding an unrelated stochastic event cannot steal random draws from another event;
- artifact start/end and channel support are sample-exact;
- completed event/noise state is pruned;
- returned blocks expose exact overlapping event provenance;
- non-finite controls and lossy sample/index coercions fail before mutating the world.

## Spectral validity / anti-aliasing

The final review uncovered a scientific bug in the earlier v3 head: changing the sample rate could allow declared alpha, SSVEP, jaw, or controller frequencies to cross Nyquist and silently alias into a different waveform while metadata continued to name the original cause.

The final contract now fails closed:

- endogenous alpha must be strictly below Nyquist;
- an SSVEP fundamental must be strictly below Nyquist;
- when the configured first harmonic has non-zero amplitude, `2*f` must also be strictly below Nyquist;
- the fixed 71 Hz jaw carrier and 46 Hz controller carrier are rejected when the configured sample rate cannot represent them;
- zero-harmonic SSVEP worlds do not synthesize an unnecessary harmonic.

This is a numerical-validity guarantee only. It does not make the fixed artifact spectra physiological models.

## ArtifactEvent

Each scheduled event records stable `event_id`, kind, inclusive start/exclusive end sample, severity, exact channel indices when channel-scoped, independent seed, and `evidence_class="synthetic_assumption"`.

`SyntheticEEGBlock.artifact_events` carries every event overlapping the returned block. The historical scalar `artifact` field remains for compatibility and reports `multiple` when different artifact kinds overlap.

## Backward compatibility

`inject_artifact()` retains its historical replacement semantics: a new legacy injection clears the previous scheduled/active artifact and creates one immediate legacy event. New scenario code should use `schedule_artifact()` with explicit stable event IDs.

## Mindforge Phantom integration

`examples/mindforge_phantom_unicorn.py` exposes the exact scheduler over the existing localhost control channel:

`artifact:ID:KIND:START_SAMPLE:DURATION_SECONDS:SEVERITY[:CHANNELS][:SEED]`

and `cancel:ID`.

Explicit future events can overlap. Late events are rejected rather than shifted to the present. Lowercased UDP/stdin scalp labels are resolved back to canonical montage labels. The Phantom LSL metadata advertises the synthetic generator/scheduler contract versions. Single-key `b/j/c/m/s` controls remain manual legacy conveniences with replacement semantics.

## Causal-layer correction

The source-level `saturation` label is explicitly documented as a compatibility source-offset stressor only. Actual Unicorn clipping/quantization remains authoritative in `UnicornHybridBlackSimulator._quantize_eeg()` at the documented sensitivity envelope. Likewise source-level `dropout` is a masking stressor, not transport packet loss or a measured electrode-physics claim.

## Versioned provenance

Generator contract: `neuros.synthetic_eeg.v3`

Artifact scheduler contract: `neuros.synthetic_eeg.artifact_schedule.v1`

The static stream descriptor names both contracts and explicitly records that the dynamic artifact schedule is not embedded in the descriptor. Recorded arrays remain replay authority; exact world regeneration requires preserving the dynamic experiment schedule separately.

## Exact-head qualification

Production base: `79d9af665422deb4d1bc8ce937bd94d0ab622c30`

Qualified head: `8ec3a357e413a532a1e82066c301543b0cb878b4`

Compare against base: 3 commits ahead, 0 behind, exactly 8 intentional paths changed.

All exact-head workflows are green:

- neurOS driver contracts, including anti-aliasing regressions, Phantom scheduler tests, Unicorn simulation suite, UDP dry runs, C# receiver compile and endpoint syntax checks;
- Synthetic BCI Arena;
- Developer Preview Journey;
- Public Trust Contracts;
- Ecosystem Compatibility;
- full neurOS CI.

## Remaining critique / not claimed

This does **not** establish physiological realism. Important remaining gaps include fixed alpha frequency/amplitude, no base-generator line-noise process, hand-authored rather than measured spatial covariance, simplified SSVEP morphology, instantaneous attention transitions, persistent rather than sample-scheduled contact gain, no measured artifact population model, and no physical Unicorn or participant evidence.

A separate architectural issue remains: Synthetic BCI Arena has its own scenario language but currently compiles artifact onsets back into a one-slot `inject_artifact()` world-model interface, and its default world model contains a second private artifact engine. That should be repaired in a focused follow-up rather than widening this driver PR.

Synthetic success remains software test evidence only and must not be reported as physical Unicorn compatibility, human SSVEP performance, closed-loop efficacy, or clinical evidence.