### PR TITLE
Arena presentation epochs: separate physical stimulus from stage bookkeeping

### DIFF
--- a/.github/workflows/synthetic-arena.yml
+++ b/.github/workflows/synthetic-arena.yml
@@ -48,6 +48,7 @@ jobs:
             tests/test_arena_authority_contracts.py \
             tests/test_arena_world_input.py \
             tests/test_arena_participant_state.py \
+            tests/test_arena_presentation.py \
             tests/test_arena_world_models.py \
             tests/test_arena_leadfield.py \
             tests/test_arena_population.py \

--- a/docs/ARENA_PARTICIPANT_RESPONSE.md
+++ b/docs/ARENA_PARTICIPANT_RESPONSE.md
@@ -39,14 +39,23 @@ The v1 compiler resolves the entire participant response on the **source sample 
 
 ## Inputs
 
-The v1 compiler consumes the existing `ParticipantProfile` and frequency-target fields from `ArenaScenario`:
+The v1 compiler consumes the existing `ParticipantProfile` plus explicit frequency-target identity from `ArenaScenario`:
 
 - `StageSpec.target_frequency_hz`;
+- `StageSpec.stimulus_id`;
 - `StageSpec.attention_gain`;
 - `ParticipantProfile.response_delay_s`;
 - `ParticipantProfile.switch_time_constant_s`;
 - `ParticipantProfile.gaze_duty_cycle`;
 - `ParticipantProfile.response_attenuation_per_minute`.
+
+For this model, attentional target identity is:
+
+```text
+(target_frequency_hz, stimulus_id)
+```
+
+Frequency is a decoder code, not necessarily a unique physical target. Two different objects may reuse the same frequency and must therefore remain distinguishable.
 
 These parameter values define a synthetic world. They are not population estimates unless a separate empirical study justifies a particular distribution.
 
@@ -57,11 +66,11 @@ These parameter values define a synthetic world. They are not population estimat
 - `attention_gain`: effective synthetic participant drive;
 - `requested_attention_gain`: requested drive after declared gaze/fatigue scaling;
 - `target_frequency_hz`: active frequency target, with NaN for rest/no-frequency target;
-- `target_switch`: frequency-target transition marker;
+- `target_switch`: attentional target-transition marker;
 - `sampling_rate_hz`;
 - versioned model identifier.
 
-The report exposes a compact participant-state summary including transition samples and effective/requested gain statistics.
+The report exposes a compact participant-state summary including transition samples, the declared target-identity rule, and effective/requested gain statistics.
 
 ## Timing authority
 
@@ -90,19 +99,31 @@ Stage labels are not participant causes.
 Two adjacent stages such as:
 
 ```text
-sight-a: 10 Hz
-sight-b: 10 Hz
+sight-a: 10 Hz, stimulus_id="sight-orb"
+sight-b: 10 Hz, stimulus_id="sight-orb"
 ```
 
 preserve the participant response state. Renaming or splitting a stage does not restart response delay.
 
-A true target change such as:
+A true frequency change such as:
 
 ```text
 10 Hz → 12 Hz
 ```
 
 resets the v1 response state and begins the declared response delay.
+
+A physical target-identity change also resets response even if the frequency is reused:
+
+```text
+10 Hz, stimulus_id="left-orb"
+→
+10 Hz, stimulus_id="right-orb"
+```
+
+This is a real attentional target switch despite identical frequency-valued decoder truth.
+
+By contrast, `stimulus_retrigger=True` restarts the **display presentation** of the same physical object. It does not by itself create an attentional target switch when `(target_frequency_hz, stimulus_id)` is unchanged. Presentation state and participant attention are separate causal layers.
 
 Transitions into or out of rest are also recorded. Initial rest is not reported as a transition because no target change has yet occurred.
 
@@ -116,7 +137,7 @@ After the delay, v1 uses a first-order discrete response state that approaches t
 
 ## WorldInputBlock
 
