### PR TITLE
Arena participant response: sample-indexed dynamics across W1/W2/W3

### DIFF
--- a/.github/workflows/synthetic-arena.yml
+++ b/.github/workflows/synthetic-arena.yml
@@ -45,6 +45,9 @@ jobs:
         run: |
           pytest -q \
             tests/test_synthetic_bci_arena.py \
+            tests/test_arena_authority_contracts.py \
+            tests/test_arena_world_input.py \
+            tests/test_arena_participant_state.py \
             tests/test_arena_world_models.py \
             tests/test_arena_leadfield.py \
             tests/test_arena_population.py \

--- a/docs/ARENA_PARTICIPANT_RESPONSE.md
+++ b/docs/ARENA_PARTICIPANT_RESPONSE.md
@@ -1,0 +1,218 @@
+# Arena participant-response contract
+
+## Purpose
+
+Synthetic BCI Arena needs a layer between a scenario's requested task state and a neural world model. Without an explicit participant layer, response delay, target switching, fatigue and gaze assumptions tend to leak into whichever world model happens to be running.
+
+Arena therefore treats participant response as a separate causal layer:
+
+```text
+scenario / requested target
+        ↓
+participant response policy
+        ↓
+per-source-sample participant state
+        ↓
+neural world model
+        ↓
+sensor-space EEG
+        ↓
+device / transport / decoder / application
+```
+
+The first contract is:
+
+`neuros.arena.frequency_target_response.v1`
+
+It is deliberately scoped to **frequency-target visual attention**, primarily SSVEP-style synthetic worlds. It is not a general model of attention, cognition, P300, motor imagery, auditory BCI, workload, intent or human behavior.
+
+## Why this layer exists
+
+Before this contract, Arena computed effective participant gain once per neural render block. That created two undesirable properties:
+
+1. internal render chunk size could change the synthetic participant;
+2. every scenario stage boundary restarted response delay, even when two adjacent stages requested the same target.
+
+Those are software artifacts, not participant dynamics.
+
+The v1 compiler resolves the entire participant response on the **source sample clock before neural rendering**. World-model render partitioning can then change implementation batching without changing the upstream participant state.
+
+## Inputs
+
+The v1 compiler consumes the existing `ParticipantProfile` and frequency-target fields from `ArenaScenario`:
+
+- `StageSpec.target_frequency_hz`;
+- `StageSpec.attention_gain`;
+- `ParticipantProfile.response_delay_s`;
+- `ParticipantProfile.switch_time_constant_s`;
+- `ParticipantProfile.gaze_duty_cycle`;
+- `ParticipantProfile.response_attenuation_per_minute`.
+
+These parameter values define a synthetic world. They are not population estimates unless a separate empirical study justifies a particular distribution.
+
+## Outputs
+
+`compile_participant_state_trace(...)` returns `ParticipantStateTrace` with one value per source sample:
+
+- `attention_gain`: effective synthetic participant drive;
+- `requested_attention_gain`: requested drive after declared gaze/fatigue scaling;
+- `target_frequency_hz`: active frequency target, with NaN for rest/no-frequency target;
+- `target_switch`: frequency-target transition marker;
+- `sampling_rate_hz`;
+- versioned model identifier.
+
+The report exposes a compact participant-state summary including transition samples and effective/requested gain statistics.
+
+## Timing authority
+
+Participant timing is sample-indexed.
+
+For a declared response delay `d` and source sampling rate `fs`, the delay sample count is:
+
+```text
+ceil(d × fs)
+```
+
+This is intentionally conservative. A delay is a lower bound. For example:
+
+```text
+41 ms at 250 Hz = 10.25 samples
+```
+
+The synthetic response cannot begin on sample 10 at 40 ms. It first becomes eligible on sample 11 at 44 ms.
+
+Stage durations use the same resolved source sample clock as the Arena runner, so participant transitions align with stage/sample evidence rather than a second floating-duration timeline.
+
+## Target-transition semantics
+
+Stage labels are not participant causes.
+
+Two adjacent stages such as:
+
+```text
+sight-a: 10 Hz
+sight-b: 10 Hz
+```
+
+preserve the participant response state. Renaming or splitting a stage does not restart response delay.
+
+A true target change such as:
+
+```text
+10 Hz → 12 Hz
+```
+
+resets the v1 response state and begins the declared response delay.
+
+Transitions into or out of rest are also recorded. Initial rest is not reported as a transition because no target change has yet occurred.
+
+## Response dynamics
+
+After the delay, v1 uses a first-order discrete response state that approaches the current requested gain with `switch_time_constant_s`.
+
+`gaze_duty_cycle` is currently implemented as a deterministic attenuation multiplier. The name does **not** mean Arena is simulating literal eye-open/eye-closed occupancy sample by sample.
+
+`response_attenuation_per_minute` is a declared synthetic time-dependent attenuation. It should not be interpreted as measured human fatigue without external evidence.
+
+## WorldInputBlock
+
+The paradigm-neutral world-model boundary now distinguishes:
+
+```text
+participant_state
+```
+
+for scalar compatibility/summary values, and:
+
+```text
+participant_streams
+```
+
+for sample-aligned participant state.
+
+Built-in W1/W2/W3 frequency-target worlds consume `participant_streams["attention_gain"]` sample by sample.
+
+Older external plugins may continue to consume the scalar compatibility surface. They do not automatically acquire sample-indexed participant semantics.
+
+## World-model ladder
+
+### W0 `legacy_synthetic`
+
+W0 intentionally retains its historical scalar attention adapter. It exists as a regression fixture and does not claim sample-indexed participant-response fidelity.
+
+### W1 `driven_state_space`
+
+W1 consumes the effective attention stream per source sample. Background noise, entrainment and resonator dynamics advance in source-sample order.
+
+### W2 `semi_synthetic_replay`
+
+W2 consumes the same participant stream while preserving a recorded EEG background. Its injected response and harmonic term use per-sample entrainment state rather than a block-final value.
+
+### W3 `leadfield_driven`
+
+W3 consumes the same participant stream before projecting the visual response through the frozen lead-field topography. Random channel/background draws also advance per source sample so render batching cannot remap stochastic draws across channel/time coordinates.
+
+## Render-partition invariance
+
+For W1/W2/W3, the following is now a software contract:
+
+> Given the same scenario, participant profile, display, world parameters, seed and source sample clock, changing Arena's internal neural render chunk size must not change the generated source/device EEG.
+
+The test suite compares 1-sample and 37-sample render chunks exactly.
+
+This is not a claim that the synthetic EEG is physiologically realistic. It proves that implementation batching is not part of the synthetic causal world.
+
+## Paradigm boundary
+
+The v1 participant compiler keys off `target_frequency_hz`. A P300, motor-imagery or other non-frequency world therefore receives zero values from this particular participant stream unless it implements its own participant semantics.
+
+That behavior is intentional. Arena should not invent a universal participant model merely to fill a field.
+
+Future participant-response models should be explicitly versioned and paradigm-aware, for example:
+
+- oddball/ERP response-state models;
+- motor-imagery engagement/state models;
+- gaze/eye-tracking coupled models;
+- auditory attention models;
+- learned or empirically fitted participant models with held-out validation.
+
+They should plug into the same `WorldInputBlock.participant_streams` boundary without changing device, transport or application layers.
+
+## What this contract proves
+
+It can support statements such as:
+
+- participant state is deterministic for a fixed manifest/profile/seed;
+- stage-label-only splits do not reset frequency-target response;
+- declared delays never begin before the source sample at-or-after the delay;
+- W1/W2/W3 are invariant to internal neural render partitioning;
+- participant-stream geometry/non-finite values fail closed.
+
+## What it does not prove
+
+It does **not** prove:
+
+- human SSVEP latency distributions;
+- human gaze duty cycles;
+- a physiological fatigue law;
+- cortical mechanism validity;
+- target-hardware performance;
+- decoder accuracy on humans;
+- closed-loop efficacy;
+- suitability for clinical claims.
+
+Those require recordings, physical hardware and/or human studies under appropriate protocols.
+
+## Next scientific steps
+
+The useful next work is empirical rather than adding arbitrary simulator knobs:
+
+1. record physical display timing and Unicorn source timestamps;
+2. collect short stationary frequency-target sessions;
+3. estimate response onset, amplitude and switching distributions with uncertainty;
+4. repeat under controller movement and light combat;
+5. compare those measurements against the declared synthetic participant envelope;
+6. fit or reject participant parameter distributions using held-out sessions;
+7. preserve raw/derived evidence so synthetic calibration never becomes circular validation.
+
+The goal is not to make the simulator harder to distinguish from reality by eye. The goal is to make every assumption explicit enough that real observations can falsify it.

--- a/packages/neuros-arena/src/neuros/arena/__init__.py
+++ b/packages/neuros-arena/src/neuros/arena/__init__.py
@@ -31,6 +31,11 @@ from .evaluation import ArenaDecision, evaluate_decisions
 from .evidence import WorldModelEvidenceCard, evidence_card_for_model
 from .leadfield import LeadFieldDrivenWorldModel, export_mne_forward_bundle, save_leadfield_bundle
 from .manifest import ArenaManifest, load_manifest, save_manifest
