### PR TITLE
Arena v2: compile sample-indexed artifact worlds without causal leakage

### DIFF
--- a/docs/SYNTHETIC_BCI_ARENA.md
+++ b/docs/SYNTHETIC_BCI_ARENA.md
@@ -12,14 +12,20 @@ This makes it useful before hardware access, between hardware sessions, in conti
 
 ## System layers
 
-A world manifest composes independently swappable layers:
+A world manifest composes independently testable causal layers:
 
 ```text
+scenario / experiment timeline
+        ↓
 participant response model
+        ↓
+source nuisances and artifacts
         ↓
 stimulus / display presentation
         ↓
-electrode + acquisition device
+sensor / contact state
+        ↓
+acquisition device
         ↓
 transport / clocks / packetization
         ↓
@@ -30,17 +36,44 @@ application / game / artwork
 closed-loop behavior
 ```
 
-The first Arena release provides dependency-light SSVEP participant simulation plus display, device and transport models. The contract is intentionally paradigm-neutral so P300, c-VEP, motor imagery and other generators can be added without changing application-facing scenario semantics.
+The rule is simple: a fault should belong to the lowest causal layer that actually owns it. A source dropout is not packet loss, a source offset is not physical ADC clipping, and packet chunk size must not reach backward and change the simulated neural source.
+
+The current Arena provides dependency-light SSVEP participant simulation plus display, source-artifact, device and transport models. The model boundary remains paradigm-neutral so P300, c-VEP, motor imagery and other generators can be added without changing application-facing scenario semantics.
+
+## Sample-indexed scenario authority
+
+Arena manifest v2 makes artifact identity and timing explicit. A stage artifact may carry:
+
+- an onset relative to its stage;
+- duration and severity;
+- an optional stable `event_id`;
+- optional channel support;
+- an optional event-local seed.
+
+For built-in world models, the runner compiles stage-relative events into one absolute source-sample timeline before neural rendering begins. The compiled schedule is recorded in the Arena report.
+
+The important invariants are:
+
+1. reordering a manifest's artifact list does not change the synthetic data;
+2. stochastic artifacts own independent deterministic seeds;
+3. dropout/channel masks are sample-exact and may cross stage boundaries;
+4. changing device packet/chunk size does not change the neural source;
+5. built-in world models share the canonical `neuros.synthetic_eeg.artifact_schedule.v1` renderer instead of maintaining separate artifact mathematics;
+6. older external world-model plugins that only implement `inject_artifact()` remain usable, but their report is explicitly labelled `legacy_injection` rather than being credited with sample-indexed semantics.
+
+Arena currently renders neural-world blocks at a fixed internal five-sample cadence. That execution cadence is reported as `render_chunk_samples` and is deliberately independent of `DeviceProfile.chunk_samples`. The latter belongs to acquisition/packetization only.
+
+This does not make the participant model physiologically exact. It makes the software timeline unambiguous.
 
 ## Verification ladder
 
 ### A0 — Determinism
 
-Same manifest + seed must produce the same synthetic signal, timestamps, stimulus trace, fault schedule and report.
+Same manifest + seed must produce the same synthetic signal, timestamps, stimulus trace, fault schedule and report. Equivalent event ordering must not alter source data.
 
 ### A1 — Controlled neural nuisance
 
-Sweep response strength, alpha overlap, switching delay, response attenuation, gaze duty cycle, blink/jaw/controller/motion contamination and electrode loss. The expected causal labels remain known.
+Sweep response strength, alpha overlap, switching delay, response attenuation, gaze duty cycle, blink/jaw/controller/motion contamination and channel loss. Expected causal labels remain known.
 
 ### A2 — Display fidelity
 
@@ -48,7 +81,7 @@ Simulate refresh quantization, response lag, jitter and dropped frames. Report t
 
 ### A3 — Device fidelity
 
-Apply montage selection, sensor noise, mains interference, ADC clipping/quantization, clock drift and device chunk size.
+Apply montage selection, sensor noise, mains interference, ADC clipping/quantization, clock drift and acquisition chunk size. Device chunk size must not alter upstream neural samples.
 
 ### A4 — Transport adversity
 
@@ -80,11 +113,13 @@ A real device replaces the synthetic source while every downstream boundary rema
 
 ## Portable creative worlds
 
-Arena manifests use schema:
+New Arena manifests are written as:
 
-`neuros.synthetic_bci_arena.manifest.v1`
+`neuros.synthetic_bci_arena.manifest.v2`
 
-They describe participant, scenario, device, display and transport state. A manifest should be small enough to paste into a bug report and complete enough to reproduce the run.
+The v2 schema extends artifact provenance while retaining read compatibility with frozen `neuros.synthetic_bci_arena.manifest.v1` files. Existing v1 examples intentionally remain in the repository as compatibility fixtures.
+
+A manifest describes participant, scenario, world model, device, display and transport state. It should be small enough to paste into a bug report and complete enough to reproduce the declared synthetic world.
 
 Example:
 
