### PR TITLE
Core signal integrity v2: immutable frames and descriptor-bound archives

### DIFF
--- a/.github/workflows/signal-integrity-ci.yml
+++ b/.github/workflows/signal-integrity-ci.yml
@@ -1,0 +1,62 @@
+name: Signal Integrity Contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-core/src/neuros/contracts/signal.py"
+      - "packages/neuros-core/src/neuros/contracts/__init__.py"
+      - "packages/neuros-core/src/neuros/recording/archive.py"
+      - "packages/neuros-core/src/neuros/recording/exporters.py"
+      - "tests/test_signal_integrity_v2.py"
+      - "tests/test_kernel_contracts.py"
+      - "tests/test_session_archive.py"
+      - "tests/test_recording_exports.py"
+      - "tests/test_replay.py"
+      - "tests/test_clock_sync.py"
+      - ".github/workflows/signal-integrity-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/neuros-core/src/neuros/contracts/signal.py"
+      - "packages/neuros-core/src/neuros/contracts/__init__.py"
+      - "packages/neuros-core/src/neuros/recording/archive.py"
+      - "packages/neuros-core/src/neuros/recording/exporters.py"
+      - "tests/test_signal_integrity_v2.py"
+      - "tests/test_kernel_contracts.py"
+      - "tests/test_session_archive.py"
+      - "tests/test_recording_exports.py"
+      - "tests/test_replay.py"
+      - "tests/test_clock_sync.py"
+      - ".github/workflows/signal-integrity-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  signal-integrity:
+    name: Signal integrity / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install neurOS recording test profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[recording,test]"
+      - name: Prove immutable signal and archive semantics
+        run: |
+          pytest -q \
+            tests/test_signal_integrity_v2.py \
+            tests/test_kernel_contracts.py \
+            tests/test_session_archive.py \
+            tests/test_replay.py \
+            tests/test_clock_sync.py \
+            tests/test_recording_exports.py

--- a/packages/neuros-core/src/neuros/contracts/__init__.py
+++ b/packages/neuros-core/src/neuros/contracts/__init__.py
@@ -3,7 +3,14 @@
 from .artifacts import ModelArtifactManifest
 from .models import Decoder, DecoderCapabilities, DecoderOutput, TrainableDecoder
 from .operators import Monitor, OutputSubscriber, Sink, Source, Transform, TransformEmission