+from .participant import (
+    PARTICIPANT_RESPONSE_MODEL,
+    ParticipantStateTrace,
+    compile_participant_state_trace,
+)
 from .population import ParameterDistribution, PopulationRun, PopulationSpec, run_population
 from .presets import get_preset, list_presets
 from .reality import RealityAnchorResult, anchor_worlds_by_covariance, anchor_worlds_by_embeddings
@@ -84,8 +89,10 @@ __all__ = [
     "MetamorphicResult",
     "MetricRule",
     "NeuralWorldModel",
+    "PARTICIPANT_RESPONSE_MODEL",
     "ParameterDistribution",
     "ParticipantProfile",
+    "ParticipantStateTrace",
     "PopulationRun",
     "PopulationSpec",
     "RealityAnchorResult",
@@ -103,6 +110,7 @@ __all__ = [
     "check_fail_closed_degradation",
     "check_transport_drop_monotonicity",
     "compare_feature_signatures",
+    "compile_participant_state_trace",
     "evaluate_application_trace",
     "evaluate_decisions",
     "evidence_card_for_model",

--- a/packages/neuros-arena/src/neuros/arena/evidence.py
+++ b/packages/neuros-arena/src/neuros/arena/evidence.py
@@ -38,6 +38,9 @@ class WorldModelEvidenceCard:
         return asdict(self)
 
 
+PARTICIPANT_STREAM_CONTRACT = "sample-indexed participant-response / render-partition invariance"
+
+
 _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
     "legacy_synthetic": WorldModelEvidenceCard(
         model_name="legacy_synthetic",
@@ -57,8 +60,12 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
         ),
         unsupported_claims=(
             "display-to-cortex causality",
+            "sample-indexed participant-response fidelity",
             "human response distribution",
             "anatomical source realism",
+        ),
+        notes=(
+            "W0 intentionally retains the historical scalar attention adapter; it is a regression fixture, not the Arena participant-dynamics authority.",
         ),
     ),
     "driven_state_space": WorldModelEvidenceCard(
@@ -74,6 +81,7 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
         validated_against=(
             "internal deterministic contracts",
             "display-causality metamorphic tests",
+            PARTICIPANT_STREAM_CONTRACT,
         ),
         intended_uses=(
             "closed-loop systems qualification",
@@ -87,6 +95,7 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
         ),
         notes=(
             "Phenomenological oscillator/background dynamics are chosen for causal controllability rather than cortical-mechanism fidelity.",
+            "Participant response delay/switching/gaze/fatigue are synthetic control assumptions compiled onto the source sample clock.",
         ),
     ),
     "semi_synthetic_replay": WorldModelEvidenceCard(
@@ -102,6 +111,7 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
         validated_against=(
             "portable recorded-background contract",
             "internal intervention-causality contracts",
+            PARTICIPANT_STREAM_CONTRACT,
         ),
         intended_uses=(
             "real-background decoder stress tests",
@@ -112,6 +122,9 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
             "the injected response occurred in the recorded participant",
             "full physiological interaction between intervention and background",
             "human closed-loop performance",
+        ),
+        notes=(
+            "The recorded background preserves observed nuisance/covariance structure, while the participant-response intervention remains synthetic and explicitly controlled.",
         ),
     ),
     "leadfield_driven": WorldModelEvidenceCard(
@@ -128,6 +141,7 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
             "portable lead-field contract",
             "explicit source-selection provenance",
             "internal display-causality contracts",
+            PARTICIPANT_STREAM_CONTRACT,
         ),
         intended_uses=(
             "montage/topography sensitivity studies",
@@ -138,6 +152,9 @@ _BUILTIN_CARDS: dict[str, WorldModelEvidenceCard] = {
             "subject-specific source localization unless the bundle is subject-specific and independently validated",
             "human response amplitude distribution",
             "human closed-loop performance",
+        ),
+        notes=(
+            "Lead-field projection is spatial structure, not evidence that the synthetic temporal participant dynamics match a human participant.",
         ),
     ),
 }

--- a/packages/neuros-arena/src/neuros/arena/leadfield.py
+++ b/packages/neuros-arena/src/neuros/arena/leadfield.py
@@ -21,6 +21,7 @@ import numpy as np
 from neuros.drivers.synthetic_eeg import ArtifactEvent as DriverArtifactEvent
 
 from .specs import ParticipantProfile
+from .world_input import WorldInputBlock
 from .world_models import WorldModelEmission, _ArtifactEngine
 
 
@@ -141,7 +142,14 @@ def export_mne_forward_bundle(
 
 
 class LeadFieldDrivenWorldModel:
-    """Display-driven neural dynamics projected through a frozen lead field."""
+    """Display-driven neural dynamics projected through a frozen lead field.
+
+    Arena's rich path supplies participant attention per source sample. Random
+    nuisance draws are also advanced one source sample at a time so internal
+    render partitioning cannot reassign stochastic values across channels/time.
+    The historical scalar ``render(...)`` surface remains available for callers
+    outside Arena and expands its scalar attention value across the block.
+    """
 
     name = "leadfield_driven"
 
@@ -212,6 +220,96 @@ class LeadFieldDrivenWorldModel:
             seed=seed,
         )
 
+    def _render_with_attention_stream(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: np.ndarray,
+    ) -> WorldModelEmission:
+        times = np.asarray(sample_times_s, dtype=float)
+        drive = np.asarray(emitted_stimulus, dtype=float)
+        gain = np.asarray(attention_gain, dtype=float)
+        if times.ndim != 1 or drive.shape != times.shape or gain.shape != times.shape:
+            raise ValueError("sample times, emitted stimulus and attention gain must be matching 1-D arrays")
+        if not np.all(np.isfinite(gain)) or np.any(gain < 0):
+            raise ValueError("attention gain stream must be finite and non-negative")
+
+        n_channels = len(self.channel_names)
+        samples = times.size
+        data = np.empty((n_channels, samples), dtype=float)
+        dt = 1.0 / self.fs
+        target_gain = gain if target_frequency_hz is not None else np.zeros(samples, dtype=float)
+        alpha_gain = np.abs(self.visual_topography).astype(float)
+        alpha_gain /= max(float(np.max(alpha_gain)), 1e-12)
+        persistence = 0.995
+        innovation = np.sqrt(1.0 - persistence**2)
+
+        for i in range(samples):
+            # Draw channel noise in source-sample order. A channels x block draw
+            # would assign the same RNG stream differently when blocks are split.
+            sample = self.rng.normal(0.0, self.participant.white_noise_uv, size=n_channels)
+            self._entrainment += (float(target_gain[i]) - self._entrainment) * min(1.0, dt / self._tau_s)
+            desired = float(np.clip(drive[i], -1.0, 1.0)) * self._entrainment
+            self._response_state += (desired - self._response_state) * min(1.0, dt / self._response_tau_s)
+            sample += (
+                self.visual_topography
+                * self.participant.ssvep_amplitude_uv
+                * self._response_state
+            )
+
+            if self.nuisance_topographies.size:
+                self._nuisance_state = (
+                    persistence * self._nuisance_state
+                    + innovation * self.rng.normal(size=self._nuisance_state.size)
+                )
+                sample += self.participant.colored_noise_uv * (
+                    self._nuisance_state @ self.nuisance_topographies
+                )
+            else:
+                sample += self.rng.normal(
+                    0.0,
+                    self.participant.colored_noise_uv,
+                    size=n_channels,
+                )
+
+            sample += (
+                alpha_gain
+                * self.participant.alpha_amplitude_uv
+                * np.sin(
+                    2 * np.pi * self.participant.alpha_frequency_hz * times[i]
+                    + self._alpha_phase
+                )
+            )
+            data[:, i] = sample
+
+        if self._artifact is not None:
+            artifact, dropout_mask, _artifact_events = self._artifact.render(times)
+            data += artifact
+            data[dropout_mask] = 0.0
+
+        return WorldModelEmission(
+            data_uv=data.astype(np.float32),
+            latent={
+                "attention_gain": float(target_gain[-1]) if target_gain.size else 0.0,
+                "entrainment": float(self._entrainment),
+                "stimulus_coupling": 1.0,
+                "participant_stream_coupling": 1.0,
+                "leadfield_projection": 1.0,
+            },
+        )
+
+    def render_world(self, block: WorldInputBlock) -> WorldModelEmission:
+        block.validate()
+        raw_frequency = block.target.get("frequency_hz")
+        target_frequency_hz = None if raw_frequency is None else float(raw_frequency)
+        return self._render_with_attention_stream(
+            block.sample_times_s,
+            block.visual_luminance,
+            target_frequency_hz,
+            block.attention_gain,
+        )
+
     def render(
         self,
         sample_times_s: np.ndarray,
@@ -220,52 +318,10 @@ class LeadFieldDrivenWorldModel:
         attention_gain: float,
     ) -> WorldModelEmission:
         times = np.asarray(sample_times_s, dtype=float)