@@ -95,13 +130,19 @@ neuros-arena \
   --npz run.npz
 ```
 
-This enables shared challenge worlds for game jams, classroom assignments, accessibility research and benchmark suites.
+When `--write-manifest` is used, the resolved world is written as v2.
+
+## Evidence and replay boundary
+
+The manifest is the requested synthetic-world specification. The Arena report additionally records the resolved artifact schedule and operational metrics. Derived arrays may be exported to NPZ for inspection.
+
+These are synthetic-world regeneration artifacts, not substitutes for observed hardware or human recordings. When real recordings exist, the recorded samples remain evidence authority for what physically happened.
 
 ## What “verified synthetic” should mean
 
 A project may say:
 
-> “The application passed Synthetic Arena scenario X across seeds 1–1000, including specified display, device and transport faults.”
+> “The application passed Synthetic Arena scenario X across seeds 1–1000, including the specified display, source-artifact, device and transport faults.”
 
 It should not say:
 
@@ -109,9 +150,24 @@ It should not say:
 
 unless that claim is independently supported by human recordings under an appropriate protocol.
 
+## Known realism limits
+
+Current deterministic rigor must not be mistaken for physiological realism. Important open modeling gaps include:
+
+- slowly varying alpha frequency/amplitude rather than a stationary oscillator;
+- richer participant response variation and fatigue models;
+- measured rather than hand-authored spatial covariance for fully synthetic worlds;
+- measured artifact amplitude/population distributions;
+- sensor/contact dynamics distinct from source dropout;
+- population-informed SSVEP morphology;
+- physical display timing and headset observations;
+- participant-level closed-loop validation.
+
+Those are future evidence/modeling layers. They should not be hidden inside arbitrary constants merely to make a simulator look more lifelike.
+
 ## Roadmap
 
-1. SSVEP closed-loop conformance and portable manifests.
+1. Sample-indexed SSVEP closed-loop conformance and portable manifests.
 2. Application event adapters and generic decoder protocol.
 3. MNE-LSL/XDF replay adapter.
 4. MOABB reference-suite adapter for SSVEP/P300/MI datasets.

--- a/packages/neuros-arena/src/neuros/arena/cli.py
+++ b/packages/neuros-arena/src/neuros/arena/cli.py
@@ -23,8 +23,12 @@ def _write_json(payload: dict, path: str | Path) -> Path:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="portable neuros.synthetic_bci_arena.manifest.v2 JSON (v1 remains readable)",
+    )
     parser.add_argument("--preset", choices=list_presets(), default=None)
-    parser.add_argument("--manifest", default=None, help="portable neuros.synthetic_bci_arena.manifest.v1 JSON")
     parser.add_argument(
         "--benchmark-pack",
         default=None,

--- a/packages/neuros-arena/src/neuros/arena/leadfield.py
+++ b/packages/neuros-arena/src/neuros/arena/leadfield.py
@@ -18,6 +18,8 @@ from typing import Any, Sequence
 
 import numpy as np
 
+from neuros.drivers.synthetic_eeg import ArtifactEvent as DriverArtifactEvent
+
 from .specs import ParticipantProfile
 from .world_models import WorldModelEmission, _ArtifactEngine
 
@@ -179,12 +181,36 @@ class LeadFieldDrivenWorldModel:
             raise ValueError("lead-field time constants must be positive")
         self._artifact = _ArtifactEngine(self.fs, seed + 1777) if len(self.channel_names) == 8 else None
 
-    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+    def _require_standard_artifact_montage(self) -> _ArtifactEngine:
         if self._artifact is None:
-            if kind != "dropout":
-                raise ValueError("generic artifact overlay currently requires the standard 8-channel Arena montage")
-            raise ValueError("dropout overlay currently requires the standard 8-channel Arena montage")
-        self._artifact.inject(kind, duration_seconds, severity)
+            raise ValueError(
+                "generic artifact overlay currently requires the standard 8-channel Arena montage"
+            )
+        return self._artifact
+
+    def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+        self._require_standard_artifact_montage().inject(kind, duration_seconds, severity)
+
+    def schedule_artifact(
+        self,
+        kind: str,
+        *,
+        event_id: str,
+        start_sample: int,
+        duration_seconds: float,
+        severity: float,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> DriverArtifactEvent:
+        return self._require_standard_artifact_montage().schedule(
+            kind,
+            event_id=event_id,
+            start_sample=start_sample,
+            duration_seconds=duration_seconds,
+            severity=severity,
+            channels=channels,
+            seed=seed,
+        )
 
     def render(
         self,
@@ -231,13 +257,9 @@ class LeadFieldDrivenWorldModel:
             * np.sin(2 * np.pi * self.participant.alpha_frequency_hz * times + self._alpha_phase)[None, :]
         )
         if self._artifact is not None:
-            artifact, artifact_kind = self._artifact.render(times)
-            dropout = artifact_kind == "dropout"
-            if dropout:
-                artifact = np.nan_to_num(artifact, nan=0.0)
+            artifact, dropout_mask, _artifact_events = self._artifact.render(times)
             data += artifact
-            if dropout:
-                data[6, :] = 0.0
+            data[dropout_mask] = 0.0
         return WorldModelEmission(
             data_uv=data.astype(np.float32),
             latent={

--- a/packages/neuros-arena/src/neuros/arena/manifest.py
+++ b/packages/neuros-arena/src/neuros/arena/manifest.py
@@ -8,7 +8,9 @@ from typing import Any
 
 from .specs import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, TransportProfile, WorldModelProfile
 
-SCHEMA = "neuros.synthetic_bci_arena.manifest.v1"
+SCHEMA_V1 = "neuros.synthetic_bci_arena.manifest.v1"
+SCHEMA = "neuros.synthetic_bci_arena.manifest.v2"
+SUPPORTED_SCHEMAS = frozenset({SCHEMA_V1, SCHEMA})
 
 
 @dataclass(frozen=True)
@@ -55,8 +57,9 @@ def _transport(raw: dict[str, Any]) -> TransportProfile:
 
 
 def manifest_from_dict(raw: dict[str, Any]) -> ArenaManifest:
-    if raw.get("schema") != SCHEMA:
-        raise ValueError(f"expected manifest schema {SCHEMA!r}")
+    schema = raw.get("schema")
+    if schema not in SUPPORTED_SCHEMAS:
+        raise ValueError(f"expected manifest schema in {sorted(SUPPORTED_SCHEMAS)!r}")
     manifest = ArenaManifest(
         scenario=ArenaScenario.from_dict(dict(raw["scenario"])),
         participant=ParticipantProfile(**dict(raw["participant"])),

--- a/packages/neuros-arena/src/neuros/arena/runner.py
+++ b/packages/neuros-arena/src/neuros/arena/runner.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import hashlib
+import json
 
 import numpy as np
 
@@ -12,6 +14,12 @@ from .simulators import DeviceOutput, StimulusTrace, TransportPacket, apply_devi
 from .specs import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, TransportProfile, WorldModelProfile
 from .world_input import WorldInputBlock
 from .world_models import NeuralWorldModel
+
+
+# Neural-world integration cadence is an Arena execution policy. It is
+# deliberately independent of DeviceProfile.chunk_samples, which belongs to the
+# acquisition/packetization layer and must not change the simulated neural source.
+WORLD_RENDER_CHUNK_SAMPLES = 5
 
 
 @dataclass(frozen=True)
@@ -52,6 +60,12 @@ def _spectral_snr_db(data_uv: np.ndarray, fs: float, target_hz: float) -> float:
     signal_power = float(np.mean(power[signal])) if np.any(signal) else 0.0
     noise_power = float(np.mean(power[noise])) if np.any(noise) else 1e-12
     return float(10.0 * np.log10(max(signal_power, 1e-12) / max(noise_power, 1e-12)))
+
+
+def _stage_sample_count(duration_s: float, sampling_rate_hz: float) -> int:
+    """Resolve a requested stage duration onto the source sample clock."""
+
+    return max(1, int(round(float(duration_s) * float(sampling_rate_hz))))
 
 
 def _create_world_model(
@@ -95,6 +109,116 @@ def _render_world_model(
     )
 
 
+def _artifact_identity_payload(artifact) -> str:
+    """Canonical semantic identity for an Arena artifact without an explicit ID.
+
+    Tuple/list position is deliberately excluded. Exact duplicate events remain
+    meaningful, so the compiler adds a deterministic duplicate ordinal after
+    sorting by this canonical payload.
+    """
+
+    payload = {
+        "at_s": float(artifact.at_s),
+        "channels": None if artifact.channels is None else sorted(str(name) for name in artifact.channels),
+        "duration_s": float(artifact.duration_s),
+        "kind": str(artifact.kind),
+        "seed": None if artifact.seed is None else int(artifact.seed),
+        "severity": float(artifact.severity),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _compile_artifact_schedule(
+    model: NeuralWorldModel,
+    scenario: ArenaScenario,
+    participant: ParticipantProfile,
+    sampling_rate_hz: float,
+) -> tuple[str, list[dict[str, object]]]:
+    """Compile Arena stage artifacts to an absolute sample-indexed timeline.
+
+    Built-in v3-aware world models expose ``schedule_artifact``. Older/external
+    plugins may implement only ``inject_artifact``; those stay on the historical
+    block-triggered fallback and are labelled explicitly in the report.
+    """
+
+    schedule = getattr(model, "schedule_artifact", None)
+    if not callable(schedule):
+        return "legacy_injection", []
+
+    compiled: list[dict[str, object]] = []
+    global_sample = 0
+    fs = float(sampling_rate_hz)
+    for stage_i, stage in enumerate(scenario.stages):
+        stage_samples = _stage_sample_count(stage.duration_s, fs)
+        entries = [
+            (
+                _artifact_identity_payload(artifact),
+                artifact_i,
+                artifact,
+            )
+            for artifact_i, artifact in enumerate(stage.artifacts)
+        ]
+        # Event order in a manifest is presentation, not causal authority. The
+        # canonical sort gives implicit stochastic events stable identities even
+        # when the artifact tuple is rearranged.
+        entries.sort(
+            key=lambda item: (
+                "" if item[2].event_id is None else str(item[2].event_id),
+                item[0],
+                item[1],
+            )
+        )
+        duplicate_ordinals: dict[str, int] = {}
+        for identity_payload, artifact_i, artifact in entries:
+            # First source sample at-or-after requested onset. If no source sample
+            # exists before stage end, reject rather than shift the event into the
+            # previous sample or silently assign it to the next stage.
+            onset_sample = int(np.ceil(artifact.at_s * fs - 1e-12))
+            if onset_sample >= stage_samples:
+                raise ValueError(
+                    f"artifact {artifact_i} in stage {stage.label!r} has no source sample "
+                    f"at-or-after onset {artifact.at_s:g}s at {fs:g} Hz"
+                )
+            if artifact.event_id is not None:
+                event_id = artifact.event_id
+            else:
+                digest = hashlib.sha256(identity_payload.encode("utf-8")).hexdigest()[:16]
+                ordinal = duplicate_ordinals.get(identity_payload, 0)
+                duplicate_ordinals[identity_payload] = ordinal + 1
+                event_id = f"{scenario.name}/stage-{stage_i}/{digest}/{ordinal}"
+            resolved = schedule(
+                artifact.kind,
+                event_id=event_id,
+                start_sample=global_sample + onset_sample,
+                duration_seconds=artifact.duration_s,
+                severity=artifact.severity * participant.artifact_gain,
+                channels=artifact.channels,
+                seed=artifact.seed,
+            )
+            event_payload = (
+                resolved.to_dict()
+                if hasattr(resolved, "to_dict") and callable(resolved.to_dict)
+                else {
+                    "event_id": event_id,
+                    "kind": artifact.kind,
+                    "start_sample": global_sample + onset_sample,
+                    "duration_seconds": artifact.duration_s,
+                    "severity": artifact.severity * participant.artifact_gain,
+                    "channels": None if artifact.channels is None else list(artifact.channels),
+                    "seed": artifact.seed,
+                }
+            )
+            compiled.append({
+                "stage": stage.label,
+                "stage_index": stage_i,
+                "artifact_index": artifact_i,
+                "requested_at_s": float(artifact.at_s),
+                **event_payload,
+            })
+        global_sample += stage_samples
+    return "sample_indexed", compiled
+
+
 def run_scenario(
     scenario: ArenaScenario,
     participant: ParticipantProfile,
@@ -117,21 +241,42 @@ def run_scenario(
     )
     evidence_card = evidence_card_for_model(model, model_profile.name)
     paradigm = scenario.metadata.get("paradigm", "ssvep")
+    artifact_execution, compiled_artifacts = _compile_artifact_schedule(
+        model,
+        scenario,
+        participant,
+        device.sampling_rate_hz,
+    )
 
-    block_samples = max(1, device.chunk_samples)
+    fs = float(device.sampling_rate_hz)
+    block_samples = WORLD_RENDER_CHUNK_SAMPLES
     data_blocks: list[np.ndarray] = []
     timestamp_blocks: list[np.ndarray] = []
     truth_blocks: list[np.ndarray] = []
     stage_blocks: list[np.ndarray] = []
     stage_intervals: list[StageInterval] = []
+    stage_timing: list[dict[str, float | int | str]] = []
     stimulus_traces: list[StimulusTrace] = []
     latent_stage_end: list[dict[str, float | str]] = []
-    global_start = 0.0
+    global_sample_start = 0
 
     for stage_i, stage in enumerate(scenario.stages):
-        stage_start = global_start
-        stage_end = stage_start + stage.duration_s
+        samples_total = _stage_sample_count(stage.duration_s, fs)
+        stage_start = global_sample_start / fs
+        stage_end = (global_sample_start + samples_total) / fs
+        resolved_duration = samples_total / fs
         stage_intervals.append(StageInterval(stage.label, stage_start, stage_end, stage.target_frequency_hz))
+        stage_timing.append({
+            "stage": stage.label,
+            "stage_index": stage_i,
+            "start_sample": global_sample_start,
+            "end_sample": global_sample_start + samples_total,
+            "resolved_start_s": float(stage_start),
+            "resolved_end_s": float(stage_end),
+            "requested_duration_s": float(stage.duration_s),
+            "resolved_duration_s": float(resolved_duration),
+            "duration_error_ms": float((resolved_duration - stage.duration_s) * 1000.0),
+        })
         trace = simulate_stimulus(
             stage.target_frequency_hz,
             stage.duration_s,
@@ -139,29 +284,30 @@ def run_scenario(
             seed=scenario.seed * 1009 + stage_i,
         )
         stimulus_traces.append(trace)
-        samples_total = max(1, int(round(stage.duration_s * device.sampling_rate_hz)))
         artifact_cursor: set[int] = set()
         produced = 0
         last_latent: dict[str, float] = {}
         while produced < samples_total:
             count = min(block_samples, samples_total - produced)
-            elapsed = produced / device.sampling_rate_hz
-            local_times = elapsed + np.arange(count, dtype=float) / device.sampling_rate_hz
-            global_times = stage_start + local_times
-            for artifact_i, artifact in enumerate(stage.artifacts):
-                if artifact_i not in artifact_cursor and elapsed <= artifact.at_s < elapsed + count / device.sampling_rate_hz:
-                    model.inject_artifact(
-                        artifact.kind,
-                        duration_seconds=artifact.duration_s,
-                        severity=artifact.severity * participant.artifact_gain,
-                    )
-                    artifact_cursor.add(artifact_i)
+            sample_offsets = produced + np.arange(count, dtype=np.int64)
+            local_times = sample_offsets.astype(float) / fs
+            global_times = (global_sample_start + sample_offsets).astype(float) / fs
+            elapsed = produced / fs
+            if artifact_execution == "legacy_injection":
+                for artifact_i, artifact in enumerate(stage.artifacts):
+                    if artifact_i not in artifact_cursor and elapsed <= artifact.at_s < elapsed + count / fs:
+                        model.inject_artifact(
+                            artifact.kind,
+                            duration_seconds=artifact.duration_s,
+                            severity=artifact.severity * participant.artifact_gain,
+                        )
+                        artifact_cursor.add(artifact_i)
             if stage.target_frequency_hz is None:
                 effective_gain = 0.0
             else:
                 after_delay = max(0.0, elapsed - participant.response_delay_s)
                 switch_gain = 0.0 if elapsed < participant.response_delay_s else 1.0 - np.exp(-after_delay / participant.switch_time_constant_s)
-                global_elapsed_min = (stage_start + elapsed) / 60.0
+                global_elapsed_min = float(global_times[0]) / 60.0
                 attenuation = max(0.0, 1.0 - participant.response_attenuation_per_minute * global_elapsed_min)
                 effective_gain = stage.attention_gain * participant.gaze_duty_cycle * switch_gain * attenuation
             emitted_drive = sample_stimulus(trace, local_times, display)
@@ -195,7 +341,7 @@ def run_scenario(
             stage_blocks.append(np.full(count, stage_i, dtype=np.int32))
             produced += count
         latent_stage_end.append({"stage": stage.label, **last_latent})
-        global_start = stage_end
+        global_sample_start += samples_total
 
     raw_data = np.concatenate(data_blocks, axis=1)
     raw_timestamps = np.concatenate(timestamp_blocks)
@@ -231,7 +377,7 @@ def run_scenario(
         })
 
     report = {
-        "schema": "neuros.synthetic_bci_arena.v1",
+        "schema": "neuros.synthetic_bci_arena.v2",
         "scenario": scenario.to_dict(),
         "paradigm": paradigm,
         "participant": asdict(participant),
@@ -248,9 +394,13 @@ def run_scenario(
             "target_snr_db": snr,
             "transport": transport_metrics,
             "display": display_metrics,
+            "stage_timing": stage_timing,
             "world_model": {
                 "name": model_profile.name,
                 "display_coupled": bool(any(item.get("stimulus_coupling", 0.0) > 0 for item in latent_stage_end)),
+                "render_chunk_samples": block_samples,
+                "artifact_execution": artifact_execution,
+                "compiled_artifact_schedule": compiled_artifacts,
                 "stage_end_latent": latent_stage_end,
             },
         },

--- a/packages/neuros-arena/src/neuros/arena/semi_synthetic.py
+++ b/packages/neuros-arena/src/neuros/arena/semi_synthetic.py
@@ -16,9 +16,11 @@ model of the person represented by the background recording.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 import numpy as np
+
+from neuros.drivers.synthetic_eeg import ArtifactEvent as DriverArtifactEvent
 
 from .specs import ParticipantProfile
 from .world_models import POSTERIOR_WEIGHTS, SOURCE_CHANNELS, WorldModelEmission, _ArtifactEngine
@@ -84,6 +86,27 @@ class SemiSyntheticReplayWorldModel:
     def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
         self._artifact.inject(kind, duration_seconds, severity)
 
+    def schedule_artifact(
+        self,
+        kind: str,
+        *,
+        event_id: str,
+        start_sample: int,
+        duration_seconds: float,
+        severity: float,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> DriverArtifactEvent:
+        return self._artifact.schedule(
+            kind,
+            event_id=event_id,
+            start_sample=start_sample,
+            duration_seconds=duration_seconds,
+            severity=severity,
+            channels=channels,
+            seed=seed,
+        )
+
     def _next_background(self, samples: int) -> np.ndarray:
         indices = (self._cursor + np.arange(samples)) % self._baseline.shape[1]
         block = self._baseline[:, indices].copy()
@@ -120,13 +143,9 @@ class SemiSyntheticReplayWorldModel:
             * self._response_scale
             * response[None, :]
         )
-        artifact, artifact_kind = self._artifact.render(times)
-        dropout = artifact_kind == "dropout"
-        if dropout:
-            artifact = np.nan_to_num(artifact, nan=0.0)
+        artifact, dropout_mask, _artifact_events = self._artifact.render(times)
         data += artifact
-        if dropout:
-            data[6, :] = 0.0
+        data[dropout_mask] = 0.0
         return WorldModelEmission(
             data_uv=data.astype(np.float32),
             latent={

--- a/packages/neuros-arena/src/neuros/arena/specs.py
+++ b/packages/neuros-arena/src/neuros/arena/specs.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+import numpy as np
+
 
 def _validate_scalar_mapping(name: str, values: dict[str, Any]) -> None:
     for key, value in values.items():
@@ -11,6 +13,8 @@ def _validate_scalar_mapping(name: str, values: dict[str, Any]) -> None:
             raise ValueError(f"{name} keys must be non-empty strings")
         if not isinstance(value, (str, int, float, bool)) and value is not None:
             raise ValueError(f"{name}.{key} must be a JSON scalar")
+        if isinstance(value, float) and not np.isfinite(value):
+            raise ValueError(f"{name}.{key} must be finite")
 
 
 @dataclass(frozen=True)
@@ -32,12 +36,31 @@ class ParticipantProfile:
     def validate(self) -> None:
         if not self.name:
             raise ValueError("participant name is required")
+        numeric = (
+            self.colored_noise_uv,
+            self.white_noise_uv,
+            self.alpha_frequency_hz,
+            self.alpha_amplitude_uv,
+            self.ssvep_amplitude_uv,
+            self.first_harmonic_ratio,
+            self.response_delay_s,
+            self.switch_time_constant_s,
+            self.response_attenuation_per_minute,
+            self.gaze_duty_cycle,
+            self.artifact_gain,
+        )
+        if not all(np.isfinite(value) for value in numeric):
+            raise ValueError("participant numeric parameters must be finite")
+        if isinstance(self.seed, (bool, np.bool_)) or not isinstance(self.seed, (int, np.integer)) or int(self.seed) < 0:
+            raise ValueError("participant seed must be a non-negative integer")
         if self.colored_noise_uv < 0 or self.white_noise_uv < 0:
             raise ValueError("noise amplitudes must be non-negative")
         if self.alpha_frequency_hz <= 0 or self.alpha_amplitude_uv < 0:
             raise ValueError("alpha parameters are invalid")
         if self.ssvep_amplitude_uv < 0:
             raise ValueError("ssvep amplitude must be non-negative")
+        if not 0 <= self.first_harmonic_ratio <= 2:
+            raise ValueError("first_harmonic_ratio must be in [0, 2]")
         if self.response_delay_s < 0 or self.switch_time_constant_s <= 0:
             raise ValueError("response timing must be non-negative/positive")
         if not 0 <= self.response_attenuation_per_minute <= 1:
@@ -77,10 +100,30 @@ class DeviceProfile:
     chunk_samples: int = 5
 
     def validate(self) -> None:
+        numeric = (
+            self.sampling_rate_hz,
+            self.input_range_uv,
+            self.sensor_noise_uv,
+            self.line_frequency_hz,
+            self.line_noise_uv,
+            self.clock_offset_ms,
+            self.clock_drift_ppm,
+            self.timestamp_jitter_ms,
+        )
+        if not all(np.isfinite(value) for value in numeric):
+            raise ValueError("device numeric parameters must be finite")
         if self.sampling_rate_hz <= 0 or not self.channel_names:
             raise ValueError("device sample rate/channels are invalid")
+        if any(not isinstance(name, str) or not name for name in self.channel_names):
+            raise ValueError("device channel names must be non-empty strings")
+        if len(set(self.channel_names)) != len(self.channel_names):
+            raise ValueError("device channel names must be unique")
+        if isinstance(self.adc_bits, (bool, np.bool_)) or not isinstance(self.adc_bits, (int, np.integer)):
+            raise ValueError("adc_bits must be an integer")
         if self.adc_bits < 8 or self.adc_bits > 32:
             raise ValueError("adc_bits must be in [8, 32]")
+        if isinstance(self.chunk_samples, (bool, np.bool_)) or not isinstance(self.chunk_samples, (int, np.integer)):
+            raise ValueError("chunk_samples must be an integer")
         if self.input_range_uv <= 0 or self.sensor_noise_uv < 0 or self.line_noise_uv < 0:
             raise ValueError("device amplitude parameters are invalid")
         if self.line_frequency_hz <= 0 or self.chunk_samples <= 0:
@@ -100,6 +143,16 @@ class DisplayProfile:
     high_luminance: float = 1.0
 
     def validate(self) -> None:
+        numeric = (
+            self.refresh_hz,
+            self.response_lag_ms,
+            self.frame_jitter_ms,
+            self.frame_drop_probability,
+            self.low_luminance,
+            self.high_luminance,
+        )
+        if not all(np.isfinite(value) for value in numeric):
+            raise ValueError("display numeric parameters must be finite")
         if self.refresh_hz <= 0 or self.response_lag_ms < 0 or self.frame_jitter_ms < 0:
             raise ValueError("display timing parameters are invalid")
         if not 0 <= self.frame_drop_probability < 1:
@@ -120,11 +173,23 @@ class TransportProfile:
     clock_correction_noise_ms: float = 0.0
 
     def validate(self) -> None:
+        numeric = (
+            self.drop_probability,
+            self.jitter_ms,
+            self.reorder_probability,
+            self.clock_correction_offset_error_ms,
+            self.clock_correction_drift_error_ppm,
+            self.clock_correction_noise_ms,
+        )
+        if not all(np.isfinite(value) for value in numeric):
+            raise ValueError("transport numeric parameters must be finite")
         if not 0 <= self.drop_probability < 1 or not 0 <= self.reorder_probability < 1:
             raise ValueError("transport probabilities must be in [0, 1)")
         if self.jitter_ms < 0 or self.clock_correction_noise_ms < 0:
             raise ValueError("transport and clock-correction jitter must be non-negative")
         for start, duration in self.silence_windows:
+            if not np.isfinite(start) or not np.isfinite(duration):
+                raise ValueError("silence windows must be finite")
             if start < 0 or duration <= 0:
                 raise ValueError("silence windows require start >= 0 and duration > 0")
 
@@ -135,12 +200,29 @@ class ArtifactEvent:
     kind: str
     duration_s: float = 0.35
     severity: float = 1.0
+    event_id: str | None = None
+    channels: tuple[str, ...] | None = None
+    seed: int | None = None
 
     def validate(self, stage_duration_s: float) -> None:
+        if not all(np.isfinite(value) for value in (self.at_s, self.duration_s, self.severity)):
+            raise ValueError("artifact timing/severity must be finite")
         if not 0 <= self.at_s < stage_duration_s:
             raise ValueError("artifact onset must fall inside its stage")
         if self.duration_s <= 0 or self.severity < 0:
             raise ValueError("artifact duration/severity are invalid")
+        if not isinstance(self.kind, str) or not self.kind:
+            raise ValueError("artifact kind must be a non-empty string")
+        if self.event_id is not None and (not isinstance(self.event_id, str) or not self.event_id.strip()):
+            raise ValueError("artifact event_id must be a non-empty string when supplied")
+        if self.channels is not None:
+            if not self.channels or any(not isinstance(name, str) or not name for name in self.channels):
+                raise ValueError("artifact channels must contain non-empty channel names")
+            if len(set(self.channels)) != len(self.channels):
+                raise ValueError("artifact channels must be unique")
+        if self.seed is not None:
+            if isinstance(self.seed, (bool, np.bool_)) or not isinstance(self.seed, (int, np.integer)) or int(self.seed) < 0:
+                raise ValueError("artifact seed must be a non-negative integer")
 
 
 @dataclass(frozen=True)
@@ -154,12 +236,13 @@ class StageSpec:
     task_state: dict[str, Any] = field(default_factory=dict)
 
     def validate(self) -> None:
-        if not self.label or self.duration_s <= 0:
+        if not self.label or not np.isfinite(self.duration_s) or self.duration_s <= 0:
             raise ValueError("stage label/duration are required")
-        if self.target_frequency_hz is not None and self.target_frequency_hz <= 0:
-            raise ValueError("target frequency must be positive")
-        if self.attention_gain < 0:
-            raise ValueError("attention gain must be non-negative")
+        if self.target_frequency_hz is not None:
+            if not np.isfinite(self.target_frequency_hz) or self.target_frequency_hz <= 0:
+                raise ValueError("target frequency must be positive and finite")
+        if not np.isfinite(self.attention_gain) or self.attention_gain < 0:
+            raise ValueError("attention gain must be non-negative and finite")
         for event in self.artifacts:
             event.validate(self.duration_s)
         _validate_scalar_mapping("stage.target", self.target)
@@ -176,6 +259,8 @@ class ArenaScenario:
     def validate(self) -> None:
         if not self.name or not self.stages:
             raise ValueError("scenario name and at least one stage are required")
+        if isinstance(self.seed, (bool, np.bool_)) or not isinstance(self.seed, (int, np.integer)) or int(self.seed) < 0:
+            raise ValueError("scenario seed must be a non-negative integer")
         for stage in self.stages:
             stage.validate()
 
@@ -186,13 +271,18 @@ class ArenaScenario:
     def from_dict(cls, raw: dict[str, Any]) -> "ArenaScenario":
         stages = []
         for stage_raw in raw.get("stages", []):
-            artifacts = tuple(ArtifactEvent(**event) for event in stage_raw.get("artifacts", []))
+            artifacts = []
+            for event_raw in stage_raw.get("artifacts", []):
+                event_values = dict(event_raw)
+                if event_values.get("channels") is not None:
+                    event_values["channels"] = tuple(str(value) for value in event_values["channels"])
+                artifacts.append(ArtifactEvent(**event_values))
             stages.append(StageSpec(
                 label=stage_raw["label"],
                 duration_s=float(stage_raw["duration_s"]),
                 target_frequency_hz=(None if stage_raw.get("target_frequency_hz") is None else float(stage_raw["target_frequency_hz"])),
                 attention_gain=float(stage_raw.get("attention_gain", 1.0)),
-                artifacts=artifacts,
+                artifacts=tuple(artifacts),
                 target=dict(stage_raw.get("target", {})),
                 task_state=dict(stage_raw.get("task_state", {})),
             ))

--- a/packages/neuros-arena/src/neuros/arena/world_input.py
+++ b/packages/neuros-arena/src/neuros/arena/world_input.py
@@ -1,6 +1,6 @@
 """Paradigm-neutral causal input blocks for neural world models.
 
-Manifest v1 remains SSVEP-friendly, but the model boundary should not be. A
+Arena manifests remain SSVEP-friendly, but the model boundary should not be. A
 world model may consume this richer block through ``render_world`` while legacy
 models continue to implement the original ``render`` method.
 """
@@ -55,6 +55,8 @@ class WorldInputBlock:
                     raise ValueError(f"{mapping_name} keys must be non-empty strings")
                 if not isinstance(value, (str, int, float, bool)) and value is not None:
                     raise ValueError(f"{mapping_name}.{key} must be a JSON scalar")
+                if isinstance(value, (float, np.floating)) and not np.isfinite(value):
+                    raise ValueError(f"{mapping_name}.{key} must be finite")
 
     @property
     def visual_luminance(self) -> np.ndarray:

--- a/packages/neuros-arena/src/neuros/arena/world_models.py
+++ b/packages/neuros-arena/src/neuros/arena/world_models.py
@@ -12,11 +12,15 @@ human digital twins.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, Sequence
 
 import numpy as np
 
-from neuros.drivers.synthetic_eeg import SyntheticEEGConfig, SyntheticEEGGenerator
+from neuros.drivers.synthetic_eeg import (
+    ArtifactEvent as DriverArtifactEvent,
+    SyntheticEEGConfig,
+    SyntheticEEGGenerator,
+)
 
 from .specs import ParticipantProfile
 
@@ -35,7 +39,13 @@ class WorldModelEmission:
 
 
 class NeuralWorldModel(Protocol):
-    """Minimal contract implemented by Arena-compatible neural generators."""
+    """Minimal contract implemented by Arena-compatible neural generators.
+
+    `inject_artifact` remains the compatibility floor for external world-model
+    plugins. Built-in models additionally expose `schedule_artifact`; the Arena
+    runner detects that capability and uses sample-indexed compilation when it is
+    present rather than making it mandatory for older plugins.
+    """
 
     name: str
     channel_names: tuple[str, ...]
@@ -87,6 +97,27 @@ class LegacySyntheticWorldModel:
     def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
         self.generator.inject_artifact(kind, duration_seconds=duration_seconds, severity=severity)
 
+    def schedule_artifact(
+        self,
+        kind: str,
+        *,
+        event_id: str,
+        start_sample: int,
+        duration_seconds: float,
+        severity: float,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> DriverArtifactEvent:
+        return self.generator.schedule_artifact(
+            kind,
+            event_id=event_id,
+            start_sample=start_sample,
+            duration_seconds=duration_seconds,
+            severity=severity,
+            channels=channels,
+            seed=seed,
+        )
+
     def render(
         self,
         sample_times_s: np.ndarray,
@@ -111,66 +142,79 @@ class LegacySyntheticWorldModel:
 
 
 class _ArtifactEngine:
-    """Stateful artifact overlay shared by phenomenological world models."""
+    """Arena adapter over the canonical v3 sample-indexed artifact renderer.
+
+    Arena used to carry an independent mutable one-slot artifact engine. That
+    duplicated source-artifact semantics and reintroduced block-boundary dropout
+    leakage. This adapter deliberately delegates event timing/waveforms/seeding to
+    `SyntheticEEGGenerator` configured with zero background neural amplitudes.
+    Arena world models then overlay the returned additive signal and apply exact
+    dropout masks using the same event provenance.
+    """
 
     def __init__(self, sampling_rate_hz: float, seed: int) -> None:
         self.fs = float(sampling_rate_hz)
-        self.rng = np.random.default_rng(seed)
-        self.kind: str | None = None
-        self.remaining = 0
-        self.total = 0
-        self.severity = 1.0
+        self.generator = SyntheticEEGGenerator(SyntheticEEGConfig(
+            sampling_rate_hz=self.fs,
+            channel_names=SOURCE_CHANNELS,
+            colored_noise_uv=0.0,
+            white_noise_uv=0.0,
+            alpha_amplitude_uv=0.0,
+            ssvep_amplitude_uv=0.0,
+            seed=int(seed),
+        ))
 
     def inject(self, kind: str, duration_seconds: float, severity: float) -> None:
-        if kind not in {"blink", "jaw", "controller", "motion", "saturation", "dropout"}:
-            raise ValueError(f"unsupported artifact kind: {kind}")
-        if duration_seconds <= 0 or severity < 0:
-            raise ValueError("artifact duration must be positive and severity non-negative")
-        self.kind = kind
-        self.total = max(1, int(round(duration_seconds * self.fs)))
-        self.remaining = self.total
-        self.severity = float(severity)
+        self.generator.inject_artifact(kind, duration_seconds, severity)
 
-    def render(self, times_s: np.ndarray) -> tuple[np.ndarray, str | None]:
+    def schedule(
+        self,
+        kind: str,
+        *,
+        event_id: str,
+        start_sample: int,
+        duration_seconds: float,
+        severity: float,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> DriverArtifactEvent:
+        return self.generator.schedule_artifact(
+            kind,
+            event_id=event_id,
+            start_sample=start_sample,
+            duration_seconds=duration_seconds,
+            severity=severity,
+            channels=channels,
+            seed=seed,
+        )
+
+    def render(
+        self,
+        times_s: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray, tuple[DriverArtifactEvent, ...]]:
         samples = int(times_s.size)
-        output = np.zeros((8, samples), dtype=float)
-        if self.kind is None or self.remaining <= 0:
-            return output, None
-        kind = self.kind
-        count = min(samples, self.remaining)
-        start = self.total - self.remaining
-        phase = (np.arange(count, dtype=float) + start) / max(self.total - 1, 1)
-        severity = self.severity
-        if kind == "blink":
-            pulse = np.sin(np.pi * np.clip(phase, 0.0, 1.0)) ** 2
-            output[:, :count] += FRONTAL_WEIGHTS[:, None] * (120.0 * severity * pulse)
-        elif kind == "jaw":
-            t = times_s[:count]
-            hf = (
-                np.sin(2 * np.pi * 38.0 * t)
-                + 0.8 * np.sin(2 * np.pi * 53.0 * t + 0.7)
-                + 0.55 * np.sin(2 * np.pi * 71.0 * t + 1.1)
+        if samples == 0:
+            return (
+                np.empty((8, 0), dtype=float),
+                np.empty((8, 0), dtype=bool),
+                (),
             )
-            output[:, :count] += (0.55 * CENTRAL_WEIGHTS + 0.35)[:, None] * (48.0 * severity * hf)
-        elif kind == "controller":
-            t = times_s[:count]
-            hf = (
-                np.sin(2 * np.pi * 31.0 * t)
-                + 0.55 * np.sin(2 * np.pi * 46.0 * t + 0.4)
-                + 0.30 * self.rng.normal(size=count)
-            )
-            output[:, :count] += CENTRAL_WEIGHTS[:, None] * (24.0 * severity * hf)
-        elif kind == "motion":
-            drift = np.sin(np.pi * np.clip(phase, 0.0, 1.0)) * np.sign(np.sin(2 * np.pi * 2.2 * times_s[:count]))
-            output[:, :count] += (0.60 + 0.40 * FRONTAL_WEIGHTS)[:, None] * (55.0 * severity * drift)
-        elif kind == "saturation":
-            output[6, :count] += 480.0 * severity
-        elif kind == "dropout":
-            output[6, :count] = np.nan
-        self.remaining -= count
-        if self.remaining <= 0:
-            self.kind = None
-        return output, kind
+        block_start = self.generator.sample_index
+        block = self.generator.render(samples)
+        dropout_mask = np.zeros((8, samples), dtype=bool)
+        for event in block.artifact_events:
+            if event.kind != "dropout":
+                continue
+            overlap_start = max(block_start, event.start_sample)
+            overlap_end = min(block_start + samples, event.end_sample)
+            if overlap_start >= overlap_end:
+                continue
+            channels = event.channel_indices or (6,)
+            dropout_mask[
+                list(channels),
+                overlap_start - block_start : overlap_end - block_start,
+            ] = True
+        return block.data_uv.astype(float), dropout_mask, block.artifact_events
 
 
 class DrivenStateSpaceWorldModel:
@@ -223,6 +267,27 @@ class DrivenStateSpaceWorldModel:
     def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
         self._artifact.inject(kind, duration_seconds, severity)
 
+    def schedule_artifact(
+        self,
+        kind: str,
+        *,
+        event_id: str,
+        start_sample: int,
+        duration_seconds: float,
+        severity: float,
+        channels: str | int | Sequence[str | int] | None = None,
+        seed: int | None = None,
+    ) -> DriverArtifactEvent:
+        return self._artifact.schedule(
+            kind,
+            event_id=event_id,
+            start_sample=start_sample,
+            duration_seconds=duration_seconds,
+            severity=severity,
+            channels=channels,
+            seed=seed,
+        )
+
     def render(
         self,
         sample_times_s: np.ndarray,
@@ -270,13 +335,9 @@ class DrivenStateSpaceWorldModel:
                 * self.participant.ssvep_amplitude_uv
                 * (self._resonator_x + self.participant.first_harmonic_ratio * self._entrainment * harmonic)
             )
-        artifact, artifact_kind = self._artifact.render(times)
-        dropout = artifact_kind == "dropout"
-        if dropout:
-            artifact = np.nan_to_num(artifact, nan=0.0)
+        artifact, dropout_mask, _artifact_events = self._artifact.render(times)
         data += artifact
-        if dropout:
-            data[6, :] = 0.0
+        data[dropout_mask] = 0.0
         return WorldModelEmission(
             data_uv=data.astype(np.float32),
             latent={

--- a/tests/test_arena_conformance.py
+++ b/tests/test_arena_conformance.py
@@ -84,4 +84,4 @@ def test_adversarial_search_returns_portable_worst_worlds():
     assert result.evaluated == 8
     assert len(result.counterexamples) == 3
     assert result.counterexamples[0].objective <= result.counterexamples[-1].objective
-    assert result.counterexamples[0].manifest["schema"] == "neuros.synthetic_bci_arena.manifest.v1"
+    assert result.counterexamples[0].manifest["schema"] == "neuros.synthetic_bci_arena.manifest.v2"

--- a/tests/test_arena_leadfield.py
+++ b/tests/test_arena_leadfield.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from neuros.arena import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile, WorldModelProfile, run_scenario
+from neuros.arena import ArenaScenario, ArtifactEvent, DeviceProfile, DisplayProfile, ParticipantProfile, StageSpec, TransportProfile, WorldModelProfile, run_scenario
 from neuros.arena.leadfield import BUNDLE_SCHEMA, save_leadfield_bundle
 
 
@@ -51,6 +51,57 @@ def test_leadfield_bundle_round_trip_and_display_driven_projection(tmp_path):
     latent = clean.report["metrics"]["world_model"]["stage_end_latent"][-1]
     assert latent["leadfield_projection"] == 1.0
     assert not np.array_equal(clean.device_output.data_uv, broken.device_output.data_uv)
+
+
+def test_leadfield_standard_montage_uses_sample_indexed_artifact_schedule(tmp_path):
+    path = tmp_path / "leadfield-artifacts.npz"
+    make_bundle(path)
+    scenario = ArenaScenario(
+        "leadfield-artifact",
+        (
+            StageSpec(
+                "sight",
+                1.0,
+                10.0,
+                0.8,
+                (
+                    ArtifactEvent(
+                        0.24,
+                        "dropout",
+                        0.12,
+                        1.0,
+                        event_id="leadfield-oz-drop",
+                        channels=("Oz",),
+                    ),
+                ),
+            ),
+        ),
+        seed=29,
+    )
+    run = run_scenario(
+        scenario,
+        ParticipantProfile(seed=29),
+        DeviceProfile(chunk_samples=31, sensor_noise_uv=0.0, line_noise_uv=0.0),
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        TransportProfile(),
+        WorldModelProfile("leadfield_driven", {"path": str(path)}),
+    )
+
+    world = run.report["metrics"]["world_model"]
+    assert world["artifact_execution"] == "sample_indexed"
+    assert len(world["compiled_artifact_schedule"]) == 1
+    event = world["compiled_artifact_schedule"][0]
+    assert event["start_sample"] == 60
+    assert event["end_sample"] == 90
+    assert event["channel_indices"] == [6]
+
+    quantized_zero = run.device_output.lsb_uv / 2.0
+    np.testing.assert_allclose(
+        run.device_output.data_uv[6, 60:90],
+        quantized_zero,
+        atol=run.device_output.lsb_uv * 1e-4,
+        rtol=0.0,
+    )
 
 
 def test_leadfield_bundle_normalizes_visual_topography(tmp_path):

--- a/tests/test_arena_timing.py
+++ b/tests/test_arena_timing.py
@@ -72,3 +72,53 @@ def test_residual_sync_error_is_reported_independently_from_delivery_latency():
     assert metrics["corrected_timestamp_p95_abs_ms"] > 1.0
     assert metrics["corrected_timestamp_max_abs_ms"] >= metrics["corrected_timestamp_p95_abs_ms"]
     assert abs(metrics["source_clock_drift_ppm_estimated"] - 75.0) < 20.0
+
+
+def test_non_grid_stage_durations_resolve_on_one_continuous_source_sample_clock():
+    fs = 250.0
+    scenario = ArenaScenario(
+        "non-grid-stage-clock",
+        (
+            StageSpec("first", 0.75, None, 0.0),
+            StageSpec("second", 0.50, 10.0, 0.8),
+        ),
+        seed=73,
+    )
+    run = run_scenario(
+        scenario,
+        ParticipantProfile(seed=73),
+        DeviceProfile(
+            sampling_rate_hz=fs,
+            chunk_samples=37,
+            sensor_noise_uv=0.0,
+            line_noise_uv=0.0,
+            timestamp_jitter_ms=0.0,
+        ),
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        TransportProfile(),
+    )
+
+    # round(0.75 * 250) = 188 samples, so the first stage resolves to
+    # 0.752 seconds. The second stage must start on sample 188 rather than the
+    # requested floating boundary at 0.750 seconds.
+    assert run.stages[0].start_s == 0.0
+    assert np.isclose(run.stages[0].end_s, 188 / fs)
+    assert np.isclose(run.stages[1].start_s, 188 / fs)
+    assert np.isclose(run.stages[1].end_s, 313 / fs)
+    assert np.count_nonzero(run.stage_index == 0) == 188
+    assert np.count_nonzero(run.stage_index == 1) == 125
+
+    timestamps = run.device_output.ground_truth_timestamps_s
+    np.testing.assert_allclose(np.diff(timestamps), 1.0 / fs, rtol=0.0, atol=1e-12)
+    assert np.isclose(timestamps[187], 187 / fs)
+    assert np.isclose(timestamps[188], 188 / fs)
+
+    timing = run.report["metrics"]["stage_timing"]
+    assert timing[0]["start_sample"] == 0
+    assert timing[0]["end_sample"] == 188
+    assert timing[0]["requested_duration_s"] == 0.75
+    assert np.isclose(timing[0]["resolved_duration_s"], 0.752)
+    assert np.isclose(timing[0]["duration_error_ms"], 2.0)
+    assert timing[1]["start_sample"] == 188
+    assert timing[1]["end_sample"] == 313
+    assert np.isclose(timing[1]["duration_error_ms"], 0.0)

--- a/tests/test_arena_world_models.py
+++ b/tests/test_arena_world_models.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+import neuros.arena.runner as arena_runner
 from neuros.arena import (
     ArenaScenario,
+    ArtifactEvent,
     DeviceProfile,
     DisplayProfile,
     ParticipantProfile,
     StageSpec,
     TransportProfile,
+    WorldModelEmission,
     WorldModelProfile,
     run_scenario,
 )
@@ -105,3 +108,200 @@ def test_display_distortion_changes_causal_state_space_emission():
     clean_snr = clean.report["metrics"]["target_snr_db"]["10Hz"]
     broken_snr = broken.report["metrics"]["target_snr_db"]["10Hz"]
     assert np.isfinite(clean_snr) and np.isfinite(broken_snr)
+
+
+def _artifact_world(events: tuple[ArtifactEvent, ...], *, device_chunk_samples: int):
+    artifact_scenario = ArenaScenario(
+        "artifact-order-contract",
+        (
+            StageSpec("rest", 0.5, None, 0.0),
+            StageSpec("sight", 1.5, 10.0, 0.9, events),
+        ),
+        seed=43,
+    )
+    return run_scenario(
+        artifact_scenario,
+        ParticipantProfile(seed=43, ssvep_amplitude_uv=6.5),
+        DeviceProfile(
+            chunk_samples=device_chunk_samples,
+            sensor_noise_uv=0.0,
+            line_noise_uv=0.0,
+            timestamp_jitter_ms=0.0,
+        ),
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        TransportProfile(),
+        WorldModelProfile("driven_state_space"),
+    )
+
+
+def _compiled_semantics(run) -> list[tuple[object, ...]]:
+    schedule = run.report["metrics"]["world_model"]["compiled_artifact_schedule"]
+    return [
+        (
+            item["event_id"],
+            item["kind"],
+            item["start_sample"],
+            item["end_sample"],
+            tuple(item["channel_indices"] or ()),
+            item["seed"],
+        )
+        for item in schedule
+    ]
+
+
+def test_sample_indexed_artifacts_ignore_manifest_order_and_device_chunking():
+    events = (
+        ArtifactEvent(0.31, "controller", 0.42, 0.75),
+        ArtifactEvent(0.36, "blink", 0.24, 0.55),
+        ArtifactEvent(0.48, "dropout", 0.19, 1.0, channels=("PO7", "Oz")),
+    )
+    forward = _artifact_world(events, device_chunk_samples=5)
+    reversed_world = _artifact_world(tuple(reversed(events)), device_chunk_samples=37)
+
+    assert forward.report["metrics"]["world_model"]["artifact_execution"] == "sample_indexed"
+    assert reversed_world.report["metrics"]["world_model"]["artifact_execution"] == "sample_indexed"
+    np.testing.assert_array_equal(forward.device_output.data_uv, reversed_world.device_output.data_uv)
+    np.testing.assert_array_equal(
+        forward.device_output.ground_truth_timestamps_s,
+        reversed_world.device_output.ground_truth_timestamps_s,
+    )
+    assert _compiled_semantics(forward) == _compiled_semantics(reversed_world)
+
+
+def test_dropout_crosses_stage_boundary_with_exact_compiled_channel_support():
+    artifact_scenario = ArenaScenario(
+        "cross-stage-dropout",
+        (
+            StageSpec(
+                "sight",
+                1.0,
+                10.0,
+                0.85,
+                (
+                    ArtifactEvent(
+                        0.92,
+                        "dropout",
+                        0.20,
+                        1.0,
+                        event_id="posterior-contact",
+                        channels=("PO7", "Oz"),
+                    ),
+                ),
+            ),
+            StageSpec("rest", 0.5, None, 0.0),
+        ),
+        seed=47,
+    )
+    run = run_scenario(
+        artifact_scenario,
+        ParticipantProfile(seed=47),
+        DeviceProfile(chunk_samples=37, sensor_noise_uv=0.0, line_noise_uv=0.0),
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        TransportProfile(),
+        WorldModelProfile("driven_state_space"),
+    )
+
+    schedule = run.report["metrics"]["world_model"]["compiled_artifact_schedule"]
+    assert len(schedule) == 1
+    event = schedule[0]
+    assert event["event_id"] == "posterior-contact"
+    assert event["start_sample"] == 230
+    assert event["end_sample"] == 280
+    assert event["channel_indices"] == [5, 6]
+
+    quantized_zero = run.device_output.lsb_uv / 2.0
+    np.testing.assert_allclose(
+        run.device_output.data_uv[[5, 6], 230:280],
+        quantized_zero,
+        atol=run.device_output.lsb_uv * 1e-4,
+        rtol=0.0,
+    )
+    assert not np.allclose(run.device_output.data_uv[5, 220:230], quantized_zero)
+    assert not np.allclose(run.device_output.data_uv[6, 280:290], quantized_zero)
+
+
+def test_duplicate_explicit_artifact_ids_fail_before_rendering():
+    duplicate = ArenaScenario(
+        "duplicate-artifact-id",
+        (
+            StageSpec(
+                "sight",
+                1.0,
+                10.0,
+                0.8,
+                (
+                    ArtifactEvent(0.2, "blink", event_id="same-id"),
+                    ArtifactEvent(0.4, "controller", event_id="same-id"),
+                ),
+            ),
+        ),
+        seed=53,
+    )
+    with pytest.raises(ValueError, match="event_id already scheduled"):
+        run_scenario(
+            duplicate,
+            ParticipantProfile(seed=53),
+            DeviceProfile(chunk_samples=5),
+            DisplayProfile(),
+            TransportProfile(),
+            WorldModelProfile("driven_state_space"),
+        )
+
+
+def test_external_legacy_world_model_remains_runnable_and_is_labelled_weaker(monkeypatch):
+    class LegacyPlugin:
+        name = "external_legacy"
+        channel_names = tuple(CHANNELS.tolist())
+
+        def __init__(self) -> None:
+            self.injected: list[tuple[str, float, float]] = []
+
+        def inject_artifact(self, kind: str, duration_seconds: float, severity: float) -> None:
+            self.injected.append((kind, duration_seconds, severity))
+
+        def render(
+            self,
+            sample_times_s: np.ndarray,
+            emitted_stimulus: np.ndarray,
+            target_frequency_hz: float | None,
+            attention_gain: float,
+        ) -> WorldModelEmission:
+            del emitted_stimulus, target_frequency_hz
+            samples = int(np.asarray(sample_times_s).size)
+            return WorldModelEmission(
+                data_uv=np.zeros((8, samples), dtype=np.float32),
+                latent={
+                    "attention_gain": float(attention_gain),
+                    "stimulus_coupling": 0.0,
+                },
+            )
+
+    plugin = LegacyPlugin()
+    monkeypatch.setattr(arena_runner, "load_plugin", lambda *args, **kwargs: plugin)
+    legacy_scenario = ArenaScenario(
+        "external-legacy-fallback",
+        (
+            StageSpec(
+                "sight",
+                0.5,
+                10.0,
+                0.8,
+                (ArtifactEvent(0.13, "blink", 0.10, 0.5),),
+            ),
+        ),
+        seed=59,
+    )
+    run = run_scenario(
+        legacy_scenario,
+        ParticipantProfile(seed=59),
+        DeviceProfile(chunk_samples=37, sensor_noise_uv=0.0, line_noise_uv=0.0),
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        TransportProfile(),
+        WorldModelProfile("external_legacy"),
+    )
+
+    world = run.report["metrics"]["world_model"]
+    assert world["artifact_execution"] == "legacy_injection"
+    assert world["compiled_artifact_schedule"] == []
+    assert plugin.injected == [("blink", 0.10, 0.5)]
+    assert run.report["world_model_evidence"]["evidence_level"] == "W?-external-unqualified"

--- a/tests/test_synthetic_bci_arena.py
+++ b/tests/test_synthetic_bci_arena.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 import json
 
 import numpy as np
+import pytest
 
 from neuros.arena import (
     ArenaDecision,
     ArenaManifest,
     ArenaScenario,
+    ArtifactEvent,
     DeviceProfile,
     DisplayProfile,
     ParticipantProfile,
     StageSpec,
     TransportProfile,
+    WorldInputBlock,
     WorldModelProfile,
     compare_feature_signatures,
     evaluate_decisions,
@@ -21,6 +24,7 @@ from neuros.arena import (
     run_scenario,
     save_manifest,
 )
+from neuros.arena.manifest import SCHEMA, SCHEMA_V1, manifest_from_dict
 
 
 def tiny_world(
@@ -109,21 +113,92 @@ def test_feature_signature_comparison_is_identity_for_same_data():
     assert comparison["max_abs_log_ratio"] == 0.0
 
 
-def test_manifest_round_trip(tmp_path):
-    run = tiny_world(world_model=WorldModelProfile("driven_state_space", {"resonance_damping": 0.31}))
-    manifest = ArenaManifest(
-        run.scenario,
-        run.participant,
-        run.device,
-        run.display,
-        run.transport,
-        run.world_model,
+def test_world_input_rejects_non_finite_scalar_metadata():
+    block = WorldInputBlock(
+        sample_times_s=np.asarray([0.0, 0.004]),
+        paradigm="ssvep",
+        stage_label="sight",
+        emitted_streams={"visual_luminance": np.asarray([1.0, -1.0])},
+        participant_state={"attention_gain": float("nan")},
     )
+    with pytest.raises(ValueError, match="participant_state.attention_gain must be finite"):
+        block.validate()
+
+    for mapping_name in ("target", "task_state"):
+        kwargs = {
+            "sample_times_s": np.asarray([0.0]),
+            "paradigm": "ssvep",
+            "stage_label": "sight",
+            "emitted_streams": {"visual_luminance": np.asarray([0.0])},
+            mapping_name: {"bad": float("inf")},
+        }
+        with pytest.raises(ValueError, match=rf"{mapping_name}.bad must be finite"):
+            WorldInputBlock(**kwargs).validate()
+
+
+def _artifact_manifest() -> ArenaManifest:
+    scenario = ArenaScenario(
+        "manifest-artifacts",
+        (
+            StageSpec(
+                "sight",
+                1.0,
+                10.0,
+                0.8,
+                (
+                    ArtifactEvent(
+                        0.2,
+                        "controller",
+                        0.3,
+                        0.7,
+                        event_id="hand-1",
+                        channels=("C3", "C4"),
+                        seed=19,
+                    ),
+                ),
+            ),
+        ),
+        seed=17,
+    )
+    return ArenaManifest(
+        scenario,
+        ParticipantProfile(seed=17),
+        DeviceProfile(chunk_samples=5),
+        DisplayProfile(),
+        TransportProfile(),
+        WorldModelProfile("driven_state_space", {"resonance_damping": 0.31}),
+    )
+
+
+def test_manifest_round_trip_writes_v2_and_preserves_artifact_provenance(tmp_path):
+    manifest = _artifact_manifest()
     path = tmp_path / "world.json"
     save_manifest(manifest, path)
     loaded = load_manifest(path)
     assert loaded == manifest
     raw = json.loads(path.read_text(encoding="utf-8"))
-    assert raw["schema"] == "neuros.synthetic_bci_arena.manifest.v1"
+    assert raw["schema"] == SCHEMA == "neuros.synthetic_bci_arena.manifest.v2"
     assert raw["world_model"]["name"] == "driven_state_space"
     assert raw["world_model"]["parameters"]["resonance_damping"] == 0.31
+    artifact = raw["scenario"]["stages"][0]["artifacts"][0]
+    assert artifact["event_id"] == "hand-1"
+    assert artifact["channels"] == ["C3", "C4"]
+    assert artifact["seed"] == 19
+
+
+def test_manifest_v1_remains_readable_with_historical_artifact_shape():
+    manifest = _artifact_manifest()
+    raw = manifest.to_dict()
+    raw["schema"] = SCHEMA_V1
+    artifact = raw["scenario"]["stages"][0]["artifacts"][0]
+    artifact.pop("event_id")
+    artifact.pop("channels")
+    artifact.pop("seed")
+
+    loaded = manifest_from_dict(raw)
+    loaded_artifact = loaded.scenario.stages[0].artifacts[0]
+    assert loaded_artifact.event_id is None
+    assert loaded_artifact.channels is None
+    assert loaded_artifact.seed is None
+    assert loaded_artifact.at_s == 0.2
+    assert loaded_artifact.kind == "controller"


### PR DESCRIPTION
## Why

Merged PR #61 established the canonical `neuros.synthetic_eeg.v3` sample-indexed artifact scheduler and anti-aliasing validity contract. Synthetic BCI Arena still collapsed its declarative artifact timeline back into mutable `model.inject_artifact(...)` calls, while several world models carried a second private artifact implementation.

That duplication reintroduced the same defect class at a higher layer: overlap was not first-class, dropout could depend on render partitioning, and stochastic identity could depend on incidental call/order structure.

This PR makes the Arena scenario/manifest the experiment authority and compiles it into the canonical v3 source schedule.

## Causal contract

```text
ArenaScenario / manifest
        ↓