-The paradigm-neutral world-model boundary now distinguishes:
+The paradigm-neutral world-model boundary distinguishes:
 
 ```text
 participant_state
@@ -154,13 +175,29 @@ W3 consumes the same participant stream before projecting the visual response th
 
 ## Render-partition invariance
 
-For W1/W2/W3, the following is now a software contract:
+For W1/W2/W3, the following is a software contract:
 
 > Given the same scenario, participant profile, display, world parameters, seed and source sample clock, changing Arena's internal neural render chunk size must not change the generated source/device EEG.
 
 The test suite compares 1-sample and 37-sample render chunks exactly.
 
 This is not a claim that the synthetic EEG is physiologically realistic. It proves that implementation batching is not part of the synthetic causal world.
+
+## Presentation boundary
+
+Participant state and physical display state are related but distinct.
+
+The presentation layer owns:
+
+- physical stimulus identity;
+- explicit retrigger;
+- display response lag;
+- frame timing/jitter/drop realization;
+- coded waveform phase.
+
+The participant layer owns the synthetic response to the attentional target identity.
+
+See `docs/ARENA_PRESENTATION_EPOCHS.md` for the presentation-epoch contract.
 
 ## Paradigm boundary
 
@@ -184,6 +221,8 @@ It can support statements such as:
 
 - participant state is deterministic for a fixed manifest/profile/seed;
 - stage-label-only splits do not reset frequency-target response;
+- same-frequency/different-stimulus switches remain real target transitions;
+- pure display retriggers do not invent attention switches;
 - declared delays never begin before the source sample at-or-after the delay;
 - W1/W2/W3 are invariant to internal neural render partitioning;
 - participant-stream geometry/non-finite values fail closed.

--- a/docs/ARENA_PRESENTATION_EPOCHS.md
+++ b/docs/ARENA_PRESENTATION_EPOCHS.md
@@ -1,0 +1,209 @@
+# Arena physical presentation epochs
+
+Synthetic BCI Arena separates **scenario structure** from **physical display events**.
+
+A stage label, task annotation or scoring boundary is not automatically a new visual stimulus. Treating every stage boundary as a display restart makes authoring choices causal: splitting one continuous target into two stages can restart display response lag, flicker phase, frame-jitter randomness and dropped-frame history even though nothing physical changed.
+
+The presentation contract removes that ambiguity.
+
+## Contracts
+
+Presentation compiler:
+
+`neuros.arena.presentation_epochs.v1`
+
+Synthetic display trace:
+
+`neuros.arena.display_trace.v2`
+
+Each `StageSpec` may declare:
+
+- `stimulus_id`: optional stable identity of the physical coded object;
+- `stimulus_retrigger`: explicit request to start a new physical presentation epoch.
+
+Adjacent stages share one presentation epoch when all of the following hold:
+
+1. target frequency is unchanged;
+2. `stimulus_id` is unchanged;
+3. the later stage does not set `stimulus_retrigger=True`.
+
+A frequency change or `stimulus_id` change starts a new epoch automatically.
+
+## Why frequency alone is insufficient
+
+Frequency is a code, not an object identity.
+
+Two spatial targets can both use 10 Hz. If the participant moves attention from a left 10 Hz orb to a right 10 Hz orb, Arena must represent a real target switch even though the decoder code is numerically unchanged.
+
+For the current frequency-target participant model, attentional identity is therefore:
+
+```text
+(target_frequency_hz, stimulus_id)
+```
+
+This affects participant response delay and switching state.
+
+Presentation retrigger is intentionally separate. Restarting the same physical object's flicker does not automatically mean that the participant stopped attending that object.
+
+## Command time and modeled emission time
+
+The display trace keeps two clocks separate:
+
+- `command_frame_times_s`: when the application/display scheduler requests each frame state;
+- `frame_times_s`: when that frame is modeled as physically emitted after the declared display response lag.
+
+The v2 display contract evaluates coded luminance on the command clock and then delays emission:
+
+```text
+commanded luminance at t
+        ↓
+response_lag_ms
+        ↓
+modeled emission at t + lag
+```
+
+Equivalently:
+
+```text
+emitted(t + lag) = commanded(t)
+```
+
+This is important for phase-sensitive stimulation. A constant 6 ms response lag must shift the complete emitted waveform by 6 ms. It must not delay only the first visible frame and then evaluate subsequent luminance against an undelayed global oscillator.
+
+`frame_jitter_ms` currently represents variability in the scheduler/frame cadence before the constant response-lag transform. Pixel-specific variable response latency is deliberately not invented here. That belongs to measured display calibration.
+
+This remains a synthetic timing model. A physical monitor can falsify it.
+
+## Causal timeline
+
+```text
+ArenaScenario stages
+        ↓
+physical stimulus identity + explicit retrigger
+        ↓
+PresentationPlan
+        ↓
+PresentationEpoch 0, 1, ...
+        ↓
+command-frame clock / coded phase / frame jitter / drops
+        ↓
+constant modeled command→emission response lag
+        ↓
+emitted luminance sampled on the EEG source clock
+        ↓
+neural world model
+```
+
+Frame timing and frame RNG belong to the presentation epoch, not to the authoring stage.
+
+## Stage segmentation invariant
+
+Given the same resolved source sample timeline:
+
+> Splitting one stage into adjacent stages with the same frequency, same `stimulus_id`, and no explicit retrigger must not change emitted luminance or downstream EEG.
+
+The Arena regression suite binds this with non-zero response lag, frame jitter and dropped-frame probability, so the invariant is not merely a zero-noise special case.
+
+A separate regression binds the response-lag contract itself: changing only `response_lag_ms` must leave command-frame times and commanded luminance unchanged while shifting every modeled emission timestamp by the declared lag.
+
+## Explicit retrigger
+
+Use:
+
+```python
+StageSpec(
+    "sight-second-block",
+    1.0,
+    target_frequency_hz=10.0,
+    stimulus_id="sight-orb",
+    stimulus_retrigger=True,
+)
+```
+
+when the application physically restarts that presentation.
+
+A retrigger creates a new display epoch and therefore a new response-lag/frame/drop/phase realization. It does **not** itself create an attentional target switch if `(frequency, stimulus_id)` is unchanged.
+
+## Same-frequency target switch
+
+Use distinct stimulus identities for distinct physical objects even if their code is identical:
+
+```python
+StageSpec("left", 1.0, 10.0, stimulus_id="left-orb")
+StageSpec("right", 1.0, 10.0, stimulus_id="right-orb")
+```
+
+This creates:
+
+- two presentation epochs;
+- one participant target transition at the boundary;
+- a new participant response-delay interval;
+- unchanged frequency-valued decoder ground truth.
+
+That distinction is important for systems studying spatial selection or code reuse.
+
+## Report evidence
+
+Arena reports expose:
+
+`metrics.presentation.model`
+
+`metrics.presentation.epoch_count`
+
+`metrics.presentation.stage_epoch_index`
+
+and one record per physical epoch containing:
+
+- presentation model and display-trace model;
+- source-sample start/end;
+- resolved timing;
+- command start and first modeled emission;
+- modeled response lag;
+- target frequency;
+- `stimulus_id`;
+- member stage indices/labels;
+- observed transition frequency;
+- frame-drop fraction;
+- interval jitter.
+
+The historical per-stage `metrics.display` list remains available and names the presentation epoch used by each stage.
+
+`ArenaRun.stimulus_traces` remains stage-addressable for compatibility. Adjacent stages in one physical presentation intentionally reference the same complete trace. The report's presentation section is the canonical source for physical-epoch interpretation.
+
+## What is guaranteed
+
+Within the declared synthetic model, Arena can guarantee:
+
+- stage-label changes do not restart a continuing presentation;
+- frame RNG belongs to physical epochs rather than stage count;
+- explicit retrigger is represented separately from task segmentation;
+- same-frequency/different-object switches remain identifiable;
+- presentation timing is resolved on the same source sample clock used by participant and neural-world layers;
+- constant declared response lag is represented as a persistent command→emission delay rather than an onset-only blank.
+
+## What is not claimed
+
+This contract does not establish:
+
+- physical monitor frame timing;
+- actual pixel response latency or its variability;
+- photodiode-measured luminance;
+- human SSVEP phase locking;
+- human response latency after a flicker restart;
+- safe or comfortable stimulation parameters.
+
+Those require measured display and participant evidence.
+
+## Physical qualification
+
+The correct next evidence ladder remains:
+
+1. render the exact competition stimulus;
+2. measure emitted luminance with a photodiode;
+3. compare requested vs measured frame/transition timing;
+4. repeat under idle and full application load;
+5. repeat across ordinary combat presentation events;
+6. test physical headset acquisition and synchronized stimulus markers;
+7. only then evaluate participant-level neural response and decoder performance.
+
+The presentation epoch model is a software authority contract. It is designed so those measurements can falsify or calibrate the synthetic layer rather than being replaced by it.

--- a/packages/neuros-arena/src/neuros/arena/__init__.py
+++ b/packages/neuros-arena/src/neuros/arena/__init__.py
@@ -37,6 +37,12 @@ from .participant import (
     compile_participant_state_trace,
 )
 from .population import ParameterDistribution, PopulationRun, PopulationSpec, run_population
+from .presentation import (
+    PRESENTATION_EPOCH_MODEL,
+    PresentationEpoch,
+    PresentationPlan,
+    compile_presentation_plan,
+)
 from .presets import get_preset, list_presets
 from .reality import RealityAnchorResult, anchor_worlds_by_covariance, anchor_worlds_by_embeddings
 from .recording import (
@@ -49,6 +55,7 @@ from .recording import (
 from .reference import compare_feature_signatures, feature_signature
 from .runner import ArenaRun, run_scenario
 from .semi_synthetic import SemiSyntheticReplayWorldModel
+from .simulators import DISPLAY_TRACE_MODEL
 from .specs import (
     ArenaScenario,
     ArtifactEvent,
@@ -79,6 +86,7 @@ __all__ = [
     "BenchmarkPackResult",
     "CohortAnchorFold",
     "CohortAnchorStudy",
+    "DISPLAY_TRACE_MODEL",
     "DeviceProfile",
     "DisplayProfile",
     "DrivenStateSpaceWorldModel",
@@ -90,11 +98,14 @@ __all__ = [
     "MetricRule",
     "NeuralWorldModel",
     "PARTICIPANT_RESPONSE_MODEL",
+    "PRESENTATION_EPOCH_MODEL",
     "ParameterDistribution",
     "ParticipantProfile",
     "ParticipantStateTrace",
     "PopulationRun",
     "PopulationSpec",
+    "PresentationEpoch",
+    "PresentationPlan",
     "RealityAnchorResult",
     "RecordingMetadata",
     "SemiSyntheticReplayWorldModel",
@@ -111,6 +122,7 @@ __all__ = [
     "check_transport_drop_monotonicity",
     "compare_feature_signatures",
     "compile_participant_state_trace",
+    "compile_presentation_plan",
     "evaluate_application_trace",
     "evaluate_decisions",
     "evidence_card_for_model",

--- a/packages/neuros-arena/src/neuros/arena/participant.py
+++ b/packages/neuros-arena/src/neuros/arena/participant.py
@@ -26,9 +26,11 @@ class ParticipantStateTrace:
     """Resolved per-sample frequency-target participant state.
 
     ``target_switch`` is retained as the compact field name for this contract,
-    but its semantics are target transitions: it is true when an active frequency
-    target first appears or whenever target identity changes, including
-    active→rest and rest→active boundaries. Initial rest is not a transition.
+    but its semantics are target transitions: it is true when an active visual
+    frequency target first appears or whenever target identity changes. Identity
+    is the pair ``(target_frequency_hz, stimulus_id)`` so two different physical
+    objects using the same code remain distinct attentional targets. Active→rest
+    and rest→active boundaries are transitions; initial rest is not.
     """
 
     attention_gain: np.ndarray
@@ -72,6 +74,7 @@ class ParticipantStateTrace:
         return {
             "model": self.model,
             "scope": PARTICIPANT_RESPONSE_SCOPE,
+            "target_identity": "target_frequency_hz+stimulus_id",
             "samples": int(np.asarray(self.attention_gain).size),
             "sampling_rate_hz": float(self.sampling_rate_hz),
             "target_transition_samples": transition_samples,
@@ -111,8 +114,12 @@ def compile_participant_state_trace(
     * ``gaze_duty_cycle`` is represented as a deterministic attenuation factor,
       not as a claim about literal eye-open sample occupancy;
     * global response attenuation scales that request with elapsed source time;
-    * frequency-target identity changes reset effective attention and start the
-      declared response delay;
+    * attentional target identity is ``(target_frequency_hz, stimulus_id)``;
+    * target-identity changes reset effective attention and start the declared
+      response delay;
+    * a pure ``stimulus_retrigger`` of the same target does not by itself reset
+      attention, because display presentation and attentional target are distinct
+      causal layers;
     * the first non-zero response sample can occur only at-or-after that delay;
     * after the delay, a first-order state approaches the current request using
       ``switch_time_constant_s``;
@@ -138,7 +145,7 @@ def compile_participant_state_trace(
 
     delay_samples = _delay_sample_count(participant.response_delay_s, fs)
     alpha = min(1.0, 1.0 / (fs * participant.switch_time_constant_s))
-    current_target: float | None = None
+    current_target: tuple[float, str | None] | None = None
     response_state = 0.0
     delay_remaining = 0
     cursor = 0
@@ -146,23 +153,24 @@ def compile_participant_state_trace(
 
     for stage in scenario.stages:
         count = _stage_sample_count(stage.duration_s, fs)
-        target = None if stage.target_frequency_hz is None else float(stage.target_frequency_hz)
+        frequency = None if stage.target_frequency_hz is None else float(stage.target_frequency_hz)
+        target_identity = None if frequency is None else (frequency, stage.stimulus_id)
         for local_index in range(count):
             sample_index = cursor + local_index
             if not initialized:
                 initialized = True
-                current_target = target
-                if target is not None:
+                current_target = target_identity
+                if target_identity is not None:
                     response_state = 0.0
                     delay_remaining = delay_samples
                     transition_trace[sample_index] = True
-            elif target != current_target:
-                current_target = target
+            elif target_identity != current_target:
+                current_target = target_identity
                 response_state = 0.0
-                delay_remaining = delay_samples if target is not None else 0
+                delay_remaining = delay_samples if target_identity is not None else 0
                 transition_trace[sample_index] = True
 
-            if target is None:
+            if target_identity is None:
                 requested_gain = 0.0
                 response_state = 0.0
             else:
@@ -186,8 +194,8 @@ def compile_participant_state_trace(
 
             requested[sample_index] = requested_gain
             effective[sample_index] = response_state
-            if target is not None:
-                target_trace[sample_index] = target
+            if frequency is not None:
+                target_trace[sample_index] = frequency
         cursor += count
 
     trace = ParticipantStateTrace(

--- a/packages/neuros-arena/src/neuros/arena/presentation.py
+++ b/packages/neuros-arena/src/neuros/arena/presentation.py
@@ -1,0 +1,224 @@
+"""Physical stimulus-epoch compilation for Synthetic BCI Arena.
+
+Scenario stages are authoring/task structure. They are not automatically physical
+stimulus boundaries. This module compiles adjacent stages onto explicit display
+presentation epochs so a label split cannot restart display lag, frame RNG or
+coded phase unless the physical stimulus identity changes or the scenario asks
+for a retrigger.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .simulators import StimulusTrace, simulate_stimulus
+from .specs import ArenaScenario, DisplayProfile, StageSpec
+
+
+PRESENTATION_EPOCH_MODEL = "neuros.arena.presentation_epochs.v1"
+
+
+@dataclass(frozen=True)
+class PresentationEpoch:
+    """One uninterrupted physical display presentation."""
+
+    index: int
+    start_sample: int
+    end_sample: int
+    target_frequency_hz: float | None
+    stimulus_id: str | None
+    stage_indices: tuple[int, ...]
+    trace: StimulusTrace
+
+    @property
+    def sample_count(self) -> int:
+        return self.end_sample - self.start_sample
+
+    def to_summary(self, scenario: ArenaScenario, sampling_rate_hz: float) -> dict[str, object]:
+        command_start = (
+            float(self.trace.command_frame_times_s[0])
+            if self.trace.command_frame_times_s.size
+            else 0.0
+        )
+        first_emission = (
+            float(self.trace.frame_times_s[0])
+            if self.trace.frame_times_s.size
+            else 0.0
+        )
+        return {
+            "epoch_index": int(self.index),
+            "model": PRESENTATION_EPOCH_MODEL,
+            "display_trace_model": self.trace.model,
+            "start_sample": int(self.start_sample),
+            "end_sample": int(self.end_sample),
+            "resolved_start_s": float(self.start_sample / sampling_rate_hz),
+            "resolved_end_s": float(self.end_sample / sampling_rate_hz),
+            "resolved_duration_s": float(self.sample_count / sampling_rate_hz),
+            "command_start_s": command_start,
+            "first_emission_s": first_emission,
+            "modeled_response_lag_ms": float((first_emission - command_start) * 1000.0),
+            "target_frequency_hz": self.target_frequency_hz,
+            "stimulus_id": self.stimulus_id,
+            "stage_indices": [int(value) for value in self.stage_indices],
+            "stages": [scenario.stages[index].label for index in self.stage_indices],
+            "observed_frequency_hz": float(self.trace.observed_frequency_hz),
+            "frequency_error_hz": (
+                0.0
+                if self.target_frequency_hz is None
+                else float(abs(self.trace.observed_frequency_hz - self.target_frequency_hz))
+            ),
+            "frame_drop_fraction": float(self.trace.frame_drop_fraction),
+            "interval_jitter_ms": float(self.trace.interval_jitter_ms),
+        }
+
+
+@dataclass(frozen=True)
+class PresentationPlan:
+    """Resolved presentation epochs plus a stage-to-epoch lookup."""
+
+    epochs: tuple[PresentationEpoch, ...]
+    stage_epoch_index: tuple[int, ...]
+    sampling_rate_hz: float
+    model: str = PRESENTATION_EPOCH_MODEL
+
+    def validate(self, scenario: ArenaScenario) -> None:
+        if len(self.stage_epoch_index) != len(scenario.stages):
+            raise ValueError("presentation plan must map every scenario stage")
+        if self.sampling_rate_hz <= 0 or not np.isfinite(self.sampling_rate_hz):
+            raise ValueError("presentation sampling rate must be positive and finite")
+        if not self.epochs:
+            raise ValueError("presentation plan requires at least one epoch")
+        cursor = 0
+        for expected_index, epoch in enumerate(self.epochs):
+            if epoch.index != expected_index:
+                raise ValueError("presentation epoch indices must be contiguous")
+            if epoch.start_sample != cursor or epoch.end_sample <= epoch.start_sample:
+                raise ValueError("presentation epochs must tile the source sample clock")
+            if not epoch.stage_indices:
+                raise ValueError("presentation epoch must own at least one stage")
+            cursor = epoch.end_sample
+        if any(index < 0 or index >= len(self.epochs) for index in self.stage_epoch_index):
+            raise ValueError("stage-to-presentation mapping contains an invalid epoch index")
+
+    def epoch_for_stage(self, stage_index: int) -> PresentationEpoch:
+        return self.epochs[self.stage_epoch_index[stage_index]]
+
+    def to_summary(self, scenario: ArenaScenario) -> dict[str, object]:
+        self.validate(scenario)
+        return {
+            "model": self.model,
+            "epoch_count": len(self.epochs),
+            "stage_epoch_index": [int(value) for value in self.stage_epoch_index],
+            "epochs": [
+                epoch.to_summary(scenario, self.sampling_rate_hz)
+                for epoch in self.epochs
+            ],
+        }
+
+
+def _stage_sample_count(stage: StageSpec, sampling_rate_hz: float) -> int:
+    return max(1, int(round(float(stage.duration_s) * float(sampling_rate_hz))))
+
+
+def _same_frequency(first: float | None, second: float | None) -> bool:
+    if first is None or second is None:
+        return first is None and second is None
+    return bool(np.isclose(float(first), float(second), rtol=0.0, atol=1e-12))
+
+
+def _same_physical_stimulus(
+    frequency_hz: float | None,
+    stimulus_id: str | None,
+    stage: StageSpec,
+) -> bool:
+    return _same_frequency(frequency_hz, stage.target_frequency_hz) and stimulus_id == stage.stimulus_id
+
+
+def compile_presentation_plan(
+    scenario: ArenaScenario,
+    display: DisplayProfile,
+    sampling_rate_hz: float,
+) -> PresentationPlan:
+    """Compile task stages into physical presentation epochs.
+
+    A new epoch begins when:
+
+    * target frequency changes;
+    * ``stimulus_id`` changes; or
+    * ``stimulus_retrigger=True`` explicitly requests a new presentation.
+
+    Otherwise adjacent stages share the same display trace. Their labels,
+    attention gain, task metadata and artifact schedule may still change without
+    causing a physical display restart.
+
+    The display trace duration is resolved from the source sample clock, not the
+    requested floating stage duration. Epoch RNG seeds depend on physical epoch
+    order rather than authoring-stage count, making label-only stage splitting
+    presentation invariant when it preserves the same resolved sample timeline.
+    """
+
+    scenario.validate()
+    display.validate()
+    fs = float(sampling_rate_hz)
+    if fs <= 0 or not np.isfinite(fs):
+        raise ValueError("sampling_rate_hz must be positive and finite")
+
+    raw_epochs: list[dict[str, object]] = []
+    stage_epoch_index: list[int] = []
+    global_sample = 0
+
+    for stage_index, stage in enumerate(scenario.stages):
+        samples = _stage_sample_count(stage, fs)
+        new_epoch = not raw_epochs
+        if raw_epochs:
+            current = raw_epochs[-1]
+            new_epoch = bool(stage.stimulus_retrigger) or not _same_physical_stimulus(
+                current["target_frequency_hz"],
+                current["stimulus_id"],
+                stage,
+            )
+        if new_epoch:
+            raw_epochs.append({
+                "start_sample": global_sample,
+                "end_sample": global_sample + samples,
+                "target_frequency_hz": stage.target_frequency_hz,
+                "stimulus_id": stage.stimulus_id,
+                "stage_indices": [stage_index],
+            })
+        else:
+            current = raw_epochs[-1]
+            current["end_sample"] = global_sample + samples
+            current["stage_indices"].append(stage_index)
+        stage_epoch_index.append(len(raw_epochs) - 1)
+        global_sample += samples
+
+    epochs: list[PresentationEpoch] = []
+    for epoch_index, raw in enumerate(raw_epochs):
+        start_sample = int(raw["start_sample"])
+        end_sample = int(raw["end_sample"])
+        target_frequency_hz = raw["target_frequency_hz"]
+        duration_s = (end_sample - start_sample) / fs
+        trace = simulate_stimulus(
+            target_frequency_hz,
+            duration_s,
+            display,
+            seed=scenario.seed * 1009 + epoch_index,
+        )
+        epochs.append(PresentationEpoch(
+            index=epoch_index,
+            start_sample=start_sample,
+            end_sample=end_sample,
+            target_frequency_hz=target_frequency_hz,
+            stimulus_id=raw["stimulus_id"],
+            stage_indices=tuple(int(value) for value in raw["stage_indices"]),
+            trace=trace,
+        ))
+
+    plan = PresentationPlan(
+        epochs=tuple(epochs),
+        stage_epoch_index=tuple(stage_epoch_index),
+        sampling_rate_hz=fs,
+    )
+    plan.validate(scenario)
+    return plan

--- a/packages/neuros-arena/src/neuros/arena/runner.py
+++ b/packages/neuros-arena/src/neuros/arena/runner.py
@@ -11,7 +11,8 @@ from neuros.plugins import PluginKind, load_plugin
 
 from .evidence import evidence_card_for_model
 from .participant import compile_participant_state_trace
-from .simulators import DeviceOutput, StimulusTrace, TransportPacket, apply_device, packetize, sample_stimulus, simulate_stimulus
+from .presentation import compile_presentation_plan
+from .simulators import DeviceOutput, StimulusTrace, TransportPacket, apply_device, packetize, sample_stimulus
 from .specs import ArenaScenario, DeviceProfile, DisplayProfile, ParticipantProfile, TransportProfile, WorldModelProfile
 from .world_input import WorldInputBlock
 from .world_models import NeuralWorldModel
@@ -44,6 +45,8 @@ class ArenaRun:
     ground_truth_target_hz: np.ndarray
     stage_index: np.ndarray
     stages: tuple[StageInterval, ...]
+    # Legacy stage-addressable view. Adjacent stages in the same physical
+    # presentation epoch intentionally reference the same complete trace.
     stimulus_traces: tuple[StimulusTrace, ...]
     report: dict
 
@@ -213,14 +216,14 @@ def run_scenario(
 
     fs = float(device.sampling_rate_hz)
     participant_trace = compile_participant_state_trace(scenario, participant, fs)
+    presentation_plan = compile_presentation_plan(scenario, display, fs)
     block_samples = WORLD_RENDER_CHUNK_SAMPLES
     data_blocks: list[np.ndarray] = []
     timestamp_blocks: list[np.ndarray] = []
     truth_blocks: list[np.ndarray] = []
     stage_blocks: list[np.ndarray] = []
     stage_intervals: list[StageInterval] = []
-    stage_timing: list[dict[str, float | int | str]] = []
-    stimulus_traces: list[StimulusTrace] = []
+    stage_timing: list[dict[str, object]] = []
     latent_stage_end: list[dict[str, float | str]] = []
     global_sample_start = 0
 
@@ -229,6 +232,7 @@ def run_scenario(
         stage_start = global_sample_start / fs
         stage_end = (global_sample_start + samples_total) / fs
         resolved_duration = samples_total / fs
+        presentation_epoch = presentation_plan.epoch_for_stage(stage_i)
         stage_intervals.append(StageInterval(stage.label, stage_start, stage_end, stage.target_frequency_hz))
         stage_timing.append({
             "stage": stage.label,
@@ -240,14 +244,10 @@ def run_scenario(
             "requested_duration_s": float(stage.duration_s),
             "resolved_duration_s": float(resolved_duration),
             "duration_error_ms": float((resolved_duration - stage.duration_s) * 1000.0),
+            "presentation_epoch_index": presentation_epoch.index,
+            "stimulus_id": stage.stimulus_id,
+            "stimulus_retrigger": bool(stage.stimulus_retrigger),
         })
-        trace = simulate_stimulus(
-            stage.target_frequency_hz,
-            stage.duration_s,
-            display,
-            seed=scenario.seed * 1009 + stage_i,
-        )
-        stimulus_traces.append(trace)
         artifact_cursor: set[int] = set()
         produced = 0
         last_latent: dict[str, float] = {}
@@ -255,8 +255,8 @@ def run_scenario(
             count = min(block_samples, samples_total - produced)
             sample_offsets = produced + np.arange(count, dtype=np.int64)
             global_indices = global_sample_start + sample_offsets
-            local_times = sample_offsets.astype(float) / fs
             global_times = global_indices.astype(float) / fs
+            epoch_local_times = (global_indices - presentation_epoch.start_sample).astype(float) / fs
             elapsed = produced / fs
             if artifact_execution == "legacy_injection":
                 for artifact_i, artifact in enumerate(stage.artifacts):
@@ -275,7 +275,7 @@ def run_scenario(
             # first source sample is the least surprising summary because the old
             # runner updated the value at block start.
             effective_gain = float(attention_stream[0]) if attention_stream.size else 0.0
-            emitted_drive = sample_stimulus(trace, local_times, display)
+            emitted_drive = sample_stimulus(presentation_epoch.trace, epoch_local_times, display)
             target = dict(stage.target)
             if stage.target_frequency_hz is not None:
                 target.setdefault("frequency_hz", float(stage.target_frequency_hz))
@@ -336,9 +336,16 @@ def run_scenario(
         snr[f"{frequency:g}Hz"] = _spectral_snr_db(output.data_uv[posterior][:, mask], device.sampling_rate_hz, float(frequency))
 
     display_metrics = []
-    for stage, trace in zip(scenario.stages, stimulus_traces, strict=True):
+    for stage_i, stage in enumerate(scenario.stages):
+        epoch = presentation_plan.epoch_for_stage(stage_i)
+        trace = epoch.trace
         display_metrics.append({
             "stage": stage.label,
+            "stage_index": stage_i,
+            "presentation_epoch_index": epoch.index,
+            "stimulus_id": stage.stimulus_id,
+            "stimulus_retrigger": bool(stage.stimulus_retrigger),
+            "shared_presentation_epoch": len(epoch.stage_indices) > 1,
             "target_frequency_hz": stage.target_frequency_hz,
             "observed_frequency_hz": trace.observed_frequency_hz,
             "frequency_error_hz": (0.0 if stage.target_frequency_hz is None else abs(trace.observed_frequency_hz - stage.target_frequency_hz)),
@@ -364,6 +371,7 @@ def run_scenario(
             "target_snr_db": snr,
             "transport": transport_metrics,
             "display": display_metrics,
+            "presentation": presentation_plan.to_summary(scenario),
             "stage_timing": stage_timing,
             "participant_state": participant_trace.to_summary(),
             "world_model": {
@@ -389,6 +397,9 @@ def run_scenario(
         ground_truth_target_hz=truth,
         stage_index=stage_index,
         stages=tuple(stage_intervals),
-        stimulus_traces=tuple(stimulus_traces),
+        stimulus_traces=tuple(
+            presentation_plan.epoch_for_stage(stage_i).trace
+            for stage_i in range(len(scenario.stages))
+        ),
         report=report,
     )

--- a/packages/neuros-arena/src/neuros/arena/simulators.py
+++ b/packages/neuros-arena/src/neuros/arena/simulators.py
@@ -8,15 +8,22 @@ import numpy as np
 from .specs import DeviceProfile, DisplayProfile, TransportProfile
 
 
+DISPLAY_TRACE_MODEL = "neuros.arena.display_trace.v2"
+
+
 @dataclass(frozen=True)
 class StimulusTrace:
     frequency_hz: float | None
+    # Command/scheduler clock: when the application requested each frame state.
+    command_frame_times_s: np.ndarray
+    # Modeled physical-emission clock: command time plus display response lag.
     frame_times_s: np.ndarray
     luminance: np.ndarray
     dropped_frames: np.ndarray
     observed_frequency_hz: float
     frame_drop_fraction: float
     interval_jitter_ms: float
+    model: str = DISPLAY_TRACE_MODEL
 
 
 @dataclass(frozen=True)
@@ -46,6 +53,22 @@ def simulate_stimulus(
     profile: DisplayProfile,
     seed: int,
 ) -> StimulusTrace:
+    """Simulate commanded display frames and their delayed physical emission.
+
+    ``command_frame_times_s`` is the application/scheduler clock. The coded
+    luminance value is evaluated on that clock. ``frame_times_s`` is the modeled
+    emission clock after applying the declared constant response lag. Therefore
+    a non-zero response lag produces a persistent phase delay:
+
+    ``emitted(t + lag) = commanded(t)``
+
+    rather than merely delaying the first frame and then snapping back onto an
+    undelayed global phase. Frame jitter belongs to the command/frame cadence;
+    dropped frames hold the previously emitted luminance value.
+
+    This remains a synthetic display model. Physical monitor timing requires
+    photodiode or equivalent observation.
+    """
     profile.validate()
     if duration_s <= 0:
         raise ValueError("duration_s must be positive")
@@ -56,18 +79,24 @@ def simulate_stimulus(
     nominal = 1.0 / profile.refresh_hz
     jitter = rng.normal(0.0, profile.frame_jitter_ms / 1000.0, size=frames)
     intervals = np.maximum(nominal * 0.25, nominal + jitter)
-    frame_times = np.cumsum(intervals) - intervals[0] + profile.response_lag_ms / 1000.0
+    command_frame_times = np.cumsum(intervals) - intervals[0]
+    response_lag_s = profile.response_lag_ms / 1000.0
+    frame_times = command_frame_times + response_lag_s
     dropped = rng.random(frames) < profile.frame_drop_probability
     luminance = np.full(frames, profile.low_luminance, dtype=float)
     previous = profile.low_luminance
-    for index, t_s in enumerate(frame_times):
+    for index, command_t_s in enumerate(command_frame_times):
         if dropped[index]:
             luminance[index] = previous
             continue
         if frequency_hz is None:
             value = profile.low_luminance
         else:
-            value = profile.high_luminance if np.sin(2 * np.pi * frequency_hz * t_s) >= 0 else profile.low_luminance
+            value = (
+                profile.high_luminance
+                if np.sin(2 * np.pi * frequency_hz * command_t_s) >= 0
+                else profile.low_luminance
+            )
         luminance[index] = value
         previous = value
     transitions = int(np.count_nonzero(np.diff(luminance) != 0))
@@ -75,6 +104,7 @@ def simulate_stimulus(
     observed = transitions / (2.0 * span) if frequency_hz is not None else 0.0
     return StimulusTrace(
         frequency_hz=frequency_hz,
+        command_frame_times_s=command_frame_times,
         frame_times_s=frame_times,
         luminance=luminance,
         dropped_frames=dropped,
@@ -91,9 +121,11 @@ def sample_stimulus(
 ) -> np.ndarray:
     """Sample-and-hold the physically emitted luminance at EEG sample times.
 
-    Values are normalized to [-1, 1] around the configured low/high luminance.
-    A no-target trace returns zeros so resting baseline does not become an
-    artificial negative periodic drive.
+    ``trace.frame_times_s`` is the modeled emission clock. Before the first
+    emitted frame the display remains at the configured low luminance. Values are
+    normalized to [-1, 1] around the configured low/high luminance. A no-target
+    trace returns zeros so resting baseline does not become an artificial
+    negative periodic drive.
     """
     times = np.asarray(sample_times_s, dtype=float)
     if times.ndim != 1:

--- a/packages/neuros-arena/src/neuros/arena/specs.py
+++ b/packages/neuros-arena/src/neuros/arena/specs.py
@@ -234,6 +234,8 @@ class StageSpec:
     artifacts: tuple[ArtifactEvent, ...] = ()
     target: dict[str, Any] = field(default_factory=dict)
     task_state: dict[str, Any] = field(default_factory=dict)
+    stimulus_id: str | None = None
+    stimulus_retrigger: bool = False
 
     def validate(self) -> None:
         if not self.label or not np.isfinite(self.duration_s) or self.duration_s <= 0:
@@ -243,6 +245,10 @@ class StageSpec:
                 raise ValueError("target frequency must be positive and finite")
         if not np.isfinite(self.attention_gain) or self.attention_gain < 0:
             raise ValueError("attention gain must be non-negative and finite")
+        if self.stimulus_id is not None and (not isinstance(self.stimulus_id, str) or not self.stimulus_id.strip()):
+            raise ValueError("stimulus_id must be a non-empty string when supplied")
+        if not isinstance(self.stimulus_retrigger, (bool, np.bool_)):
+            raise ValueError("stimulus_retrigger must be boolean")
         for event in self.artifacts:
             event.validate(self.duration_s)
         _validate_scalar_mapping("stage.target", self.target)
@@ -307,6 +313,8 @@ class ArenaScenario:
                 artifacts=tuple(artifacts),
                 target=dict(stage_raw.get("target", {})),
                 task_state=dict(stage_raw.get("task_state", {})),
+                stimulus_id=(None if stage_raw.get("stimulus_id") is None else str(stage_raw["stimulus_id"])),
+                stimulus_retrigger=stage_raw.get("stimulus_retrigger", False),
             ))
         scenario = cls(name=str(raw["name"]), stages=tuple(stages), seed=int(raw.get("seed", 7)), metadata=dict(raw.get("metadata", {})))
         scenario.validate()

--- a/tests/test_arena_presentation.py
+++ b/tests/test_arena_presentation.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.arena import (
+    ArenaScenario,
+    DeviceProfile,
+    DisplayProfile,
+    ParticipantProfile,
+    PRESENTATION_EPOCH_MODEL,
+    StageSpec,
+    TransportProfile,
+    WorldModelProfile,
+    compile_participant_state_trace,
+    compile_presentation_plan,
+    run_scenario,
+)
+
+
+def _participant() -> ParticipantProfile:
+    return ParticipantProfile(
+        seed=141,
+        response_delay_s=0.04,
+        switch_time_constant_s=0.20,
+        gaze_duty_cycle=0.85,
+    )
+
+
+def _display() -> DisplayProfile:
+    return DisplayProfile(
+        response_lag_ms=6.0,
+        frame_jitter_ms=0.9,
+        frame_drop_probability=0.18,
+    )
+
+
+def _run(scenario: ArenaScenario):
+    return run_scenario(
+        scenario,
+        _participant(),
+        DeviceProfile(
+            chunk_samples=31,
+            sensor_noise_uv=0.0,
+            line_noise_uv=0.0,
+            timestamp_jitter_ms=0.0,
+        ),
+        _display(),
+        TransportProfile(),
+        WorldModelProfile("driven_state_space"),
+    )
+
+
+def test_label_only_stage_split_preserves_physical_presentation_and_eeg():
+    whole = ArenaScenario(
+        "presentation-whole",
+        (
+            StageSpec(
+                "sight",
+                2.0,
+                10.0,
+                0.9,
+                stimulus_id="sight-orb",
+            ),
+        ),
+        seed=151,
+    )
+    split = ArenaScenario(
+        "presentation-split",
+        (
+            StageSpec(
+                "sight-a",
+                0.8,
+                10.0,
+                0.9,
+                stimulus_id="sight-orb",
+            ),
+            StageSpec(
+                "sight-b",
+                1.2,
+                10.0,
+                0.9,
+                stimulus_id="sight-orb",
+            ),
+        ),
+        seed=151,
+    )
+
+    whole_run = _run(whole)
+    split_run = _run(split)
+
+    np.testing.assert_array_equal(whole_run.device_output.data_uv, split_run.device_output.data_uv)
+    np.testing.assert_array_equal(
+        whole_run.device_output.ground_truth_timestamps_s,
+        split_run.device_output.ground_truth_timestamps_s,
+    )
+    whole_presentation = whole_run.report["metrics"]["presentation"]
+    split_presentation = split_run.report["metrics"]["presentation"]
+    assert whole_presentation["model"] == PRESENTATION_EPOCH_MODEL
+    assert whole_presentation["epoch_count"] == 1
+    assert split_presentation["epoch_count"] == 1
+    assert split_presentation["stage_epoch_index"] == [0, 0]
+    assert split_presentation["epochs"][0]["stages"] == ["sight-a", "sight-b"]
+    assert split_run.report["metrics"]["participant_state"]["target_transition_samples"] == [0]
+
+
+def test_response_lag_delays_emission_clock_without_advancing_code_phase():
+    scenario = ArenaScenario(
+        "display-lag-phase",
+        (StageSpec("sight", 0.6, 10.0, 0.9, stimulus_id="sight"),),
+        seed=153,
+    )
+    zero_lag = DisplayProfile(
+        refresh_hz=120.0,
+        response_lag_ms=0.0,
+        frame_jitter_ms=0.0,
+        frame_drop_probability=0.0,
+    )
+    delayed = DisplayProfile(
+        refresh_hz=120.0,
+        response_lag_ms=17.0,
+        frame_jitter_ms=0.0,
+        frame_drop_probability=0.0,
+    )
+
+    zero_trace = compile_presentation_plan(scenario, zero_lag, 250.0).epochs[0].trace
+    delayed_trace = compile_presentation_plan(scenario, delayed, 250.0).epochs[0].trace
+
+    # Response lag is command -> emission latency. It must not be fed back into
+    # the code oscillator and thereby alter which luminance each command frame
+    # requested. The emitted waveform is the same command sequence shifted later.
+    np.testing.assert_array_equal(
+        zero_trace.command_frame_times_s,
+        delayed_trace.command_frame_times_s,
+    )
+    np.testing.assert_array_equal(zero_trace.luminance, delayed_trace.luminance)
+    np.testing.assert_allclose(
+        delayed_trace.frame_times_s - delayed_trace.command_frame_times_s,
+        0.017,
+        rtol=0.0,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        delayed_trace.frame_times_s - zero_trace.frame_times_s,
+        0.017,
+        rtol=0.0,
+        atol=1e-12,
+    )
+    assert delayed_trace.model == "neuros.arena.display_trace.v2"
+
+
+def test_explicit_retrigger_creates_new_display_epoch_without_inventing_attention_switch():
+    continuation = ArenaScenario(
+        "continuation",
+        (
+            StageSpec("a", 0.5, 10.0, 0.9, stimulus_id="sight"),
+            StageSpec("b", 0.5, 10.0, 0.9, stimulus_id="sight"),
+        ),
+        seed=157,
+    )
+    retrigger = ArenaScenario(
+        "retrigger",
+        (
+            StageSpec("a", 0.5, 10.0, 0.9, stimulus_id="sight"),
+            StageSpec(
+                "b",
+                0.5,
+                10.0,
+                0.9,
+                stimulus_id="sight",
+                stimulus_retrigger=True,
+            ),
+        ),
+        seed=157,
+    )
+
+    continued = _run(continuation)
+    restarted = _run(retrigger)
+
+    assert continued.report["metrics"]["presentation"]["epoch_count"] == 1
+    assert restarted.report["metrics"]["presentation"]["epoch_count"] == 2
+    assert restarted.report["metrics"]["presentation"]["stage_epoch_index"] == [0, 1]
+    assert restarted.report["metrics"]["participant_state"]["target_transition_samples"] == [0]
+    assert not np.array_equal(continued.device_output.data_uv, restarted.device_output.data_uv)
+
+
+def test_same_frequency_different_stimulus_is_real_target_switch():
+    scenario = ArenaScenario(
+        "same-frequency-different-object",
+        (
+            StageSpec("left", 0.5, 10.0, 1.0, stimulus_id="left-orb"),
+            StageSpec("right", 0.5, 10.0, 1.0, stimulus_id="right-orb"),
+        ),
+        seed=163,
+    )
+
+    plan = compile_presentation_plan(scenario, _display(), 250.0)
+    trace = compile_participant_state_trace(scenario, _participant(), 250.0)
+
+    assert plan.stage_epoch_index == (0, 1)
+    assert len(plan.epochs) == 2
+    assert np.flatnonzero(trace.target_switch).tolist() == [0, 125]
+    # 40 ms at 250 Hz is 10 samples. Changing physical target identity restarts
+    # the declared participant response delay even when both objects use 10 Hz.
+    assert np.all(trace.attention_gain[125:135] == 0.0)
+    assert trace.attention_gain[135] > 0.0
+
+
+def test_frequency_change_creates_epoch_without_explicit_retrigger():
+    scenario = ArenaScenario(
+        "frequency-switch",
+        (
+            StageSpec("sight", 0.5, 10.0, 0.9, stimulus_id="wisp"),
+            StageSpec("guard", 0.5, 12.0, 0.9, stimulus_id="wisp"),
+        ),
+        seed=167,
+    )
+    plan = compile_presentation_plan(scenario, _display(), 250.0)
+    assert plan.stage_epoch_index == (0, 1)
+    assert [epoch.target_frequency_hz for epoch in plan.epochs] == [10.0, 12.0]
+
+
+def test_stage_round_trip_preserves_presentation_controls():
+    scenario = ArenaScenario(
+        "presentation-round-trip",
+        (
+            StageSpec(
+                "target",
+                0.5,
+                10.0,
+                0.8,
+                stimulus_id="sight-orb",
+                stimulus_retrigger=True,
+            ),
+        ),
+        seed=173,
+    )
+    loaded = ArenaScenario.from_dict(scenario.to_dict())
+    assert loaded.stages[0].stimulus_id == "sight-orb"
+    assert loaded.stages[0].stimulus_retrigger is True
+
+
+def test_presentation_controls_fail_closed_on_ambiguous_types():
+    with pytest.raises(ValueError, match="stimulus_id"):
+        StageSpec("bad-id", 0.5, 10.0, stimulus_id="").validate()
+    with pytest.raises(ValueError, match="stimulus_retrigger"):
+        StageSpec("bad-reset", 0.5, 10.0, stimulus_retrigger=1).validate()


### PR DESCRIPTION
## Why

PR #63 makes frequency-target participant response sample-indexed and render-partition invariant. The next causal audit found that display presentation was still stage-indexed: every `StageSpec` constructed a fresh display trace with a fresh response lag, frame-jitter/drop random stream and local coded phase.

That meant an author could split one continuous 10 Hz target into two labels and change the physically emitted synthetic luminance even though no physical presentation changed.

This stacked PR makes **physical presentation** its own explicit causal layer and, after adversarial review, corrects the synthetic display response-lag semantics so declared latency shifts the complete modeled emission waveform rather than acting as an onset-only blank.

Base dependency: exact-head-qualified draft PR #63 at `c3f8dbdf6e2dc8453450ce510bc7652c4e6bd9a8`.

## Architecture

```text
ArenaScenario stages
        ↓
