### PR TITLE
Streaming DSP v2: causal stateful chunk-invariant filters

### DIFF
--- a/.github/workflows/streaming-dsp-ci.yml
+++ b/.github/workflows/streaming-dsp-ci.yml
@@ -1,0 +1,41 @@
+name: Streaming DSP Contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-core/src/neuros/processing/filters.py"
+      - "packages/neuros-core/src/neuros/processing/plugin_transforms.py"
+      - "tests/test_streaming_filters.py"
+      - ".github/workflows/streaming-dsp-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/neuros-core/src/neuros/processing/filters.py"
+      - "packages/neuros-core/src/neuros/processing/plugin_transforms.py"
+      - "tests/test_streaming_filters.py"
+      - ".github/workflows/streaming-dsp-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  streaming-dsp:
+    name: Streaming DSP / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install neurOS core test profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[test]"
+      - name: Prove causal chunk-invariant filtering
+        run: pytest -q tests/test_streaming_filters.py

--- a/packages/neuros-core/src/neuros/processing/filters.py
+++ b/packages/neuros-core/src/neuros/processing/filters.py
@@ -1,61 +1,191 @@
-"""
-Filtering utilities for neural signals.
+"""Causal, stateful filtering utilities for live neural streams.
 
-The provided classes implement simple bandpass and smoothing filters using
-SciPy and NumPy.  These filters operate on 1‑D or 2‑D arrays and return
-arrays of the same shape.  They can be used inside a processing agent to
-clean raw data before feature extraction.
+The live neurOS processing path treats transport chunking as an implementation
+detail, not part of the scientific signal. Therefore filters in this module
+carry their causal state across ``apply()`` calls and expose explicit ``reset()``
+methods for acquisition/session boundaries.
+
+Samples are always interpreted along the last array axis. Leading dimensions
+identify independent streams/channels and are bound to filter state after the
+first non-empty block. A geometry change requires an explicit reset so state is
+never silently reassigned to different channels.
 """
 
 from __future__ import annotations
 
+from numbers import Integral, Real
+
 import numpy as np
-from scipy.signal import butter, lfilter
+from scipy.signal import butter, sosfilt
+
+
+def _finite_real(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise ValueError(f"{name} must be a finite real scalar")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return result
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer")
+    result = int(value)
+    if result < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
+
+
+def _stream_array(data: np.ndarray | object) -> np.ndarray:
+    array = np.asarray(data)
+    if array.ndim < 1:
+        raise ValueError("filter input must have a sample axis")
+    if not (np.issubdtype(array.dtype, np.number) and not np.issubdtype(array.dtype, np.complexfloating)):
+        raise ValueError("filter input must contain real numeric samples")
+    return np.asarray(array, dtype=np.result_type(array.dtype, np.float64))
 
 
 class BandpassFilter:
-    """Butterworth bandpass filter.
+    """Causal Butterworth bandpass filter with persistent streaming state.
 
     Parameters
     ----------
     lowcut : float
-        Low cut‑off frequency in Hz.
+        Low cutoff frequency in Hz, strictly greater than zero.
     highcut : float
-        High cut‑off frequency in Hz.
+        High cutoff frequency in Hz, strictly below Nyquist.
     fs : float
         Sampling frequency in Hz.
     order : int, optional
-        Order of the filter.  Defaults to 4.
+        Butterworth prototype order. Defaults to 4.
+
+    Notes
+    -----
+    The implementation uses second-order sections for numerical robustness and
+    zero initial state. The same ordered sample stream therefore produces the
+    same output, within floating-point tolerance, whether delivered as one block
+    or many blocks. ``reset()`` returns the filter to that deterministic initial
+    state.
     """
 
     def __init__(self, lowcut: float, highcut: float, fs: float, order: int = 4) -> None:
-        self.lowcut = lowcut
-        self.highcut = highcut
-        self.fs = fs
-        self.order = order
-        nyq = 0.5 * fs
-        low = lowcut / nyq
-        high = highcut / nyq
-        self.b, self.a = butter(order, [low, high], btype="band")
+        self.lowcut = _finite_real(lowcut, name="lowcut")
+        self.highcut = _finite_real(highcut, name="highcut")
+        self.fs = _finite_real(fs, name="fs")
+        self.order = _positive_integer(order, name="order")
+        if self.fs <= 0:
+            raise ValueError("fs must be positive")
+        nyquist = 0.5 * self.fs
+        if not 0.0 < self.lowcut < self.highcut < nyquist:
+            raise ValueError(
+                "bandpass cutoffs must satisfy 0 < lowcut < highcut < Nyquist "
+                f"({nyquist:g} Hz)"
+            )
+        self.sos = butter(
+            self.order,
+            [self.lowcut, self.highcut],
+            btype="bandpass",
+            fs=self.fs,
+            output="sos",
+        )
+        self._state: np.ndarray | None = None
+        self._leading_shape: tuple[int, ...] | None = None
+
+    @property
+    def nyquist_hz(self) -> float:
+        return 0.5 * self.fs
+
+    @property
+    def initialized(self) -> bool:
+        return self._state is not None
+
+    def reset(self) -> None:
+        """Forget stream history and return to deterministic zero initial state."""
+        self._state = None
+        self._leading_shape = None
+
+    def _ensure_state(self, array: np.ndarray) -> None:
+        leading_shape = tuple(array.shape[:-1])
+        if self._leading_shape is not None and leading_shape != self._leading_shape:
+            raise ValueError(
+                "bandpass stream geometry changed from "
+                f"{self._leading_shape} to {leading_shape}; call reset() before reusing "
+                "the filter for a different channel/stream geometry"
+            )
+        if self._state is None:
+            self._leading_shape = leading_shape
+            state_shape = (self.sos.shape[0], *leading_shape, 2)
+            self._state = np.zeros(
+                state_shape,
+                dtype=np.result_type(array.dtype, self.sos.dtype, np.float64),
+            )
 
     def apply(self, data: np.ndarray) -> np.ndarray:
-        """Apply the filter to an array of samples.
-
-        The filter is applied along the last axis.  If `data` is 2‑D, each
-        channel is filtered independently.
-        """
-        return lfilter(self.b, self.a, data, axis=-1)
+        """Filter a live block along the last axis while preserving causal state."""
+        array = _stream_array(data)
+        if array.shape[-1] == 0:
+            return array.copy()
+        self._ensure_state(array)
+        assert self._state is not None
+        filtered, final_state = sosfilt(self.sos, array, axis=-1, zi=self._state)
+        self._state = final_state
+        return np.asarray(filtered)
 
 
 class SmoothingFilter:
-    """Simple moving average (boxcar) filter."""
+    """Causal moving-average filter with persistent trailing history.
+
+    Unlike centered ``mode='same'`` convolution, each output sample depends only
+    on the current and preceding samples. Startup history is deterministic zero
+    state. This makes online output independent of transport chunk boundaries
+    and avoids hidden within-block look-ahead.
+    """
 
     def __init__(self, window_size: int = 5) -> None:
-        self.window_size = max(1, int(window_size))
-        self.kernel = np.ones(self.window_size) / self.window_size
+        self.window_size = _positive_integer(window_size, name="window_size")
+        self.kernel = np.ones(self.window_size, dtype=float) / float(self.window_size)
+        self._history: np.ndarray | None = None
+        self._leading_shape: tuple[int, ...] | None = None
+
+    @property
+    def initialized(self) -> bool:
+        return self._leading_shape is not None
+
+    def reset(self) -> None:
+        """Forget trailing samples and restore deterministic zero startup history."""
+        self._history = None
+        self._leading_shape = None
+
+    def _ensure_history(self, array: np.ndarray) -> None:
+        leading_shape = tuple(array.shape[:-1])
+        if self._leading_shape is not None and leading_shape != self._leading_shape:
+            raise ValueError(
+                "smoothing stream geometry changed from "
+                f"{self._leading_shape} to {leading_shape}; call reset() before reusing "
+                "the filter for a different channel/stream geometry"
+            )
+        if self._leading_shape is None:
+            self._leading_shape = leading_shape
+            self._history = np.zeros(
+                (*leading_shape, self.window_size - 1),
+                dtype=np.result_type(array.dtype, np.float64),
+            )
 
     def apply(self, data: np.ndarray) -> np.ndarray:
-        # for 1‑D or 2‑D array, convolve along last axis
-        return np.apply_along_axis(
-            lambda m: np.convolve(m, self.kernel, mode="same"), axis=-1, arr=data
+        """Apply a causal moving average along the last axis."""
+        array = _stream_array(data)
+        if array.shape[-1] == 0:
+            return array.copy()
+        self._ensure_history(array)
+        if self.window_size == 1:
+            return array.copy()
+        assert self._history is not None
+        combined = np.concatenate((self._history, array), axis=-1)
+        result = np.apply_along_axis(
+            lambda values: np.convolve(values, self.kernel, mode="valid"),
+            axis=-1,
+            arr=combined,
         )
+        self._history = combined[..., -(self.window_size - 1) :].copy()
+        return np.asarray(result)

--- a/packages/neuros-core/src/neuros/processing/plugin_transforms.py
+++ b/packages/neuros-core/src/neuros/processing/plugin_transforms.py
@@ -24,8 +24,14 @@ def _map(item: Any, data: np.ndarray, *, representation: str) -> Any:
 
 
 class BandpassTransform:
+    """Plugin adapter for the causal stateful live bandpass filter."""
+
     def __init__(self, lowcut: float, highcut: float, fs: float, order: int = 4) -> None:
         self.filter = BandpassFilter(lowcut=lowcut, highcut=highcut, fs=fs, order=order)
+
+    def reset(self) -> None:
+        """Start a new acquisition/filter epoch with zero filter state."""
+        self.filter.reset()
 
     def transform(self, item: Any) -> Any:
         data = np.asarray(item.data if isinstance(item, SignalFrame) else item)
@@ -33,8 +39,14 @@ class BandpassTransform:
 
 
 class SmoothingTransform:
+    """Plugin adapter for the causal stateful live moving average."""
+
     def __init__(self, window_size: int = 5) -> None:
         self.filter = SmoothingFilter(window_size=window_size)
+
+    def reset(self) -> None:
+        """Start a new acquisition/filter epoch with zero smoothing history."""
+        self.filter.reset()
 
     def transform(self, item: Any) -> Any:
         data = np.asarray(item.data if isinstance(item, SignalFrame) else item)

--- a/tests/test_streaming_filters.py
+++ b/tests/test_streaming_filters.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.processing.filters import BandpassFilter, SmoothingFilter
+from neuros.processing.plugin_transforms import BandpassTransform, SmoothingTransform
+
+
+def _partition(data: np.ndarray, lengths: tuple[int, ...]) -> list[np.ndarray]:
+    assert sum(lengths) == data.shape[-1]
+    chunks: list[np.ndarray] = []
+    start = 0
+    for length in lengths:
+        chunks.append(data[..., start : start + length])
+        start += length
+    return chunks
+
+
+def test_bandpass_is_chunk_partition_invariant_for_one_dimensional_stream():
+    rng = np.random.default_rng(7)
+    data = rng.normal(size=2048)
+
+    whole_filter = BandpassFilter(1.0, 45.0, fs=250.0, order=4)
+    expected = whole_filter.apply(data)
+
+    chunked_filter = BandpassFilter(1.0, 45.0, fs=250.0, order=4)
+    actual = np.concatenate(
+        [chunked_filter.apply(chunk) for chunk in _partition(data, (1, 7, 64, 511, 3, 1462))]
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_bandpass_is_chunk_partition_invariant_for_multichannel_stream():
+    rng = np.random.default_rng(11)
+    data = rng.normal(size=(8, 1500))
+
+    whole_filter = BandpassFilter(8.0, 30.0, fs=250.0, order=6)
+    expected = whole_filter.apply(data)
+
+    chunked_filter = BandpassFilter(8.0, 30.0, fs=250.0, order=6)
+    actual = np.concatenate(
+        [chunked_filter.apply(chunk) for chunk in _partition(data, (113, 1, 256, 509, 621))],
+        axis=-1,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_bandpass_reset_restores_fresh_filter_state():
+    rng = np.random.default_rng(17)
+    prefix = rng.normal(size=(4, 200))
+    target = rng.normal(size=(4, 300))
+    bandpass = BandpassFilter(2.0, 40.0, fs=250.0)
+    bandpass.apply(prefix)
+    continued = bandpass.apply(target)
+
+    bandpass.reset()
+    reset_output = bandpass.apply(target)
+    fresh_output = BandpassFilter(2.0, 40.0, fs=250.0).apply(target)
+
+    assert not np.allclose(continued, fresh_output)
+    np.testing.assert_allclose(reset_output, fresh_output, rtol=0.0, atol=0.0)
+
+
+def test_bandpass_requires_explicit_reset_before_geometry_change():
+    bandpass = BandpassFilter(1.0, 30.0, fs=250.0)
+    bandpass.apply(np.zeros((2, 20)))
+    with pytest.raises(ValueError, match="geometry changed"):
+        bandpass.apply(np.zeros((3, 20)))
+    bandpass.reset()
+    assert bandpass.apply(np.zeros((3, 20))).shape == (3, 20)
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        ((0.0, 30.0, 250.0, 4), "cutoffs"),
+        ((30.0, 10.0, 250.0, 4), "cutoffs"),
+        ((1.0, 125.0, 250.0, 4), "Nyquist"),
+        ((1.0, 30.0, 0.0, 4), "fs must be positive"),
+        ((1.0, 30.0, 250.0, 0), "positive integer"),
+        ((1.0, 30.0, 250.0, 4.0), "positive integer"),
+    ],
+)
+def test_bandpass_rejects_invalid_configuration(args, message):
+    with pytest.raises(ValueError, match=message):
+        BandpassFilter(*args)
+
+
+def test_smoothing_is_causal_and_chunk_partition_invariant():
+    data = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+    whole_filter = SmoothingFilter(window_size=3)
+    expected = whole_filter.apply(data)
+
+    # No sample before the impulse can depend on that future impulse.
+    np.testing.assert_allclose(expected[:3], 0.0, rtol=0.0, atol=0.0)
+    np.testing.assert_allclose(expected[3:6], 1.0 / 3.0, rtol=0.0, atol=1e-15)
+    assert expected[6] == pytest.approx(0.0)
+
+    chunked_filter = SmoothingFilter(window_size=3)
+    actual = np.concatenate(
+        [chunked_filter.apply(chunk) for chunk in _partition(data, (1, 2, 1, 3))]
+    )
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_smoothing_is_chunk_partition_invariant_for_multichannel_stream():
+    rng = np.random.default_rng(23)
+    data = rng.normal(size=(5, 777))
+    expected = SmoothingFilter(window_size=9).apply(data)
+
+    chunked = SmoothingFilter(window_size=9)
+    actual = np.concatenate(
+        [chunked.apply(chunk) for chunk in _partition(data, (8, 1, 41, 250, 477))],
+        axis=-1,
+    )
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_smoothing_reset_and_geometry_contract():
+    smoothing = SmoothingFilter(window_size=5)
+    prefix = np.arange(20.0).reshape(2, 10)
+    target = np.ones((2, 6))
+    smoothing.apply(prefix)
+    continued = smoothing.apply(target)
+
+    smoothing.reset()
+    reset_output = smoothing.apply(target)
+    fresh_output = SmoothingFilter(window_size=5).apply(target)
+    assert not np.allclose(continued, fresh_output)
+    np.testing.assert_allclose(reset_output, fresh_output, rtol=0.0, atol=0.0)
+
+    with pytest.raises(ValueError, match="geometry changed"):
+        smoothing.apply(np.ones((3, 2)))
+
+
+def test_smoothing_requires_strict_positive_integer_window():
+    with pytest.raises(ValueError, match="positive integer"):
+        SmoothingFilter(window_size=0)
+    with pytest.raises(ValueError, match="positive integer"):
+        SmoothingFilter(window_size=3.5)
+
+
+def test_plugin_transforms_preserve_state_and_expose_epoch_reset():
+    data = np.linspace(-1.0, 1.0, 120)
+
+    bandpass = BandpassTransform(1.0, 30.0, fs=250.0)
+    chunked = np.concatenate((bandpass.transform(data[:50]), bandpass.transform(data[50:])))
+    whole = BandpassTransform(1.0, 30.0, fs=250.0).transform(data)
+    np.testing.assert_allclose(chunked, whole, rtol=1e-12, atol=1e-12)
+    bandpass.reset()
+    np.testing.assert_allclose(bandpass.transform(data), whole, rtol=0.0, atol=0.0)
+
+    smoothing = SmoothingTransform(window_size=5)
+    chunked_smooth = np.concatenate(
+        (smoothing.transform(data[:17]), smoothing.transform(data[17:91]), smoothing.transform(data[91:]))
+    )
+    whole_smooth = SmoothingTransform(window_size=5).transform(data)
+    np.testing.assert_allclose(chunked_smooth, whole_smooth, rtol=0.0, atol=0.0)
+    smoothing.reset()
+    np.testing.assert_allclose(smoothing.transform(data), whole_smooth, rtol=0.0, atol=0.0)


### PR DESCRIPTION
## Why

The audit found a core runtime-validity defect below the model layer.

The existing `BandpassFilter` restarted IIR state at every incoming block. The existing `SmoothingFilter` used centered block-local convolution. Identical continuous neural samples could therefore produce different preprocessing solely because transport chunk sizes differed, and smoothing could depend on future samples inside the current block.

## Runtime invariant

> Given the same ordered samples and the same explicit initial filter state, online preprocessing must be causal and independent of transport chunk partitioning.

## Bandpass v2

- Butterworth second-order sections via `butter(..., output="sos")`;
- persistent causal `sosfilt` state across `apply()` calls;
- deterministic zero initial state;
- explicit `reset()` for acquisition/session epoch transitions;
- state bound to input leading/channel geometry;
- geometry changes fail closed until reset;
- finite scalar configuration validation;
- strict `0 < lowcut < highcut < Nyquist`;
- strict positive integer filter order.

## Smoothing v2

- causal trailing moving average rather than centered within-block convolution;
- persistent `window_size - 1` history;
- deterministic zero startup history;
- exact chunk-partition invariance;
- explicit `reset()` and geometry contract;
- strict positive integer window size.

If an offline centered smoother is useful later, it should be exposed under an explicitly offline/noncausal API.

## Plugin lifecycle

`BandpassTransform` and `SmoothingTransform` expose `reset()` so callers can declare a new acquisition/filter epoch without reaching through plugin internals.

## Qualification authority

The audit also found that normal `neurOS CI` uses fixed test-file lists, so adding a new regression file alone would not guarantee it executes. This PR therefore adds `.github/workflows/streaming-dsp-ci.yml`, path-bound to the live filter surfaces, and runs `tests/test_streaming_filters.py` on Python 3.10, 3.11, and 3.12.

The focused suite proves:

- one-dimensional and multichannel whole-stream vs adversarial partition equivalence;
- high-order SOS state continuity;
- causal smoothing impulse behavior with no future-sample dependence;
- explicit reset equivalence to a fresh filter;
- geometry-change refusal until reset;
- cutoff/Nyquist/order/window fail-closed validation;
- plugin state continuity and reset.

## Exact-head qualification

Production base: `9d5f81c957e570327d31e84eb31d94cf3030c6b9`

Qualified head: `878f4bbce9b519d69c5213dc3428a5bc5fb00a9f`

Four intentional files changed.

All exact-head workflows are green:

- Streaming DSP Contracts, Python 3.10/3.11/3.12;
- full neurOS CI;
- Braindecode Compatibility;
- Neural Window Contracts;
- Developer Preview Journey;
- neurOS driver contracts;
- Ecosystem Compatibility;
- External Plugin Contract.

## Evidence boundary

This establishes deterministic causal software preprocessing semantics. It does **not** establish that a specific filter band or order is physiologically optimal, and it does not validate any decoder, device, participant, closed-loop, or clinical claim.

Closes #66.