-from .signal import ClockDomain, QualityFlag, SignalFrame, StreamDescriptor
+from .signal import (
+    ClockDomain,
+    QualityFlag,
+    SignalFrame,
+    StreamDescriptor,
+    frame_channel_count,
+    validate_frame_against_descriptor,
+)
 from .window import NeuralWindow, WindowSpec
 
 __all__ = [
@@ -24,4 +31,6 @@ __all__ = [
     "Transform",
     "TransformEmission",
     "WindowSpec",
+    "frame_channel_count",
+    "validate_frame_against_descriptor",
 ]

--- a/packages/neuros-core/src/neuros/contracts/signal.py
+++ b/packages/neuros-core/src/neuros/contracts/signal.py
@@ -78,32 +78,34 @@ def _optional_nonnegative_integer(value: Any, *, field_name: str) -> int | None:
 
 
 def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
-    """Recursively detach mutable provenance containers from caller ownership.
+    """Recursively detach provenance values from caller-owned mutable state.
 
-    Metadata is intentionally constrained to deterministic provenance-like
-    values. Arrays are copied and made read-only; nested mappings and sequences
-    are recursively frozen. Opaque Python objects are rejected instead of being
-    retained by reference inside a supposedly immutable scientific record.
+    The metadata contract intentionally remains JSON-like. That is stricter
+    than accepting arbitrary Python objects, but it guarantees that a static
+    stream identity has the same scientific meaning before and after archival
+    serialization. NumPy arrays are accepted as convenient input and frozen as
+    nested tuples of values; dtype-specific identity belongs in a dedicated
+    typed contract rather than an incidental metadata container.
     """
 
-    if value is None or isinstance(value, (str, bytes, bool, int)):
-        return value
+    if isinstance(value, Enum):
+        return _freeze_metadata(value.value, path=path)
     if isinstance(value, np.generic):
         return _freeze_metadata(value.item(), path=path)
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError(f"{path} contains a non-finite float")
         return value
-    if isinstance(value, Enum):
-        return _freeze_metadata(value.value, path=path)
+    if isinstance(value, bytes):
+        raise TypeError(f"{path} cannot contain bytes; encode them explicitly as text")
     if isinstance(value, np.ndarray):
         if value.dtype.kind == "O":
             raise TypeError(f"{path} cannot contain object-dtype arrays")
         if value.dtype.kind in "fc" and not np.isfinite(value).all():
             raise ValueError(f"{path} contains a non-finite array")
-        copied = np.array(value, copy=True, subok=False)
-        copied.setflags(write=False)
-        return copied
+        return _freeze_metadata(value.tolist(), path=path)
     if isinstance(value, Mapping):
         frozen: dict[str, Any] = {}
         for key, item in value.items():
@@ -117,7 +119,7 @@ def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
             for index, item in enumerate(value)
         )
     if isinstance(value, (set, frozenset)):
-        return frozenset(_freeze_metadata(item, path=f"{path}[]") for item in value)
+        raise TypeError(f"{path} cannot contain unordered set values")
     raise TypeError(
         f"{path} contains unsupported value type {type(value).__module__}."
         f"{type(value).__qualname__}; use deterministic provenance primitives"
@@ -125,38 +127,24 @@ def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
 
 
 def _canonical_value(value: Any) -> Any:
-    """Convert frozen contract values into a deterministic JSON representation."""
+    """Convert frozen contract values into deterministic JSON values."""
 
+    if isinstance(value, Enum):
+        return _canonical_value(value.value)
+    if isinstance(value, np.generic):
+        return _canonical_value(value.item())
     if value is None or isinstance(value, (str, bool, int)):
         return value
-    if isinstance(value, bytes):
-        return {"__bytes_hex__": value.hex()}
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError("canonical identity cannot contain NaN or infinity")
         return value
-    if isinstance(value, np.generic):
-        return _canonical_value(value.item())
-    if isinstance(value, Enum):
-        return _canonical_value(value.value)
     if isinstance(value, np.ndarray):
-        return {
-            "__ndarray__": {
-                "dtype": str(value.dtype),
-                "shape": list(value.shape),
-                "values": _canonical_value(value.tolist()),
-            }
-        }
+        return _canonical_value(value.tolist())
     if isinstance(value, Mapping):
         return {str(key): _canonical_value(item) for key, item in sorted(value.items())}
     if isinstance(value, (list, tuple)):
         return [_canonical_value(item) for item in value]
-    if isinstance(value, (set, frozenset)):
-        items = [_canonical_value(item) for item in value]
-        return sorted(
-            items,
-            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
-        )
     raise TypeError(f"Unsupported canonical identity value: {type(value)!r}")
 
 
@@ -312,7 +300,7 @@ class SignalFrame:
             raise ValueError("clock_domain='synchronized' requires synchronized_time_ns")
         object.__setattr__(self, "clock_domain", domain)
 
-        quality_value = _nonnegative_integer(int(self.quality), field_name="quality")
+        quality_value = _nonnegative_integer(self.quality, field_name="quality")
         object.__setattr__(self, "quality", QualityFlag(quality_value))
 
         arr = np.array(self.data, copy=True, subok=False)

--- a/packages/neuros-core/src/neuros/contracts/signal.py
+++ b/packages/neuros-core/src/neuros/contracts/signal.py
@@ -3,13 +3,22 @@
 These dataclasses intentionally live in ``neuros-core`` so drivers, runtimes,
 models, storage backends, and ORION can exchange neural data without importing
 one another's concrete implementations.
+
+The contracts are deliberately fail-closed at the software boundary. They do
+not claim that a physical device clock, sampling rate, or signal is accurate;
+they ensure that the *representation* of those observations is internally
+unambiguous and cannot be silently mutated after construction.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import math
 import time
 from dataclasses import dataclass, field
 from enum import Enum, IntFlag, auto
+from numbers import Integral, Real
 from types import MappingProxyType
 from typing import Any, Mapping
 
@@ -18,7 +27,7 @@ from numpy.typing import NDArray
 
 
 class ClockDomain(str, Enum):
-    """Clock used by a timestamp."""
+    """Clock used as the authoritative timestamp for a frame."""
 
     DEVICE = "device"
     HOST_MONOTONIC = "host_monotonic"
@@ -38,9 +47,138 @@ class QualityFlag(IntFlag):
     ARTIFACT_SUSPECTED = auto()
 
 
+def _nonempty_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _finite_positive_real(value: Any, *, field_name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{field_name} must be a real numeric scalar")
+    resolved = float(value)
+    if not math.isfinite(resolved) or resolved <= 0:
+        raise ValueError(f"{field_name} must be finite and positive")
+    return resolved
+
+
+def _nonnegative_integer(value: Any, *, field_name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{field_name} must be an integer")
+    resolved = int(value)
+    if resolved < 0:
+        raise ValueError(f"{field_name} must be >= 0")
+    return resolved
+
+
+def _optional_nonnegative_integer(value: Any, *, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _nonnegative_integer(value, field_name=field_name)
+
+
+def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
+    """Recursively detach mutable provenance containers from caller ownership.
+
+    Metadata is intentionally constrained to deterministic provenance-like
+    values. Arrays are copied and made read-only; nested mappings and sequences
+    are recursively frozen. Opaque Python objects are rejected instead of being
+    retained by reference inside a supposedly immutable scientific record.
+    """
+
+    if value is None or isinstance(value, (str, bytes, bool, int)):
+        return value
+    if isinstance(value, np.generic):
+        return _freeze_metadata(value.item(), path=path)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains a non-finite float")
+        return value
+    if isinstance(value, Enum):
+        return _freeze_metadata(value.value, path=path)
+    if isinstance(value, np.ndarray):
+        if value.dtype.kind == "O":
+            raise TypeError(f"{path} cannot contain object-dtype arrays")
+        if value.dtype.kind in "fc" and not np.isfinite(value).all():
+            raise ValueError(f"{path} contains a non-finite array")
+        copied = np.array(value, copy=True, subok=False)
+        copied.setflags(write=False)
+        return copied
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} keys must be strings")
+            frozen[key] = _freeze_metadata(item, path=f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _freeze_metadata(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        )
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_metadata(item, path=f"{path}[]") for item in value)
+    raise TypeError(
+        f"{path} contains unsupported value type {type(value).__module__}."
+        f"{type(value).__qualname__}; use deterministic provenance primitives"
+    )
+
+
+def _canonical_value(value: Any) -> Any:
+    """Convert frozen contract values into a deterministic JSON representation."""
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, bytes):
+        return {"__bytes_hex__": value.hex()}
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("canonical identity cannot contain NaN or infinity")
+        return value
+    if isinstance(value, np.generic):
+        return _canonical_value(value.item())
+    if isinstance(value, Enum):
+        return _canonical_value(value.value)
+    if isinstance(value, np.ndarray):
+        return {
+            "__ndarray__": {
+                "dtype": str(value.dtype),
+                "shape": list(value.shape),
+                "values": _canonical_value(value.tolist()),
+            }
+        }
+    if isinstance(value, Mapping):
+        return {str(key): _canonical_value(item) for key, item in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_canonical_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        items = [_canonical_value(item) for item in value]
+        return sorted(
+            items,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    raise TypeError(f"Unsupported canonical identity value: {type(value)!r}")
+
+
+def _sha256_identity(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        _canonical_value(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
 @dataclass(frozen=True, slots=True)
 class StreamDescriptor:
-    """Static metadata describing a neural or behavioral stream."""
+    """Static metadata describing a neural or behavioral stream.
+
+    ``sample_rate_hz`` is the declared/nominal stream rate. Evidence about a
+    measured physical clock, drift, or effective sample interval belongs in
+    timing/qualification evidence rather than being inferred from this field.
+    """
 
     stream_id: str
     modality: str
@@ -54,20 +192,77 @@ class StreamDescriptor:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.stream_id:
-            raise ValueError("stream_id must be non-empty")
-        if self.sample_rate_hz <= 0:
-            raise ValueError("sample_rate_hz must be positive")
-        if self.channel_types and len(self.channel_types) != len(self.channel_names):
+        object.__setattr__(self, "stream_id", _nonempty_string(self.stream_id, field_name="stream_id"))
+        object.__setattr__(self, "modality", _nonempty_string(self.modality, field_name="modality"))
+        object.__setattr__(
+            self,
+            "sample_rate_hz",
+            _finite_positive_real(self.sample_rate_hz, field_name="sample_rate_hz"),
+        )
+
+        names = tuple(self.channel_names)
+        types = tuple(self.channel_types)
+        units = tuple(self.units)
+        for index, name in enumerate(names):
+            _nonempty_string(name, field_name=f"channel_names[{index}]")
+        if len(set(names)) != len(names):
+            raise ValueError("channel_names must be unique")
+        if types and len(types) != len(names):
             raise ValueError("channel_types must match channel_names length")
-        if self.units and len(self.units) != len(self.channel_names):
+        if units and len(units) != len(names):
             raise ValueError("units must match channel_names length")
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+        for index, channel_type in enumerate(types):
+            _nonempty_string(channel_type, field_name=f"channel_types[{index}]")
+        for index, unit in enumerate(units):
+            _nonempty_string(unit, field_name=f"units[{index}]")
+        object.__setattr__(self, "channel_names", names)
+        object.__setattr__(self, "channel_types", types)
+        object.__setattr__(self, "units", units)
+
+        if self.device is not None:
+            _nonempty_string(self.device, field_name="device")
+        if self.manufacturer is not None:
+            _nonempty_string(self.manufacturer, field_name="manufacturer")
+        object.__setattr__(self, "clock_domain", ClockDomain(self.clock_domain))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+    @property
+    def nominal_sample_rate_hz(self) -> float:
+        """Explicit alias emphasizing that the descriptor rate is nominal."""
+
+        return self.sample_rate_hz
+
+    def identity_payload(self) -> dict[str, Any]:
+        """Return the canonical static stream identity used for provenance."""
+
+        return {
+            "schema": "neuros.stream_descriptor.v1",
+            "stream_id": self.stream_id,
+            "modality": self.modality,
+            "sample_rate_hz": self.sample_rate_hz,
+            "channel_names": self.channel_names,
+            "channel_types": self.channel_types,
+            "units": self.units,
+            "device": self.device,
+            "manufacturer": self.manufacturer,
+            "clock_domain": self.clock_domain.value,
+            "metadata": self.metadata,
+        }
+
+    def fingerprint(self) -> str:
+        """SHA-256 identity over canonical static descriptor metadata."""
+
+        return _sha256_identity(self.identity_payload())
 
 
 @dataclass(frozen=True, slots=True)
 class SignalFrame:
-    """A timestamped chunk of neural data with explicit clock semantics."""
+    """A timestamped chunk of neural data with explicit clock semantics.
+
+    Sample buffers are copied at construction and stored read-only. This makes
+    a frame an immutable software observation boundary rather than a view into
+    caller-owned mutable memory.
+    """
 
     stream_id: str
     sequence_id: int
@@ -81,21 +276,80 @@ class SignalFrame:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.stream_id:
-            raise ValueError("stream_id must be non-empty")
-        if self.sequence_id < 0:
-            raise ValueError("sequence_id must be >= 0")
-        if self.sample_rate_hz <= 0:
-            raise ValueError("sample_rate_hz must be positive")
-        arr = np.asarray(self.data)
+        object.__setattr__(self, "stream_id", _nonempty_string(self.stream_id, field_name="stream_id"))
+        object.__setattr__(
+            self,
+            "sequence_id",
+            _nonnegative_integer(self.sequence_id, field_name="sequence_id"),
+        )
+        object.__setattr__(
+            self,
+            "sample_rate_hz",
+            _finite_positive_real(self.sample_rate_hz, field_name="sample_rate_hz"),
+        )
+        object.__setattr__(
+            self,
+            "host_receive_time_ns",
+            _nonnegative_integer(self.host_receive_time_ns, field_name="host_receive_time_ns"),
+        )
+        object.__setattr__(
+            self,
+            "device_time_ns",
+            _optional_nonnegative_integer(self.device_time_ns, field_name="device_time_ns"),
+        )
+        object.__setattr__(
+            self,
+            "synchronized_time_ns",
+            _optional_nonnegative_integer(
+                self.synchronized_time_ns, field_name="synchronized_time_ns"
+            ),
+        )
+
+        domain = ClockDomain(self.clock_domain)
+        if domain is ClockDomain.DEVICE and self.device_time_ns is None:
+            raise ValueError("clock_domain='device' requires device_time_ns")
+        if domain is ClockDomain.SYNCHRONIZED and self.synchronized_time_ns is None:
+            raise ValueError("clock_domain='synchronized' requires synchronized_time_ns")
+        object.__setattr__(self, "clock_domain", domain)
+
+        quality_value = _nonnegative_integer(int(self.quality), field_name="quality")
+        object.__setattr__(self, "quality", QualityFlag(quality_value))
+
+        arr = np.array(self.data, copy=True, subok=False)
         if arr.ndim == 0:
             raise ValueError("SignalFrame.data must have at least one dimension")
+        if arr.size == 0:
+            raise ValueError("SignalFrame.data cannot be empty")
+        if arr.dtype.kind not in "biufc":
+            raise TypeError(
+                "SignalFrame.data must use a boolean or numeric dtype; "
+                f"received {arr.dtype}"
+            )
+        if arr.dtype.kind in "fc" and not np.isfinite(arr).all():
+            raise ValueError(
+                "SignalFrame.data must be finite; represent dropouts/artifacts with "
+                "explicit samples and QualityFlag provenance"
+            )
+        arr.setflags(write=False)
         object.__setattr__(self, "data", arr)
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
 
     @property
     def timestamp_ns(self) -> int:
-        """Best available timestamp in nanoseconds."""
+        """Authoritative timestamp in the declared clock domain.
+
+        ``UNKNOWN`` retains the historical best-available fallback without
+        pretending that the resulting value belongs to a qualified clock.
+        """
+
+        if self.clock_domain is ClockDomain.SYNCHRONIZED:
+            assert self.synchronized_time_ns is not None
+            return self.synchronized_time_ns
+        if self.clock_domain is ClockDomain.DEVICE:
+            assert self.device_time_ns is not None
+            return self.device_time_ns
+        if self.clock_domain is ClockDomain.HOST_MONOTONIC:
+            return self.host_receive_time_ns
         if self.synchronized_time_ns is not None:
             return self.synchronized_time_ns
         if self.device_time_ns is not None:
@@ -118,15 +372,120 @@ class SignalFrame:
         clock_domain: ClockDomain = ClockDomain.UNKNOWN,
         metadata: Mapping[str, Any] | None = None,
     ) -> "SignalFrame":
-        """Convert the legacy ``(timestamp_seconds, ndarray)`` representation."""
-        timestamp_ns = int(timestamp_seconds * 1_000_000_000)
+        """Convert the legacy ``(timestamp_seconds, ndarray)`` representation.
+
+        The legacy scalar timestamp has no independently measured uncertainty.
+        Its destination field therefore follows the explicitly supplied clock
+        domain. ``UNKNOWN`` keeps it as an unqualified source/device timestamp.
+        """
+
+        if isinstance(timestamp_seconds, (bool, np.bool_)) or not isinstance(
+            timestamp_seconds, Real
+        ):
+            raise TypeError("timestamp_seconds must be a real numeric scalar")
+        timestamp_value = float(timestamp_seconds)
+        if not math.isfinite(timestamp_value) or timestamp_value < 0:
+            raise ValueError("timestamp_seconds must be finite and >= 0")
+        timestamp_ns = int(round(timestamp_value * 1_000_000_000))
+        domain = ClockDomain(clock_domain)
+        host_receive_time_ns = time.monotonic_ns()
+        device_time_ns: int | None = None
+        synchronized_time_ns: int | None = None
+        if domain is ClockDomain.HOST_MONOTONIC:
+            host_receive_time_ns = timestamp_ns
+        elif domain is ClockDomain.SYNCHRONIZED:
+            synchronized_time_ns = timestamp_ns
+        else:
+            device_time_ns = timestamp_ns
+
         return cls(
             stream_id=stream_id,
             sequence_id=sequence_id,
-            data=np.asarray(data),
+            data=data,
             sample_rate_hz=sample_rate_hz,
-            host_receive_time_ns=time.monotonic_ns(),
-            device_time_ns=timestamp_ns,
-            clock_domain=clock_domain,
+            host_receive_time_ns=host_receive_time_ns,
+            device_time_ns=device_time_ns,
+            synchronized_time_ns=synchronized_time_ns,
+            clock_domain=domain,
             metadata=metadata or {},
         )
+
+
+def frame_channel_count(frame: SignalFrame) -> int:
+    """Resolve the explicit channel axis of a canonical frame.
+
+    One-dimensional streaming frames are one multi-channel sample. For arrays
+    with more than one dimension, ``metadata['axis_order']`` must identify
+    exactly one ``'channel'`` axis. neurOS refuses to guess from shape alone.
+    """
+
+    if not isinstance(frame, SignalFrame):
+        raise TypeError("frame_channel_count requires a SignalFrame")
+    if frame.data.ndim == 1:
+        return int(frame.data.shape[0])
+
+    axis_order = tuple(frame.metadata.get("axis_order", ()))
+    if len(axis_order) != frame.data.ndim:
+        raise ValueError(
+            "Multi-dimensional SignalFrames require axis_order metadata with one "
+            "entry per data dimension"
+        )
+    if axis_order.count("channel") != 1:
+        raise ValueError(
+            "Multi-dimensional SignalFrames require exactly one 'channel' axis"
+        )
+    return int(frame.data.shape[axis_order.index("channel")])
+
+
+def validate_frame_against_descriptor(
+    descriptor: StreamDescriptor,
+    frame: SignalFrame,
+    *,
+    sample_rate_atol_hz: float = 1e-12,
+) -> None:
+    """Fail closed when a frame contradicts its registered stream identity."""
+
+    if not isinstance(descriptor, StreamDescriptor):
+        raise TypeError("descriptor must be a StreamDescriptor")
+    if not isinstance(frame, SignalFrame):
+        raise TypeError("frame must be a SignalFrame")
+    if not isinstance(sample_rate_atol_hz, Real) or isinstance(
+        sample_rate_atol_hz, (bool, np.bool_)
+    ):
+        raise TypeError("sample_rate_atol_hz must be a real numeric scalar")
+    tolerance = float(sample_rate_atol_hz)
+    if not math.isfinite(tolerance) or tolerance < 0:
+        raise ValueError("sample_rate_atol_hz must be finite and >= 0")
+
+    if frame.stream_id != descriptor.stream_id:
+        raise ValueError("SignalFrame stream_id does not match StreamDescriptor")
+    if not math.isclose(
+        frame.sample_rate_hz,
+        descriptor.sample_rate_hz,
+        rel_tol=0.0,
+        abs_tol=tolerance,
+    ):
+        raise ValueError("SignalFrame sample_rate_hz does not match StreamDescriptor")
+    if (
+        descriptor.clock_domain is not ClockDomain.UNKNOWN
+        and frame.clock_domain is not descriptor.clock_domain
+    ):
+        raise ValueError("SignalFrame clock_domain does not match StreamDescriptor")
+
+    if descriptor.channel_names:
+        observed_channels = frame_channel_count(frame)
+        if observed_channels != len(descriptor.channel_names):
+            raise ValueError("SignalFrame channel geometry does not match StreamDescriptor")
+
+    metadata_names = tuple(frame.metadata.get("channel_names", ()))
+    if metadata_names and descriptor.channel_names and metadata_names != descriptor.channel_names:
+        raise ValueError("SignalFrame channel_names contradict StreamDescriptor")
+    metadata_types = tuple(frame.metadata.get("channel_types", ()))
+    if metadata_types and descriptor.channel_types and metadata_types != descriptor.channel_types:
+        raise ValueError("SignalFrame channel_types contradict StreamDescriptor")
+    metadata_units = tuple(frame.metadata.get("units", ()))
+    if metadata_units and descriptor.units and metadata_units != descriptor.units:
+        raise ValueError("SignalFrame units contradict StreamDescriptor")
+    metadata_modality = frame.metadata.get("modality")
+    if metadata_modality is not None and str(metadata_modality) != descriptor.modality:
+        raise ValueError("SignalFrame modality contradicts StreamDescriptor")

--- a/packages/neuros-core/src/neuros/contracts/signal.py
+++ b/packages/neuros-core/src/neuros/contracts/signal.py
@@ -47,6 +47,11 @@ class QualityFlag(IntFlag):
     ARTIFACT_SUSPECTED = auto()
 
 
+_KNOWN_QUALITY_MASK = 0
+for _quality_flag in QualityFlag:
+    _KNOWN_QUALITY_MASK |= int(_quality_flag)
+
+
 def _nonempty_string(value: Any, *, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{field_name} must be a non-empty string")
@@ -124,6 +129,14 @@ def _freeze_metadata(value: Any, *, path: str = "metadata") -> Any:
         f"{path} contains unsupported value type {type(value).__module__}."
         f"{type(value).__qualname__}; use deterministic provenance primitives"
     )
+
+
+def _freeze_metadata_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError("metadata must be a mapping")
+    frozen = _freeze_metadata(value)
+    assert isinstance(frozen, Mapping)
+    return frozen
 
 
 def _canonical_value(value: Any) -> Any:
@@ -212,7 +225,7 @@ class StreamDescriptor:
         if self.manufacturer is not None:
             _nonempty_string(self.manufacturer, field_name="manufacturer")
         object.__setattr__(self, "clock_domain", ClockDomain(self.clock_domain))
-        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+        object.__setattr__(self, "metadata", _freeze_metadata_mapping(self.metadata))
 
     @property
     def nominal_sample_rate_hz(self) -> float:
@@ -301,6 +314,8 @@ class SignalFrame:
         object.__setattr__(self, "clock_domain", domain)
 
         quality_value = _nonnegative_integer(self.quality, field_name="quality")
+        if quality_value & ~_KNOWN_QUALITY_MASK:
+            raise ValueError("quality contains undefined QualityFlag bits")
         object.__setattr__(self, "quality", QualityFlag(quality_value))
 
         arr = np.array(self.data, copy=True, subok=False)
@@ -320,7 +335,7 @@ class SignalFrame:
             )
         arr.setflags(write=False)
         object.__setattr__(self, "data", arr)
-        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+        object.__setattr__(self, "metadata", _freeze_metadata_mapping(self.metadata))
 
     @property
     def timestamp_ns(self) -> int:

--- a/packages/neuros-core/src/neuros/recording/archive.py
+++ b/packages/neuros-core/src/neuros/recording/archive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
 import os
 import platform
 import subprocess
@@ -26,7 +27,8 @@ from neuros.contracts import (
 )
 
 
-ARCHIVE_SCHEMA_VERSION = 1
+ARCHIVE_SCHEMA_VERSION = 2
+SUPPORTED_ARCHIVE_SCHEMA_VERSIONS = frozenset({1, ARCHIVE_SCHEMA_VERSION})
 
 
 def _jsonable(value: Any) -> Any:
@@ -38,7 +40,7 @@ def _jsonable(value: Any) -> Any:
         return value.value
     if isinstance(value, Mapping):
         return {str(key): _jsonable(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple, set, frozenset)):
+    if isinstance(value, (list, tuple)):
         return [_jsonable(item) for item in value]
     return value
 
@@ -87,7 +89,11 @@ def _descriptor_to_dict(descriptor: StreamDescriptor) -> dict[str, Any]:
     }
 
 
-def _descriptor_from_dict(raw: Mapping[str, Any]) -> StreamDescriptor:
+def _descriptor_from_dict(
+    raw: Mapping[str, Any],
+    *,
+    require_fingerprint: bool = False,
+) -> StreamDescriptor:
     descriptor = StreamDescriptor(
         stream_id=str(raw["stream_id"]),
         modality=str(raw["modality"]),
@@ -101,9 +107,35 @@ def _descriptor_from_dict(raw: Mapping[str, Any]) -> StreamDescriptor:
         metadata=raw.get("metadata", {}),
     )
     expected = raw.get("fingerprint_sha256")
+    if require_fingerprint and expected is None:
+        raise IOError("Archive v2 StreamDescriptor is missing fingerprint_sha256")
     if expected is not None and str(expected) != descriptor.fingerprint():
         raise IOError("StreamDescriptor fingerprint mismatch")
     return descriptor
+
+
+def _validate_legacy_frame(descriptor: StreamDescriptor, frame: SignalFrame) -> None:
+    """Validate only invariants that archive v1 actually encoded unambiguously.
+
+    v1 did not require explicit multidimensional axis metadata or bind frames to
+    a descriptor fingerprint. Reading an old archive must not retroactively
+    claim those stronger v2 guarantees.
+    """
+
+    if frame.stream_id != descriptor.stream_id:
+        raise ValueError("SignalFrame stream_id does not match StreamDescriptor")
+    if not math.isclose(
+        frame.sample_rate_hz,
+        descriptor.sample_rate_hz,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    ):
+        raise ValueError("SignalFrame sample_rate_hz does not match StreamDescriptor")
+    if (
+        descriptor.clock_domain is not ClockDomain.UNKNOWN
+        and frame.clock_domain is not descriptor.clock_domain
+    ):
+        raise ValueError("SignalFrame clock_domain does not match StreamDescriptor")
 
 
 @dataclass(slots=True)
@@ -128,15 +160,15 @@ class SessionManifest:
 class SessionArchiveWriter:
     """Append SignalFrames to a lossless, dependency-free directory archive.
 
-    Data arrays are stored as individual NPY payloads so arbitrary frame shapes
-    are preserved. An NDJSON index records every timing/provenance field and a
-    SHA-256 hash of each data payload. This is the canonical replay source; NWB
-    and Zarr are export formats rather than the authority for neurOS semantics.
+    Archive v2 binds every registered stream to a deterministic descriptor
+    fingerprint and validates each frame against that descriptor before bytes
+    are written. The canonical archive therefore cannot silently mix stream
+    IDs, sample rates, asserted clock domains, or channel geometries under one
+    v2 stream identity.
 
-    Once a stream is registered, every frame is validated against that exact
-    descriptor before bytes are written. The archive therefore cannot silently
-    mix stream IDs, sample rates, clock domains, or channel geometries under one
-    stream identity.
+    Data arrays remain individual NPY payloads so exact dtype/shape are
+    preserved. NWB and Zarr remain interoperability exports rather than the
+    authority for exact neurOS replay semantics.
     """
 
     def __init__(
@@ -285,20 +317,26 @@ class SessionArchiveReader:
     def __init__(self, root: str | Path, *, verify_hashes: bool = True) -> None:
         self.root = Path(root)
         raw = json.loads((self.root / "manifest.json").read_text(encoding="utf-8"))
-        if int(raw.get("schema_version", -1)) != ARCHIVE_SCHEMA_VERSION:
-            raise ValueError("Unsupported neurOS archive schema")
+        schema_version = int(raw.get("schema_version", -1))
+        if schema_version not in SUPPORTED_ARCHIVE_SCHEMA_VERSIONS:
+            raise ValueError(f"Unsupported neurOS archive schema: {schema_version}")
         self.manifest = raw
+        self.schema_version = schema_version
         self.verify_hashes = verify_hashes
 
     @property
     def stream_ids(self) -> tuple[str, ...]:
         return tuple(self.manifest.get("streams", {}).keys())
 
+    @property
+    def descriptor_integrity(self) -> str:
+        return "sha256-bound" if self.schema_version >= 2 else "legacy-unbound"
+
     def descriptor(self, stream_id: str) -> StreamDescriptor:
         raw = json.loads(
             (self.root / "streams" / stream_id / "descriptor.json").read_text(encoding="utf-8")
         )
-        return _descriptor_from_dict(raw)
+        return _descriptor_from_dict(raw, require_fingerprint=self.schema_version >= 2)
 
     def iter_frames(self, stream_id: str) -> Iterable[SignalFrame]:
         stream_root = self.root / "streams" / stream_id
@@ -331,7 +369,10 @@ class SessionArchiveReader:
                 quality=QualityFlag(int(row["quality"])),
                 metadata=row.get("metadata", {}),
             )
-            validate_frame_against_descriptor(descriptor, frame)
+            if self.schema_version >= 2:
+                validate_frame_against_descriptor(descriptor, frame)
+            else:
+                _validate_legacy_frame(descriptor, frame)
             yield frame
 
     def summary(self) -> dict[str, Any]:
@@ -339,6 +380,8 @@ class SessionArchiveReader:
             "session_id": self.manifest["session_id"],
             "status": self.manifest["status"],
             "created_at": self.manifest["created_at"],
+            "schema_version": self.schema_version,
+            "descriptor_integrity": self.descriptor_integrity,
             "git_sha": self.manifest.get("git_sha"),
             "config_hash": self.manifest.get("config_hash"),
             "streams": {

--- a/packages/neuros-core/src/neuros/recording/archive.py
+++ b/packages/neuros-core/src/neuros/recording/archive.py
@@ -94,7 +94,29 @@ def _descriptor_from_dict(
     *,
     require_fingerprint: bool = False,
 ) -> StreamDescriptor:
-    descriptor = StreamDescriptor(
+    if require_fingerprint:
+        expected = raw.get("fingerprint_sha256")
+        if not isinstance(expected, str):
+            raise IOError("Archive v2 StreamDescriptor requires string fingerprint_sha256")
+        descriptor = StreamDescriptor(
+            stream_id=raw["stream_id"],
+            modality=raw["modality"],
+            sample_rate_hz=raw["sample_rate_hz"],
+            channel_names=tuple(raw.get("channel_names", [])),
+            channel_types=tuple(raw.get("channel_types", [])),
+            units=tuple(raw.get("units", [])),
+            device=raw.get("device"),
+            manufacturer=raw.get("manufacturer"),
+            clock_domain=ClockDomain(raw.get("clock_domain", ClockDomain.UNKNOWN.value)),
+            metadata=raw.get("metadata", {}),
+        )
+        if expected != descriptor.fingerprint():
+            raise IOError("StreamDescriptor fingerprint mismatch")
+        return descriptor
+
+    # Archive v1 historically decoded these scalar fields permissively. Keep
+    # that read path for compatibility without crediting it with v2 integrity.
+    return StreamDescriptor(
         stream_id=str(raw["stream_id"]),
         modality=str(raw["modality"]),
         sample_rate_hz=float(raw["sample_rate_hz"]),
@@ -106,21 +128,10 @@ def _descriptor_from_dict(
         clock_domain=ClockDomain(raw.get("clock_domain", ClockDomain.UNKNOWN.value)),
         metadata=raw.get("metadata", {}),
     )
-    expected = raw.get("fingerprint_sha256")
-    if require_fingerprint and expected is None:
-        raise IOError("Archive v2 StreamDescriptor is missing fingerprint_sha256")
-    if expected is not None and str(expected) != descriptor.fingerprint():
-        raise IOError("StreamDescriptor fingerprint mismatch")
-    return descriptor
 
 
 def _validate_legacy_frame(descriptor: StreamDescriptor, frame: SignalFrame) -> None:
-    """Validate only invariants that archive v1 actually encoded unambiguously.
-
-    v1 did not require explicit multidimensional axis metadata or bind frames to
-    a descriptor fingerprint. Reading an old archive must not retroactively
-    claim those stronger v2 guarantees.
-    """
+    """Validate only invariants that archive v1 actually encoded unambiguously."""
 
     if frame.stream_id != descriptor.stream_id:
         raise ValueError("SignalFrame stream_id does not match StreamDescriptor")
@@ -136,6 +147,43 @@ def _validate_legacy_frame(descriptor: StreamDescriptor, frame: SignalFrame) -> 
         and frame.clock_domain is not descriptor.clock_domain
     ):
         raise ValueError("SignalFrame clock_domain does not match StreamDescriptor")
+
+
+def _frame_from_row(
+    *,
+    stream_id: str,
+    row: Mapping[str, Any],
+    data: np.ndarray,
+    schema_version: int,
+) -> SignalFrame:
+    if schema_version >= 2:
+        return SignalFrame(
+            stream_id=stream_id,
+            sequence_id=row["sequence_id"],
+            data=data,
+            sample_rate_hz=row["sample_rate_hz"],
+            host_receive_time_ns=row["host_receive_time_ns"],
+            device_time_ns=row["device_time_ns"],
+            synchronized_time_ns=row["synchronized_time_ns"],
+            clock_domain=ClockDomain(row["clock_domain"]),
+            quality=row["quality"],
+            metadata=row.get("metadata", {}),
+        )
+
+    return SignalFrame(
+        stream_id=stream_id,
+        sequence_id=int(row["sequence_id"]),
+        data=data,
+        sample_rate_hz=float(row["sample_rate_hz"]),
+        host_receive_time_ns=int(row["host_receive_time_ns"]),
+        device_time_ns=None if row["device_time_ns"] is None else int(row["device_time_ns"]),
+        synchronized_time_ns=None
+        if row["synchronized_time_ns"] is None
+        else int(row["synchronized_time_ns"]),
+        clock_domain=ClockDomain(row["clock_domain"]),
+        quality=QualityFlag(int(row["quality"])),
+        metadata=row.get("metadata", {}),
+    )
 
 
 @dataclass(slots=True)
@@ -317,7 +365,9 @@ class SessionArchiveReader:
     def __init__(self, root: str | Path, *, verify_hashes: bool = True) -> None:
         self.root = Path(root)
         raw = json.loads((self.root / "manifest.json").read_text(encoding="utf-8"))
-        schema_version = int(raw.get("schema_version", -1))
+        schema_version = raw.get("schema_version")
+        if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+            raise ValueError("neurOS archive schema_version must be an integer")
         if schema_version not in SUPPORTED_ARCHIVE_SCHEMA_VERSIONS:
             raise ValueError(f"Unsupported neurOS archive schema: {schema_version}")
         self.manifest = raw
@@ -355,19 +405,11 @@ class SessionArchiveReader:
                     raise IOError(f"Data hash mismatch: {data_path}")
             with data_path.open("rb") as handle:
                 data = np.load(handle, allow_pickle=False)
-            frame = SignalFrame(
+            frame = _frame_from_row(
                 stream_id=stream_id,
-                sequence_id=int(row["sequence_id"]),
+                row=row,
                 data=data,
-                sample_rate_hz=float(row["sample_rate_hz"]),
-                host_receive_time_ns=int(row["host_receive_time_ns"]),
-                device_time_ns=None if row["device_time_ns"] is None else int(row["device_time_ns"]),
-                synchronized_time_ns=None
-                if row["synchronized_time_ns"] is None
-                else int(row["synchronized_time_ns"]),
-                clock_domain=ClockDomain(row["clock_domain"]),
-                quality=QualityFlag(int(row["quality"])),
-                metadata=row.get("metadata", {}),
+                schema_version=self.schema_version,
             )
             if self.schema_version >= 2:
                 validate_frame_against_descriptor(descriptor, frame)

--- a/packages/neuros-core/src/neuros/recording/archive.py
+++ b/packages/neuros-core/src/neuros/recording/archive.py
@@ -16,7 +16,14 @@ from typing import Any, AsyncIterator, Iterable, Mapping
 
 import numpy as np
 
-from neuros.contracts import ClockDomain, QualityFlag, SignalFrame, StreamDescriptor
+from neuros.contracts import (
+    ClockDomain,
+    QualityFlag,
+    SignalFrame,
+    StreamDescriptor,
+    frame_channel_count,
+    validate_frame_against_descriptor,
+)
 
 
 ARCHIVE_SCHEMA_VERSION = 1
@@ -31,7 +38,7 @@ def _jsonable(value: Any) -> Any:
         return value.value
     if isinstance(value, Mapping):
         return {str(key): _jsonable(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, (list, tuple, set, frozenset)):
         return [_jsonable(item) for item in value]
     return value
 
@@ -76,11 +83,12 @@ def _descriptor_to_dict(descriptor: StreamDescriptor) -> dict[str, Any]:
         "manufacturer": descriptor.manufacturer,
         "clock_domain": descriptor.clock_domain.value,
         "metadata": _jsonable(dict(descriptor.metadata)),
+        "fingerprint_sha256": descriptor.fingerprint(),
     }
 
 
 def _descriptor_from_dict(raw: Mapping[str, Any]) -> StreamDescriptor:
-    return StreamDescriptor(
+    descriptor = StreamDescriptor(
         stream_id=str(raw["stream_id"]),
         modality=str(raw["modality"]),
         sample_rate_hz=float(raw["sample_rate_hz"]),
@@ -92,6 +100,10 @@ def _descriptor_from_dict(raw: Mapping[str, Any]) -> StreamDescriptor:
         clock_domain=ClockDomain(raw.get("clock_domain", ClockDomain.UNKNOWN.value)),
         metadata=raw.get("metadata", {}),
     )
+    expected = raw.get("fingerprint_sha256")
+    if expected is not None and str(expected) != descriptor.fingerprint():
+        raise IOError("StreamDescriptor fingerprint mismatch")
+    return descriptor
 
 
 @dataclass(slots=True)
@@ -120,6 +132,11 @@ class SessionArchiveWriter:
     are preserved. An NDJSON index records every timing/provenance field and a
     SHA-256 hash of each data payload. This is the canonical replay source; NWB
     and Zarr are export formats rather than the authority for neurOS semantics.
+
+    Once a stream is registered, every frame is validated against that exact
+    descriptor before bytes are written. The archive therefore cannot silently
+    mix stream IDs, sample rates, clock domains, or channel geometries under one
+    stream identity.
     """
 
     def __init__(
@@ -170,8 +187,10 @@ class SessionArchiveWriter:
         self._write_json_atomic(self.root / "manifest.json", self.manifest.to_dict())
 
     def register_stream(self, descriptor: StreamDescriptor) -> None:
+        if not isinstance(descriptor, StreamDescriptor):
+            raise TypeError("register_stream requires a StreamDescriptor")
         existing = self._descriptors.get(descriptor.stream_id)
-        if existing is not None and existing != descriptor:
+        if existing is not None and existing.fingerprint() != descriptor.fingerprint():
             raise ValueError(f"Conflicting descriptor for stream {descriptor.stream_id}")
         if existing is not None:
             return
@@ -179,12 +198,36 @@ class SessionArchiveWriter:
         self._counts[descriptor.stream_id] = 0
         stream_root = self.root / "streams" / descriptor.stream_id
         (stream_root / "frames").mkdir(parents=True, exist_ok=True)
-        self._write_json_atomic(stream_root / "descriptor.json", _descriptor_to_dict(descriptor))
+        encoded = _descriptor_to_dict(descriptor)
+        self._write_json_atomic(stream_root / "descriptor.json", encoded)
         self.manifest.streams[descriptor.stream_id] = {
-            "descriptor": _descriptor_to_dict(descriptor),
+            "descriptor": encoded,
+            "descriptor_fingerprint_sha256": descriptor.fingerprint(),
             "frame_count": 0,
         }
         self._flush_manifest()
+
+    def _descriptor_from_unregistered_frame(self, item: SignalFrame) -> StreamDescriptor:
+        channels = frame_channel_count(item)
+        metadata_names = tuple(item.metadata.get("channel_names", ()))
+        metadata_types = tuple(item.metadata.get("channel_types", ()))
+        metadata_units = tuple(item.metadata.get("units", ()))
+        if metadata_names and len(metadata_names) != channels:
+            raise ValueError("SignalFrame channel_names do not match its channel axis")
+        if metadata_types and len(metadata_types) != channels:
+            raise ValueError("SignalFrame channel_types do not match its channel axis")
+        if metadata_units and len(metadata_units) != channels:
+            raise ValueError("SignalFrame units do not match its channel axis")
+        return StreamDescriptor(
+            stream_id=item.stream_id,
+            modality=str(item.metadata.get("modality", "unknown")),
+            sample_rate_hz=item.sample_rate_hz,
+            channel_names=metadata_names or tuple(f"ch{i}" for i in range(channels)),
+            channel_types=metadata_types,
+            units=metadata_units,
+            clock_domain=item.clock_domain,
+            metadata={"auto_registered_from_frame": True},
+        )
 
     async def write(self, item: SignalFrame) -> None:
         if self._closed:
@@ -193,23 +236,17 @@ class SessionArchiveWriter:
             raise TypeError("SessionArchiveWriter accepts SignalFrame objects")
         async with self._lock:
             if item.stream_id not in self._descriptors:
-                channels = int(np.asarray(item.data).shape[0]) if np.asarray(item.data).ndim else 1
-                self.register_stream(
-                    StreamDescriptor(
-                        stream_id=item.stream_id,
-                        modality=str(item.metadata.get("modality", "unknown")),
-                        sample_rate_hz=item.sample_rate_hz,
-                        channel_names=tuple(f"ch{i}" for i in range(channels)),
-                        clock_domain=item.clock_domain,
-                    )
-                )
+                self.register_stream(self._descriptor_from_unregistered_frame(item))
+            descriptor = self._descriptors[item.stream_id]
+            validate_frame_against_descriptor(descriptor, item)
+
             index = self._counts[item.stream_id]
             stream_root = self.root / "streams" / item.stream_id
             relative_data = Path("frames") / f"{index:012d}.npy"
             data_path = stream_root / relative_data
             temporary = data_path.with_suffix(".npy.tmp")
             with temporary.open("wb") as handle:
-                np.save(handle, np.asarray(item.data), allow_pickle=False)
+                np.save(handle, item.data, allow_pickle=False)
                 handle.flush()
                 os.fsync(handle.fileno())
             temporary.replace(data_path)
@@ -268,6 +305,7 @@ class SessionArchiveReader:
         index_path = stream_root / "index.ndjson"
         if not index_path.exists():
             return
+        descriptor = self.descriptor(stream_id)
         for line in index_path.read_text(encoding="utf-8").splitlines():
             if not line.strip():
                 continue
@@ -279,7 +317,7 @@ class SessionArchiveReader:
                     raise IOError(f"Data hash mismatch: {data_path}")
             with data_path.open("rb") as handle:
                 data = np.load(handle, allow_pickle=False)
-            yield SignalFrame(
+            frame = SignalFrame(
                 stream_id=stream_id,
                 sequence_id=int(row["sequence_id"]),
                 data=data,
@@ -293,6 +331,8 @@ class SessionArchiveReader:
                 quality=QualityFlag(int(row["quality"])),
                 metadata=row.get("metadata", {}),
             )
+            validate_frame_against_descriptor(descriptor, frame)
+            yield frame
 
     def summary(self) -> dict[str, Any]:
         return {

--- a/tests/test_recording_exports.py
+++ b/tests/test_recording_exports.py
@@ -23,11 +23,11 @@ async def _archive(root: Path) -> Path:
             SignalFrame(
                 stream_id="eeg",
                 sequence_id=index,
-                data=np.ones((2, 4), dtype=np.float32) * index,
+                data=np.ones((4, 2), dtype=np.float32) * index,
                 sample_rate_hz=100.0,
                 host_receive_time_ns=1_000_000_000 + index * 10_000_000,
                 synchronized_time_ns=1_000_000_000 + index * 10_000_000,
-                metadata={"index": index},
+                metadata={"index": index, "axis_order": ("sample", "channel")},
             )
         )
     await writer.close()
@@ -40,7 +40,7 @@ async def test_zarr_export_contains_frame_and_timing_arrays(tmp_path: Path):
     archive = await _archive(tmp_path / "session")
     destination = export_zarr(archive, tmp_path / "session.zarr")
     root = zarr.open_group(str(destination), mode="r")
-    assert root["eeg/data"].shape == (3, 2, 4)
+    assert root["eeg/data"].shape == (3, 4, 2)
     np.testing.assert_array_equal(root["eeg/sequence_id"][:], [0, 1, 2])
     assert "descriptor_json" in root["eeg"].attrs
 
@@ -53,5 +53,5 @@ async def test_nwb_export_contains_acquisition_and_exact_metadata(tmp_path: Path
     with pynwb.NWBHDF5IO(str(destination), "r", load_namespaces=True) as io:
         nwbfile = io.read()
         assert "eeg" in nwbfile.acquisition
-        assert nwbfile.acquisition["eeg"].data.shape == (3, 2, 4)
+        assert nwbfile.acquisition["eeg"].data.shape == (3, 4, 2)
         assert "neuros_exact_metadata" in nwbfile.scratch

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -13,14 +13,18 @@ def _frames():
         SignalFrame(
             stream_id="eeg",
             sequence_id=index,
-            data=np.arange(6, dtype=np.float32).reshape(2, 3) + index,
+            data=np.arange(6, dtype=np.float32).reshape(3, 2) + index,
             sample_rate_hz=250.0,
             host_receive_time_ns=1_000_000 + index,
             device_time_ns=2_000_000 + index,
             synchronized_time_ns=3_000_000 + index,
             clock_domain=ClockDomain.SYNCHRONIZED,
             quality=QualityFlag.ARTIFACT_SUSPECTED if index == 1 else QualityFlag.GOOD,
-            metadata={"trial": index, "label": "left" if index % 2 == 0 else "right"},
+            metadata={
+                "trial": index,
+                "label": "left" if index % 2 == 0 else "right",
+                "axis_order": ("sample", "channel"),
+            },
         )
         for index in range(3)
     ]
@@ -55,11 +59,13 @@ async def test_session_archive_round_trips_exact_frame_semantics(tmp_path: Path)
 
     reader = SessionArchiveReader(root)
     assert reader.descriptor("eeg") == descriptor
+    assert reader.descriptor("eeg").fingerprint() == descriptor.fingerprint()
     restored = list(reader.iter_frames("eeg"))
     assert len(restored) == len(original)
     for expected, actual in zip(original, restored):
         assert actual.sequence_id == expected.sequence_id
         np.testing.assert_array_equal(actual.data, expected.data)
+        assert not actual.data.flags.writeable
         assert actual.sample_rate_hz == expected.sample_rate_hz
         assert actual.host_receive_time_ns == expected.host_receive_time_ns
         assert actual.device_time_ns == expected.device_time_ns
@@ -74,6 +80,10 @@ async def test_session_archive_round_trips_exact_frame_semantics(tmp_path: Path)
     assert summary["runtime_metrics"]["dropped"] == 0
     manifest = json.loads((root / "manifest.json").read_text())
     assert manifest["status"] == "complete"
+    assert (
+        manifest["streams"]["eeg"]["descriptor_fingerprint_sha256"]
+        == descriptor.fingerprint()
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_signal_integrity_v2.py
+++ b/tests/test_signal_integrity_v2.py
@@ -68,6 +68,13 @@ def test_signal_frame_recursively_detaches_metadata():
         frame.metadata["nested"]["new"] = 1
 
 
+def test_metadata_requires_mapping_at_contract_root():
+    with pytest.raises(TypeError, match="metadata must be a mapping"):
+        _frame(metadata=[("modality", "eeg")])
+    with pytest.raises(TypeError, match="metadata must be a mapping"):
+        _descriptor(metadata=[("reference", "average")])
+
+
 def test_provenance_metadata_rejects_unstable_python_values():
     with pytest.raises(TypeError, match="bytes"):
         _descriptor(metadata={"blob": b"opaque"})
@@ -109,11 +116,13 @@ def test_frame_integer_identity_fields_reject_lossy_coercion(field, bad_value):
         _frame(**{field: bad_value})
 
 
-def test_quality_flags_do_not_accept_lossy_numeric_coercion():
+def test_quality_flags_do_not_accept_lossy_or_undefined_states():
     with pytest.raises(TypeError):
         _frame(quality=1.5)
     with pytest.raises(TypeError):
         _frame(quality=True)
+    with pytest.raises(ValueError, match="undefined"):
+        _frame(quality=1 << 20)
 
 
 def test_declared_clock_domain_requires_corresponding_timestamp():
@@ -264,6 +273,24 @@ def test_archive_v2_descriptor_tampering_is_detected(tmp_path: Path):
     reader = SessionArchiveReader(root)
     with pytest.raises(IOError, match="fingerprint mismatch"):
         reader.descriptor("eeg")
+
+
+@pytest.mark.asyncio
+async def test_archive_v2_index_does_not_coerce_malformed_identity_fields(tmp_path: Path):
+    root = tmp_path / "strict-index"
+    writer = SessionArchiveWriter(root, session_id="strict-index")
+    writer.register_stream(_descriptor())
+    await writer.write(_frame())
+    await writer.close()
+
+    index_path = root / "streams" / "eeg" / "index.ndjson"
+    row = json.loads(index_path.read_text(encoding="utf-8").strip())
+    row["sequence_id"] = 3.5
+    index_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    reader = SessionArchiveReader(root)
+    with pytest.raises(TypeError, match="sequence_id must be an integer"):
+        list(reader.iter_frames("eeg"))
 
 
 @pytest.mark.asyncio

--- a/tests/test_signal_integrity_v2.py
+++ b/tests/test_signal_integrity_v2.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import numpy as np
@@ -11,7 +12,7 @@ from neuros.contracts import (
     frame_channel_count,
     validate_frame_against_descriptor,
 )
-from neuros.recording import SessionArchiveReader, SessionArchiveWriter
+from neuros.recording import ARCHIVE_SCHEMA_VERSION, SessionArchiveReader, SessionArchiveWriter
 
 
 def _frame(**overrides):
@@ -67,6 +68,24 @@ def test_signal_frame_recursively_detaches_metadata():
         frame.metadata["nested"]["new"] = 1
 
 
+def test_provenance_metadata_rejects_unstable_python_values():
+    with pytest.raises(TypeError, match="bytes"):
+        _descriptor(metadata={"blob": b"opaque"})
+    with pytest.raises(TypeError, match="set"):
+        _descriptor(metadata={"unordered": {"C3", "C4"}})
+    with pytest.raises(ValueError, match="non-finite"):
+        _descriptor(metadata={"value": float("nan")})
+
+
+def test_numpy_metadata_is_detached_into_archive_stable_values():
+    source = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    descriptor = _descriptor(metadata={"coordinates": source})
+    before = descriptor.fingerprint()
+    source[0, 0] = 99.0
+    assert descriptor.metadata["coordinates"] == ((1.0, 2.0), (3.0, 4.0))
+    assert descriptor.fingerprint() == before
+
+
 @pytest.mark.parametrize("bad_rate", [float("nan"), float("inf"), 0.0, -1.0])
 def test_sample_rates_must_be_finite_and_positive(bad_rate):
     with pytest.raises(ValueError):
@@ -88,6 +107,13 @@ def test_sample_rates_do_not_accept_boolean_or_string_coercion(bad_rate):
 def test_frame_integer_identity_fields_reject_lossy_coercion(field, bad_value):
     with pytest.raises(TypeError):
         _frame(**{field: bad_value})
+
+
+def test_quality_flags_do_not_accept_lossy_numeric_coercion():
+    with pytest.raises(TypeError):
+        _frame(quality=1.5)
+    with pytest.raises(TypeError):
+        _frame(quality=True)
 
 
 def test_declared_clock_domain_requires_corresponding_timestamp():
@@ -126,9 +152,17 @@ def test_frame_rejects_nonfinite_and_object_signal_payloads():
 
 def test_stream_descriptor_requires_unique_nonempty_channel_identity():
     with pytest.raises(ValueError, match="unique"):
-        _descriptor(channel_names=("C3", "C3"), channel_types=("eeg", "eeg"), units=("uV", "uV"))
+        _descriptor(
+            channel_names=("C3", "C3"),
+            channel_types=("eeg", "eeg"),
+            units=("uV", "uV"),
+        )
     with pytest.raises(ValueError, match="non-empty"):
-        _descriptor(channel_names=("C3", ""), channel_types=("eeg", "eeg"), units=("uV", "uV"))
+        _descriptor(
+            channel_names=("C3", ""),
+            channel_types=("eeg", "eeg"),
+            units=("uV", "uV"),
+        )
 
 
 def test_descriptor_fingerprint_is_deterministic_and_semantically_sensitive():
@@ -181,8 +215,8 @@ def test_descriptor_frame_validator_checks_declared_channel_names():
 
 
 @pytest.mark.asyncio
-async def test_archive_persists_and_verifies_descriptor_identity(tmp_path: Path):
-    descriptor = _descriptor()
+async def test_archive_v2_persists_and_verifies_descriptor_identity(tmp_path: Path):
+    descriptor = _descriptor(metadata={"coordinates": np.arange(4).reshape(2, 2)})
     frame = _frame()
     root = tmp_path / "session"
 
@@ -194,10 +228,60 @@ async def test_archive_persists_and_verifies_descriptor_identity(tmp_path: Path)
     reader = SessionArchiveReader(root)
     restored_descriptor = reader.descriptor("eeg")
     restored_frame = list(reader.iter_frames("eeg"))[0]
+    assert reader.schema_version == ARCHIVE_SCHEMA_VERSION == 2
+    assert reader.descriptor_integrity == "sha256-bound"
     assert restored_descriptor.fingerprint() == descriptor.fingerprint()
     assert not restored_frame.data.flags.writeable
     np.testing.assert_array_equal(restored_frame.data, frame.data)
     assert restored_frame.timestamp_ns == frame.timestamp_ns
+
+
+def _downgrade_archive_to_legacy_v1(root: Path) -> None:
+    manifest_path = root / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["schema_version"] = 1
+    for stream in manifest["streams"].values():
+        stream.pop("descriptor_fingerprint_sha256", None)
+        stream["descriptor"].pop("fingerprint_sha256", None)
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+    descriptor_path = root / "streams" / "eeg" / "descriptor.json"
+    descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    descriptor.pop("fingerprint_sha256", None)
+    descriptor_path.write_text(json.dumps(descriptor, sort_keys=True), encoding="utf-8")
+
+
+def test_archive_v2_descriptor_tampering_is_detected(tmp_path: Path):
+    root = tmp_path / "session"
+    writer = SessionArchiveWriter(root, session_id="tamper")
+    writer.register_stream(_descriptor())
+
+    descriptor_path = root / "streams" / "eeg" / "descriptor.json"
+    encoded = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    encoded["sample_rate_hz"] = 200.0
+    descriptor_path.write_text(json.dumps(encoded), encoding="utf-8")
+
+    reader = SessionArchiveReader(root)
+    with pytest.raises(IOError, match="fingerprint mismatch"):
+        reader.descriptor("eeg")
+
+
+@pytest.mark.asyncio
+async def test_archive_v1_remains_readable_without_claiming_v2_integrity(tmp_path: Path):
+    root = tmp_path / "legacy"
+    writer = SessionArchiveWriter(root, session_id="legacy")
+    writer.register_stream(_descriptor())
+    await writer.write(_frame())
+    await writer.close()
+    _downgrade_archive_to_legacy_v1(root)
+
+    reader = SessionArchiveReader(root)
+    assert reader.schema_version == 1
+    assert reader.descriptor_integrity == "legacy-unbound"
+    assert len(list(reader.iter_frames("eeg"))) == 1
+    summary = reader.summary()
+    assert summary["schema_version"] == 1
+    assert summary["descriptor_integrity"] == "legacy-unbound"
 
 
 @pytest.mark.asyncio

--- a/tests/test_signal_integrity_v2.py
+++ b/tests/test_signal_integrity_v2.py
@@ -1,0 +1,225 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuros.contracts import (
+    ClockDomain,
+    QualityFlag,
+    SignalFrame,
+    StreamDescriptor,
+    frame_channel_count,
+    validate_frame_against_descriptor,
+)
+from neuros.recording import SessionArchiveReader, SessionArchiveWriter
+
+
+def _frame(**overrides):
+    values = {
+        "stream_id": "eeg",
+        "sequence_id": 3,
+        "data": np.arange(8, dtype=np.float32),
+        "sample_rate_hz": 250.0,
+        "host_receive_time_ns": 100,
+        "device_time_ns": 200,
+        "synchronized_time_ns": 300,
+        "clock_domain": ClockDomain.SYNCHRONIZED,
+        "quality": QualityFlag.GOOD,
+        "metadata": {"modality": "eeg"},
+    }
+    values.update(overrides)
+    return SignalFrame(**values)
+
+
+def _descriptor(**overrides):
+    values = {
+        "stream_id": "eeg",
+        "modality": "eeg",
+        "sample_rate_hz": 250.0,
+        "channel_names": tuple(f"C{index}" for index in range(8)),
+        "channel_types": ("eeg",) * 8,
+        "units": ("uV",) * 8,
+        "clock_domain": ClockDomain.SYNCHRONIZED,
+        "metadata": {"reference": "common-average", "nested": {"version": 1}},
+    }
+    values.update(overrides)
+    return StreamDescriptor(**values)
+
+
+def test_signal_frame_detaches_and_freezes_sample_buffer():
+    source = np.arange(8, dtype=np.float32)
+    frame = _frame(data=source)
+
+    source[0] = 999.0
+    assert frame.data[0] == 0.0
+    assert not frame.data.flags.writeable
+    with pytest.raises(ValueError):
+        frame.data[0] = 1.0
+
+
+def test_signal_frame_recursively_detaches_metadata():
+    metadata = {"nested": {"labels": ["left", "right"]}}
+    frame = _frame(metadata=metadata)
+
+    metadata["nested"]["labels"][0] = "changed"
+    assert frame.metadata["nested"]["labels"] == ("left", "right")
+    with pytest.raises(TypeError):
+        frame.metadata["nested"]["new"] = 1
+
+
+@pytest.mark.parametrize("bad_rate", [float("nan"), float("inf"), 0.0, -1.0])
+def test_sample_rates_must_be_finite_and_positive(bad_rate):
+    with pytest.raises(ValueError):
+        _descriptor(sample_rate_hz=bad_rate)
+    with pytest.raises(ValueError):
+        _frame(sample_rate_hz=bad_rate)
+
+
+@pytest.mark.parametrize("bad_rate", [True, "250"])
+def test_sample_rates_do_not_accept_boolean_or_string_coercion(bad_rate):
+    with pytest.raises(TypeError):
+        _descriptor(sample_rate_hz=bad_rate)
+    with pytest.raises(TypeError):
+        _frame(sample_rate_hz=bad_rate)
+
+
+@pytest.mark.parametrize("field", ["sequence_id", "host_receive_time_ns", "device_time_ns"])
+@pytest.mark.parametrize("bad_value", [True, 1.5])
+def test_frame_integer_identity_fields_reject_lossy_coercion(field, bad_value):
+    with pytest.raises(TypeError):
+        _frame(**{field: bad_value})
+
+
+def test_declared_clock_domain_requires_corresponding_timestamp():
+    with pytest.raises(ValueError, match="device_time_ns"):
+        _frame(clock_domain=ClockDomain.DEVICE, device_time_ns=None)
+    with pytest.raises(ValueError, match="synchronized_time_ns"):
+        _frame(clock_domain=ClockDomain.SYNCHRONIZED, synchronized_time_ns=None)
+
+
+def test_timestamp_authority_follows_declared_clock_domain():
+    assert _frame(clock_domain=ClockDomain.DEVICE).timestamp_ns == 200
+    assert _frame(clock_domain=ClockDomain.HOST_MONOTONIC).timestamp_ns == 100
+    assert _frame(clock_domain=ClockDomain.SYNCHRONIZED).timestamp_ns == 300
+
+
+def test_legacy_conversion_places_timestamp_in_declared_domain():
+    synchronized = SignalFrame.from_legacy(
+        stream_id="legacy",
+        sequence_id=0,
+        timestamp_seconds=1.25,
+        data=np.ones(2),
+        sample_rate_hz=100.0,
+        clock_domain=ClockDomain.SYNCHRONIZED,
+    )
+    assert synchronized.synchronized_time_ns == 1_250_000_000
+    assert synchronized.device_time_ns is None
+    assert synchronized.timestamp_ns == 1_250_000_000
+
+
+def test_frame_rejects_nonfinite_and_object_signal_payloads():
+    with pytest.raises(ValueError, match="finite"):
+        _frame(data=np.array([1.0, np.nan]))
+    with pytest.raises(TypeError, match="numeric dtype"):
+        _frame(data=np.array(["C3", "C4"], dtype=object))
+
+
+def test_stream_descriptor_requires_unique_nonempty_channel_identity():
+    with pytest.raises(ValueError, match="unique"):
+        _descriptor(channel_names=("C3", "C3"), channel_types=("eeg", "eeg"), units=("uV", "uV"))
+    with pytest.raises(ValueError, match="non-empty"):
+        _descriptor(channel_names=("C3", ""), channel_types=("eeg", "eeg"), units=("uV", "uV"))
+
+
+def test_descriptor_fingerprint_is_deterministic_and_semantically_sensitive():
+    first = _descriptor(metadata={"a": 1, "b": {"x": [1, 2]}})
+    reordered = _descriptor(metadata={"b": {"x": (1, 2)}, "a": 1})
+    changed = _descriptor(metadata={"a": 1, "b": {"x": [1, 3]}})
+
+    assert first.fingerprint() == reordered.fingerprint()
+    assert first.fingerprint() != changed.fingerprint()
+    assert len(first.fingerprint()) == 64
+
+
+def test_multidimensional_channel_geometry_is_never_guessed():
+    ambiguous = _frame(data=np.zeros((5, 8)), metadata={"modality": "eeg"})
+    with pytest.raises(ValueError, match="axis_order"):
+        frame_channel_count(ambiguous)
+
+    explicit = _frame(
+        data=np.zeros((5, 8)),
+        metadata={"modality": "eeg", "axis_order": ("sample", "channel")},
+    )
+    assert frame_channel_count(explicit) == 8
+
+
+def test_descriptor_frame_validator_binds_stream_rate_clock_and_channels():
+    descriptor = _descriptor()
+    valid = _frame()
+    validate_frame_against_descriptor(descriptor, valid)
+
+    with pytest.raises(ValueError, match="stream_id"):
+        validate_frame_against_descriptor(descriptor, _frame(stream_id="other"))
+    with pytest.raises(ValueError, match="sample_rate"):
+        validate_frame_against_descriptor(descriptor, _frame(sample_rate_hz=200.0))
+    with pytest.raises(ValueError, match="clock_domain"):
+        validate_frame_against_descriptor(
+            descriptor,
+            _frame(clock_domain=ClockDomain.DEVICE),
+        )
+
+    wrong_channels = _frame(data=np.zeros(7, dtype=np.float32))
+    with pytest.raises(ValueError, match="channel geometry"):
+        validate_frame_against_descriptor(descriptor, wrong_channels)
+
+
+def test_descriptor_frame_validator_checks_declared_channel_names():
+    descriptor = _descriptor()
+    frame = _frame(metadata={"channel_names": tuple(reversed(descriptor.channel_names))})
+    with pytest.raises(ValueError, match="channel_names"):
+        validate_frame_against_descriptor(descriptor, frame)
+
+
+@pytest.mark.asyncio
+async def test_archive_persists_and_verifies_descriptor_identity(tmp_path: Path):
+    descriptor = _descriptor()
+    frame = _frame()
+    root = tmp_path / "session"
+
+    writer = SessionArchiveWriter(root, session_id="identity")
+    writer.register_stream(descriptor)
+    await writer.write(frame)
+    await writer.close()
+
+    reader = SessionArchiveReader(root)
+    restored_descriptor = reader.descriptor("eeg")
+    restored_frame = list(reader.iter_frames("eeg"))[0]
+    assert restored_descriptor.fingerprint() == descriptor.fingerprint()
+    assert not restored_frame.data.flags.writeable
+    np.testing.assert_array_equal(restored_frame.data, frame.data)
+    assert restored_frame.timestamp_ns == frame.timestamp_ns
+
+
+@pytest.mark.asyncio
+async def test_archive_rejects_frame_descriptor_mismatch_before_writing(tmp_path: Path):
+    descriptor = _descriptor()
+    root = tmp_path / "session"
+    writer = SessionArchiveWriter(root, session_id="mismatch")
+    writer.register_stream(descriptor)
+
+    with pytest.raises(ValueError, match="channel geometry"):
+        await writer.write(_frame(data=np.zeros(7, dtype=np.float32)))
+
+    assert not list((root / "streams" / "eeg" / "frames").glob("*.npy"))
+
+
+@pytest.mark.asyncio
+async def test_archive_auto_registration_requires_explicit_multidimensional_axis(tmp_path: Path):
+    writer = SessionArchiveWriter(tmp_path / "session", session_id="ambiguous")
+    ambiguous = _frame(
+        stream_id="unregistered",
+        data=np.zeros((4, 2)),
+        metadata={"modality": "eeg"},
+    )
+    with pytest.raises(ValueError, match="axis_order"):
+        await writer.write(ambiguous)

--- a/tests/test_synthetic_eeg_driver.py
+++ b/tests/test_synthetic_eeg_driver.py
@@ -346,7 +346,15 @@ def test_driver_exposes_versioned_replay_configuration():
     assert descriptor.metadata["artifact_scheduler"] == SYNTHETIC_EEG_ARTIFACT_SCHEDULER_CONTRACT
     assert descriptor.metadata["artifact_scheduler"] == "neuros.synthetic_eeg.artifact_schedule.v1"
     assert descriptor.metadata["artifact_schedule_in_descriptor"] is False
-    assert descriptor.metadata["generator_config"] == _expected_generator_config()
+
+    generator_config = descriptor.metadata["generator_config"]
+    expected = _expected_generator_config()
+    assert generator_config["channel_names"] == tuple(expected["channel_names"])
+    for key, value in expected.items():
+        if key != "channel_names":
+            assert generator_config[key] == value
+    with pytest.raises(TypeError):
+        generator_config["seed"] = 42
 
 
 def test_driver_exposes_composable_scheduler_without_bypassing_generator_contract():


### PR DESCRIPTION
## Why

The scientific audit found that neurOS's canonical neural boundary was structurally frozen but not actually immutable or fully fail-closed. Caller-owned NumPy buffers could mutate a `SignalFrame` after construction, NaN sample rates could bypass simple positivity checks, timestamp/sequence fields could be lossily coerced, and recording could auto-register a two-dimensional frame by guessing the wrong channel axis.

Those defects sit below every decoder, replay comparison, timing analysis, ORION representation, and evidence artifact.

## Canonical `SignalFrame` v2 integrity

- sample data are copied at construction and stored read-only;
- scalar/sample buffers cannot be changed through caller aliases after construction;
- signal payloads must be non-empty boolean/numeric arrays;
- floating/complex payloads must be finite;
- missingness/artifact conditions belong in explicit samples plus `QualityFlag`, not NaN/Inf payload ambiguity;
- sampling rates must be finite positive real scalars and cannot be bool/string-coerced;
- sequence and nanosecond timestamps require actual non-negative integer values;
- undefined quality bits and lossy quality coercions fail closed;
- top-level metadata must be a mapping;
- nested provenance is detached and recursively frozen;
- unordered sets, opaque bytes, non-finite values, object arrays, and arbitrary Python objects are rejected from canonical provenance.

## Clock authority

The declared `ClockDomain` determines the authoritative `timestamp_ns`:

- `DEVICE` requires and uses `device_time_ns`;
- `HOST_MONOTONIC` uses `host_receive_time_ns`;
- `SYNCHRONIZED` requires and uses `synchronized_time_ns`;
- `UNKNOWN` preserves the historical best-available fallback without pretending it is a qualified clock.

`SignalFrame.from_legacy()` places its scalar legacy timestamp into the explicitly declared clock domain instead of always storing it as device time.

This is software clock semantics only. It does not prove a physical device clock is accurate or synchronized.

## `StreamDescriptor` identity

- non-empty stream/modality identity;
- finite positive nominal sampling rate;
- unique, non-empty channel names;
- channel type/unit alignment;
- archive-stable deterministic provenance metadata;
- `fingerprint()` provides a SHA-256 identity over canonical static stream metadata;
- `nominal_sample_rate_hz` makes explicit that descriptor sampling rate is a declaration, not measured clock evidence.

## Descriptor/frame binding

New public helpers:

- `frame_channel_count(frame)`;
- `validate_frame_against_descriptor(descriptor, frame)`.

One-dimensional streaming frames remain one multi-channel sample. Multi-dimensional frames must identify exactly one channel axis through `metadata['axis_order']`; neurOS no longer guesses channel identity from shape.

The validator binds stream ID, nominal sample rate, asserted clock domain, channel geometry, and declared channel/type/unit/modality metadata.

## Archive schema v2

New archives are written as schema **v2**. v2:

- stores descriptor fingerprints in descriptor and manifest records;
- verifies fingerprints on read;
- validates every frame against its registered descriptor before writing bytes;
- validates every restored frame against the same descriptor;
- refuses coercive parsing of v2 identity/time fields;
- cannot silently reinterpret an ambiguous multi-dimensional frame during auto-registration.

Archive v1 remains readable through an explicit legacy path, but reports `descriptor_integrity='legacy-unbound'`. v1 is **not** retroactively credited with descriptor fingerprint/channel-axis guarantees it never recorded. v2 reports `descriptor_integrity='sha256-bound'`.

## Canonical axis correction

The audit found a real inconsistency: windowing and MNE already define 2-D neurOS frames as `sample x channel`, while archive auto-registration historically used `shape[0]` as channels. Recording/export fixtures are corrected to the canonical sample-major convention and carry explicit axis metadata.

## Driver provenance correction

The first exact-head matrix exposed one old regression that asserted a mutable `dict`/`list` representation for synthetic generator provenance. The generator values were unchanged. The regression now asserts canonical semantic values, requires channel identity to be immutable, and explicitly proves the nested replay configuration cannot be mutated. Runtime immutability was not weakened to satisfy the old container-type assertion.

## Qualification authority

A dedicated `.github/workflows/signal-integrity-ci.yml` runs the signal, archive, replay, clock, and NWB/Zarr export contracts on Python 3.10, 3.11, and 3.12.

Qualified production base: `578989707a69e40155ea174503534755e7c43d32`

Qualified exact head: `7975dd5b16af68263063209f082618771b3c0e7d`

All exact-head workflows are green:

- Signal Integrity Contracts, Python 3.10/3.11/3.12;
- full neurOS CI;
- neurOS driver contracts, including Unicorn Hybrid Black and synthetic replay provenance;
- Braindecode Compatibility;
- Neural Window Contracts;
- Ecosystem Compatibility;
- External Plugin Contract;
- Developer Preview Journey.

The adversarial suite covers buffer aliasing, read-only samples, recursive metadata immutability, non-finite and lossy numeric states, clock-domain consistency, deterministic descriptor identity, ambiguous axes, descriptor mismatch, v2 tamper detection, coercive index tampering, v1 compatibility, exact archive round trips, replay, clocks, and interoperability exports.

## Evidence boundary

This strengthens integrity of neurOS's software representation and archive authority. It does **not** establish physical sampling-clock accuracy, physiological signal quality, participant validity, device qualification, decoder superiority, closed-loop performance, or clinical benefit.

Closes #68 after production-push qualification.