physical stimulus identity + explicit retrigger
        ↓
PresentationPlan
        ↓
PresentationEpoch(s)
        ↓
command-frame clock / coded state / jitter / drops
        ↓
modeled command→emission response lag
        ↓
source-sample luminance
        ↓
participant + neural world
        ↓
device / transport / decoder / application
```

Stage labels and task metadata are authoring structure. They are not physical display events by default.

## Versioned contracts

Presentation compiler:

`neuros.arena.presentation_epochs.v1`

Synthetic display trace:

`neuros.arena.display_trace.v2`

`StageSpec` adds two backward-compatible keyword fields after the historical positional surface:

- `stimulus_id: str | None`
- `stimulus_retrigger: bool = False`

A new presentation epoch begins when:

1. target frequency changes;
2. `stimulus_id` changes; or
3. the later stage explicitly sets `stimulus_retrigger=True`.

Otherwise adjacent stages share one physical presentation trace.

## Why stimulus identity is explicit

Frequency is a code, not necessarily an object identity. Two different spatial targets can both use 10 Hz.

Presentation identity is therefore:

`(target_frequency_hz, stimulus_id)`

Absent `stimulus_id` preserves historical frequency-only behavior.

## Participant-layer alignment

The frequency-target participant compiler uses the same `(frequency, stimulus_id)` target identity.

This means:

- same frequency + same `stimulus_id` across a label split does **not** restart participant delay;
- same frequency + different `stimulus_id` **does** create a participant target switch;
- `stimulus_retrigger=True` for the same target restarts display presentation but does **not** invent an attention switch.

Display state and participant state remain separate causal layers.

## Stage-segmentation invariant

Given the same resolved source-sample timeline:

> Splitting a continuous physical presentation into adjacent stages with the same frequency, same `stimulus_id`, and no retrigger must not change emitted luminance or downstream EEG.

The regression exercises this with non-zero display response lag, frame jitter and dropped-frame probability and compares device EEG exactly.

## Command clock versus modeled emission clock

The deeper review found that the earlier display model added `response_lag_ms` to frame timestamps and then also evaluated coded luminance at those delayed timestamps. After the initial blank, the waveform therefore snapped back onto an undelayed global phase instead of remaining delayed.

Display trace v2 separates:

- `command_frame_times_s`: when the application/display scheduler requests each frame state;
- `frame_times_s`: when that state is modeled as physically emitted after the declared response lag.

The coded luminance is evaluated on the command clock and then delayed:

```text
emitted(t + lag) = commanded(t)
```

A regression compares 0 ms and 17 ms lag and proves:

- command-frame times are unchanged;
- commanded luminance is unchanged;
- every modeled emission timestamp shifts by exactly 17 ms;
- the display trace identifies itself as `neuros.arena.display_trace.v2`.

This is a synthetic timing contract only. Pixel-specific variable latency is deliberately not invented here and remains a measured-calibration problem.

## Source-clock integration

Presentation epoch duration is resolved from the same source-sample clock already used by Arena v2 and the participant layer.

During rendering, the runner samples emitted luminance in epoch-local time:

`(global_sample_index - epoch.start_sample) / fs`

rather than resetting time to zero at every stage.

Epoch RNG seeds depend on physical epoch order rather than authoring-stage count, so a label-only split does not perturb the frame random stream.

## Reporting

Arena reports include canonical presentation evidence at `metrics.presentation`, including:

- presentation and display-trace model/version;
- epoch count;
- stage→epoch mapping;
- epoch source-sample timing;
- command start and first modeled emission;
- modeled response lag;
- target frequency and `stimulus_id`;
- member stages;
- observed transition frequency;
- frame-drop fraction;
- interval jitter.

The historical per-stage `metrics.display` view remains available and names the presentation epoch used by each stage.

## Adversarial contracts

The exact-head suite binds:

- label-only split vs unsplit output equality under lag+jitter+drops;
- explicit retrigger creates a new display epoch and changes emitted world;
- retrigger of the same target does not invent an attentional switch;
- same-frequency/different-object creates both a new presentation epoch and participant target transition;
- response delay restarts on that true target-identity change;
- frequency changes create epochs without explicit retrigger;
- scenario round-trip preserves presentation controls;
- invalid/ambiguous presentation-control types fail closed;
- response lag is a persistent command→emission delay rather than an onset-only phase artifact.

## Documentation

New: `docs/ARENA_PRESENTATION_EPOCHS.md`

Updated: `docs/ARENA_PARTICIPANT_RESPONSE.md`

## Exact-head qualification

Base:

`c3f8dbdf6e2dc8453450ce510bc7652c4e6bd9a8`

Qualified head:

`61732b450068747fecc82bf01e717524bce785b0`

Delta: **1 commit ahead, 0 behind, exactly 10 focused paths changed.**

All triggered exact-head workflows are green:

- **Synthetic BCI Arena**: deterministic contracts across Python 3.10/3.11/3.12, presentation and display-lag regressions, CLI exercises, Arena wheel, real-domain anchoring;
- **Public Trust Contracts**;
- **Developer Preview Journey** installed-wheel external-user path;
- **full neurOS CI**, including kernel, wheel ownership, BCI smoke, scientific/latency, recording, Foundation, SourceWeigher, ORION, model/mech-int and repository-hygiene lanes.

## Evidence boundary

This PR strengthens software causal semantics only. It does **not** establish:

- physical monitor frame timing;
- actual pixel response latency or its variability;
- photodiode-observed 10/12 Hz emission;
- human SSVEP phase locking or latency;
- physical Unicorn behavior;
- human decoder performance;
- closed-loop efficacy or clinical validity.

Those remain physical/human qualification tasks. PR #71 is stacked on this exact head to ingest independent photodiode-like observations without promoting synthetic timing to physical evidence.

## Qualification state

**Exact-head software qualification is green. PR remains draft intentionally because it is stacked on draft PR #63 and physical/human evidence remains outside the software contract.**