stage-relative artifact events
        ↓
absolute source-sample schedule
        ↓
canonical synthetic_eeg v3 artifact renderer
        ↓
neural world model
        ↓
device simulation
        ↓
transport / packetization
```

A lower layer may not reach backward and change an upstream world. In particular, `DeviceProfile.chunk_samples` is acquisition/packetization geometry only; it no longer controls neural-world rendering.

## Arena manifest v2

New manifests are written as:

`neuros.synthetic_bci_arena.manifest.v2`

v2 artifact events can carry stable `event_id`, optional exact channel support, optional event-local seed, and existing onset/duration/kind/severity fields.

Frozen v1 manifests remain readable. Existing v1 examples and benchmark fixtures intentionally remain in the repository as compatibility tests.

## Sample-indexed compilation

Built-in v3-aware world models expose `schedule_artifact()`. Arena compiles all stage-relative artifact events before rendering.

For implicit event IDs:

- identity is derived from canonical event content, not tuple position;
- artifact-list reordering cannot steal or change stochastic seeds;
- exact duplicate events receive deterministic duplicate ordinals.

The report records the resolved schedule with source sample indices and v3 event provenance.

Older/external plugins that only implement `inject_artifact()` remain runnable through the historical block-triggered fallback, but reports label that path `legacy_injection` rather than crediting it with sample-indexed semantics. A regression also proves that an external plugin without an evidence card remains scientifically fail-closed as `W?-external-unqualified`.

## One artifact authority

Arena's private artifact implementation is replaced by an adapter over the canonical v3 `SyntheticEEGGenerator`, configured with zero background neural amplitudes.

The shared artifact authority covers:

- `LegacySyntheticWorldModel`;
- `DrivenStateSpaceWorldModel`;
- `SemiSyntheticReplayWorldModel`;
- standard-eight-channel `LeadFieldDrivenWorldModel`.

A holistic review also caught and fixed a hidden lead-field integration break where that model still expected the old two-value artifact-engine return signature.

## Device / neural authority repair

The review found that `DeviceProfile.chunk_samples` previously controlled both neural render blocks and packetization. Participant response was evaluated per neural block, so changing a device packet setting could change the synthetic brain signal.

Arena now uses an explicit internal neural render cadence (`render_chunk_samples=5`) independent of device packetization. PR #63 builds on this boundary by moving frequency-target participant dynamics themselves onto the source sample clock and proving W1/W2/W3 render-partition invariance.

## Source sample clock authority

Artifact scheduling previously advanced on cumulative source samples while stage timestamps advanced on requested floating durations. For example, `0.75 s × 250 Hz` resolves to 188 samples, or `0.752 s`; the old path could therefore place the next stage two milliseconds earlier than the source sample clock.

Arena now uses one continuous source sample clock across stages:

- sample counts are resolved once from requested duration and sample rate;
- the next stage starts at the previous stage's exclusive end sample;
- source timestamps remain uniformly spaced across boundaries;
- `stage_timing` records requested duration, resolved duration, start/end samples and rounding error.

A regression binds the `0.750 s → 188 samples → 0.752 s` case explicitly.

## Input-integrity hardening

Arena profile/spec validation rejects non-finite numeric controls across participant, device, display, transport, stages and artifacts, strengthens integer seed/chunk/ADC checks, and rejects duplicate/empty channel declarations.

`WorldInputBlock` also rejects non-finite scalar target/task/participant metadata so external rich world-model callers cannot bypass manifest guards with NaN or infinity.

## Adversarial contracts

The exact-head suite proves, among other things:

- overlapping artifact worlds are invariant to artifact tuple ordering;
- device chunk size 5 vs 37 does not alter upstream neural/device samples;
- implicit event identities/seeds are order-invariant;
- PO7/Oz dropout crossing a stage boundary masks the exact compiled source interval;
- duplicate explicit event IDs fail before rendering;
- standard lead-field worlds use the canonical sample-indexed scheduler;
- v2 manifests preserve event IDs/channels/seeds while v1 remains readable;
- generated counterexample manifests are v2;
- non-grid stage durations resolve onto one continuous source clock;
- external legacy world models remain runnable only through the explicitly weaker `legacy_injection` path.

## Report contract

Arena reports move to:

`neuros.synthetic_bci_arena.v2`

World metrics expose `render_chunk_samples`, `artifact_execution`, `compiled_artifact_schedule`, existing latent/display-coupling evidence, and per-stage sample-clock geometry.

One terminology cleanup remains intentionally deferred: historical `metrics.duration_s` is first-to-last sample span rather than `N/fs` observation duration. No current benchmark depends on it. A future report revision should expose `sample_span_s` and observation duration explicitly rather than silently changing an existing metric.

## Exact-head qualification

Production base:

`9d5f81c957e570327d31e84eb31d94cf3030c6b9`

Qualified head:

`732ced9e2c1c88613cf1e34d10da6e818d23b5c9`

Delta: **1 commit ahead, 0 behind, exactly 14 Arena/docs/test paths changed.**

All triggered exact-head workflows are green:

- **Synthetic BCI Arena**: Python 3.10/3.11/3.12 contracts, preset/v1-v2 manifest/benchmark CLI, wheel build, real-domain anchoring;
- **neurOS driver contracts**;
- **Developer Preview Journey** installed-wheel external-user path;
- **Public Trust Contracts**;
- **Ecosystem Compatibility**;
- **ORION Adaptation Authority**, inherited from the current production lineage;
- **full neurOS CI**, including wheel ownership, BCI smoke, recording, scientific/latency, Foundation, SourceWeigher, ORION, model/mech-int, kernel and hygiene lanes.

## Evidence boundary

This PR establishes deterministic experiment semantics and causal software layering. It does **not** establish physiological realism, physical Unicorn behavior, participant SSVEP performance, human decoder accuracy, closed-loop efficacy or clinical evidence.

Remaining empirical work includes physical display/headset timing, measured sensor/contact and artifact distributions, and participant-level qualification.

## Qualification state

**Exact-head software qualification is green. PR remains draft intentionally; it is not merged automatically, and PR #63 is stacked on this exact head.**