-        drive = np.asarray(emitted_stimulus, dtype=float)
-        if times.ndim != 1 or drive.shape != times.shape:
-            raise ValueError("sample_times_s and emitted_stimulus must match")
-        n_channels = len(self.channel_names)
-        data = self.rng.normal(0.0, self.participant.white_noise_uv, size=(n_channels, times.size))
-        dt = 1.0 / self.fs
-        target_gain = max(0.0, float(attention_gain)) if target_frequency_hz is not None else 0.0
-        visual_response = np.zeros(times.size, dtype=float)
-        for i in range(times.size):
-            self._entrainment += (target_gain - self._entrainment) * min(1.0, dt / self._tau_s)
-            desired = float(np.clip(drive[i], -1.0, 1.0)) * self._entrainment
-            self._response_state += (desired - self._response_state) * min(1.0, dt / self._response_tau_s)
-            visual_response[i] = self._response_state
-        data += (
-            self.visual_topography[:, None]
-            * self.participant.ssvep_amplitude_uv
-            * visual_response[None, :]
-        )
-        # Use frozen lead-field nuisance topographies for low-frequency background
-        # sources, then add a global endogenous alpha component with channel gain
-        # derived from the absolute visual topography.
-        if self.nuisance_topographies.size:
-            persistence = 0.995
-            innovation = np.sqrt(1.0 - persistence**2)
-            for i in range(times.size):
-                self._nuisance_state = persistence * self._nuisance_state + innovation * self.rng.normal(size=self._nuisance_state.size)
-                data[:, i] += self.participant.colored_noise_uv * (self._nuisance_state @ self.nuisance_topographies)
-        else:
-            data += self.rng.normal(0.0, self.participant.colored_noise_uv, size=data.shape)
-        alpha_gain = np.abs(self.visual_topography)
-        alpha_gain /= max(float(np.max(alpha_gain)), 1e-12)
-        data += (
-            alpha_gain[:, None]
-            * self.participant.alpha_amplitude_uv
-            * np.sin(2 * np.pi * self.participant.alpha_frequency_hz * times + self._alpha_phase)[None, :]
-        )
-        if self._artifact is not None:
-            artifact, dropout_mask, _artifact_events = self._artifact.render(times)
-            data += artifact
-            data[dropout_mask] = 0.0
-        return WorldModelEmission(
-            data_uv=data.astype(np.float32),
-            latent={
-                "attention_gain": target_gain,
-                "entrainment": float(self._entrainment),
-                "stimulus_coupling": 1.0,
-                "leadfield_projection": 1.0,
-            },
+        gain = np.full(times.size, max(0.0, float(attention_gain)), dtype=float)
+        return self._render_with_attention_stream(
+            times,
+            emitted_stimulus,
+            target_frequency_hz,
+            gain,
         )

--- a/packages/neuros-arena/src/neuros/arena/participant.py
+++ b/packages/neuros-arena/src/neuros/arena/participant.py
@@ -1,0 +1,201 @@
+"""Deterministic participant-state traces for Synthetic BCI Arena.
+
+The first participant-response contract is deliberately narrow: it models
+frequency-target visual-attention dynamics for SSVEP-style worlds. It does not
+pretend that P300, motor-imagery, auditory or other paradigms share the same
+participant dynamics merely because they use the same ``WorldInputBlock``.
+
+The output is causal ground truth for a declared synthetic world, not a claim
+that human visual attention follows this exact dynamical system.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .specs import ArenaScenario, ParticipantProfile
+
+
+PARTICIPANT_RESPONSE_MODEL = "neuros.arena.frequency_target_response.v1"
+PARTICIPANT_RESPONSE_SCOPE = "frequency_target_visual_attention"
+
+
+@dataclass(frozen=True)
+class ParticipantStateTrace:
+    """Resolved per-sample frequency-target participant state.
+
+    ``target_switch`` is retained as the compact field name for this contract,
+    but its semantics are target transitions: it is true when an active frequency
+    target first appears or whenever target identity changes, including
+    active→rest and rest→active boundaries. Initial rest is not a transition.
+    """
+
+    attention_gain: np.ndarray
+    requested_attention_gain: np.ndarray
+    target_frequency_hz: np.ndarray
+    target_switch: np.ndarray
+    sampling_rate_hz: float
+    model: str = PARTICIPANT_RESPONSE_MODEL
+
+    def validate(self) -> None:
+        arrays = (
+            self.attention_gain,
+            self.requested_attention_gain,
+            self.target_frequency_hz,
+            self.target_switch,
+        )
+        sizes = {np.asarray(array).size for array in arrays}
+        if len(sizes) != 1:
+            raise ValueError("participant trace arrays must have equal length")
+        if self.sampling_rate_hz <= 0 or not np.isfinite(self.sampling_rate_hz):
+            raise ValueError("sampling_rate_hz must be positive and finite")
+        if not np.all(np.isfinite(self.attention_gain)):
+            raise ValueError("attention_gain trace must be finite")
+        if not np.all(np.isfinite(self.requested_attention_gain)):
+            raise ValueError("requested_attention_gain trace must be finite")
+        if np.any(self.attention_gain < 0) or np.any(self.requested_attention_gain < 0):
+            raise ValueError("participant attention gains must be non-negative")
+        target = np.asarray(self.target_frequency_hz, dtype=float)
+        finite_or_nan = np.isfinite(target) | np.isnan(target)
+        if not np.all(finite_or_nan):
+            raise ValueError("target_frequency_hz trace may contain only finite values or NaN rest markers")
+        transition = np.asarray(self.target_switch)
+        if transition.dtype.kind not in {"b", "i", "u"}:
+            raise ValueError("target_switch trace must be boolean/integer-like")
+
+    def to_summary(self) -> dict[str, object]:
+        self.validate()
+        transitions = np.flatnonzero(np.asarray(self.target_switch, dtype=bool))
+        target = np.asarray(self.target_frequency_hz, dtype=float)
+        transition_samples = [int(value) for value in transitions.tolist()]
+        return {
+            "model": self.model,
+            "scope": PARTICIPANT_RESPONSE_SCOPE,
+            "samples": int(np.asarray(self.attention_gain).size),
+            "sampling_rate_hz": float(self.sampling_rate_hz),
+            "target_transition_samples": transition_samples,
+            "target_switch_samples": transition_samples,
+            "peak_requested_attention_gain": float(np.max(self.requested_attention_gain, initial=0.0)),
+            "peak_effective_attention_gain": float(np.max(self.attention_gain, initial=0.0)),
+            "mean_effective_attention_gain": float(np.mean(self.attention_gain)) if self.attention_gain.size else 0.0,
+            "active_target_fraction": float(np.mean(np.isfinite(target))) if target.size else 0.0,
+        }
+
+
+def _stage_sample_count(duration_s: float, sampling_rate_hz: float) -> int:
+    return max(1, int(round(float(duration_s) * float(sampling_rate_hz))))
+
+
+def _delay_sample_count(delay_s: float, sampling_rate_hz: float) -> int:
+    """Return the first eligible sample count at-or-after a declared delay."""
+
+    # Delay is a causal lower bound. `round` could make a non-grid delay shorter
+    # than requested, e.g. 41 ms at 250 Hz -> 10 samples = 40 ms.
+    return max(0, int(np.ceil(float(delay_s) * float(sampling_rate_hz) - 1e-12)))
+
+
+def compile_participant_state_trace(
+    scenario: ArenaScenario,
+    participant: ParticipantProfile,
+    sampling_rate_hz: float,
+) -> ParticipantStateTrace:
+    """Compile frequency-target response dynamics onto the source sample clock.
+
+    Policy:
+
+    * only stages with ``target_frequency_hz`` participate in this v1 response
+      model; non-frequency paradigms receive zero values from this specific
+      stream and remain free to define their own participant semantics;
+    * stage ``attention_gain`` is the requested control magnitude;
+    * ``gaze_duty_cycle`` is represented as a deterministic attenuation factor,
+      not as a claim about literal eye-open sample occupancy;
+    * global response attenuation scales that request with elapsed source time;
+    * frequency-target identity changes reset effective attention and start the
+      declared response delay;
+    * the first non-zero response sample can occur only at-or-after that delay;
+    * after the delay, a first-order state approaches the current request using
+      ``switch_time_constant_s``;
+    * adjacent stages with the same target preserve response state rather than
+      restarting it because of scenario segmentation;
+    * rest/no-frequency-target samples revoke this response immediately.
+
+    These are transparent synthetic assumptions, not physiological population
+    estimates or a general participant model for all BCI paradigms.
+    """
+
+    scenario.validate()
+    participant.validate()
+    fs = float(sampling_rate_hz)
+    if fs <= 0 or not np.isfinite(fs):
+        raise ValueError("sampling_rate_hz must be positive and finite")
+
+    total_samples = sum(_stage_sample_count(stage.duration_s, fs) for stage in scenario.stages)
+    effective = np.zeros(total_samples, dtype=float)
+    requested = np.zeros(total_samples, dtype=float)
+    target_trace = np.full(total_samples, np.nan, dtype=float)
+    transition_trace = np.zeros(total_samples, dtype=bool)
+
+    delay_samples = _delay_sample_count(participant.response_delay_s, fs)
+    alpha = min(1.0, 1.0 / (fs * participant.switch_time_constant_s))
+    current_target: float | None = None
+    response_state = 0.0
+    delay_remaining = 0
+    cursor = 0
+    initialized = False
+
+    for stage in scenario.stages:
+        count = _stage_sample_count(stage.duration_s, fs)
+        target = None if stage.target_frequency_hz is None else float(stage.target_frequency_hz)
+        for local_index in range(count):
+            sample_index = cursor + local_index
+            if not initialized:
+                initialized = True
+                current_target = target
+                if target is not None:
+                    response_state = 0.0
+                    delay_remaining = delay_samples
+                    transition_trace[sample_index] = True
+            elif target != current_target:
+                current_target = target
+                response_state = 0.0
+                delay_remaining = delay_samples if target is not None else 0
+                transition_trace[sample_index] = True
+
+            if target is None:
+                requested_gain = 0.0
+                response_state = 0.0
+            else:
+                global_time_s = sample_index / fs
+                attenuation = max(
+                    0.0,
+                    1.0
+                    - participant.response_attenuation_per_minute
+                    * (global_time_s / 60.0),
+                )
+                requested_gain = (
+                    float(stage.attention_gain)
+                    * float(participant.gaze_duty_cycle)
+                    * attenuation
+                )
+                if delay_remaining > 0:
+                    response_state = 0.0
+                    delay_remaining -= 1
+                else:
+                    response_state += (requested_gain - response_state) * alpha
+
+            requested[sample_index] = requested_gain
+            effective[sample_index] = response_state
+            if target is not None:
+                target_trace[sample_index] = target
+        cursor += count
+
+    trace = ParticipantStateTrace(
+        attention_gain=effective.astype(np.float32),
+        requested_attention_gain=requested.astype(np.float32),
+        target_frequency_hz=target_trace,
+        target_switch=transition_trace,
+        sampling_rate_hz=fs,
+    )
+    trace.validate()
+    return trace

--- a/packages/neuros-arena/src/neuros/arena/runner.py
+++ b/packages/neuros-arena/src/neuros/arena/runner.py
@@ -10,6 +10,7 @@ import numpy as np
 from neuros.plugins import PluginKind, load_plugin
 
 from .evidence import evidence_card_for_model
+from .participant import compile_participant_state_trace
 from .simulators import DeviceOutput, StimulusTrace, TransportPacket, apply_device, packetize, sample_stimulus, simulate_stimulus
 from .specs import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, TransportProfile, WorldModelProfile
 from .world_input import WorldInputBlock
@@ -63,8 +64,6 @@ def _spectral_snr_db(data_uv: np.ndarray, fs: float, target_hz: float) -> float:
 
 
 def _stage_sample_count(duration_s: float, sampling_rate_hz: float) -> int:
-    """Resolve a requested stage duration onto the source sample clock."""
-
     return max(1, int(round(float(duration_s) * float(sampling_rate_hz))))
 
 
@@ -110,13 +109,6 @@ def _render_world_model(
 
 
 def _artifact_identity_payload(artifact) -> str:
-    """Canonical semantic identity for an Arena artifact without an explicit ID.
-
-    Tuple/list position is deliberately excluded. Exact duplicate events remain
-    meaningful, so the compiler adds a deterministic duplicate ordinal after
-    sorting by this canonical payload.
-    """
-
     payload = {
         "at_s": float(artifact.at_s),
         "channels": None if artifact.channels is None else sorted(str(name) for name in artifact.channels),
@@ -134,13 +126,6 @@ def _compile_artifact_schedule(
     participant: ParticipantProfile,
     sampling_rate_hz: float,
 ) -> tuple[str, list[dict[str, object]]]:
-    """Compile Arena stage artifacts to an absolute sample-indexed timeline.
-
-    Built-in v3-aware world models expose ``schedule_artifact``. Older/external
-    plugins may implement only ``inject_artifact``; those stay on the historical
-    block-triggered fallback and are labelled explicitly in the report.
-    """
-
     schedule = getattr(model, "schedule_artifact", None)
     if not callable(schedule):
         return "legacy_injection", []
@@ -150,29 +135,10 @@ def _compile_artifact_schedule(
     fs = float(sampling_rate_hz)
     for stage_i, stage in enumerate(scenario.stages):
         stage_samples = _stage_sample_count(stage.duration_s, fs)
-        entries = [
-            (
-                _artifact_identity_payload(artifact),
-                artifact_i,
-                artifact,
-            )
-            for artifact_i, artifact in enumerate(stage.artifacts)
-        ]
-        # Event order in a manifest is presentation, not causal authority. The
-        # canonical sort gives implicit stochastic events stable identities even
-        # when the artifact tuple is rearranged.
-        entries.sort(
-            key=lambda item: (
-                "" if item[2].event_id is None else str(item[2].event_id),
-                item[0],
-                item[1],
-            )
-        )
+        entries = [(_artifact_identity_payload(artifact), artifact_i, artifact) for artifact_i, artifact in enumerate(stage.artifacts)]
+        entries.sort(key=lambda item: ("" if item[2].event_id is None else str(item[2].event_id), item[0], item[1]))
         duplicate_ordinals: dict[str, int] = {}
         for identity_payload, artifact_i, artifact in entries:
-            # First source sample at-or-after requested onset. If no source sample
-            # exists before stage end, reject rather than shift the event into the
-            # previous sample or silently assign it to the next stage.
             onset_sample = int(np.ceil(artifact.at_s * fs - 1e-12))
             if onset_sample >= stage_samples:
                 raise ValueError(
@@ -242,13 +208,11 @@ def run_scenario(
     evidence_card = evidence_card_for_model(model, model_profile.name)
     paradigm = scenario.metadata.get("paradigm", "ssvep")
     artifact_execution, compiled_artifacts = _compile_artifact_schedule(
-        model,
-        scenario,
-        participant,
-        device.sampling_rate_hz,
+        model, scenario, participant, device.sampling_rate_hz
     )
 
     fs = float(device.sampling_rate_hz)
+    participant_trace = compile_participant_state_trace(scenario, participant, fs)
     block_samples = WORLD_RENDER_CHUNK_SAMPLES
     data_blocks: list[np.ndarray] = []
     timestamp_blocks: list[np.ndarray] = []
@@ -290,8 +254,9 @@ def run_scenario(
         while produced < samples_total:
             count = min(block_samples, samples_total - produced)
             sample_offsets = produced + np.arange(count, dtype=np.int64)
+            global_indices = global_sample_start + sample_offsets
             local_times = sample_offsets.astype(float) / fs
-            global_times = (global_sample_start + sample_offsets).astype(float) / fs
+            global_times = global_indices.astype(float) / fs
             elapsed = produced / fs
             if artifact_execution == "legacy_injection":
                 for artifact_i, artifact in enumerate(stage.artifacts):
@@ -302,14 +267,14 @@ def run_scenario(
                             severity=artifact.severity * participant.artifact_gain,
                         )
                         artifact_cursor.add(artifact_i)
-            if stage.target_frequency_hz is None:
-                effective_gain = 0.0
-            else:
-                after_delay = max(0.0, elapsed - participant.response_delay_s)
-                switch_gain = 0.0 if elapsed < participant.response_delay_s else 1.0 - np.exp(-after_delay / participant.switch_time_constant_s)
-                global_elapsed_min = float(global_times[0]) / 60.0
-                attenuation = max(0.0, 1.0 - participant.response_attenuation_per_minute * global_elapsed_min)
-                effective_gain = stage.attention_gain * participant.gaze_duty_cycle * switch_gain * attenuation
+
+            attention_stream = participant_trace.attention_gain[global_indices]
+            requested_attention_stream = participant_trace.requested_attention_gain[global_indices]
+            target_switch_stream = participant_trace.target_switch[global_indices].astype(float)
+            # Legacy render(...) plugins retain the historical scalar surface. The
+            # first source sample is the least surprising summary because the old
+            # runner updated the value at block start.
+            effective_gain = float(attention_stream[0]) if attention_stream.size else 0.0
             emitted_drive = sample_stimulus(trace, local_times, display)
             target = dict(stage.target)
             if stage.target_frequency_hz is not None:
@@ -321,13 +286,18 @@ def run_scenario(
                 emitted_streams={"visual_luminance": emitted_drive},
                 target=target,
                 task_state=dict(stage.task_state),
-                participant_state={"attention_gain": float(effective_gain)},
+                participant_state={"attention_gain": effective_gain},
+                participant_streams={
+                    "attention_gain": attention_stream,
+                    "requested_attention_gain": requested_attention_stream,
+                    "target_switch": target_switch_stream,
+                },
             )
             emission = _render_world_model(
                 model,
                 input_block=input_block,
                 target_frequency_hz=stage.target_frequency_hz,
-                attention_gain=float(effective_gain),
+                attention_gain=effective_gain,
             )
             if emission.data_uv.shape != (len(model.channel_names), count):
                 raise ValueError(
@@ -395,6 +365,7 @@ def run_scenario(
             "transport": transport_metrics,
             "display": display_metrics,
             "stage_timing": stage_timing,
+            "participant_state": participant_trace.to_summary(),
             "world_model": {
                 "name": model_profile.name,
                 "display_coupled": bool(any(item.get("stimulus_coupling", 0.0) > 0 for item in latent_stage_end)),

--- a/packages/neuros-arena/src/neuros/arena/semi_synthetic.py
+++ b/packages/neuros-arena/src/neuros/arena/semi_synthetic.py
@@ -1,17 +1,8 @@
 """Semi-synthetic EEG world model using real or recorded background data.
 
-The model replays an observed EEG background and injects a *known* response that
-is driven by Arena's emitted display waveform. This preserves much of the
-background covariance/artifact texture of recorded EEG while retaining exact
-causal ground truth for the injected BCI signal.
-
-Input NPZ contract:
-    data_uv: channels x samples
-    sampling_rate_hz: scalar
-    channel_names: string array
-
-The model never claims that its injected response is a faithful physiological
-model of the person represented by the background recording.
+The model replays an observed EEG background and injects a known response driven
+by Arena's emitted display waveform. Recorded background does not imply that the
+synthetic injected response occurred in the recorded participant.
 """
 from __future__ import annotations
 
@@ -23,6 +14,7 @@ import numpy as np
 from neuros.drivers.synthetic_eeg import ArtifactEvent as DriverArtifactEvent
 
 from .specs import ParticipantProfile
+from .world_input import WorldInputBlock
 from .world_models import POSTERIOR_WEIGHTS, SOURCE_CHANNELS, WorldModelEmission, _ArtifactEngine
 
 
@@ -113,30 +105,35 @@ class SemiSyntheticReplayWorldModel:
         self._cursor = int((self._cursor + samples) % self._baseline.shape[1])
         return block
 
-    def render(
+    def _render_with_attention_stream(
         self,
         sample_times_s: np.ndarray,
         emitted_stimulus: np.ndarray,
         target_frequency_hz: float | None,
-        attention_gain: float,
+        attention_gain: np.ndarray,
     ) -> WorldModelEmission:
         times = np.asarray(sample_times_s, dtype=float)
         drive = np.asarray(emitted_stimulus, dtype=float)
-        if drive.shape != times.shape:
-            raise ValueError("sample_times_s and emitted_stimulus must match")
+        gain = np.asarray(attention_gain, dtype=float)
+        if drive.shape != times.shape or gain.shape != times.shape:
+            raise ValueError("sample times, emitted stimulus and attention gain must match")
+        if not np.all(np.isfinite(gain)) or np.any(gain < 0):
+            raise ValueError("attention gain stream must be finite and non-negative")
         samples = times.size
         data = self._next_background(samples).astype(float)
         dt = 1.0 / self.fs
-        target_gain = max(0.0, float(attention_gain)) if target_frequency_hz is not None else 0.0
+        target_gain = gain if target_frequency_hz is not None else np.zeros(samples, dtype=float)
         response = np.zeros(samples, dtype=float)
+        entrainment_trace = np.zeros(samples, dtype=float)
         for i in range(samples):
-            self._entrainment += (target_gain - self._entrainment) * min(1.0, dt / self._tau_s)
+            self._entrainment += (float(target_gain[i]) - self._entrainment) * min(1.0, dt / self._tau_s)
+            entrainment_trace[i] = self._entrainment
             desired = float(np.clip(drive[i], -1.0, 1.0)) * self._entrainment
             self._response_state += (desired - self._response_state) * min(1.0, dt / 0.035)
             response[i] = self._response_state
         if target_frequency_hz is not None:
             harmonic = np.sin(4.0 * np.pi * float(target_frequency_hz) * times + 0.4)
-            response = response + self.participant.first_harmonic_ratio * self._entrainment * harmonic
+            response = response + self.participant.first_harmonic_ratio * entrainment_trace * harmonic
         data += (
             POSTERIOR_WEIGHTS[:, None]
             * self.participant.ssvep_amplitude_uv
@@ -149,9 +146,36 @@ class SemiSyntheticReplayWorldModel:
         return WorldModelEmission(
             data_uv=data.astype(np.float32),
             latent={
-                "attention_gain": target_gain,
+                "attention_gain": float(target_gain[-1]) if target_gain.size else 0.0,
                 "entrainment": float(self._entrainment),
                 "stimulus_coupling": 1.0,
+                "participant_stream_coupling": 1.0,
                 "baseline_replay": 1.0,
             },
+        )
+
+    def render_world(self, block: WorldInputBlock) -> WorldModelEmission:
+        block.validate()
+        raw_frequency = block.target.get("frequency_hz")
+        target_frequency_hz = None if raw_frequency is None else float(raw_frequency)
+        return self._render_with_attention_stream(
+            block.sample_times_s,
+            block.visual_luminance,
+            target_frequency_hz,
+            block.attention_gain,
+        )
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission:
+        times = np.asarray(sample_times_s, dtype=float)
+        return self._render_with_attention_stream(
+            times,
+            emitted_stimulus,
+            target_frequency_hz,
+            np.full(times.size, max(0.0, float(attention_gain)), dtype=float),
         )

--- a/packages/neuros-arena/src/neuros/arena/specs.py
+++ b/packages/neuros-arena/src/neuros/arena/specs.py
@@ -248,6 +248,28 @@ class StageSpec:
         _validate_scalar_mapping("stage.target", self.target)
         _validate_scalar_mapping("stage.task_state", self.task_state)
 
+        # `frequency_hz` inside generic target metadata is a reserved mirror of
+        # the typed frequency-target authority. Allowing it without the typed
+        # field would let rich world models see a target while participant state
+        # and Arena ground truth still describe rest.
+        if "frequency_hz" in self.target:
+            if self.target_frequency_hz is None:
+                raise ValueError(
+                    "stage.target.frequency_hz is reserved; set authoritative target_frequency_hz instead"
+                )
+            metadata_frequency = self.target["frequency_hz"]
+            if isinstance(metadata_frequency, bool) or not isinstance(metadata_frequency, (int, float, np.integer, np.floating)):
+                raise ValueError("stage.target.frequency_hz must be numeric when target_frequency_hz is set")
+            if not np.isfinite(float(metadata_frequency)) or not np.isclose(
+                float(metadata_frequency),
+                float(self.target_frequency_hz),
+                rtol=0.0,
+                atol=1e-12,
+            ):
+                raise ValueError(
+                    "stage.target.frequency_hz conflicts with authoritative target_frequency_hz"
+                )
+
 
 @dataclass(frozen=True)
 class ArenaScenario:

--- a/packages/neuros-arena/src/neuros/arena/world_input.py
+++ b/packages/neuros-arena/src/neuros/arena/world_input.py
@@ -7,7 +7,6 @@ models continue to implement the original ``render`` method.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
 import numpy as np
 
@@ -19,10 +18,10 @@ _JSON_SCALAR = str | int | float | bool | None
 class WorldInputBlock:
     """One causal chunk presented to a paradigm-neutral neural world model.
 
-    ``emitted_streams`` contains physical/simulated sensory streams *after*
-    presentation effects. Examples include ``visual_luminance``, audio envelope,
-    haptic pulses, or future VR pose-dependent stimulus values. ``target`` and
-    ``task_state`` are declarative labels/metadata, not decoded neural truth.
+    ``emitted_streams`` contains physical/simulated sensory streams after
+    presentation effects. ``participant_streams`` contains resolved synthetic
+    participant state on the same sample clock. Scalar ``participant_state`` is
+    retained as a compatibility/summary surface for older plugins.
     """
 
     sample_times_s: np.ndarray
@@ -32,6 +31,7 @@ class WorldInputBlock:
     target: dict[str, _JSON_SCALAR] = field(default_factory=dict)
     task_state: dict[str, _JSON_SCALAR] = field(default_factory=dict)
     participant_state: dict[str, _JSON_SCALAR] = field(default_factory=dict)
+    participant_streams: dict[str, np.ndarray] = field(default_factory=dict)
 
     def validate(self) -> None:
         times = np.asarray(self.sample_times_s, dtype=float)
@@ -39,12 +39,18 @@ class WorldInputBlock:
             raise ValueError("sample_times_s must be a finite 1-D array")
         if not self.paradigm or not self.stage_label:
             raise ValueError("paradigm and stage_label are required")
-        for name, values in self.emitted_streams.items():
-            if not name:
-                raise ValueError("emitted stream names must be non-empty")
-            array = np.asarray(values, dtype=float)
-            if array.shape != times.shape or not np.all(np.isfinite(array)):
-                raise ValueError(f"emitted stream {name!r} must be finite and match sample_times_s")
+        for mapping_name, streams in (
+            ("emitted_streams", self.emitted_streams),
+            ("participant_streams", self.participant_streams),
+        ):
+            for name, values in streams.items():
+                if not name:
+                    raise ValueError(f"{mapping_name} names must be non-empty")
+                array = np.asarray(values, dtype=float)
+                if array.shape != times.shape or not np.all(np.isfinite(array)):
+                    raise ValueError(
+                        f"{mapping_name}.{name} must be finite and match sample_times_s"
+                    )
         for mapping_name, mapping in (
             ("target", self.target),
             ("task_state", self.task_state),
@@ -64,3 +70,11 @@ class WorldInputBlock:
         if values is None:
             return np.zeros(np.asarray(self.sample_times_s).size, dtype=float)
         return np.asarray(values, dtype=float)
+
+    @property
+    def attention_gain(self) -> np.ndarray:
+        values = self.participant_streams.get("attention_gain")
+        if values is not None:
+            return np.asarray(values, dtype=float)
+        scalar = float(self.participant_state.get("attention_gain", 0.0) or 0.0)
+        return np.full(np.asarray(self.sample_times_s).size, scalar, dtype=float)

--- a/packages/neuros-arena/src/neuros/arena/world_models.py
+++ b/packages/neuros-arena/src/neuros/arena/world_models.py
@@ -23,6 +23,7 @@ from neuros.drivers.synthetic_eeg import (
 )
 
 from .specs import ParticipantProfile
+from .world_input import WorldInputBlock
 
 SOURCE_CHANNELS = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
 POSTERIOR_WEIGHTS = np.asarray([0.05, 0.05, 0.08, 0.05, 0.45, 0.85, 1.0, 0.85], dtype=float)
@@ -39,13 +40,7 @@ class WorldModelEmission:
 
 
 class NeuralWorldModel(Protocol):
-    """Minimal contract implemented by Arena-compatible neural generators.
-
-    `inject_artifact` remains the compatibility floor for external world-model
-    plugins. Built-in models additionally expose `schedule_artifact`; the Arena
-    runner detects that capability and uses sample-indexed compilation when it is
-    present rather than making it mandatory for older plugins.
-    """
+    """Minimal compatibility floor for Arena-compatible neural generators."""
 
     name: str
     channel_names: tuple[str, ...]
@@ -62,12 +57,7 @@ class NeuralWorldModel(Protocol):
 
 
 class LegacySyntheticWorldModel:
-    """Compatibility adapter around the original neurOS synthetic EEG driver.
-
-    This model responds to the nominal target frequency rather than the actual
-    frame-quantized luminance trace. It remains available for regression tests,
-    but the causally display-driven model is the Arena default.
-    """
+    """Compatibility adapter around the original neurOS synthetic EEG driver."""
 
     name = "legacy_synthetic"
     channel_names = SOURCE_CHANNELS
@@ -137,20 +127,13 @@ class LegacySyntheticWorldModel:
                 "attention_gain": float(attention_gain),
                 "entrainment": float(attention_gain if target_frequency_hz is not None else 0.0),
                 "stimulus_coupling": 0.0,
+                "participant_stream_coupling": 0.0,
             },
         )
 
 
 class _ArtifactEngine:
-    """Arena adapter over the canonical v3 sample-indexed artifact renderer.
-
-    Arena used to carry an independent mutable one-slot artifact engine. That
-    duplicated source-artifact semantics and reintroduced block-boundary dropout
-    leakage. This adapter deliberately delegates event timing/waveforms/seeding to
-    `SyntheticEEGGenerator` configured with zero background neural amplitudes.
-    Arena world models then overlay the returned additive signal and apply exact
-    dropout masks using the same event provenance.
-    """
+    """Arena adapter over the canonical v3 sample-indexed artifact renderer."""
 
     def __init__(self, sampling_rate_hz: float, seed: int) -> None:
         self.fs = float(sampling_rate_hz)
@@ -194,11 +177,7 @@ class _ArtifactEngine:
     ) -> tuple[np.ndarray, np.ndarray, tuple[DriverArtifactEvent, ...]]:
         samples = int(times_s.size)
         if samples == 0:
-            return (
-                np.empty((8, 0), dtype=float),
-                np.empty((8, 0), dtype=bool),
-                (),
-            )
+            return np.empty((8, 0), dtype=float), np.empty((8, 0), dtype=bool), ()
         block_start = self.generator.sample_index
         block = self.generator.render(samples)
         dropout_mask = np.zeros((8, samples), dtype=bool)
@@ -220,14 +199,9 @@ class _ArtifactEngine:
 class DrivenStateSpaceWorldModel:
     """Causal stochastic EEG state-space model driven by emitted luminance.
 
-    The model contains correlated background dynamics, an endogenous posterior
-    alpha oscillator, and a damped stimulus-entrainment state. The stimulus
-    state is driven by the *actual sample-and-held display waveform* supplied by
-    Arena, not by an ideal sine wave. This makes frame drops and timing jitter
-    causally visible in the generated EEG.
-
-    It is intentionally phenomenological rather than a biophysical neural-mass
-    model. More expensive MNE/TVB/learned models can implement the same contract.
+    The participant attention drive may be supplied per source sample through
+    `WorldInputBlock.participant_streams`. The older scalar `render(...)` path is
+    retained for compatibility and expands its scalar across the requested block.
     """
 
     name = "driven_state_space"
@@ -288,23 +262,29 @@ class DrivenStateSpaceWorldModel:
             seed=seed,
         )
 
-    def render(
+    def _render_with_attention_stream(
         self,
         sample_times_s: np.ndarray,
         emitted_stimulus: np.ndarray,
         target_frequency_hz: float | None,
-        attention_gain: float,
+        attention_gain: np.ndarray,
     ) -> WorldModelEmission:
         times = np.asarray(sample_times_s, dtype=float)
         drive = np.asarray(emitted_stimulus, dtype=float)
-        if times.ndim != 1 or drive.shape != times.shape:
-            raise ValueError("sample_times_s and emitted_stimulus must be matching 1-D arrays")
+        gain = np.asarray(attention_gain, dtype=float)
+        if times.ndim != 1 or drive.shape != times.shape or gain.shape != times.shape:
+            raise ValueError("time, emitted stimulus and attention gain must be matching 1-D arrays")
+        if not np.all(np.isfinite(gain)) or np.any(gain < 0):
+            raise ValueError("attention gain stream must be finite and non-negative")
         samples = times.size
         if samples == 0:
-            return WorldModelEmission(np.empty((8, 0), dtype=np.float32), {"entrainment": self._entrainment})
+            return WorldModelEmission(
+                np.empty((8, 0), dtype=np.float32),
+                {"entrainment": self._entrainment, "participant_stream_coupling": 1.0},
+            )
         dt = 1.0 / self.fs
         data = np.empty((8, samples), dtype=float)
-        target_gain = float(max(0.0, attention_gain)) if target_frequency_hz is not None else 0.0
+        target_gain = gain if target_frequency_hz is not None else np.zeros(samples, dtype=float)
         alpha_omega = 2.0 * np.pi * self.participant.alpha_frequency_hz
         target_omega = 0.0 if target_frequency_hz is None else 2.0 * np.pi * float(target_frequency_hz)
         innovation_scale = np.sqrt(max(1.0 - self.background_persistence**2, 1e-9))
@@ -313,7 +293,7 @@ class DrivenStateSpaceWorldModel:
                 self.background_persistence * self._background
                 + innovation_scale * self.rng.normal(size=8)
             )
-            self._entrainment += (target_gain - self._entrainment) * min(1.0, dt / self.entrainment_tau_s)
+            self._entrainment += (float(target_gain[i]) - self._entrainment) * min(1.0, dt / self.entrainment_tau_s)
             alpha = np.sin(alpha_omega * times[i] + self._alpha_phase + self._alpha_channel_phase)
             if target_frequency_hz is None:
                 self._resonator_x *= 0.98
@@ -341,10 +321,38 @@ class DrivenStateSpaceWorldModel:
         return WorldModelEmission(
             data_uv=data.astype(np.float32),
             latent={
-                "attention_gain": target_gain,
+                "attention_gain": float(target_gain[-1]) if target_gain.size else 0.0,
                 "entrainment": float(self._entrainment),
                 "resonator_x": float(self._resonator_x),
                 "resonator_v": float(self._resonator_v),
                 "stimulus_coupling": 1.0,
+                "participant_stream_coupling": 1.0,
             },
+        )
+
+    def render_world(self, block: WorldInputBlock) -> WorldModelEmission:
+        block.validate()
+        raw_frequency = block.target.get("frequency_hz")
+        target_frequency_hz = None if raw_frequency is None else float(raw_frequency)
+        return self._render_with_attention_stream(
+            block.sample_times_s,
+            block.visual_luminance,
+            target_frequency_hz,
+            block.attention_gain,
+        )
+
+    def render(
+        self,
+        sample_times_s: np.ndarray,
+        emitted_stimulus: np.ndarray,
+        target_frequency_hz: float | None,
+        attention_gain: float,
+    ) -> WorldModelEmission:
+        times = np.asarray(sample_times_s, dtype=float)
+        gain = np.full(times.size, max(0.0, float(attention_gain)), dtype=float)
+        return self._render_with_attention_stream(
+            times,
+            emitted_stimulus,
+            target_frequency_hz,
+            gain,
         )

--- a/tests/test_arena_authority_contracts.py
+++ b/tests/test_arena_authority_contracts.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from neuros.arena import (
+    PARTICIPANT_RESPONSE_MODEL,
+    ArenaScenario,
+    StageSpec,
+    compile_participant_state_trace,
+    ParticipantProfile,
+)
+
+
+def test_typed_target_frequency_rejects_conflicting_generic_metadata():
+    scenario = ArenaScenario(
+        "conflicting-frequency-authority",
+        (
+            StageSpec(
+                "target",
+                1.0,
+                target_frequency_hz=10.0,
+                attention_gain=0.8,
+                target={"frequency_hz": 12.0},
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="conflicts with authoritative target_frequency_hz"):
+        scenario.validate()
+
+
+def test_matching_frequency_metadata_is_allowed_but_typed_field_remains_authority():
+    scenario = ArenaScenario(
+        "matching-frequency-authority",
+        (
+            StageSpec(
+                "target",
+                0.2,
+                target_frequency_hz=10.0,
+                attention_gain=0.8,
+                target={"frequency_hz": 10.0, "semantic": "sight"},
+            ),
+        ),
+    )
+    scenario.validate()
+    trace = compile_participant_state_trace(scenario, ParticipantProfile(response_delay_s=0.0), 250.0)
+    assert trace.model == PARTICIPANT_RESPONSE_MODEL
+    assert trace.target_frequency_hz[0] == 10.0
+
+
+def test_reserved_frequency_metadata_without_typed_authority_fails_closed():
+    scenario = ArenaScenario(
+        "untyped-frequency-authority",
+        (
+            StageSpec(
+                "ambiguous-target",
+                0.2,
+                target_frequency_hz=None,
+                attention_gain=1.0,
+                target={"frequency_hz": 10.0, "semantic": "ambiguous"},
+            ),
+        ),
+    )
+    with pytest.raises(ValueError, match="reserved; set authoritative target_frequency_hz"):
+        scenario.validate()
+
+
+def test_non_frequency_target_metadata_does_not_invent_frequency_participant_dynamics():
+    scenario = ArenaScenario(
+        "p300-authority-boundary",
+        (
+            StageSpec(
+                "oddball",
+                0.2,
+                target_frequency_hz=None,
+                attention_gain=1.0,
+                target={"oddball": True, "symbol": "B"},
+            ),
+        ),
+        metadata={"paradigm": "p300"},
+    )
+    trace = compile_participant_state_trace(scenario, ParticipantProfile(), 250.0)
+    assert trace.to_summary()["scope"] == "frequency_target_visual_attention"
+    assert not trace.target_switch.any()
+    assert not trace.attention_gain.any()

--- a/tests/test_arena_participant_state.py
+++ b/tests/test_arena_participant_state.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import numpy as np
+
+import neuros.arena.runner as arena_runner
+from neuros.arena import (
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    StageSpec,
+    TransportProfile,
+    WorldModelProfile,
+    run_scenario,
+)
+from neuros.arena.leadfield import save_leadfield_bundle
+from neuros.arena.participant import compile_participant_state_trace
+
+
+CHANNELS = ("Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8")
+
+
+def _participant(**overrides) -> ParticipantProfile:
+    values = dict(
+        seed=91,
+        response_delay_s=0.04,
+        switch_time_constant_s=0.20,
+        gaze_duty_cycle=0.80,
+        response_attenuation_per_minute=0.05,
+    )
+    values.update(overrides)
+    return ParticipantProfile(**values)
+
+
+def _scenario() -> ArenaScenario:
+    return ArenaScenario(
+        "participant-chunk-probe",
+        (
+            StageSpec("rest", 0.25, None, 0.0),
+            StageSpec("sight-a", 0.75, 10.0, 0.9),
+            StageSpec("sight-b", 0.75, 10.0, 0.9),
+            StageSpec("guard", 0.75, 12.0, 0.85),
+        ),
+        seed=97,
+    )
+
+
+def _device() -> DeviceProfile:
+    return DeviceProfile(
+        chunk_samples=31,
+        sensor_noise_uv=0.0,
+        line_noise_uv=0.0,
+        timestamp_jitter_ms=0.0,
+    )
+
+
+def test_same_target_stage_segmentation_does_not_restart_participant_response():
+    whole = ArenaScenario(
+        "whole",
+        (StageSpec("target", 2.0, 10.0, 0.9),),
+        seed=91,
+    )
+    split = ArenaScenario(
+        "split",
+        (
+            StageSpec("target-a", 0.75, 10.0, 0.9),
+            StageSpec("target-b", 1.25, 10.0, 0.9),
+        ),
+        seed=91,
+    )
+
+    whole_trace = compile_participant_state_trace(whole, _participant(), 250.0)
+    split_trace = compile_participant_state_trace(split, _participant(), 250.0)
+
+    np.testing.assert_array_equal(whole_trace.attention_gain, split_trace.attention_gain)
+    np.testing.assert_array_equal(
+        whole_trace.requested_attention_gain,
+        split_trace.requested_attention_gain,
+    )
+    np.testing.assert_array_equal(whole_trace.target_frequency_hz, split_trace.target_frequency_hz)
+    assert np.flatnonzero(whole_trace.target_switch).tolist() == [0]
+    assert np.flatnonzero(split_trace.target_switch).tolist() == [0]
+
+
+def test_response_delay_restarts_on_target_identity_switch_not_stage_label():
+    scenario = ArenaScenario(
+        "switches",
+        (
+            StageSpec("sight-a", 0.5, 10.0, 1.0),
+            StageSpec("sight-b", 0.5, 10.0, 1.0),
+            StageSpec("guard", 0.5, 12.0, 1.0),
+        ),
+        seed=93,
+    )
+    trace = compile_participant_state_trace(scenario, _participant(), 250.0)
+
+    # 40 ms at 250 Hz is exactly ten samples. A label-only boundary at sample
+    # 125 does not restart it; the 10 -> 12 Hz identity switch at 250 does.
+    assert np.flatnonzero(trace.target_switch).tolist() == [0, 250]
+    assert np.all(trace.attention_gain[:10] == 0.0)
+    assert trace.attention_gain[10] > 0.0
+    assert trace.attention_gain[124] > 0.0
+    assert trace.attention_gain[125] > 0.0
+    assert np.all(trace.attention_gain[250:260] == 0.0)
+    assert trace.attention_gain[260] > 0.0
+
+
+def test_non_grid_response_delay_never_starts_early():
+    scenario = ArenaScenario(
+        "non-grid-delay",
+        (StageSpec("target", 0.25, 10.0, 1.0),),
+        seed=94,
+    )
+    trace = compile_participant_state_trace(
+        scenario,
+        _participant(response_delay_s=0.041),
+        250.0,
+    )
+
+    # 41 ms lies between source samples 10 (40 ms) and 11 (44 ms). Causal delay
+    # is a lower bound, so the first non-zero response is sample 11, never 10.
+    assert np.all(trace.attention_gain[:11] == 0.0)
+    assert trace.attention_gain[11] > 0.0
+
+
+def test_target_transition_semantics_include_rest_boundaries_but_not_initial_rest():
+    scenario = ArenaScenario(
+        "rest-transitions",
+        (
+            StageSpec("rest-a", 0.20, None, 0.0),
+            StageSpec("sight", 0.20, 10.0, 1.0),
+            StageSpec("rest-b", 0.20, None, 0.0),
+            StageSpec("guard", 0.20, 12.0, 1.0),
+        ),
+        seed=95,
+    )
+    trace = compile_participant_state_trace(scenario, _participant(), 250.0)
+    summary = trace.to_summary()
+
+    assert np.flatnonzero(trace.target_switch).tolist() == [50, 100, 150]
+    assert summary["target_transition_samples"] == [50, 100, 150]
+    assert summary["target_switch_samples"] == [50, 100, 150]
+
+
+def _run_world(profile: WorldModelProfile):
+    return run_scenario(
+        _scenario(),
+        _participant(),
+        _device(),
+        DisplayProfile(frame_drop_probability=0.0, frame_jitter_ms=0.0),
+        TransportProfile(),
+        profile,
+    )
+
+
+def _assert_partition_invariant(monkeypatch, profile: WorldModelProfile):
+    monkeypatch.setattr(arena_runner, "WORLD_RENDER_CHUNK_SAMPLES", 1)
+    fine = _run_world(profile)
+    monkeypatch.setattr(arena_runner, "WORLD_RENDER_CHUNK_SAMPLES", 37)
+    coarse = _run_world(profile)
+
+    np.testing.assert_array_equal(fine.device_output.data_uv, coarse.device_output.data_uv)
+    np.testing.assert_array_equal(
+        fine.device_output.ground_truth_timestamps_s,
+        coarse.device_output.ground_truth_timestamps_s,
+    )
+    assert fine.report["metrics"]["participant_state"] == coarse.report["metrics"]["participant_state"]
+    assert fine.report["metrics"]["world_model"]["stage_end_latent"] == coarse.report["metrics"]["world_model"]["stage_end_latent"]
+    assert fine.report["metrics"]["world_model"]["render_chunk_samples"] == 1
+    assert coarse.report["metrics"]["world_model"]["render_chunk_samples"] == 37
+    assert fine.report["metrics"]["world_model"]["stage_end_latent"][-1]["participant_stream_coupling"] == 1.0
+
+
+def test_w1_default_world_is_invariant_to_internal_render_chunking(monkeypatch):
+    _assert_partition_invariant(monkeypatch, WorldModelProfile("driven_state_space"))
+
+
+def _write_baseline(path) -> None:
+    fs = 250.0
+    time = np.arange(int(8 * fs), dtype=float) / fs
+    rng = np.random.default_rng(707)
+    data = rng.normal(0.0, 3.5, size=(8, time.size))
+    data += 1.8 * np.sin(2 * np.pi * 9.3 * time)[None, :]
+    np.savez(
+        path,
+        data_uv=data.astype(np.float32),
+        sampling_rate_hz=np.asarray(fs),
+        channel_names=np.asarray(CHANNELS),
+    )
+
+
+def test_w2_semi_synthetic_world_is_invariant_to_internal_render_chunking(monkeypatch, tmp_path):
+    baseline = tmp_path / "participant-background.npz"
+    _write_baseline(baseline)
+    _assert_partition_invariant(
+        monkeypatch,
+        WorldModelProfile(
+            "semi_synthetic_replay",
+            {"path": str(baseline), "random_offset": False, "response_scale": 0.8},
+        ),
+    )
+
+
+def _write_leadfield(path) -> None:
+    visual = np.asarray([0.05, 0.08, 0.10, 0.08, 0.42, 0.86, 1.0, 0.81])
+    nuisance = np.asarray([
+        [1.0, 0.3, 0.4, 0.3, 0.2, 0.1, 0.05, 0.1],
+        [0.1, 0.8, 1.0, 0.8, 0.3, 0.1, 0.1, 0.1],
+    ])
+    save_leadfield_bundle(
+        path,
+        channel_names=CHANNELS,
+        visual_topography=visual,
+        nuisance_topographies=nuisance,
+        metadata={"test": "participant-stream-partition"},
+    )
+
+
+def test_w3_leadfield_world_is_invariant_to_internal_render_chunking(monkeypatch, tmp_path):
+    bundle = tmp_path / "participant-leadfield.npz"
+    _write_leadfield(bundle)
+    _assert_partition_invariant(
+        monkeypatch,
+        WorldModelProfile("leadfield_driven", {"path": str(bundle)}),
+    )

--- a/tests/test_arena_world_input.py
+++ b/tests/test_arena_world_input.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from neuros.arena import (
     ArenaManifest,
@@ -10,6 +11,7 @@ from neuros.arena import (
     ParticipantProfile,
     StageSpec,
     TransportProfile,
+    WorldInputBlock,
     WorldModelEmission,
     WorldModelProfile,
     run_scenario,
@@ -29,12 +31,14 @@ class RichProbeWorldModel:
         return None
 
     def render_world(self, block):
+        block.validate()
         RichProbeWorldModel.seen.append({
             "paradigm": block.paradigm,
             "stage": block.stage_label,
             "target": dict(block.target),
             "task_state": dict(block.task_state),
             "attention_gain": block.participant_state.get("attention_gain"),
+            "attention_stream": block.attention_gain.copy(),
             "visual_shape": block.visual_luminance.shape,
         })
         amplitude = 2.0 if block.target.get("oddball") is True else 0.0
@@ -107,10 +111,61 @@ def test_runner_prefers_paradigm_neutral_render_world_contract():
     assert any(item["target"].get("oddball") is True for item in RichProbeWorldModel.seen)
     assert all(item["paradigm"] == "p300" for item in RichProbeWorldModel.seen)
     assert all(item["visual_shape"] for item in RichProbeWorldModel.seen)
+    # Arena's built-in participant_response.v1 is explicitly frequency-target
+    # scoped. A P300 plugin receives the rich transport surface but does not
+    # inherit made-up SSVEP attention dynamics.
+    assert all(np.all(item["attention_stream"] == 0.0) for item in RichProbeWorldModel.seen)
     assert float(np.max(run.device_output.data_uv)) > 1.5
 
 
-def test_manifest_v1_round_trip_preserves_rich_stage_metadata():
+def test_world_input_rejects_bad_participant_stream_geometry_and_nonfinite_values():
+    times = np.arange(5, dtype=float) / 250.0
+    base = dict(
+        sample_times_s=times,
+        paradigm="ssvep",
+        stage_label="target",
+        emitted_streams={"visual_luminance": np.zeros(5)},
+        target={"frequency_hz": 10.0},
+    )
+    with pytest.raises(ValueError, match="participant_streams.attention_gain"):
+        WorldInputBlock(
+            **base,
+            participant_streams={"attention_gain": np.zeros(4)},
+        ).validate()
+    bad = np.zeros(5)
+    bad[2] = np.nan
+    with pytest.raises(ValueError, match="participant_streams.attention_gain"):
+        WorldInputBlock(
+            **base,
+            participant_streams={"attention_gain": bad},
+        ).validate()
+
+
+def test_attention_gain_property_prefers_stream_and_falls_back_to_scalar():
+    times = np.arange(4, dtype=float) / 250.0
+    streamed = WorldInputBlock(
+        sample_times_s=times,
+        paradigm="ssvep",
+        stage_label="target",
+        emitted_streams={},
+        participant_state={"attention_gain": 0.2},
+        participant_streams={"attention_gain": np.asarray([0.0, 0.1, 0.3, 0.6])},
+    )
+    streamed.validate()
+    np.testing.assert_array_equal(streamed.attention_gain, [0.0, 0.1, 0.3, 0.6])
+
+    scalar = WorldInputBlock(
+        sample_times_s=times,
+        paradigm="ssvep",
+        stage_label="target",
+        emitted_streams={},
+        participant_state={"attention_gain": 0.25},
+    )
+    scalar.validate()
+    np.testing.assert_array_equal(scalar.attention_gain, np.full(4, 0.25))
+
+
+def test_manifest_v2_round_trip_preserves_rich_stage_metadata():
     manifest = ArenaManifest(
         ArenaScenario(
             "rich-manifest",


### PR DESCRIPTION
## Why

PR #62 makes Arena artifact execution and source timing sample-indexed. A deeper review found that participant response was still computed once per neural render block and restarted at every scenario stage boundary. That made implementation batching and stage labeling capable of changing the synthetic participant.

This stacked PR makes participant response its own explicit source-sample layer before neural world rendering.

Base dependency: exact-head-qualified draft PR #62 at `732ced9e2c1c88613cf1e34d10da6e818d23b5c9`.

## Causal architecture

```text
ArenaScenario
    ↓
frequency-target participant response
    ↓
per-source-sample participant streams
    ↓
W1 / W2 / W3 neural world
    ↓
device
    ↓
transport / decoder / application
```

Device packetization and neural render chunking are downstream implementation details and must not reach backward into participant state.

## Versioned participant contract

The first participant model is:

`neuros.arena.frequency_target_response.v1`

It is intentionally scoped to frequency-target visual attention for SSVEP-style synthetic worlds. It is **not** a universal participant model for P300, motor imagery, auditory BCI, cognition, workload or intent.

The public API exposes `ParticipantStateTrace` and `compile_participant_state_trace(...)`.

## Sample-indexed response

For each source sample the compiler records:

- effective attention gain;
- requested attention gain after declared gaze/fatigue attenuation;
- active target frequency or rest marker;
- target-transition marker.

Adjacent stages with the same frequency target preserve response state. Stage labels are not participant causes.

A true target transition resets response state and starts the declared response delay. Active↔rest boundaries are recorded; initial rest is not a transition.

Non-grid response delays use the first sample at-or-after the declared delay (`ceil(delay × fs)`), so the simulator never begins a response earlier than requested.

## Paradigm boundary

`WorldInputBlock` remains paradigm-neutral and carries `participant_streams` in addition to the historical scalar `participant_state` surface.

The built-in frequency-target response stream is zero for non-frequency worlds. A P300/MI plugin can use the same rich container without silently inheriting SSVEP response assumptions.

## World-model integration

### W0

`legacy_synthetic` intentionally retains its historical scalar adapter. Its evidence card explicitly does not claim sample-indexed participant-response fidelity.

### W1

`driven_state_space` consumes attention sample by sample.

### W2

`semi_synthetic_replay` consumes the same stream. The review also fixed a block dependency where its harmonic term used the final entrainment value of a render block for every sample in that block.

### W3

`leadfield_driven` consumes the participant stream too. The review found a second hidden batching defect: white/background noise was drawn as `channels × block`, so changing block size remapped RNG samples across channel/time coordinates. W3 now advances random nuisance and latent state in source-sample order.

## Render-partition invariant

For W1/W2/W3:

> Same world + seed + source clock must produce identical EEG whether Arena renders internally in 1-sample or 37-sample chunks.

The exact-head test matrix binds that invariant.

## Rich-input and authority hardening

`WorldInputBlock` rejects participant streams with mismatched geometry or non-finite values. `block.attention_gain` prefers the sample stream and falls back to the scalar compatibility value.

Frequency authority is single-source:

- typed `StageSpec.target_frequency_hz` is authoritative;
- generic `target.frequency_hz` may only mirror the same value;
- generic metadata cannot invent a frequency target while participant/ground truth say rest.

The previously omitted `tests/test_arena_world_input.py` suite plus the participant and authority suites are explicitly included in Arena CI.

## Evidence governance

W1/W2/W3 evidence cards list sample-indexed participant-response and render-partition invariance as software validation. They continue to reject human-performance and physiological claims.

See `docs/ARENA_PARTICIPANT_RESPONSE.md`.

## Exact-head qualification

Base:

`732ced9e2c1c88613cf1e34d10da6e818d23b5c9`

Qualified head:

`c3f8dbdf6e2dc8453450ce510bc7652c4e6bd9a8`

Delta: **1 commit ahead, 0 behind, 14 focused paths changed.**

All triggered exact-head workflows are green:

- **Synthetic BCI Arena**, including Python 3.10/3.11/3.12 deterministic contracts, CLI exercises, Arena wheel and real-domain anchoring;
- **Public Trust Contracts**;
- **Developer Preview Journey**, including the installed-wheel external-user path;
- **full neurOS CI**.

## Not claimed

This PR does **not** establish:

- human SSVEP response latency distributions;
- human gaze duty-cycle behavior;
- a physiological fatigue law;
- physical Unicorn timing/performance;
- human decoder accuracy;
- closed-loop efficacy;
- clinical validity.

Those require physical and/or human evidence.

## Follow-up

Draft PR #69 builds on this exact head and separates physical presentation epochs from stage bookkeeping. It also adds explicit `stimulus_id` semantics so future same-frequency/different-object worlds can distinguish physical target identity without weakening this PR's qualification boundary.

## Qualification state

**Exact-head software qualification is green. PR remains draft intentionally because it is stacked on draft PR #62 and physical/human evidence remains outside the software contract.**