### PR TITLE
NSQ Runner v1: execute external methods under frozen authority

### DIFF
--- a/.github/workflows/nsq-runner-ci.yml
+++ b/.github/workflows/nsq-runner-ci.yml
@@ -54,4 +54,46 @@ jobs:
       - name: Compile runner surface
         run: |
           python -m compileall -q \
-            packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py
+            packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py \
+            packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py
+
+  mne-csp-lda:
+    name: External MNE CSP + sklearn LDA
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install MNE reference profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[eeg]" pytest pytest-asyncio
+      - name: Prove MNE CSP + LDA through NSQ
+        run: |
+          pytest -q \
+            tests/test_neural_system_qualification_baselines.py::test_mne_csp_lda_participates_as_external_probability_method
+
+  upstream-braindecode:
+    name: Direct upstream Braindecode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install upstream Braindecode profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e "packages/neuros-foundation[braindecode-evidence]" pytest pytest-asyncio
+      - name: Prove direct Braindecode factory and execution
+        run: |
+          pytest -q \
+            tests/test_neural_system_qualification_baselines.py::test_braindecode_factory_is_direct_upstream_not_neuros_model_wrapper \
+            tests/test_neural_system_qualification_baselines.py::test_upstream_braindecode_executes_through_same_nsq_referee

--- a/.github/workflows/nsq-runner-ci.yml
+++ b/.github/workflows/nsq-runner-ci.yml
@@ -1,0 +1,57 @@
+name: NSQ Runner v1
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/qualification.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py"
+      - "tests/test_neural_system_qualification_runner.py"
+      - "tests/test_neural_system_qualification_baselines.py"
+      - "docs/NSQ_RUNNER_V1.md"
+      - ".github/workflows/nsq-runner-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros-foundation/src/neuros/foundation_models/qualification.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py"
+      - "tests/test_neural_system_qualification_runner.py"
+      - "tests/test_neural_system_qualification_baselines.py"
+      - "docs/NSQ_RUNNER_V1.md"
+      - ".github/workflows/nsq-runner-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nsq-runner-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runner-contracts:
+    name: Runner contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install runner core
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e packages/neuros-foundation pytest pytest-asyncio
+      - name: Exercise NSQ runner authority
+        run: |
+          pytest -q tests/test_neural_system_qualification_runner.py
+      - name: Compile runner surface
+        run: |
+          python -m compileall -q \
+            packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py

--- a/docs/NSQ_RUNNER_V1.md
+++ b/docs/NSQ_RUNNER_V1.md
@@ -1,0 +1,249 @@
+# NSQ Runner v1
+
+The **Neural System Qualification (NSQ) Runner v1** is the executable referee for the peer-facing NSQ participation contract.
+
+Its job is intentionally narrower than model training:
+
+> Given a frozen neural-data case, a frozen scientific protocol, and an external model factory, control exactly which observations may cross the model boundary and preserve what happened under a cryptographically identified evidence contract.
+
+The runner does **not** rewrite the submitted model, optimizer, architecture, augmentation policy, or training loop.
+
+## Authority chain
+
+A successful budget row binds:
+
+```text
+observed upstream dataset lineage
+              |
+              v
+frozen QualificationProtocolSpec
+              |
+              v
+frozen LongitudinalCaseAuthority
+              |
+              +--> source-history observation SHA
+              +--> labeled-target observation SHA
+              +--> exact supervised-fit observation SHA
+              +--> untouched final-assessment SHA
+              |
+              v
+ExternalDecoderMethodSpec
+              |
+              v
+QualificationRunContract
+              |
+              v
+fresh factory.create()
+              |
+              +--> fit(authorized X, y)
+              |
+              v
+ExternalLearnedState
+              |
+              v
+QualificationModelState
+              |
+              +--> predict(untouched X_final)
+              +--> optional predict_proba(X_final)
+              |
+              v
+frozen metric scorecard
+              |
+              v
+failure-preserving QualificationBudgetResult
+```
+
+The full SHA-256 values are scientific joins. Sixteen-character prefixes are display conveniences only.
+
+## Two different model-state identities
+
+The runner deliberately exposes two different hashes when possible.
+
+### `external_learned_state_sha256`
+
+This is the upstream model's exact tensor/checkpoint identity when the external implementation can honestly provide one.
+
+The direct Braindecode reference hashes the fitted upstream PyTorch module's complete `state_dict()`, including registered buffers. Optimizer state is not part of the inference-state hash and is declared separately in metadata.
+
+### `qualification_model_state_sha256`
+
+This is the NSQ binding of the learned-state record to the exact method and run authority that produced it.
+
+These hashes answer different questions and must not be conflated:
+
+```text
+external_learned_state_sha256
+    = "what fitted inference state was this?"
+
+qualification_model_state_sha256
+    = "under which exact scientific authority did this state participate?"
+```
+
+For the MNE/scikit-learn CSP + LDA reference, `external_learned_state_sha256` remains `None`. NSQ does not pickle/joblib an arbitrary estimator merely to manufacture a strong scientific state identity. The method may still participate, and the run binding remains identified, but the learned estimator is explicitly `opaque_unverified`.
+
+## Exact observation identity
+
+Counts are insufficient scientific authority.
+
+A row that says `4 labeled target examples` does not identify *which* four examples were used. Therefore each run contract also binds full SHA-256 identities for:
+
+- source-history indices;
+- labeled-target calibration indices;
+- complete supervised-fit indices;
+- untouched final-assessment indices.
+
+Each observation-set SHA is domain-separated and includes the processed-data SHA. The same integer indices on a different processed array therefore do not silently become the same authority.
+
+## Upstream versus processed data identity
+
+NSQ keeps two provenance layers separate:
+
+- `observed_dataset_lineage_sha256` identifies the upstream dataset/revision actually loaded;
+- `processed_data_sha256` identifies the exact processed neural array governed by the longitudinal case authority.
+
+Both must match before external model construction begins.
+
+This prevents a benchmark from validating only the final array while quietly changing its upstream corpus provenance, or validating only the corpus name while changing the actual samples used by the decoder.
+
+## Labeled target calibration
+
+For `LongitudinalCaseAuthority`, Runner v1 executes the frozen calibration ladder exactly.
+
+At every declared budget:
+
+1. restore the same frozen case authority;
+2. select the exact balanced labeled-target indices for that budget;
+3. construct a **fresh external decoder**;
+4. fit on source history plus only those labeled-target rows;
+5. bind learned state;
+6. predict on the untouched final-assessment rows;
+7. validate output semantics;
+8. score under the exact scorecard SHA;
+9. retain success or failure as a result row.
+
+No warm-start across budgets is permitted by the runner.
+
+## Why unlabeled adaptation is refused in this executor
+
+The generic NSQ participation schema supports a distinct `adapt_unlabeled(X)` capability and separately records unlabeled target information.
+
+However, the first `LongitudinalCaseAuthority` has only:
+
+- source history;
+- a labeled calibration pool;
+- untouched evaluation rows.
+
+It does **not** freeze a scientifically distinct unlabeled-adaptation pool.
+
+An earlier runner draft attempted to use calibration rows not yet selected by the current labeled budget as unlabeled target observations. That was rejected because the unlabeled set changed as labeled budget increased and disappeared entirely at the maximum budget. The same observation could therefore change scientific role across the calibration frontier.
+
+Runner v1 now fails **before external model creation** if unlabeled target observations are requested under this authority.
+
+A future adaptive executor must first introduce or reuse an authority that freezes a distinct unlabeled target role with no overlap with labeled calibration, state-selection/qualification, or final assessment. We will not infer that role from "leftover" rows.
+
+## Output semantics
+
+Every external decoder must provide task-label `predict()`.
+
+Probability output is optional. A probability-capable method additionally must provide:
+
+- `predict_proba()`;
+- fitted probability-column class order.
+
+The class order must exactly equal the canonical source-derived class vocabulary before ROC AUC, Brier score, or ECE are computed.
+
+The runner never renormalizes malformed probabilities or guesses their class order.
+
+### Label-only methods
+
+A label-only method remains a valid participant:
+
+```text
+balanced accuracy       available
+accuracy                available
+ROC AUC                 unavailable_probability_output
+Brier score             unavailable_probability_output
+ECE                     unavailable_probability_output
+```
+
+Unavailable metrics remain explicit evidence rather than becoming dropped cells or synthetic probabilities.
+
+## Classification scorecard v1
+
+The dependency-light `ClassificationScorecardV1` binds these semantics into a full SHA-256:
+
+- **balanced accuracy:** macro mean recall over the source-derived class vocabulary;
+- **accuracy:** exact task-label fraction;
+- **ROC AUC:** binary rank AUC only in v1, with the second canonical source label as positive class;
+- **Brier score:** mean per-sample sum of squared multiclass probability error;
+- **ECE:** top-label expected calibration error with 10 equal-width bins by default.
+
+The protocol cannot execute unless its `metric_scorecard_sha256` equals the scorecard supplied to the runner.
+
+## Failure preservation
+
+External model/runtime failures do not disappear from the frontier.
+
+Runner v1 preserves statuses including:
+
+- `success`;
+- `unavailable`;
+- `oom`;
+- `failed`;
+- `skipped`;
+- `nonconverged`.
+
+If fitting succeeded and a later output-semantic check failed, the row may retain the already-produced learned-state evidence while remaining a failed result. This prevents a result bundle from pretending the model was never fitted simply because its output contract was invalid.
+
+Scientific-authority mismatches such as wrong dataset lineage, tampered processed data, wrong metric authority, an unfrozen protocol, or a forbidden unlabeled-target request fail before external code sees data.
+
+## First external proving methods
+
+### MNE CSP + scikit-learn LDA
+
+`MNECSPLDAFactory` uses maintained upstream components:
+
+- `mne.decoding.CSP`;
+- `sklearn.discriminant_analysis.LinearDiscriminantAnalysis`;
+- sklearn pipeline composition.
+
+The runner does not reimplement CSP or LDA.
+
+### Direct upstream Braindecode
+
+`UpstreamBraindecodeFactory` constructs:
+
+- `braindecode.models.<model>`;
+- upstream `braindecode.EEGClassifier`;
+- PyTorch cross-entropy;
+- PyTorch AdamW.
+
+It deliberately does not route training through the existing neurOS `BraindecodeDecoder` wrapper. This makes the interoperability claim stronger: upstream Braindecode is the contestant; neurOS supplies scientific authority and scoring.
+
+## What this proves
+
+Passing Runner v1 contracts can establish that:
+
+- the declared upstream/processed data authority matched;
+- exact source/calibration/final observation sets were controlled;
+- a fresh external model was used at every budget;
+- final-assessment rows did not enter fitting;
+- output semantics were checked rather than repaired;
+- metric semantics were frozen;
+- failures remained visible;
+- real MNE/sklearn and Braindecode implementations can participate without adopting neurOS training code.
+
+It does **not** establish that any model is better, that EEG features are physiologically meaningful, that hardware is reliable, that an online BCI works, or that a system is clinically useful.
+
+## Next scientific milestone
+
+After this runner is production-qualified, the next milestone is not another abstraction. It is a real frozen longitudinal study:
+
+1. bind the Kumar2024 dataset lineage and processed-data authorities;
+2. freeze the v1 metric scorecard;
+3. execute the same participant/session cases for MNE CSP + LDA and upstream Braindecode;
+4. add additional strong upstream decoders;
+5. audit pretrained foundation-model lineage before admitting foundation representations;
+6. only then place ORION variants into the same qualification frontier.
+
+The flagship comparison should be **task performance versus per-user calibration cost**, with participant as the independent inferential unit and failures retained.

--- a/packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py
@@ -1,0 +1,387 @@
+"""Reference external methods for Neural System Qualification v1.
+
+These adapters exist to prove that the NSQ referee can qualify maintained
+upstream implementations without asking researchers to adopt neurOS training
+code. They deliberately do not copy MNE or Braindecode algorithms.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import inspect
+import json
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import numpy as np
+
+from .qualification import ExternalDecoderMethodSpec, ExternalLearnedState
+
+
+def _package_version(distribution: str) -> str:
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise ImportError(
+            f"optional NSQ reference method requires installed distribution {distribution!r}"
+        ) from exc
+
+
+def _frozen_json_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    options = dict(value)
+    try:
+        payload = json.dumps(
+            options,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("reference-method options must be finite JSON values") from exc
+    del payload
+    return MappingProxyType(options)
+
+
+def _torch_state_sha256(module: Any) -> str:
+    """Hash exact inference-relevant tensor/buffer state without pickle."""
+
+    state = module.state_dict()
+    digest = hashlib.sha256()
+    digest.update(b"neuros.external-torch-state.v1\0")
+    for name in sorted(state):
+        tensor = state[name].detach().cpu().contiguous()
+        array = tensor.numpy()
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(array.dtype).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(json.dumps(list(array.shape), separators=(",", ":")).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+class _MNECSPLDADecoder:
+    def __init__(self, *, n_components: int) -> None:
+        self.n_components = int(n_components)
+        self._pipeline: Any | None = None
+        self._classes: tuple[str, ...] = ()
+
+    def _require_pipeline(self) -> Any:
+        if self._pipeline is None:
+            raise RuntimeError("MNE CSP+LDA decoder has not been fitted")
+        return self._pipeline
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        try:
+            from mne.decoding import CSP
+            from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
+            from sklearn.pipeline import make_pipeline
+        except ImportError as exc:  # pragma: no cover - optional integration lane
+            raise ImportError("MNE CSP+LDA requires MNE and scikit-learn") from exc
+
+        array = np.asarray(X)
+        labels = np.asarray(y).astype(str)
+        if array.ndim != 3:
+            raise ValueError("MNE CSP+LDA expects X=(sample, channel, time)")
+        if labels.ndim != 1 or len(labels) != len(array):
+            raise ValueError("MNE CSP+LDA labels must align with X")
+        if not np.isfinite(array).all():
+            raise ValueError("MNE CSP+LDA refuses non-finite neural input")
+        classes = tuple(sorted(np.unique(labels).tolist()))
+        if len(classes) < 2:
+            raise ValueError("MNE CSP+LDA requires at least two classes")
+
+        # Keep the reference intentionally boring and aligned with the existing
+        # neurOS longitudinal baseline: upstream MNE CSP followed by sklearn LDA.
+        pipeline = make_pipeline(
+            CSP(n_components=self.n_components, reg=None),
+            LDA(),
+        )
+        pipeline.fit(array, labels)
+        self._pipeline = pipeline
+        self._classes = classes
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return np.asarray(self._require_pipeline().predict(np.asarray(X))).astype(str)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        return np.asarray(
+            self._require_pipeline().predict_proba(np.asarray(X)),
+            dtype=np.float64,
+        )
+
+    def probability_class_labels(self) -> tuple[str, ...]:
+        pipeline = self._require_pipeline()
+        estimator = pipeline.steps[-1][1]
+        return tuple(str(value) for value in estimator.classes_)
+
+    def learned_state(self) -> ExternalLearnedState:
+        # MNE/sklearn do not currently have a qualified tensor-only NSQ state
+        # serializer. Preserve scientific comparison without manufacturing a
+        # strong checkpoint identity through pickle/joblib.
+        self._require_pipeline()
+        return ExternalLearnedState(
+            state_identity_kind="opaque_unverified",
+            metadata={
+                "reason": "mne_sklearn_state_serializer_not_qualified",
+                "n_components": self.n_components,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MNECSPLDAFactory:
+    """Trusted-code factory for upstream MNE CSP + sklearn LDA."""
+
+    n_components: int = 8
+    source_reference: str = "MNE CSP + scikit-learn LinearDiscriminantAnalysis"
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("MNECSPLDAFactory schema_version must be 1")
+        if isinstance(self.n_components, bool) or not isinstance(self.n_components, int):
+            raise ValueError("n_components must be an integer without coercion")
+        if self.n_components <= 0:
+            raise ValueError("n_components must be positive")
+
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        mne_version = _package_version("mne")
+        sklearn_version = _package_version("scikit-learn")
+        return ExternalDecoderMethodSpec(
+            method_id="mne-csp-lda",
+            implementation="mne.decoding.CSP+sklearn.discriminant_analysis.LinearDiscriminantAnalysis",
+            implementation_version=f"mne={mne_version};scikit-learn={sklearn_version}",
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="uncalibrated_probability",
+            target_adaptation_mode="none",
+            source_reference=self.source_reference,
+            metadata={
+                "csp_n_components": self.n_components,
+                "csp_reg": None,
+                "lda": "default",
+                "hidden_preprocessing": False,
+            },
+        )
+
+    def create(self) -> _MNECSPLDADecoder:
+        return _MNECSPLDADecoder(n_components=self.n_components)
+
+
+class _UpstreamBraindecodeDecoder:
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        sample_rate_hz: float | None,
+        model_options: Mapping[str, Any],
+        learning_rate: float,
+        weight_decay: float,
+        n_epochs: int,
+        batch_size: int,
+        device: str,
+        random_state: int,
+    ) -> None:
+        self.model_name = model_name
+        self.sample_rate_hz = sample_rate_hz
+        self.model_options = dict(model_options)
+        self.learning_rate = learning_rate
+        self.weight_decay = weight_decay
+        self.n_epochs = n_epochs
+        self.batch_size = batch_size
+        self.device = device
+        self.random_state = random_state
+        self._classifier: Any | None = None
+        self._module: Any | None = None
+        self._classes: tuple[str, ...] = ()
+
+    def _require_classifier(self) -> Any:
+        if self._classifier is None:
+            raise RuntimeError("upstream Braindecode decoder has not been fitted")
+        return self._classifier
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        try:
+            import torch
+            from braindecode import EEGClassifier
+            import braindecode.models as models
+        except ImportError as exc:  # pragma: no cover - optional integration lane
+            raise ImportError("upstream Braindecode NSQ reference requires braindecode") from exc
+
+        array = np.asarray(X, dtype=np.float32)
+        labels = np.asarray(y).astype(str)
+        if array.ndim != 3:
+            raise ValueError("Braindecode reference expects X=(sample, channel, time)")
+        if labels.ndim != 1 or len(labels) != len(array):
+            raise ValueError("Braindecode labels must align with X")
+        if not np.isfinite(array).all():
+            raise ValueError("Braindecode reference refuses non-finite neural input")
+        classes = tuple(sorted(np.unique(labels).tolist()))
+        if len(classes) < 2:
+            raise ValueError("Braindecode reference requires at least two classes")
+        mapping = {label: index for index, label in enumerate(classes)}
+        encoded = np.asarray([mapping[value] for value in labels], dtype=np.int64)
+
+        model_type = getattr(models, self.model_name, None)
+        if model_type is None:
+            raise RuntimeError(
+                f"installed Braindecode does not expose model {self.model_name!r}"
+            )
+        kwargs: dict[str, Any] = {
+            "n_chans": int(array.shape[1]),
+            "n_outputs": len(classes),
+            "n_times": int(array.shape[2]),
+            **self.model_options,
+        }
+        if self.sample_rate_hz is not None:
+            signature = inspect.signature(model_type)
+            if "sfreq" in signature.parameters:
+                kwargs["sfreq"] = self.sample_rate_hz
+
+        np.random.seed(self.random_state)
+        torch.manual_seed(self.random_state)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self.random_state)
+
+        module = model_type(**kwargs)
+        classifier = EEGClassifier(
+            module,
+            criterion=torch.nn.CrossEntropyLoss,
+            optimizer=torch.optim.AdamW,
+            optimizer__lr=self.learning_rate,
+            optimizer__weight_decay=self.weight_decay,
+            batch_size=self.batch_size,
+            max_epochs=self.n_epochs,
+            train_split=None,
+            device=self.device,
+            classes=np.arange(len(classes)),
+            verbose=0,
+        )
+        classifier.fit(array, encoded)
+        self._module = module
+        self._classifier = classifier
+        self._classes = classes
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        encoded = np.asarray(
+            self._require_classifier().predict(np.asarray(X, dtype=np.float32)),
+            dtype=np.int64,
+        )
+        return np.asarray([self._classes[index] for index in encoded], dtype=str)
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        return np.asarray(
+            self._require_classifier().predict_proba(np.asarray(X, dtype=np.float32)),
+            dtype=np.float64,
+        )
+
+    def probability_class_labels(self) -> tuple[str, ...]:
+        self._require_classifier()
+        return self._classes
+
+    def learned_state(self) -> ExternalLearnedState:
+        classifier = self._require_classifier()
+        module = getattr(classifier, "module_", None) or self._module
+        if module is None:
+            raise RuntimeError("Braindecode classifier has no fitted module state")
+        return ExternalLearnedState(
+            state_identity_kind="tensor_sha256",
+            state_sha256=_torch_state_sha256(module),
+            metadata={
+                "state_scope": "upstream_model_state_dict_including_registered_buffers",
+                "optimizer_state_included": False,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class UpstreamBraindecodeFactory:
+    """Direct upstream Braindecode model + EEGClassifier NSQ factory."""
+
+    model_name: str = "EEGNet"
+    sample_rate_hz: float | None = None
+    model_options: Mapping[str, Any] = field(default_factory=dict)
+    learning_rate: float = 1e-3
+    weight_decay: float = 0.0
+    n_epochs: int = 1
+    batch_size: int = 32
+    device: str = "cpu"
+    random_state: int = 0
+    source_reference: str = "Braindecode upstream model + EEGClassifier"
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("UpstreamBraindecodeFactory schema_version must be 1")
+        if not isinstance(self.model_name, str) or not self.model_name.strip():
+            raise ValueError("model_name must be non-empty")
+        if self.sample_rate_hz is not None:
+            rate = float(self.sample_rate_hz)
+            if not np.isfinite(rate) or rate <= 0:
+                raise ValueError("sample_rate_hz must be finite and positive")
+            object.__setattr__(self, "sample_rate_hz", rate)
+        if self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+        if self.weight_decay < 0:
+            raise ValueError("weight_decay must be non-negative")
+        if self.n_epochs <= 0 or self.batch_size <= 0:
+            raise ValueError("n_epochs and batch_size must be positive")
+        if isinstance(self.random_state, bool) or not isinstance(self.random_state, int):
+            raise ValueError("random_state must be an integer without coercion")
+        object.__setattr__(self, "model_name", self.model_name.strip())
+        object.__setattr__(self, "model_options", _frozen_json_mapping(self.model_options))
+
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        braindecode_version = _package_version("braindecode")
+        torch_version = _package_version("torch")
+        return ExternalDecoderMethodSpec(
+            method_id=f"braindecode-{self.model_name.lower()}",
+            implementation=f"braindecode.models.{self.model_name}+braindecode.EEGClassifier",
+            implementation_version=(
+                f"braindecode={braindecode_version};torch={torch_version}"
+            ),
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="uncalibrated_softmax",
+            target_adaptation_mode="none",
+            source_reference=self.source_reference,
+            metadata={
+                "model_name": self.model_name,
+                "sample_rate_hz": self.sample_rate_hz,
+                "model_options": dict(self.model_options),
+                "criterion": "torch.nn.CrossEntropyLoss",
+                "optimizer": "torch.optim.AdamW",
+                "learning_rate": self.learning_rate,
+                "weight_decay": self.weight_decay,
+                "n_epochs": self.n_epochs,
+                "batch_size": self.batch_size,
+                "device": self.device,
+                "random_state": self.random_state,
+                "train_split": None,
+                "hidden_preprocessing": False,
+                "neuros_model_wrapper_used": False,
+            },
+        )
+
+    def create(self) -> _UpstreamBraindecodeDecoder:
+        return _UpstreamBraindecodeDecoder(
+            model_name=self.model_name,
+            sample_rate_hz=self.sample_rate_hz,
+            model_options=self.model_options,
+            learning_rate=self.learning_rate,
+            weight_decay=self.weight_decay,
+            n_epochs=self.n_epochs,
+            batch_size=self.batch_size,
+            device=self.device,
+            random_state=self.random_state,
+        )
+
+
+__all__ = [
+    "MNECSPLDAFactory",
+    "UpstreamBraindecodeFactory",
+]

--- a/packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py
@@ -1,0 +1,1039 @@
+"""Executable referee for Neural System Qualification (NSQ) v1.
+
+The runner owns evidence authority, not external model training. It restores an
+existing :class:`LongitudinalCaseAuthority`, exposes only authorized observations
+to a fresh external decoder at each calibration budget, validates output
+semantics, and preserves every attempted run including failures.
+
+Upstream dataset lineage and downstream processed-array identity are deliberately
+separate authorities: both must match before fitting begins.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import time
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal, Mapping, Protocol, Sequence, runtime_checkable
+
+import numpy as np
+
+from .longitudinal_authority import LongitudinalCaseAuthority
+from .qualification import (
+    ExternalDecoderMethodSpec,
+    ExternalLearnedState,
+    ExternalProbabilityDecoder,
+    ExternalQualificationDecoder,
+    ExternalQualificationFactory,
+    ExternalUnlabeledTargetAdapter,
+    QualificationModelState,
+    QualificationProtocolSpec,
+    QualificationRunContract,
+    bind_learned_state,
+    validate_prediction_output,
+    validate_probability_output,
+    validate_run_capabilities,
+)
+from .real_world import GroupedEvaluationData
+
+QualificationStatus = Literal[
+    "success",
+    "failed",
+    "skipped",
+    "unavailable",
+    "nonconverged",
+    "oom",
+]
+MetricAvailability = Literal[
+    "available",
+    "unavailable_probability_output",
+    "unavailable_class_support",
+]
+
+_SHA256_HEX = frozenset("0123456789abcdef")
+
+
+def _sha256(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    normalized = value.strip()
+    if len(normalized) != 64 or any(char not in _SHA256_HEX for char in normalized):
+        raise ValueError(f"{name} must be a 64-character lowercase SHA-256 digest")
+    return normalized
+
+
+def _sha_tuple(name: str, values: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a sequence of SHA-256 digests")
+    result = tuple(_sha256(name, value) for value in values)
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} cannot contain duplicate SHA-256 digests")
+    return result
+
+
+def _exact_nonnegative_int(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer without coercion")
+    result = int(value)
+    if result < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _finite_nonnegative(name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
+        raise ValueError(f"{name} must be numeric without coercion")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return result
+
+
+def _canonical(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("qualification result cannot contain NaN or infinity")
+        return value
+    if isinstance(value, np.generic):
+        return _canonical(value.item())
+    if isinstance(value, np.ndarray):
+        if value.dtype.hasobject:
+            raise TypeError("qualification identity cannot contain object arrays")
+        return _canonical(value.tolist())
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("qualification mapping keys must be non-empty strings")
+            name = key.strip()
+            if name in normalized:
+                raise ValueError("qualification mapping keys collide after normalization")
+            normalized[name] = _canonical(item)
+        return {key: normalized[key] for key in sorted(normalized)}
+    if isinstance(value, (list, tuple)):
+        return [_canonical(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        raise TypeError("unordered sets are not valid qualification identity values")
+    raise TypeError(
+        "qualification identity must use deterministic JSON-compatible values; "
+        f"got {type(value).__name__}"
+    )
+
+
+def _freeze(value: Any) -> Any:
+    normalized = _canonical(value)
+    if isinstance(normalized, dict):
+        return MappingProxyType({key: _freeze(item) for key, item in normalized.items()})
+    if isinstance(normalized, list):
+        return tuple(_freeze(item) for item in normalized)
+    return normalized
+
+
+def _thaw(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+def _identity_sha256(schema: str, payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        {"schema": schema, "payload": _canonical(payload)},
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+class QualificationUnavailableError(RuntimeError):
+    """External method/runtime is unavailable for the attempted case."""
+
+
+class QualificationSkippedError(RuntimeError):
+    """Case was intentionally skipped under a predeclared scientific rule."""
+
+
+class QualificationNonConvergenceError(RuntimeError):
+    """External method completed its budget but did not satisfy convergence."""
+
+
+@runtime_checkable
+class ExternalProbabilityClassOrderProvider(Protocol):
+    """Required fitted-class order for probability-capable external methods."""
+
+    def probability_class_labels(self) -> Sequence[Any]:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationExecutionContext:
+    """Observed provenance and target-observation plan for one execution.
+
+    ``observed_dataset_lineage_sha256`` is the lineage of the upstream dataset
+    actually loaded for this run. It is distinct from
+    ``LongitudinalCaseAuthority.processed_data_sha256``, which binds the exact
+    downstream processed array.
+    """
+
+    observed_dataset_lineage_sha256: str
+    preprocessing_authority_sha256s: tuple[str, ...] = ()
+    calibration_authority_sha256s: tuple[str, ...] = ()
+    unlabeled_target_examples: int = 0
+    target_example_duration_s: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("QualificationExecutionContext schema_version must be 1")
+        object.__setattr__(
+            self,
+            "observed_dataset_lineage_sha256",
+            _sha256(
+                "observed_dataset_lineage_sha256",
+                self.observed_dataset_lineage_sha256,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "preprocessing_authority_sha256s",
+            _sha_tuple(
+                "preprocessing_authority_sha256s",
+                self.preprocessing_authority_sha256s,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "calibration_authority_sha256s",
+            _sha_tuple(
+                "calibration_authority_sha256s",
+                self.calibration_authority_sha256s,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "unlabeled_target_examples",
+            _exact_nonnegative_int(
+                "unlabeled_target_examples", self.unlabeled_target_examples
+            ),
+        )
+        if self.target_example_duration_s is not None:
+            duration = _finite_nonnegative(
+                "target_example_duration_s", self.target_example_duration_s
+            )
+            if duration <= 0:
+                raise ValueError("target_example_duration_s must be positive when provided")
+            object.__setattr__(self, "target_example_duration_s", duration)
+        metadata = _freeze(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def unlabeled_target_seconds(self) -> float:
+        if self.target_example_duration_s is None:
+            return 0.0
+        return float(self.unlabeled_target_examples * self.target_example_duration_s)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "observed_dataset_lineage_sha256": self.observed_dataset_lineage_sha256,
+            "preprocessing_authority_sha256s": list(
+                self.preprocessing_authority_sha256s
+            ),
+            "calibration_authority_sha256s": list(
+                self.calibration_authority_sha256s
+            ),
+            "unlabeled_target_examples": self.unlabeled_target_examples,
+            "target_example_duration_s": self.target_example_duration_s,
+            "metadata": _thaw(self.metadata),
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _identity_sha256("neuros.qualification_execution_context.v1", self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationScore:
+    """Metric values plus explicit availability for one successful execution."""
+
+    metrics: Mapping[str, float | None]
+    availability: Mapping[str, MetricAvailability]
+
+    def __post_init__(self) -> None:
+        metrics = dict(self.metrics)
+        availability = dict(self.availability)
+        if set(metrics) != set(availability):
+            raise ValueError("metrics and availability must contain identical keys")
+        normalized: dict[str, float | None] = {}
+        for name, value in metrics.items():
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("metric names must be non-empty strings")
+            if value is None:
+                normalized[name] = None
+            else:
+                number = float(value)
+                if not math.isfinite(number):
+                    raise ValueError(f"metric {name!r} must be finite when available")
+                normalized[name] = number
+            state = availability[name]
+            if state not in {
+                "available",
+                "unavailable_probability_output",
+                "unavailable_class_support",
+            }:
+                raise ValueError(f"unsupported availability state {state!r}")
+            if (value is None) == (state == "available"):
+                raise ValueError(
+                    f"metric {name!r} value/availability are semantically inconsistent"
+                )
+        object.__setattr__(self, "metrics", MappingProxyType(normalized))
+        object.__setattr__(self, "availability", MappingProxyType(availability))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metrics": dict(self.metrics),
+            "availability": dict(self.availability),
+        }
+
+
+@runtime_checkable
+class QualificationScorecard(Protocol):
+    """Trusted-code metric authority bound by full SHA-256 in the protocol."""
+
+    @property
+    def sha256(self) -> str:
+        ...
+
+    @property
+    def metric_names(self) -> tuple[str, ...]:
+        ...
+
+    def score(
+        self,
+        *,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        probability: np.ndarray | None,
+        class_labels: tuple[str, ...],
+    ) -> QualificationScore:
+        ...
+
+
+def _average_ranks(values: np.ndarray) -> np.ndarray:
+    """One-based average ranks with deterministic tie handling."""
+
+    order = np.argsort(values, kind="mergesort")
+    sorted_values = values[order]
+    ranks = np.empty(len(values), dtype=np.float64)
+    start = 0
+    while start < len(values):
+        stop = start + 1
+        while stop < len(values) and sorted_values[stop] == sorted_values[start]:
+            stop += 1
+        average = 0.5 * ((start + 1) + stop)
+        ranks[order[start:stop]] = average
+        start = stop
+    return ranks
+
+
+def _binary_auc(y_true: np.ndarray, positive_score: np.ndarray) -> float | None:
+    y = np.asarray(y_true, dtype=bool)
+    scores = np.asarray(positive_score, dtype=np.float64)
+    n_positive = int(np.sum(y))
+    n_negative = int(len(y) - n_positive)
+    if n_positive == 0 or n_negative == 0:
+        return None
+    ranks = _average_ranks(scores)
+    rank_sum_positive = float(np.sum(ranks[y]))
+    auc = (
+        rank_sum_positive - n_positive * (n_positive + 1) / 2.0
+    ) / (n_positive * n_negative)
+    return float(auc)
+
+
+@dataclass(frozen=True, slots=True)
+class ClassificationScorecardV1:
+    """Dependency-light classification scorecard for the first NSQ benchmark.
+
+    Semantics are deliberately explicit:
+
+    - balanced accuracy = macro mean recall over the source-derived class set;
+    - ROC AUC is binary only in v1 and uses the second canonical class as the
+      positive class;
+    - Brier score is mean per-sample sum of squared multiclass probability error;
+    - ECE uses 10 equal-width top-label confidence bins over [0, 1].
+    """
+
+    ece_bins: int = 10
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("ClassificationScorecardV1 schema_version must be 1")
+        if isinstance(self.ece_bins, bool) or not isinstance(self.ece_bins, int):
+            raise ValueError("ece_bins must be an integer without coercion")
+        if self.ece_bins <= 1:
+            raise ValueError("ece_bins must be greater than one")
+
+    @property
+    def metric_names(self) -> tuple[str, ...]:
+        return (
+            "balanced_accuracy",
+            "accuracy",
+            "roc_auc",
+            "brier_score",
+            "expected_calibration_error",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "metric_semantics": {
+                "balanced_accuracy": {
+                    "direction": "higher",
+                    "definition": "macro_mean_recall_over_source_class_vocabulary",
+                },
+                "accuracy": {
+                    "direction": "higher",
+                    "definition": "fraction_exact_task_labels",
+                },
+                "roc_auc": {
+                    "direction": "higher",
+                    "definition": "binary_rank_auc",
+                    "positive_class": "second_canonical_source_label",
+                    "undefined_policy": "unavailable_class_support",
+                },
+                "brier_score": {
+                    "direction": "lower",
+                    "definition": "mean_multiclass_sum_squared_probability_error",
+                    "undefined_policy": "unavailable_probability_output",
+                },
+                "expected_calibration_error": {
+                    "direction": "lower",
+                    "definition": "top_label_ece_equal_width",
+                    "bins": self.ece_bins,
+                    "undefined_policy": "unavailable_probability_output",
+                },
+            },
+            "aggregation_unit": "trial_within_case",
+            "implementation": "neuros-foundation:numpy",
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _identity_sha256("neuros.classification_scorecard.v1", self.to_dict())
+
+    def score(
+        self,
+        *,
+        y_true: np.ndarray,
+        y_pred: np.ndarray,
+        probability: np.ndarray | None,
+        class_labels: tuple[str, ...],
+    ) -> QualificationScore:
+        truth = np.asarray(y_true).astype(str)
+        prediction = np.asarray(y_pred).astype(str)
+        if truth.shape != prediction.shape or truth.ndim != 1:
+            raise ValueError("scorecard expects aligned one-dimensional labels")
+        if not class_labels:
+            raise ValueError("class_labels must be non-empty")
+
+        recalls: list[float] = []
+        for label in class_labels:
+            mask = truth == label
+            if not np.any(mask):
+                continue
+            recalls.append(float(np.mean(prediction[mask] == label)))
+        if not recalls:
+            raise ValueError("evaluation set contains no declared task classes")
+
+        metrics: dict[str, float | None] = {
+            "balanced_accuracy": float(np.mean(recalls)),
+            "accuracy": float(np.mean(prediction == truth)),
+            "roc_auc": None,
+            "brier_score": None,
+            "expected_calibration_error": None,
+        }
+        availability: dict[str, MetricAvailability] = {
+            "balanced_accuracy": "available",
+            "accuracy": "available",
+            "roc_auc": "unavailable_probability_output",
+            "brier_score": "unavailable_probability_output",
+            "expected_calibration_error": "unavailable_probability_output",
+        }
+
+        if probability is None:
+            return QualificationScore(metrics=metrics, availability=availability)
+
+        probs = np.asarray(probability, dtype=np.float64)
+        n_classes = len(class_labels)
+        label_to_index = {label: index for index, label in enumerate(class_labels)}
+        encoded = np.asarray([label_to_index[label] for label in truth], dtype=np.int64)
+        one_hot = np.eye(n_classes, dtype=np.float64)[encoded]
+        metrics["brier_score"] = float(np.mean(np.sum((probs - one_hot) ** 2, axis=1)))
+        availability["brier_score"] = "available"
+
+        predicted_index = probs.argmax(axis=1)
+        confidence = probs.max(axis=1)
+        correct = (predicted_index == encoded).astype(np.float64)
+        edges = np.linspace(0.0, 1.0, self.ece_bins + 1)
+        ece = 0.0
+        for index in range(self.ece_bins):
+            if index == self.ece_bins - 1:
+                mask = (confidence >= edges[index]) & (confidence <= edges[index + 1])
+            else:
+                mask = (confidence >= edges[index]) & (confidence < edges[index + 1])
+            if not np.any(mask):
+                continue
+            ece += float(np.mean(mask)) * abs(
+                float(np.mean(correct[mask])) - float(np.mean(confidence[mask]))
+            )
+        metrics["expected_calibration_error"] = float(ece)
+        availability["expected_calibration_error"] = "available"
+
+        if n_classes == 2:
+            binary_truth = truth == class_labels[1]
+            auc = _binary_auc(binary_truth, probs[:, 1])
+            if auc is None:
+                availability["roc_auc"] = "unavailable_class_support"
+            else:
+                metrics["roc_auc"] = auc
+                availability["roc_auc"] = "available"
+        else:
+            availability["roc_auc"] = "unavailable_class_support"
+
+        return QualificationScore(metrics=metrics, availability=availability)
+
+
+DEFAULT_CLASSIFICATION_SCORECARD = ClassificationScorecardV1()
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationBudgetResult:
+    """Failure-preserving result for one case/method/calibration budget."""
+
+    status: QualificationStatus
+    case_id: str
+    method_id: str
+    calibration_per_class: int
+    protocol_sha256: str
+    case_authority_sha256: str
+    method_spec_sha256: str
+    run_contract_sha256: str
+    execution_context_sha256: str
+    metric_scorecard_sha256: str
+    processed_data_sha256: str
+    observed_dataset_lineage_sha256: str
+    model_state_sha256: str | None
+    learned_state_addressable: bool
+    source_train_samples: int
+    labeled_target_examples: int
+    unlabeled_target_examples: int
+    unlabeled_target_seconds: float
+    evaluation_samples: int
+    class_labels: tuple[str, ...]
+    score: QualificationScore | None = None
+    probability_available: bool = False
+    fit_s: float | None = None
+    adaptation_s: float | None = None
+    inference_s: float | None = None
+    failure_type: str | None = None
+    failure_reason: str | None = None
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.status not in {
+            "success",
+            "failed",
+            "skipped",
+            "unavailable",
+            "nonconverged",
+            "oom",
+        }:
+            raise ValueError(f"unsupported qualification status {self.status!r}")
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("QualificationBudgetResult schema_version must be 1")
+        for name in (
+            "protocol_sha256",
+            "case_authority_sha256",
+            "method_spec_sha256",
+            "run_contract_sha256",
+            "execution_context_sha256",
+            "metric_scorecard_sha256",
+            "processed_data_sha256",
+            "observed_dataset_lineage_sha256",
+        ):
+            object.__setattr__(self, name, _sha256(name, getattr(self, name)))
+        if self.model_state_sha256 is not None:
+            object.__setattr__(
+                self,
+                "model_state_sha256",
+                _sha256("model_state_sha256", self.model_state_sha256),
+            )
+        if self.status == "success":
+            if self.score is None or self.model_state_sha256 is None:
+                raise ValueError("successful result requires score and bound model state")
+            if self.failure_type is not None or self.failure_reason is not None:
+                raise ValueError("successful result cannot contain failure metadata")
+        else:
+            if self.score is not None or self.model_state_sha256 is not None:
+                raise ValueError("failed/unavailable result cannot contain success evidence")
+            if not self.failure_type or not self.failure_reason:
+                raise ValueError("non-success result requires failure_type and failure_reason")
+
+    def to_dict(self, *, include_sha256: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "case_id": self.case_id,
+            "method_id": self.method_id,
+            "calibration_per_class": self.calibration_per_class,
+            "protocol_sha256": self.protocol_sha256,
+            "case_authority_sha256": self.case_authority_sha256,
+            "method_spec_sha256": self.method_spec_sha256,
+            "run_contract_sha256": self.run_contract_sha256,
+            "execution_context_sha256": self.execution_context_sha256,
+            "metric_scorecard_sha256": self.metric_scorecard_sha256,
+            "processed_data_sha256": self.processed_data_sha256,
+            "observed_dataset_lineage_sha256": self.observed_dataset_lineage_sha256,
+            "model_state_sha256": self.model_state_sha256,
+            "learned_state_addressable": self.learned_state_addressable,
+            "source_train_samples": self.source_train_samples,
+            "labeled_target_examples": self.labeled_target_examples,
+            "unlabeled_target_examples": self.unlabeled_target_examples,
+            "unlabeled_target_seconds": self.unlabeled_target_seconds,
+            "evaluation_samples": self.evaluation_samples,
+            "class_labels": list(self.class_labels),
+            "score": None if self.score is None else self.score.to_dict(),
+            "probability_available": self.probability_available,
+            "fit_s": self.fit_s,
+            "adaptation_s": self.adaptation_s,
+            "inference_s": self.inference_s,
+            "failure_type": self.failure_type,
+            "failure_reason": self.failure_reason,
+        }
+        if include_sha256:
+            payload["result_sha256"] = self.sha256
+        return payload
+
+    @property
+    def sha256(self) -> str:
+        return _identity_sha256(
+            "neuros.qualification_budget_result.v1",
+            self.to_dict(include_sha256=False),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationCaseResult:
+    """Complete failure-preserving budget frontier for one case and method."""
+
+    protocol_sha256: str
+    case_authority_sha256: str
+    method_spec_sha256: str
+    execution_context_sha256: str
+    metric_scorecard_sha256: str
+    rows: tuple[QualificationBudgetResult, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("QualificationCaseResult schema_version must be 1")
+        for name in (
+            "protocol_sha256",
+            "case_authority_sha256",
+            "method_spec_sha256",
+            "execution_context_sha256",
+            "metric_scorecard_sha256",
+        ):
+            object.__setattr__(self, name, _sha256(name, getattr(self, name)))
+        if not self.rows:
+            raise ValueError("qualification case result must contain at least one budget row")
+        budgets = tuple(row.calibration_per_class for row in self.rows)
+        if len(set(budgets)) != len(budgets):
+            raise ValueError("qualification result cannot duplicate calibration budgets")
+        for row in self.rows:
+            if row.protocol_sha256 != self.protocol_sha256:
+                raise ValueError("row protocol SHA differs from case result")
+            if row.case_authority_sha256 != self.case_authority_sha256:
+                raise ValueError("row case-authority SHA differs from case result")
+            if row.method_spec_sha256 != self.method_spec_sha256:
+                raise ValueError("row method SHA differs from case result")
+            if row.execution_context_sha256 != self.execution_context_sha256:
+                raise ValueError("row execution-context SHA differs from case result")
+            if row.metric_scorecard_sha256 != self.metric_scorecard_sha256:
+                raise ValueError("row metric-scorecard SHA differs from case result")
+
+    def to_dict(self, *, include_sha256: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "protocol_sha256": self.protocol_sha256,
+            "case_authority_sha256": self.case_authority_sha256,
+            "method_spec_sha256": self.method_spec_sha256,
+            "execution_context_sha256": self.execution_context_sha256,
+            "metric_scorecard_sha256": self.metric_scorecard_sha256,
+            "rows": [row.to_dict() for row in self.rows],
+        }
+        if include_sha256:
+            payload["result_sha256"] = self.sha256
+        return payload
+
+    @property
+    def sha256(self) -> str:
+        return _identity_sha256(
+            "neuros.qualification_case_result.v1",
+            self.to_dict(include_sha256=False),
+        )
+
+
+def _canonical_class_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[str, ...]:
+    source_labels = np.asarray(y)[source_indices].astype(str)
+    labels = tuple(sorted(np.unique(source_labels).tolist()))
+    if len(labels) < 2:
+        raise ValueError("source history must contain at least two task classes")
+    all_labels = np.asarray(y).astype(str)
+    unknown = sorted(set(all_labels.tolist()) - set(labels))
+    if unknown:
+        raise ValueError(
+            "loaded data contains labels absent from source-history vocabulary: "
+            f"{unknown}"
+        )
+    return labels
+
+
+def _unlabeled_target_indices(
+    split: Any,
+    *,
+    labeled_calibration_indices: np.ndarray,
+    count: int,
+) -> np.ndarray:
+    if count == 0:
+        return np.asarray([], dtype=np.int64)
+    all_target = np.sort(
+        np.concatenate(
+            [np.asarray(values, dtype=np.int64) for values in split.calibration_order_by_class.values()]
+        )
+    )
+    remaining = np.setdiff1d(
+        all_target,
+        np.asarray(labeled_calibration_indices, dtype=np.int64),
+        assume_unique=True,
+    )
+    if count > len(remaining):
+        raise ValueError(
+            f"requested {count} unlabeled target examples but only {len(remaining)} "
+            "authorized non-evaluation target observations remain"
+        )
+    return remaining[:count].copy()
+
+
+def _failure_status(exc: Exception) -> QualificationStatus:
+    if isinstance(exc, QualificationSkippedError):
+        return "skipped"
+    if isinstance(exc, QualificationUnavailableError) or isinstance(exc, ImportError):
+        return "unavailable"
+    if isinstance(exc, QualificationNonConvergenceError):
+        return "nonconverged"
+    if isinstance(exc, MemoryError):
+        return "oom"
+    return "failed"
+
+
+def _failure_reason(exc: Exception) -> tuple[str, str]:
+    kind = type(exc).__name__
+    reason = str(exc).strip() or kind
+    if len(reason) > 512:
+        reason = reason[:509] + "..."
+    return kind, reason
+
+
+def _validate_preflight(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    protocol: QualificationProtocolSpec,
+    factory: ExternalQualificationFactory,
+    execution_context: QualificationExecutionContext,
+    scorecard: QualificationScorecard,
+) -> tuple[Any, ExternalDecoderMethodSpec, tuple[str, ...]]:
+    if protocol.protocol_status != "frozen":
+        raise ValueError("qualification execution requires protocol_status='frozen'")
+    if protocol.dataset_id != data.dataset_id:
+        raise ValueError(
+            f"protocol dataset_id={protocol.dataset_id!r} does not match loaded "
+            f"dataset_id={data.dataset_id!r}"
+        )
+    if execution_context.observed_dataset_lineage_sha256 != protocol.dataset_lineage_sha256:
+        raise ValueError("observed dataset lineage SHA-256 differs from frozen protocol")
+    if protocol.metric_scorecard_sha256 != scorecard.sha256:
+        raise ValueError("metric scorecard SHA-256 differs from frozen protocol")
+    declared_metrics = (protocol.primary_metric, *protocol.secondary_metrics)
+    if tuple(declared_metrics) != tuple(scorecard.metric_names):
+        raise ValueError("protocol metric names/order differ from scorecard authority")
+
+    split = authority.restore(data)
+    if authority.split_unit not in protocol.grouping_hierarchy:
+        raise ValueError(
+            f"case split unit {authority.split_unit!r} is absent from protocol grouping hierarchy"
+        )
+    for budget in protocol.calibration_budgets_per_class:
+        if budget > split.max_budget_per_class:
+            raise ValueError(
+                f"protocol budget {budget}/class exceeds frozen authority maximum "
+                f"{split.max_budget_per_class}/class"
+            )
+
+    method_spec = factory.method_spec
+    if not isinstance(method_spec, ExternalDecoderMethodSpec):
+        raise TypeError("factory.method_spec must be an ExternalDecoderMethodSpec")
+    X = np.asarray(data.X)
+    if not method_spec.input_axes or method_spec.input_axes[0] != "sample":
+        raise ValueError("external method input_axes must begin with 'sample'")
+    if len(method_spec.input_axes) != X.ndim:
+        raise ValueError(
+            "external method input_axes dimensionality differs from processed neural array"
+        )
+
+    labels = _canonical_class_labels(np.asarray(data.y), split.source_train_indices)
+    return split, method_spec, labels
+
+
+def run_external_qualification_case(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    protocol: QualificationProtocolSpec,
+    factory: ExternalQualificationFactory,
+    *,
+    execution_context: QualificationExecutionContext,
+    scorecard: QualificationScorecard = DEFAULT_CLASSIFICATION_SCORECARD,
+) -> QualificationCaseResult:
+    """Execute one external method across the frozen calibration frontier.
+
+    Scientific-authority failures are preflight errors and abort the entire case.
+    External model/runtime failures after a valid run contract exists are retained
+    as explicit per-budget rows.
+    """
+
+    split, method_spec, class_labels = _validate_preflight(
+        data,
+        authority,
+        protocol,
+        factory,
+        execution_context,
+        scorecard,
+    )
+
+    X = np.asarray(data.X)
+    y = np.asarray(data.y).astype(str)
+    evaluation_indices = np.asarray(split.evaluation_indices, dtype=np.int64)
+    source_indices = np.asarray(split.source_train_indices, dtype=np.int64)
+    rows: list[QualificationBudgetResult] = []
+
+    for budget in protocol.calibration_budgets_per_class:
+        calibration_indices = np.asarray(split.calibration_indices(budget), dtype=np.int64)
+        train_indices = np.asarray(split.train_indices_for_budget(budget), dtype=np.int64)
+        unlabeled_indices = _unlabeled_target_indices(
+            split,
+            labeled_calibration_indices=calibration_indices,
+            count=execution_context.unlabeled_target_examples,
+        )
+        if np.intersect1d(unlabeled_indices, evaluation_indices).size:
+            raise RuntimeError("internal authority error: unlabeled target overlaps final assessment")
+        if np.intersect1d(train_indices, evaluation_indices).size:
+            raise RuntimeError("internal authority error: fit set overlaps final assessment")
+
+        run_contract = QualificationRunContract(
+            protocol_sha256=protocol.sha256,
+            method_spec_sha256=method_spec.sha256,
+            case_authority_sha256=authority.authority_sha256,
+            labeled_target_examples=int(len(calibration_indices)),
+            unlabeled_target_examples=int(len(unlabeled_indices)),
+            unlabeled_target_seconds=(
+                0.0
+                if execution_context.target_example_duration_s is None
+                else float(len(unlabeled_indices) * execution_context.target_example_duration_s)
+            ),
+            preprocessing_authority_sha256s=(
+                execution_context.preprocessing_authority_sha256s
+            ),
+            calibration_authority_sha256s=(
+                execution_context.calibration_authority_sha256s
+            ),
+            metadata={"calibration_per_class": int(budget)},
+        )
+
+        fit_s: float | None = None
+        adaptation_s: float | None = None
+        inference_s: float | None = None
+        try:
+            decoder = factory.create()
+            if not isinstance(decoder, ExternalQualificationDecoder):
+                raise TypeError(
+                    "factory.create() must return an ExternalQualificationDecoder"
+                )
+            validate_run_capabilities(method_spec, run_contract, decoder)
+
+            started = time.perf_counter()
+            decoder.fit(X[train_indices], y[train_indices])
+            fit_s = float(time.perf_counter() - started)
+
+            if len(unlabeled_indices):
+                if not isinstance(decoder, ExternalUnlabeledTargetAdapter):
+                    raise TypeError(
+                        "authorized unlabeled target observations require adapt_unlabeled(X)"
+                    )
+                started = time.perf_counter()
+                decoder.adapt_unlabeled(X[unlabeled_indices])
+                adaptation_s = float(time.perf_counter() - started)
+
+            learned_state = decoder.learned_state()
+            if not isinstance(learned_state, ExternalLearnedState):
+                raise TypeError("decoder.learned_state() must return ExternalLearnedState")
+            bound_state: QualificationModelState = bind_learned_state(
+                method_spec,
+                run_contract,
+                learned_state,
+            )
+
+            started = time.perf_counter()
+            raw_prediction = decoder.predict(X[evaluation_indices])
+            inference_s = float(time.perf_counter() - started)
+            prediction = validate_prediction_output(
+                raw_prediction,
+                expected_samples=len(evaluation_indices),
+                allowed_labels=class_labels,
+            ).astype(str)
+
+            probability: np.ndarray | None = None
+            probability_available = method_spec.probability_semantics != "unavailable"
+            if probability_available:
+                if not isinstance(decoder, ExternalProbabilityDecoder):
+                    raise TypeError(
+                        "method declares probability output but decoder lacks predict_proba(X)"
+                    )
+                if not isinstance(decoder, ExternalProbabilityClassOrderProvider):
+                    raise TypeError(
+                        "probability-capable decoder must expose probability_class_labels()"
+                    )
+                probability_labels = tuple(
+                    str(value) for value in decoder.probability_class_labels()
+                )
+                if probability_labels != class_labels:
+                    raise ValueError(
+                        "probability class order differs from canonical source-derived class order"
+                    )
+                probability = validate_probability_output(
+                    method_spec,
+                    decoder.predict_proba(X[evaluation_indices]),
+                    expected_samples=len(evaluation_indices),
+                    expected_classes=len(class_labels),
+                )
+
+            score = scorecard.score(
+                y_true=y[evaluation_indices],
+                y_pred=prediction,
+                probability=probability,
+                class_labels=class_labels,
+            )
+            rows.append(
+                QualificationBudgetResult(
+                    status="success",
+                    case_id=authority.case_id,
+                    method_id=method_spec.method_id,
+                    calibration_per_class=int(budget),
+                    protocol_sha256=protocol.sha256,
+                    case_authority_sha256=authority.authority_sha256,
+                    method_spec_sha256=method_spec.sha256,
+                    run_contract_sha256=run_contract.sha256,
+                    execution_context_sha256=execution_context.sha256,
+                    metric_scorecard_sha256=scorecard.sha256,
+                    processed_data_sha256=authority.processed_data_sha256,
+                    observed_dataset_lineage_sha256=(
+                        execution_context.observed_dataset_lineage_sha256
+                    ),
+                    model_state_sha256=bound_state.sha256,
+                    learned_state_addressable=bound_state.state_addressable,
+                    source_train_samples=int(len(source_indices)),
+                    labeled_target_examples=int(len(calibration_indices)),
+                    unlabeled_target_examples=int(len(unlabeled_indices)),
+                    unlabeled_target_seconds=run_contract.unlabeled_target_seconds,
+                    evaluation_samples=int(len(evaluation_indices)),
+                    class_labels=class_labels,
+                    score=score,
+                    probability_available=probability_available,
+                    fit_s=fit_s,
+                    adaptation_s=adaptation_s,
+                    inference_s=inference_s,
+                )
+            )
+        except Exception as exc:
+            failure_type, failure_reason = _failure_reason(exc)
+            rows.append(
+                QualificationBudgetResult(
+                    status=_failure_status(exc),
+                    case_id=authority.case_id,
+                    method_id=method_spec.method_id,
+                    calibration_per_class=int(budget),
+                    protocol_sha256=protocol.sha256,
+                    case_authority_sha256=authority.authority_sha256,
+                    method_spec_sha256=method_spec.sha256,
+                    run_contract_sha256=run_contract.sha256,
+                    execution_context_sha256=execution_context.sha256,
+                    metric_scorecard_sha256=scorecard.sha256,
+                    processed_data_sha256=authority.processed_data_sha256,
+                    observed_dataset_lineage_sha256=(
+                        execution_context.observed_dataset_lineage_sha256
+                    ),
+                    model_state_sha256=None,
+                    learned_state_addressable=False,
+                    source_train_samples=int(len(source_indices)),
+                    labeled_target_examples=int(len(calibration_indices)),
+                    unlabeled_target_examples=int(len(unlabeled_indices)),
+                    unlabeled_target_seconds=run_contract.unlabeled_target_seconds,
+                    evaluation_samples=int(len(evaluation_indices)),
+                    class_labels=class_labels,
+                    score=None,
+                    probability_available=False,
+                    fit_s=fit_s,
+                    adaptation_s=adaptation_s,
+                    inference_s=inference_s,
+                    failure_type=failure_type,
+                    failure_reason=failure_reason,
+                )
+            )
+
+    return QualificationCaseResult(
+        protocol_sha256=protocol.sha256,
+        case_authority_sha256=authority.authority_sha256,
+        method_spec_sha256=method_spec.sha256,
+        execution_context_sha256=execution_context.sha256,
+        metric_scorecard_sha256=scorecard.sha256,
+        rows=tuple(rows),
+    )
+
+
+__all__ = [
+    "ClassificationScorecardV1",
+    "DEFAULT_CLASSIFICATION_SCORECARD",
+    "ExternalProbabilityClassOrderProvider",
+    "MetricAvailability",
+    "QualificationBudgetResult",
+    "QualificationCaseResult",
+    "QualificationExecutionContext",
+    "QualificationNonConvergenceError",
+    "QualificationScore",
+    "QualificationScorecard",
+    "QualificationSkippedError",
+    "QualificationStatus",
+    "QualificationUnavailableError",
+    "run_external_qualification_case",
+]

--- a/packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/qualification_runner.py
@@ -1,12 +1,15 @@
 """Executable referee for Neural System Qualification (NSQ) v1.
 
-The runner owns evidence authority, not external model training. It restores an
+The runner owns evidence authority, not external model training. It composes the
 existing :class:`LongitudinalCaseAuthority`, exposes only authorized observations
 to a fresh external decoder at each calibration budget, validates output
-semantics, and preserves every attempted run including failures.
+semantics, and preserves every attempted external run including failures.
 
-Upstream dataset lineage and downstream processed-array identity are deliberately
-separate authorities: both must match before fitting begins.
+The v1 longitudinal executor is intentionally *labeled-target only*. The generic
+NSQ participation schema can describe unlabeled target adaptation, but this
+executor refuses to manufacture an unlabeled pool from leftover calibration
+rows. A future executor must receive a separately frozen unlabeled-target
+observation authority before ``adapt_unlabeled(X)`` may be called.
 """
 
 from __future__ import annotations
@@ -28,7 +31,6 @@ from .qualification import (
     ExternalProbabilityDecoder,
     ExternalQualificationDecoder,
     ExternalQualificationFactory,
-    ExternalUnlabeledTargetAdapter,
     QualificationModelState,
     QualificationProtocolSpec,
     QualificationRunContract,
@@ -74,7 +76,7 @@ def _sha_tuple(name: str, values: Sequence[str]) -> tuple[str, ...]:
     return result
 
 
-def _exact_nonnegative_int(name: str, value: Any) -> int:
+def _strict_nonnegative_int(name: str, value: Any) -> int:
     if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
         raise ValueError(f"{name} must be an integer without coercion")
     result = int(value)
@@ -83,12 +85,12 @@ def _exact_nonnegative_int(name: str, value: Any) -> int:
     return result
 
 
-def _finite_nonnegative(name: str, value: Any) -> float:
+def _strict_positive_float(name: str, value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float, np.number)):
         raise ValueError(f"{name} must be numeric without coercion")
     result = float(value)
-    if not math.isfinite(result) or result < 0:
-        raise ValueError(f"{name} must be finite and non-negative")
+    if not math.isfinite(result) or result <= 0:
+        raise ValueError(f"{name} must be finite and positive")
     return result
 
 
@@ -97,7 +99,7 @@ def _canonical(value: Any) -> Any:
         return value
     if isinstance(value, float):
         if not math.isfinite(value):
-            raise ValueError("qualification result cannot contain NaN or infinity")
+            raise ValueError("qualification identity cannot contain NaN or infinity")
         return value
     if isinstance(value, np.generic):
         return _canonical(value.item())
@@ -152,6 +154,31 @@ def _identity_sha256(schema: str, payload: Mapping[str, Any]) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
+def _index_set_sha256(
+    role: str,
+    processed_data_sha256: str,
+    indices: Sequence[int] | np.ndarray,
+) -> str:
+    values = np.asarray(indices)
+    if values.ndim != 1:
+        raise ValueError(f"{role} indices must be one-dimensional")
+    if values.dtype == np.bool_:
+        raise ValueError(f"{role} indices cannot be booleans")
+    integer = values.astype(np.int64)
+    if not np.array_equal(values, integer):
+        raise ValueError(f"{role} indices must be integers without coercion")
+    return _identity_sha256(
+        "neuros.qualification_observation_set.v1",
+        {
+            "role": role,
+            "processed_data_sha256": _sha256(
+                "processed_data_sha256", processed_data_sha256
+            ),
+            "indices": [int(value) for value in integer.tolist()],
+        },
+    )
+
+
 class QualificationUnavailableError(RuntimeError):
     """External method/runtime is unavailable for the attempted case."""
 
@@ -166,7 +193,7 @@ class QualificationNonConvergenceError(RuntimeError):
 
 @runtime_checkable
 class ExternalProbabilityClassOrderProvider(Protocol):
-    """Required fitted-class order for probability-capable external methods."""
+    """Fitted class-column order required for probability-capable methods."""
 
     def probability_class_labels(self) -> Sequence[Any]:
         ...
@@ -174,12 +201,16 @@ class ExternalProbabilityClassOrderProvider(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class QualificationExecutionContext:
-    """Observed provenance and target-observation plan for one execution.
+    """Observed upstream provenance for one qualification execution.
 
-    ``observed_dataset_lineage_sha256`` is the lineage of the upstream dataset
-    actually loaded for this run. It is distinct from
-    ``LongitudinalCaseAuthority.processed_data_sha256``, which binds the exact
-    downstream processed array.
+    ``observed_dataset_lineage_sha256`` identifies the upstream dataset/revision
+    actually loaded. It is intentionally distinct from the case authority's
+    processed-array SHA-256.
+
+    ``unlabeled_target_examples`` is retained in the context schema so callers
+    cannot accidentally erase that intent. The v1 ``LongitudinalCaseAuthority``
+    executor refuses any nonzero value because that authority does not freeze a
+    scientifically distinct unlabeled-adaptation pool.
     """
 
     observed_dataset_lineage_sha256: str
@@ -217,19 +248,18 @@ class QualificationExecutionContext:
                 self.calibration_authority_sha256s,
             ),
         )
-        object.__setattr__(
-            self,
-            "unlabeled_target_examples",
-            _exact_nonnegative_int(
-                "unlabeled_target_examples", self.unlabeled_target_examples
-            ),
+        count = _strict_nonnegative_int(
+            "unlabeled_target_examples", self.unlabeled_target_examples
         )
+        object.__setattr__(self, "unlabeled_target_examples", count)
         if self.target_example_duration_s is not None:
-            duration = _finite_nonnegative(
+            duration = _strict_positive_float(
                 "target_example_duration_s", self.target_example_duration_s
             )
-            if duration <= 0:
-                raise ValueError("target_example_duration_s must be positive when provided")
+            if count == 0:
+                raise ValueError(
+                    "target_example_duration_s requires unlabeled_target_examples > 0"
+                )
             object.__setattr__(self, "target_example_duration_s", duration)
         metadata = _freeze(self.metadata)
         if not isinstance(metadata, Mapping):
@@ -259,7 +289,9 @@ class QualificationExecutionContext:
 
     @property
     def sha256(self) -> str:
-        return _identity_sha256("neuros.qualification_execution_context.v1", self.to_dict())
+        return _identity_sha256(
+            "neuros.qualification_execution_context.v1", self.to_dict()
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -278,13 +310,6 @@ class QualificationScore:
         for name, value in metrics.items():
             if not isinstance(name, str) or not name.strip():
                 raise ValueError("metric names must be non-empty strings")
-            if value is None:
-                normalized[name] = None
-            else:
-                number = float(value)
-                if not math.isfinite(number):
-                    raise ValueError(f"metric {name!r} must be finite when available")
-                normalized[name] = number
             state = availability[name]
             if state not in {
                 "available",
@@ -292,10 +317,21 @@ class QualificationScore:
                 "unavailable_class_support",
             }:
                 raise ValueError(f"unsupported availability state {state!r}")
-            if (value is None) == (state == "available"):
-                raise ValueError(
-                    f"metric {name!r} value/availability are semantically inconsistent"
-                )
+            if value is None:
+                if state == "available":
+                    raise ValueError(
+                        f"metric {name!r} cannot be available with a null value"
+                    )
+                normalized[name] = None
+            else:
+                if state != "available":
+                    raise ValueError(
+                        f"metric {name!r} has a value but is marked unavailable"
+                    )
+                number = float(value)
+                if not math.isfinite(number):
+                    raise ValueError(f"metric {name!r} must be finite")
+                normalized[name] = number
         object.__setattr__(self, "metrics", MappingProxyType(normalized))
         object.__setattr__(self, "availability", MappingProxyType(availability))
 
@@ -330,8 +366,6 @@ class QualificationScorecard(Protocol):
 
 
 def _average_ranks(values: np.ndarray) -> np.ndarray:
-    """One-based average ranks with deterministic tie handling."""
-
     order = np.argsort(values, kind="mergesort")
     sorted_values = values[order]
     ranks = np.empty(len(values), dtype=np.float64)
@@ -340,8 +374,7 @@ def _average_ranks(values: np.ndarray) -> np.ndarray:
         stop = start + 1
         while stop < len(values) and sorted_values[stop] == sorted_values[start]:
             stop += 1
-        average = 0.5 * ((start + 1) + stop)
-        ranks[order[start:stop]] = average
+        ranks[order[start:stop]] = 0.5 * ((start + 1) + stop)
         start = stop
     return ranks
 
@@ -355,23 +388,21 @@ def _binary_auc(y_true: np.ndarray, positive_score: np.ndarray) -> float | None:
         return None
     ranks = _average_ranks(scores)
     rank_sum_positive = float(np.sum(ranks[y]))
-    auc = (
-        rank_sum_positive - n_positive * (n_positive + 1) / 2.0
-    ) / (n_positive * n_negative)
-    return float(auc)
+    return float(
+        (rank_sum_positive - n_positive * (n_positive + 1) / 2.0)
+        / (n_positive * n_negative)
+    )
 
 
 @dataclass(frozen=True, slots=True)
 class ClassificationScorecardV1:
-    """Dependency-light classification scorecard for the first NSQ benchmark.
+    """Dependency-light classification scorecard for NSQ v1.
 
-    Semantics are deliberately explicit:
-
-    - balanced accuracy = macro mean recall over the source-derived class set;
-    - ROC AUC is binary only in v1 and uses the second canonical class as the
-      positive class;
-    - Brier score is mean per-sample sum of squared multiclass probability error;
-    - ECE uses 10 equal-width top-label confidence bins over [0, 1].
+    Semantics:
+    - balanced accuracy: macro mean recall over the source-derived vocabulary;
+    - ROC AUC: binary rank AUC, positive class = second canonical source label;
+    - Brier: mean per-sample multiclass sum-squared probability error;
+    - ECE: 10 equal-width top-label confidence bins by default.
     """
 
     ece_bins: int = 10
@@ -448,12 +479,11 @@ class ClassificationScorecardV1:
         if not class_labels:
             raise ValueError("class_labels must be non-empty")
 
-        recalls: list[float] = []
-        for label in class_labels:
-            mask = truth == label
-            if not np.any(mask):
-                continue
-            recalls.append(float(np.mean(prediction[mask] == label)))
+        recalls = [
+            float(np.mean(prediction[truth == label] == label))
+            for label in class_labels
+            if np.any(truth == label)
+        ]
         if not recalls:
             raise ValueError("evaluation set contains no declared task classes")
 
@@ -471,16 +501,19 @@ class ClassificationScorecardV1:
             "brier_score": "unavailable_probability_output",
             "expected_calibration_error": "unavailable_probability_output",
         }
-
         if probability is None:
             return QualificationScore(metrics=metrics, availability=availability)
 
         probs = np.asarray(probability, dtype=np.float64)
         n_classes = len(class_labels)
         label_to_index = {label: index for index, label in enumerate(class_labels)}
-        encoded = np.asarray([label_to_index[label] for label in truth], dtype=np.int64)
+        encoded = np.asarray(
+            [label_to_index[label] for label in truth], dtype=np.int64
+        )
         one_hot = np.eye(n_classes, dtype=np.float64)[encoded]
-        metrics["brier_score"] = float(np.mean(np.sum((probs - one_hot) ** 2, axis=1)))
+        metrics["brier_score"] = float(
+            np.mean(np.sum((probs - one_hot) ** 2, axis=1))
+        )
         availability["brier_score"] = "available"
 
         predicted_index = probs.argmax(axis=1)
@@ -490,20 +523,25 @@ class ClassificationScorecardV1:
         ece = 0.0
         for index in range(self.ece_bins):
             if index == self.ece_bins - 1:
-                mask = (confidence >= edges[index]) & (confidence <= edges[index + 1])
+                mask = (
+                    (confidence >= edges[index])
+                    & (confidence <= edges[index + 1])
+                )
             else:
-                mask = (confidence >= edges[index]) & (confidence < edges[index + 1])
-            if not np.any(mask):
-                continue
-            ece += float(np.mean(mask)) * abs(
-                float(np.mean(correct[mask])) - float(np.mean(confidence[mask]))
-            )
+                mask = (
+                    (confidence >= edges[index])
+                    & (confidence < edges[index + 1])
+                )
+            if np.any(mask):
+                ece += float(np.mean(mask)) * abs(
+                    float(np.mean(correct[mask]))
+                    - float(np.mean(confidence[mask]))
+                )
         metrics["expected_calibration_error"] = float(ece)
         availability["expected_calibration_error"] = "available"
 
         if n_classes == 2:
-            binary_truth = truth == class_labels[1]
-            auc = _binary_auc(binary_truth, probs[:, 1])
+            auc = _binary_auc(truth == class_labels[1], probs[:, 1])
             if auc is None:
                 availability["roc_auc"] = "unavailable_class_support"
             else:
@@ -534,22 +572,25 @@ class QualificationBudgetResult:
     metric_scorecard_sha256: str
     processed_data_sha256: str
     observed_dataset_lineage_sha256: str
-    model_state_sha256: str | None
+    source_train_indices_sha256: str
+    labeled_target_indices_sha256: str
+    fit_indices_sha256: str
+    evaluation_indices_sha256: str
+    qualification_model_state_sha256: str | None
+    external_learned_state_sha256: str | None
+    external_state_identity_kind: str | None
     learned_state_addressable: bool
     source_train_samples: int
     labeled_target_examples: int
-    unlabeled_target_examples: int
-    unlabeled_target_seconds: float
     evaluation_samples: int
     class_labels: tuple[str, ...]
     score: QualificationScore | None = None
     probability_available: bool = False
     fit_s: float | None = None
-    adaptation_s: float | None = None
     inference_s: float | None = None
     failure_type: str | None = None
     failure_reason: str | None = None
-    schema_version: int = 1
+    schema_version: int = 2
 
     def __post_init__(self) -> None:
         if self.status not in {
@@ -561,8 +602,8 @@ class QualificationBudgetResult:
             "oom",
         }:
             raise ValueError(f"unsupported qualification status {self.status!r}")
-        if isinstance(self.schema_version, bool) or self.schema_version != 1:
-            raise ValueError("QualificationBudgetResult schema_version must be 1")
+        if isinstance(self.schema_version, bool) or self.schema_version != 2:
+            raise ValueError("QualificationBudgetResult schema_version must be 2")
         for name in (
             "protocol_sha256",
             "case_authority_sha256",
@@ -572,24 +613,48 @@ class QualificationBudgetResult:
             "metric_scorecard_sha256",
             "processed_data_sha256",
             "observed_dataset_lineage_sha256",
+            "source_train_indices_sha256",
+            "labeled_target_indices_sha256",
+            "fit_indices_sha256",
+            "evaluation_indices_sha256",
         ):
             object.__setattr__(self, name, _sha256(name, getattr(self, name)))
-        if self.model_state_sha256 is not None:
-            object.__setattr__(
-                self,
-                "model_state_sha256",
-                _sha256("model_state_sha256", self.model_state_sha256),
+        for name in (
+            "qualification_model_state_sha256",
+            "external_learned_state_sha256",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                object.__setattr__(self, name, _sha256(name, value))
+
+        if self.learned_state_addressable:
+            if self.external_learned_state_sha256 is None:
+                raise ValueError(
+                    "addressable learned state requires external_learned_state_sha256"
+                )
+        elif self.external_learned_state_sha256 is not None:
+            raise ValueError(
+                "opaque learned state cannot expose external_learned_state_sha256"
             )
+
         if self.status == "success":
-            if self.score is None or self.model_state_sha256 is None:
-                raise ValueError("successful result requires score and bound model state")
+            if self.score is None or self.qualification_model_state_sha256 is None:
+                raise ValueError(
+                    "successful result requires score and qualification model-state binding"
+                )
+            if self.external_state_identity_kind is None:
+                raise ValueError(
+                    "successful result requires external_state_identity_kind"
+                )
             if self.failure_type is not None or self.failure_reason is not None:
                 raise ValueError("successful result cannot contain failure metadata")
         else:
-            if self.score is not None or self.model_state_sha256 is not None:
-                raise ValueError("failed/unavailable result cannot contain success evidence")
+            if self.score is not None:
+                raise ValueError("non-success result cannot contain a score")
             if not self.failure_type or not self.failure_reason:
-                raise ValueError("non-success result requires failure_type and failure_reason")
+                raise ValueError(
+                    "non-success result requires failure_type and failure_reason"
+                )
 
     def to_dict(self, *, include_sha256: bool = True) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -606,18 +671,23 @@ class QualificationBudgetResult:
             "metric_scorecard_sha256": self.metric_scorecard_sha256,
             "processed_data_sha256": self.processed_data_sha256,
             "observed_dataset_lineage_sha256": self.observed_dataset_lineage_sha256,
-            "model_state_sha256": self.model_state_sha256,
+            "source_train_indices_sha256": self.source_train_indices_sha256,
+            "labeled_target_indices_sha256": self.labeled_target_indices_sha256,
+            "fit_indices_sha256": self.fit_indices_sha256,
+            "evaluation_indices_sha256": self.evaluation_indices_sha256,
+            "qualification_model_state_sha256": self.qualification_model_state_sha256,
+            "external_learned_state_sha256": self.external_learned_state_sha256,
+            "external_state_identity_kind": self.external_state_identity_kind,
             "learned_state_addressable": self.learned_state_addressable,
             "source_train_samples": self.source_train_samples,
             "labeled_target_examples": self.labeled_target_examples,
-            "unlabeled_target_examples": self.unlabeled_target_examples,
-            "unlabeled_target_seconds": self.unlabeled_target_seconds,
+            "unlabeled_target_examples": 0,
+            "unlabeled_target_seconds": 0.0,
             "evaluation_samples": self.evaluation_samples,
             "class_labels": list(self.class_labels),
             "score": None if self.score is None else self.score.to_dict(),
             "probability_available": self.probability_available,
             "fit_s": self.fit_s,
-            "adaptation_s": self.adaptation_s,
             "inference_s": self.inference_s,
             "failure_type": self.failure_type,
             "failure_reason": self.failure_reason,
@@ -629,7 +699,7 @@ class QualificationBudgetResult:
     @property
     def sha256(self) -> str:
         return _identity_sha256(
-            "neuros.qualification_budget_result.v1",
+            "neuros.qualification_budget_result.v2",
             self.to_dict(include_sha256=False),
         )
 
@@ -644,11 +714,11 @@ class QualificationCaseResult:
     execution_context_sha256: str
     metric_scorecard_sha256: str
     rows: tuple[QualificationBudgetResult, ...]
-    schema_version: int = 1
+    schema_version: int = 2
 
     def __post_init__(self) -> None:
-        if isinstance(self.schema_version, bool) or self.schema_version != 1:
-            raise ValueError("QualificationCaseResult schema_version must be 1")
+        if isinstance(self.schema_version, bool) or self.schema_version != 2:
+            raise ValueError("QualificationCaseResult schema_version must be 2")
         for name in (
             "protocol_sha256",
             "case_authority_sha256",
@@ -658,7 +728,9 @@ class QualificationCaseResult:
         ):
             object.__setattr__(self, name, _sha256(name, getattr(self, name)))
         if not self.rows:
-            raise ValueError("qualification case result must contain at least one budget row")
+            raise ValueError(
+                "qualification case result must contain at least one budget row"
+            )
         budgets = tuple(row.calibration_per_class for row in self.rows)
         if len(set(budgets)) != len(budgets):
             raise ValueError("qualification result cannot duplicate calibration budgets")
@@ -691,12 +763,15 @@ class QualificationCaseResult:
     @property
     def sha256(self) -> str:
         return _identity_sha256(
-            "neuros.qualification_case_result.v1",
+            "neuros.qualification_case_result.v2",
             self.to_dict(include_sha256=False),
         )
 
 
-def _canonical_class_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[str, ...]:
+def _canonical_class_labels(
+    y: np.ndarray,
+    source_indices: np.ndarray,
+) -> tuple[str, ...]:
     source_labels = np.asarray(y)[source_indices].astype(str)
     labels = tuple(sorted(np.unique(source_labels).tolist()))
     if len(labels) < 2:
@@ -711,32 +786,6 @@ def _canonical_class_labels(y: np.ndarray, source_indices: np.ndarray) -> tuple[
     return labels
 
 
-def _unlabeled_target_indices(
-    split: Any,
-    *,
-    labeled_calibration_indices: np.ndarray,
-    count: int,
-) -> np.ndarray:
-    if count == 0:
-        return np.asarray([], dtype=np.int64)
-    all_target = np.sort(
-        np.concatenate(
-            [np.asarray(values, dtype=np.int64) for values in split.calibration_order_by_class.values()]
-        )
-    )
-    remaining = np.setdiff1d(
-        all_target,
-        np.asarray(labeled_calibration_indices, dtype=np.int64),
-        assume_unique=True,
-    )
-    if count > len(remaining):
-        raise ValueError(
-            f"requested {count} unlabeled target examples but only {len(remaining)} "
-            "authorized non-evaluation target observations remain"
-        )
-    return remaining[:count].copy()
-
-
 def _failure_status(exc: Exception) -> QualificationStatus:
     if isinstance(exc, QualificationSkippedError):
         return "skipped"
@@ -744,7 +793,7 @@ def _failure_status(exc: Exception) -> QualificationStatus:
         return "unavailable"
     if isinstance(exc, QualificationNonConvergenceError):
         return "nonconverged"
-    if isinstance(exc, MemoryError):
+    if isinstance(exc, MemoryError) or "OutOfMemoryError" in type(exc).__name__:
         return "oom"
     return "failed"
 
@@ -772,18 +821,30 @@ def _validate_preflight(
             f"protocol dataset_id={protocol.dataset_id!r} does not match loaded "
             f"dataset_id={data.dataset_id!r}"
         )
-    if execution_context.observed_dataset_lineage_sha256 != protocol.dataset_lineage_sha256:
-        raise ValueError("observed dataset lineage SHA-256 differs from frozen protocol")
+    if (
+        execution_context.observed_dataset_lineage_sha256
+        != protocol.dataset_lineage_sha256
+    ):
+        raise ValueError(
+            "observed dataset lineage SHA-256 differs from frozen protocol"
+        )
     if protocol.metric_scorecard_sha256 != scorecard.sha256:
         raise ValueError("metric scorecard SHA-256 differs from frozen protocol")
     declared_metrics = (protocol.primary_metric, *protocol.secondary_metrics)
     if tuple(declared_metrics) != tuple(scorecard.metric_names):
         raise ValueError("protocol metric names/order differ from scorecard authority")
+    if execution_context.unlabeled_target_examples:
+        raise ValueError(
+            "LongitudinalCaseAuthority NSQ runner v1 is labeled-target only; "
+            "unlabeled adaptation requires a separately frozen unlabeled-target "
+            "observation authority and cannot reuse leftover calibration rows"
+        )
 
     split = authority.restore(data)
     if authority.split_unit not in protocol.grouping_hierarchy:
         raise ValueError(
-            f"case split unit {authority.split_unit!r} is absent from protocol grouping hierarchy"
+            f"case split unit {authority.split_unit!r} is absent from protocol "
+            "grouping hierarchy"
         )
     for budget in protocol.calibration_budgets_per_class:
         if budget > split.max_budget_per_class:
@@ -803,7 +864,9 @@ def _validate_preflight(
             "external method input_axes dimensionality differs from processed neural array"
         )
 
-    labels = _canonical_class_labels(np.asarray(data.y), split.source_train_indices)
+    labels = _canonical_class_labels(
+        np.asarray(data.y), np.asarray(split.source_train_indices, dtype=np.int64)
+    )
     return split, method_spec, labels
 
 
@@ -816,9 +879,9 @@ def run_external_qualification_case(
     execution_context: QualificationExecutionContext,
     scorecard: QualificationScorecard = DEFAULT_CLASSIFICATION_SCORECARD,
 ) -> QualificationCaseResult:
-    """Execute one external method across the frozen calibration frontier.
+    """Execute one external method across a frozen labeled-calibration frontier.
 
-    Scientific-authority failures are preflight errors and abort the entire case.
+    Scientific-authority failures abort before any external model is created.
     External model/runtime failures after a valid run contract exists are retained
     as explicit per-budget rows.
     """
@@ -836,44 +899,67 @@ def run_external_qualification_case(
     y = np.asarray(data.y).astype(str)
     evaluation_indices = np.asarray(split.evaluation_indices, dtype=np.int64)
     source_indices = np.asarray(split.source_train_indices, dtype=np.int64)
+    source_sha = _index_set_sha256(
+        "supervised_source_history",
+        authority.processed_data_sha256,
+        source_indices,
+    )
+    evaluation_sha = _index_set_sha256(
+        "untouched_final_assessment",
+        authority.processed_data_sha256,
+        evaluation_indices,
+    )
     rows: list[QualificationBudgetResult] = []
 
     for budget in protocol.calibration_budgets_per_class:
-        calibration_indices = np.asarray(split.calibration_indices(budget), dtype=np.int64)
-        train_indices = np.asarray(split.train_indices_for_budget(budget), dtype=np.int64)
-        unlabeled_indices = _unlabeled_target_indices(
-            split,
-            labeled_calibration_indices=calibration_indices,
-            count=execution_context.unlabeled_target_examples,
+        calibration_indices = np.asarray(
+            split.calibration_indices(budget), dtype=np.int64
         )
-        if np.intersect1d(unlabeled_indices, evaluation_indices).size:
-            raise RuntimeError("internal authority error: unlabeled target overlaps final assessment")
+        train_indices = np.asarray(
+            split.train_indices_for_budget(budget), dtype=np.int64
+        )
         if np.intersect1d(train_indices, evaluation_indices).size:
-            raise RuntimeError("internal authority error: fit set overlaps final assessment")
+            raise RuntimeError(
+                "internal authority error: fit set overlaps final assessment"
+            )
+        labeled_sha = _index_set_sha256(
+            "labeled_target_calibration",
+            authority.processed_data_sha256,
+            calibration_indices,
+        )
+        fit_sha = _index_set_sha256(
+            "supervised_fit",
+            authority.processed_data_sha256,
+            train_indices,
+        )
 
         run_contract = QualificationRunContract(
             protocol_sha256=protocol.sha256,
             method_spec_sha256=method_spec.sha256,
             case_authority_sha256=authority.authority_sha256,
             labeled_target_examples=int(len(calibration_indices)),
-            unlabeled_target_examples=int(len(unlabeled_indices)),
-            unlabeled_target_seconds=(
-                0.0
-                if execution_context.target_example_duration_s is None
-                else float(len(unlabeled_indices) * execution_context.target_example_duration_s)
-            ),
+            unlabeled_target_examples=0,
+            unlabeled_target_seconds=0.0,
             preprocessing_authority_sha256s=(
                 execution_context.preprocessing_authority_sha256s
             ),
             calibration_authority_sha256s=(
                 execution_context.calibration_authority_sha256s
             ),
-            metadata={"calibration_per_class": int(budget)},
+            metadata={
+                "calibration_per_class": int(budget),
+                "source_train_indices_sha256": source_sha,
+                "labeled_target_indices_sha256": labeled_sha,
+                "fit_indices_sha256": fit_sha,
+                "evaluation_indices_sha256": evaluation_sha,
+                "observation_authority_schema": "neuros.nsq_observation_roles.v1",
+            },
         )
 
         fit_s: float | None = None
-        adaptation_s: float | None = None
         inference_s: float | None = None
+        bound_state: QualificationModelState | None = None
+        learned_state: ExternalLearnedState | None = None
         try:
             decoder = factory.create()
             if not isinstance(decoder, ExternalQualificationDecoder):
@@ -886,19 +972,12 @@ def run_external_qualification_case(
             decoder.fit(X[train_indices], y[train_indices])
             fit_s = float(time.perf_counter() - started)
 
-            if len(unlabeled_indices):
-                if not isinstance(decoder, ExternalUnlabeledTargetAdapter):
-                    raise TypeError(
-                        "authorized unlabeled target observations require adapt_unlabeled(X)"
-                    )
-                started = time.perf_counter()
-                decoder.adapt_unlabeled(X[unlabeled_indices])
-                adaptation_s = float(time.perf_counter() - started)
-
             learned_state = decoder.learned_state()
             if not isinstance(learned_state, ExternalLearnedState):
-                raise TypeError("decoder.learned_state() must return ExternalLearnedState")
-            bound_state: QualificationModelState = bind_learned_state(
+                raise TypeError(
+                    "decoder.learned_state() must return ExternalLearnedState"
+                )
+            bound_state = bind_learned_state(
                 method_spec,
                 run_contract,
                 learned_state,
@@ -914,22 +993,29 @@ def run_external_qualification_case(
             ).astype(str)
 
             probability: np.ndarray | None = None
-            probability_available = method_spec.probability_semantics != "unavailable"
+            probability_available = (
+                method_spec.probability_semantics != "unavailable"
+            )
             if probability_available:
                 if not isinstance(decoder, ExternalProbabilityDecoder):
                     raise TypeError(
-                        "method declares probability output but decoder lacks predict_proba(X)"
+                        "method declares probability output but decoder lacks "
+                        "predict_proba(X)"
                     )
-                if not isinstance(decoder, ExternalProbabilityClassOrderProvider):
+                if not isinstance(
+                    decoder, ExternalProbabilityClassOrderProvider
+                ):
                     raise TypeError(
-                        "probability-capable decoder must expose probability_class_labels()"
+                        "probability-capable decoder must expose "
+                        "probability_class_labels()"
                     )
                 probability_labels = tuple(
                     str(value) for value in decoder.probability_class_labels()
                 )
                 if probability_labels != class_labels:
                     raise ValueError(
-                        "probability class order differs from canonical source-derived class order"
+                        "probability class order differs from canonical "
+                        "source-derived class order"
                     )
                 probability = validate_probability_output(
                     method_spec,
@@ -960,18 +1046,23 @@ def run_external_qualification_case(
                     observed_dataset_lineage_sha256=(
                         execution_context.observed_dataset_lineage_sha256
                     ),
-                    model_state_sha256=bound_state.sha256,
+                    source_train_indices_sha256=source_sha,
+                    labeled_target_indices_sha256=labeled_sha,
+                    fit_indices_sha256=fit_sha,
+                    evaluation_indices_sha256=evaluation_sha,
+                    qualification_model_state_sha256=bound_state.sha256,
+                    external_learned_state_sha256=learned_state.state_sha256,
+                    external_state_identity_kind=(
+                        learned_state.state_identity_kind
+                    ),
                     learned_state_addressable=bound_state.state_addressable,
                     source_train_samples=int(len(source_indices)),
                     labeled_target_examples=int(len(calibration_indices)),
-                    unlabeled_target_examples=int(len(unlabeled_indices)),
-                    unlabeled_target_seconds=run_contract.unlabeled_target_seconds,
                     evaluation_samples=int(len(evaluation_indices)),
                     class_labels=class_labels,
                     score=score,
                     probability_available=probability_available,
                     fit_s=fit_s,
-                    adaptation_s=adaptation_s,
                     inference_s=inference_s,
                 )
             )
@@ -993,18 +1084,33 @@ def run_external_qualification_case(
                     observed_dataset_lineage_sha256=(
                         execution_context.observed_dataset_lineage_sha256
                     ),
-                    model_state_sha256=None,
-                    learned_state_addressable=False,
+                    source_train_indices_sha256=source_sha,
+                    labeled_target_indices_sha256=labeled_sha,
+                    fit_indices_sha256=fit_sha,
+                    evaluation_indices_sha256=evaluation_sha,
+                    qualification_model_state_sha256=(
+                        None if bound_state is None else bound_state.sha256
+                    ),
+                    external_learned_state_sha256=(
+                        None if learned_state is None else learned_state.state_sha256
+                    ),
+                    external_state_identity_kind=(
+                        None
+                        if learned_state is None
+                        else learned_state.state_identity_kind
+                    ),
+                    learned_state_addressable=(
+                        False
+                        if bound_state is None
+                        else bound_state.state_addressable
+                    ),
                     source_train_samples=int(len(source_indices)),
                     labeled_target_examples=int(len(calibration_indices)),
-                    unlabeled_target_examples=int(len(unlabeled_indices)),
-                    unlabeled_target_seconds=run_contract.unlabeled_target_seconds,
                     evaluation_samples=int(len(evaluation_indices)),
                     class_labels=class_labels,
                     score=None,
                     probability_available=False,
                     fit_s=fit_s,
-                    adaptation_s=adaptation_s,
                     inference_s=inference_s,
                     failure_type=failure_type,
                     failure_reason=failure_reason,

--- a/tests/test_neural_system_qualification_baselines.py
+++ b/tests/test_neural_system_qualification_baselines.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.longitudinal import (
+    chronological_partition,
+    make_nested_calibration_split,
+)
+from neuros.foundation_models.longitudinal_authority import LongitudinalCaseAuthority
+from neuros.foundation_models.qualification import QualificationProtocolSpec
+from neuros.foundation_models.qualification_baselines import (
+    MNECSPLDAFactory,
+    UpstreamBraindecodeFactory,
+)
+from neuros.foundation_models.qualification_runner import (
+    DEFAULT_CLASSIFICATION_SCORECARD,
+    QualificationExecutionContext,
+    run_external_qualification_case,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+LINEAGE_SHA = "e" * 64
+
+
+def _eeg_data() -> GroupedEvaluationData:
+    rng = np.random.default_rng(19)
+    n_sessions = 3
+    trials_per_session = 16
+    n_samples = n_sessions * trials_per_session
+    n_channels = 4
+    n_times = 128
+    time = np.linspace(0.0, 1.0, n_times, endpoint=False)
+    X = rng.normal(scale=0.2, size=(n_samples, n_channels, n_times)).astype(np.float32)
+    y = np.asarray(["left", "right"] * (n_samples // 2), dtype=str)
+    for index, label in enumerate(y):
+        if label == "left":
+            X[index, 0] += np.sin(2.0 * np.pi * 10.0 * time).astype(np.float32)
+            X[index, 1] += 0.35 * np.sin(2.0 * np.pi * 10.0 * time).astype(np.float32)
+        else:
+            X[index, 2] += np.sin(2.0 * np.pi * 12.0 * time).astype(np.float32)
+            X[index, 3] += 0.35 * np.sin(2.0 * np.pi * 12.0 * time).astype(np.float32)
+    session = np.repeat(np.asarray(["s1", "s2", "s3"], dtype=str), trials_per_session)
+    subject = np.asarray(["p1"] * n_samples, dtype=str)
+    trial = np.asarray([f"t{index:03d}" for index in range(n_samples)], dtype=str)
+    return GroupedEvaluationData(
+        dataset_id="fixture-upstream-mi",
+        X=X,
+        y=y,
+        groups={"subject": subject, "session": session, "trial": trial},
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="s3",
+        order=("s1", "s2", "s3"),
+    )
+    split = make_nested_calibration_split(partition, evaluation_fraction=0.5, seed=5)
+    return LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="p1:s3",
+        history_policy="prior",
+        observed_group_order=("s1", "s2", "s3"),
+    )
+
+
+def _protocol(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+    *,
+    budgets: tuple[int, ...],
+) -> QualificationProtocolSpec:
+    return QualificationProtocolSpec(
+        protocol_id="fixture-upstream-nsq-v1",
+        dataset_id=data.dataset_id,
+        dataset_lineage_sha256=LINEAGE_SHA,
+        task_id="left-vs-right-mi",
+        independent_unit="participant",
+        grouping_hierarchy=("participant", "session", "trial"),
+        calibration_budgets_per_class=budgets,
+        metric_scorecard_sha256=DEFAULT_CLASSIFICATION_SCORECARD.sha256,
+        protocol_status="frozen",
+    )
+
+
+def _context() -> QualificationExecutionContext:
+    return QualificationExecutionContext(
+        observed_dataset_lineage_sha256=LINEAGE_SHA,
+    )
+
+
+def test_mne_csp_lda_participates_as_external_probability_method():
+    pytest.importorskip("mne")
+    pytest.importorskip("sklearn")
+    data = _eeg_data()
+    authority = _authority(data)
+    factory = MNECSPLDAFactory(n_components=2)
+    result = run_external_qualification_case(
+        data,
+        authority,
+        _protocol(data, authority, budgets=(0, 1)),
+        factory,
+        execution_context=_context(),
+    )
+
+    assert factory.method_spec.method_id == "mne-csp-lda"
+    assert "mne.decoding.CSP" in factory.method_spec.implementation
+    assert all(row.status == "success" for row in result.rows)
+    assert all(row.probability_available for row in result.rows)
+    assert all(row.score is not None for row in result.rows)
+    assert all(row.score.availability["brier_score"] == "available" for row in result.rows)
+    # Scientific comparison is allowed without pretending joblib/pickle is a
+    # qualified promoted-state identity.
+    assert all(row.learned_state_addressable is False for row in result.rows)
+
+
+def test_braindecode_factory_is_direct_upstream_not_neuros_model_wrapper():
+    pytest.importorskip("braindecode")
+    pytest.importorskip("torch")
+    factory = UpstreamBraindecodeFactory(
+        model_name="EEGNet",
+        sample_rate_hz=128.0,
+        n_epochs=1,
+        batch_size=8,
+        random_state=3,
+    )
+    spec = factory.method_spec
+    assert spec.implementation.startswith("braindecode.models.EEGNet+")
+    assert spec.metadata["neuros_model_wrapper_used"] is False
+    assert spec.probability_semantics == "uncalibrated_softmax"
+
+
+def test_upstream_braindecode_executes_through_same_nsq_referee():
+    pytest.importorskip("braindecode")
+    pytest.importorskip("torch")
+    data = _eeg_data()
+    authority = _authority(data)
+    factory = UpstreamBraindecodeFactory(
+        model_name="EEGNet",
+        sample_rate_hz=128.0,
+        n_epochs=1,
+        batch_size=8,
+        random_state=3,
+    )
+    result = run_external_qualification_case(
+        data,
+        authority,
+        _protocol(data, authority, budgets=(0,)),
+        factory,
+        execution_context=_context(),
+    )
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.status == "success"
+    assert row.probability_available is True
+    assert row.learned_state_addressable is True
+    assert row.model_state_sha256 is not None
+    assert row.score is not None
+    assert row.score.availability["brier_score"] == "available"

--- a/tests/test_neural_system_qualification_baselines.py
+++ b/tests/test_neural_system_qualification_baselines.py
@@ -115,6 +115,8 @@ def test_mne_csp_lda_participates_as_external_probability_method():
     # Scientific comparison is allowed without pretending joblib/pickle is a
     # qualified promoted-state identity.
     assert all(row.learned_state_addressable is False for row in result.rows)
+    assert all(row.external_learned_state_sha256 is None for row in result.rows)
+    assert all(row.qualification_model_state_sha256 is not None for row in result.rows)
 
 
 def test_braindecode_factory_is_direct_upstream_not_neuros_model_wrapper():
@@ -158,6 +160,9 @@ def test_upstream_braindecode_executes_through_same_nsq_referee():
     assert row.status == "success"
     assert row.probability_available is True
     assert row.learned_state_addressable is True
-    assert row.model_state_sha256 is not None
+    assert row.external_state_identity_kind == "tensor_sha256"
+    assert row.external_learned_state_sha256 is not None
+    assert row.qualification_model_state_sha256 is not None
+    assert row.external_learned_state_sha256 != row.qualification_model_state_sha256
     assert row.score is not None
     assert row.score.availability["brier_score"] == "available"

--- a/tests/test_neural_system_qualification_runner.py
+++ b/tests/test_neural_system_qualification_runner.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.longitudinal import (
+    chronological_partition,
+    make_nested_calibration_split,
+)
+from neuros.foundation_models.longitudinal_authority import LongitudinalCaseAuthority
+from neuros.foundation_models.qualification import (
+    ExternalDecoderMethodSpec,
+    ExternalLearnedState,
+)
+from neuros.foundation_models.qualification_runner import (
+    DEFAULT_CLASSIFICATION_SCORECARD,
+    ClassificationScorecardV1,
+    QualificationExecutionContext,
+    run_external_qualification_case,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+LINEAGE_SHA = "a" * 64
+PREPROCESSING_SHA = "b" * 64
+CALIBRATION_SHA = "c" * 64
+STATE_SHA = "d" * 64
+
+
+def _data() -> GroupedEvaluationData:
+    # Every sample encodes its row index, allowing tests to audit exactly which
+    # observations crossed the external-model boundary.
+    n_samples = 36
+    X = np.arange(n_samples, dtype=np.float32)[:, None, None]
+    X = np.repeat(X, 8, axis=2)
+    y = np.asarray(["left", "right"] * (n_samples // 2), dtype=str)
+    session = np.repeat(np.asarray(["s1", "s2", "s3"], dtype=str), 12)
+    subject = np.asarray(["p1"] * n_samples, dtype=str)
+    trial = np.asarray([f"t{index:02d}" for index in range(n_samples)], dtype=str)
+    return GroupedEvaluationData(
+        dataset_id="fixture-longitudinal-mi",
+        X=X,
+        y=y,
+        groups={"subject": subject, "session": session, "trial": trial},
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    partition = chronological_partition(
+        data,
+        split_unit="session",
+        held_out_value="s3",
+        order=("s1", "s2", "s3"),
+    )
+    split = make_nested_calibration_split(
+        partition,
+        evaluation_fraction=0.5,
+        seed=11,
+    )
+    return LongitudinalCaseAuthority.from_split(
+        split,
+        case_id="p1:s3",
+        history_policy="prior",
+        observed_group_order=("s1", "s2", "s3"),
+        case_metadata={"participant": "p1"},
+    )
+
+
+def _protocol(data: GroupedEvaluationData, authority: LongitudinalCaseAuthority):
+    from neuros.foundation_models.qualification import QualificationProtocolSpec
+
+    split = authority.restore(data)
+    return QualificationProtocolSpec(
+        protocol_id="fixture-nsq-v1",
+        dataset_id=data.dataset_id,
+        dataset_lineage_sha256=LINEAGE_SHA,
+        task_id="left-vs-right-motor-imagery",
+        independent_unit="participant",
+        grouping_hierarchy=("participant", "session", "trial"),
+        calibration_budgets_per_class=tuple(range(split.max_budget_per_class + 1)),
+        metric_scorecard_sha256=DEFAULT_CLASSIFICATION_SCORECARD.sha256,
+        protocol_status="frozen",
+        metadata={"fixture": True},
+    )
+
+
+def _context(*, unlabeled_target_examples: int = 0) -> QualificationExecutionContext:
+    return QualificationExecutionContext(
+        observed_dataset_lineage_sha256=LINEAGE_SHA,
+        preprocessing_authority_sha256s=(PREPROCESSING_SHA,),
+        calibration_authority_sha256s=(CALIBRATION_SHA,),
+        unlabeled_target_examples=unlabeled_target_examples,
+        target_example_duration_s=1.25 if unlabeled_target_examples else None,
+    )
+
+
+class LabelOnlyDecoder:
+    def __init__(self) -> None:
+        self.fit_indices: tuple[int, ...] = ()
+        self.labels: tuple[str, ...] = ()
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self.fit_indices = tuple(int(value) for value in X[:, 0, 0])
+        self.labels = tuple(sorted(np.unique(y.astype(str)).tolist()))
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        assert self.labels
+        return np.asarray([self.labels[0]] * len(X), dtype=str)
+
+    def learned_state(self) -> ExternalLearnedState:
+        return ExternalLearnedState()
+
+
+class LabelOnlyFactory:
+    def __init__(self, *, adaptation: str = "none") -> None:
+        self.created: list[LabelOnlyDecoder] = []
+        self._spec = ExternalDecoderMethodSpec(
+            method_id=f"fixture-label-only-{adaptation}",
+            implementation="tests.LabelOnlyDecoder",
+            implementation_version="1",
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="unavailable",
+            target_adaptation_mode=adaptation,  # type: ignore[arg-type]
+        )
+
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        return self._spec
+
+    def create(self) -> LabelOnlyDecoder:
+        decoder = LabelOnlyDecoder()
+        self.created.append(decoder)
+        return decoder
+
+
+class AdaptiveDecoder(LabelOnlyDecoder):
+    def __init__(self) -> None:
+        super().__init__()
+        self.adaptation_indices: tuple[int, ...] = ()
+
+    def adapt_unlabeled(self, X: np.ndarray) -> None:
+        self.adaptation_indices = tuple(int(value) for value in X[:, 0, 0])
+
+
+class AdaptiveFactory:
+    def __init__(self) -> None:
+        self.created: list[AdaptiveDecoder] = []
+        self._spec = ExternalDecoderMethodSpec(
+            method_id="fixture-unlabeled-adapter",
+            implementation="tests.AdaptiveDecoder",
+            implementation_version="1",
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="unavailable",
+            target_adaptation_mode="unlabeled",
+        )
+
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        return self._spec
+
+    def create(self) -> AdaptiveDecoder:
+        decoder = AdaptiveDecoder()
+        self.created.append(decoder)
+        return decoder
+
+
+class ProbabilityDecoder(LabelOnlyDecoder):
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        assert len(self.labels) == 2
+        return np.full((len(X), 2), 0.5, dtype=np.float32)
+
+    def probability_class_labels(self):
+        return self.labels
+
+    def learned_state(self) -> ExternalLearnedState:
+        return ExternalLearnedState(
+            state_identity_kind="tensor_sha256",
+            state_sha256=STATE_SHA,
+        )
+
+
+class ProbabilityFactory:
+    def __init__(self, *, reverse_probability_order: bool = False) -> None:
+        self.created: list[ProbabilityDecoder] = []
+        self.reverse_probability_order = reverse_probability_order
+        self._spec = ExternalDecoderMethodSpec(
+            method_id="fixture-probability",
+            implementation="tests.ProbabilityDecoder",
+            implementation_version="1",
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="uncalibrated_probability",
+        )
+
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        return self._spec
+
+    def create(self) -> ProbabilityDecoder:
+        decoder = ProbabilityDecoder()
+        if self.reverse_probability_order:
+            original = decoder.probability_class_labels
+
+            def reversed_labels():
+                return tuple(reversed(original()))
+
+            decoder.probability_class_labels = reversed_labels  # type: ignore[method-assign]
+        self.created.append(decoder)
+        return decoder
+
+
+class FailingDecoder(LabelOnlyDecoder):
+    def __init__(self, failure: Exception | None) -> None:
+        super().__init__()
+        self.failure = failure
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        if self.failure is not None:
+            raise self.failure
+        super().fit(X, y)
+
+
+class FailingFactory:
+    def __init__(self, failures: list[Exception | None]) -> None:
+        self.failures = list(failures)
+        self.created = 0
+        self._spec = ExternalDecoderMethodSpec(
+            method_id="fixture-failure-preservation",
+            implementation="tests.FailingDecoder",
+            implementation_version="1",
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="unavailable",
+        )
+
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        return self._spec
+
+    def create(self) -> FailingDecoder:
+        failure = self.failures[self.created]
+        self.created += 1
+        return FailingDecoder(failure)
+
+
+def test_default_scorecard_has_full_stable_identity_and_explicit_semantics():
+    first = ClassificationScorecardV1()
+    second = ClassificationScorecardV1()
+    assert len(first.sha256) == 64
+    assert first.sha256 == second.sha256
+    assert first.metric_names == (
+        "balanced_accuracy",
+        "accuracy",
+        "roc_auc",
+        "brier_score",
+        "expected_calibration_error",
+    )
+    assert first.to_dict()["metric_semantics"]["roc_auc"]["positive_class"] == (
+        "second_canonical_source_label"
+    )
+
+
+def test_runner_creates_fresh_external_state_for_every_declared_budget():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    factory = LabelOnlyFactory()
+
+    result = run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        factory,
+        execution_context=_context(),
+    )
+
+    assert len(factory.created) == len(protocol.calibration_budgets_per_class)
+    assert len({id(decoder) for decoder in factory.created}) == len(factory.created)
+    assert tuple(row.calibration_per_class for row in result.rows) == (
+        protocol.calibration_budgets_per_class
+    )
+    assert all(row.status == "success" for row in result.rows)
+    assert len(result.sha256) == 64
+
+
+def test_final_assessment_rows_never_cross_the_fit_boundary():
+    data = _data()
+    authority = _authority(data)
+    split = authority.restore(data)
+    evaluation = set(split.evaluation_indices.tolist())
+    protocol = _protocol(data, authority)
+    factory = LabelOnlyFactory()
+
+    run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        factory,
+        execution_context=_context(),
+    )
+
+    for decoder in factory.created:
+        assert not evaluation.intersection(decoder.fit_indices)
+
+
+def test_unlabeled_target_rows_use_only_non_evaluation_authorized_target_pool():
+    data = _data()
+    authority = _authority(data)
+    split = authority.restore(data)
+    evaluation = set(split.evaluation_indices.tolist())
+    source = set(split.source_train_indices.tolist())
+    protocol = _protocol(data, authority)
+    factory = AdaptiveFactory()
+
+    result = run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        factory,
+        execution_context=_context(unlabeled_target_examples=1),
+    )
+
+    assert all(row.status == "success" for row in result.rows)
+    assert all(row.unlabeled_target_examples == 1 for row in result.rows)
+    assert all(row.unlabeled_target_seconds == pytest.approx(1.25) for row in result.rows)
+    for decoder in factory.created:
+        assert len(decoder.adaptation_indices) == 1
+        assert not evaluation.intersection(decoder.adaptation_indices)
+        assert not source.intersection(decoder.adaptation_indices)
+        assert not evaluation.intersection(decoder.fit_indices)
+
+
+def test_label_only_method_keeps_probability_metrics_explicitly_unavailable():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    result = run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        LabelOnlyFactory(),
+        execution_context=_context(),
+    )
+
+    row = result.rows[0]
+    assert row.status == "success"
+    assert row.probability_available is False
+    assert row.score is not None
+    assert row.score.availability["balanced_accuracy"] == "available"
+    assert row.score.availability["accuracy"] == "available"
+    assert row.score.metrics["brier_score"] is None
+    assert row.score.availability["brier_score"] == "unavailable_probability_output"
+    assert row.score.metrics["expected_calibration_error"] is None
+
+
+def test_probability_method_requires_exact_fitted_class_order():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    result = run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        ProbabilityFactory(reverse_probability_order=True),
+        execution_context=_context(),
+    )
+
+    assert len(result.rows) == len(protocol.calibration_budgets_per_class)
+    assert all(row.status == "failed" for row in result.rows)
+    assert all(row.failure_type == "ValueError" for row in result.rows)
+    assert all("probability class order" in row.failure_reason for row in result.rows)
+
+
+def test_probability_method_scores_only_after_validated_class_order():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    result = run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        ProbabilityFactory(),
+        execution_context=_context(),
+    )
+
+    row = result.rows[0]
+    assert row.status == "success"
+    assert row.probability_available is True
+    assert row.score is not None
+    assert row.score.availability["brier_score"] == "available"
+    assert row.score.availability["expected_calibration_error"] == "available"
+    assert row.score.availability["roc_auc"] == "available"
+    assert row.learned_state_addressable is True
+
+
+def test_external_failures_remain_in_the_frontier_instead_of_disappearing():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    failures: list[Exception | None] = [
+        None,
+        ImportError("optional backend absent"),
+        MemoryError("synthetic oom"),
+        RuntimeError("optimizer exploded"),
+    ]
+    assert len(failures) == len(protocol.calibration_budgets_per_class)
+
+    result = run_external_qualification_case(
+        data,
+        authority,
+        protocol,
+        FailingFactory(failures),
+        execution_context=_context(),
+    )
+
+    assert [row.status for row in result.rows] == [
+        "success",
+        "unavailable",
+        "oom",
+        "failed",
+    ]
+    assert len(result.rows) == len(protocol.calibration_budgets_per_class)
+    assert result.rows[1].failure_reason == "optional backend absent"
+    assert result.rows[2].failure_type == "MemoryError"
+
+
+def test_observed_dataset_lineage_mismatch_fails_before_external_model_creation():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    factory = LabelOnlyFactory()
+    wrong = QualificationExecutionContext(
+        observed_dataset_lineage_sha256="f" * 64,
+    )
+
+    with pytest.raises(ValueError, match="observed dataset lineage"):
+        run_external_qualification_case(
+            data,
+            authority,
+            protocol,
+            factory,
+            execution_context=wrong,
+        )
+    assert factory.created == []
+
+
+def test_metric_authority_mismatch_fails_before_external_model_creation():
+    data = _data()
+    authority = _authority(data)
+    protocol = replace(_protocol(data, authority), metric_scorecard_sha256="f" * 64)
+    factory = LabelOnlyFactory()
+
+    with pytest.raises(ValueError, match="metric scorecard"):
+        run_external_qualification_case(
+            data,
+            authority,
+            protocol,
+            factory,
+            execution_context=_context(),
+        )
+    assert factory.created == []
+
+
+def test_processed_array_tampering_is_rejected_by_existing_case_authority():
+    data = _data()
+    authority = _authority(data)
+    protocol = _protocol(data, authority)
+    factory = LabelOnlyFactory()
+    tampered_X = data.X.copy()
+    tampered_X[0, 0, 0] += 0.125
+    tampered = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=tampered_X,
+        y=data.y,
+        groups=data.groups,
+    )
+
+    with pytest.raises(ValueError, match="processed neural data SHA-256"):
+        run_external_qualification_case(
+            tampered,
+            authority,
+            protocol,
+            factory,
+            execution_context=_context(),
+        )
+    assert factory.created == []
+
+
+def test_protocol_budget_beyond_case_authority_fails_before_fit():
+    data = _data()
+    authority = _authority(data)
+    protocol = replace(
+        _protocol(data, authority),
+        calibration_budgets_per_class=(0, 99),
+    )
+    factory = LabelOnlyFactory()
+
+    with pytest.raises(ValueError, match="exceeds frozen authority maximum"):
+        run_external_qualification_case(
+            data,
+            authority,
+            protocol,
+            factory,
+            execution_context=_context(),
+        )
+    assert factory.created == []
+
+
+def test_runner_refuses_draft_protocol_even_when_every_other_hash_matches():
+    data = _data()
+    authority = _authority(data)
+    protocol = replace(_protocol(data, authority), protocol_status="draft")
+    with pytest.raises(ValueError, match="requires protocol_status='frozen'"):
+        run_external_qualification_case(
+            data,
+            authority,
+            protocol,
+            LabelOnlyFactory(),
+            execution_context=_context(),
+        )

--- a/tests/test_neural_system_qualification_runner.py
+++ b/tests/test_neural_system_qualification_runner.py
@@ -29,8 +29,8 @@ STATE_SHA = "d" * 64
 
 
 def _data() -> GroupedEvaluationData:
-    # Every sample encodes its row index, allowing tests to audit exactly which
-    # observations crossed the external-model boundary.
+    # Every sample encodes its row index so tests can audit the observations
+    # actually delivered to an external model.
     n_samples = 36
     X = np.arange(n_samples, dtype=np.float32)[:, None, None]
     X = np.repeat(X, 8, axis=2)
@@ -67,7 +67,10 @@ def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
     )
 
 
-def _protocol(data: GroupedEvaluationData, authority: LongitudinalCaseAuthority):
+def _protocol(
+    data: GroupedEvaluationData,
+    authority: LongitudinalCaseAuthority,
+):
     from neuros.foundation_models.qualification import QualificationProtocolSpec
 
     split = authority.restore(data)
@@ -78,20 +81,27 @@ def _protocol(data: GroupedEvaluationData, authority: LongitudinalCaseAuthority)
         task_id="left-vs-right-motor-imagery",
         independent_unit="participant",
         grouping_hierarchy=("participant", "session", "trial"),
-        calibration_budgets_per_class=tuple(range(split.max_budget_per_class + 1)),
+        calibration_budgets_per_class=tuple(
+            range(split.max_budget_per_class + 1)
+        ),
         metric_scorecard_sha256=DEFAULT_CLASSIFICATION_SCORECARD.sha256,
         protocol_status="frozen",
         metadata={"fixture": True},
     )
 
 
-def _context(*, unlabeled_target_examples: int = 0) -> QualificationExecutionContext:
+def _context(
+    *,
+    unlabeled_target_examples: int = 0,
+) -> QualificationExecutionContext:
     return QualificationExecutionContext(
         observed_dataset_lineage_sha256=LINEAGE_SHA,
         preprocessing_authority_sha256s=(PREPROCESSING_SHA,),
         calibration_authority_sha256s=(CALIBRATION_SHA,),
         unlabeled_target_examples=unlabeled_target_examples,
-        target_example_duration_s=1.25 if unlabeled_target_examples else None,
+        target_example_duration_s=(
+            1.25 if unlabeled_target_examples else None
+        ),
     )
 
 
@@ -135,29 +145,15 @@ class LabelOnlyFactory:
 
 
 class AdaptiveDecoder(LabelOnlyDecoder):
-    def __init__(self) -> None:
-        super().__init__()
-        self.adaptation_indices: tuple[int, ...] = ()
-
     def adapt_unlabeled(self, X: np.ndarray) -> None:
-        self.adaptation_indices = tuple(int(value) for value in X[:, 0, 0])
-
-
-class AdaptiveFactory:
-    def __init__(self) -> None:
-        self.created: list[AdaptiveDecoder] = []
-        self._spec = ExternalDecoderMethodSpec(
-            method_id="fixture-unlabeled-adapter",
-            implementation="tests.AdaptiveDecoder",
-            implementation_version="1",
-            input_axes=("sample", "channel", "time"),
-            probability_semantics="unavailable",
-            target_adaptation_mode="unlabeled",
+        raise AssertionError(
+            "labeled-only runner must never expose an unlabeled target array"
         )
 
-    @property
-    def method_spec(self) -> ExternalDecoderMethodSpec:
-        return self._spec
+
+class AdaptiveFactory(LabelOnlyFactory):
+    def __init__(self) -> None:
+        super().__init__(adaptation="unlabeled")
 
     def create(self) -> AdaptiveDecoder:
         decoder = AdaptiveDecoder()
@@ -254,9 +250,9 @@ def test_default_scorecard_has_full_stable_identity_and_explicit_semantics():
         "brier_score",
         "expected_calibration_error",
     )
-    assert first.to_dict()["metric_semantics"]["roc_auc"]["positive_class"] == (
-        "second_canonical_source_label"
-    )
+    assert first.to_dict()["metric_semantics"]["roc_auc"][
+        "positive_class"
+    ] == "second_canonical_source_label"
 
 
 def test_runner_creates_fresh_external_state_for_every_declared_budget():
@@ -274,7 +270,9 @@ def test_runner_creates_fresh_external_state_for_every_declared_budget():
     )
 
     assert len(factory.created) == len(protocol.calibration_budgets_per_class)
-    assert len({id(decoder) for decoder in factory.created}) == len(factory.created)
+    assert len({id(decoder) for decoder in factory.created}) == len(
+        factory.created
+    )
     assert tuple(row.calibration_per_class for row in result.rows) == (
         protocol.calibration_budgets_per_class
     )
@@ -287,56 +285,73 @@ def test_final_assessment_rows_never_cross_the_fit_boundary():
     authority = _authority(data)
     split = authority.restore(data)
     evaluation = set(split.evaluation_indices.tolist())
-    protocol = _protocol(data, authority)
     factory = LabelOnlyFactory()
 
-    run_external_qualification_case(
+    result = run_external_qualification_case(
         data,
         authority,
-        protocol,
+        _protocol(data, authority),
         factory,
         execution_context=_context(),
     )
 
     for decoder in factory.created:
         assert not evaluation.intersection(decoder.fit_indices)
+    assert len({row.evaluation_indices_sha256 for row in result.rows}) == 1
+    assert len({row.source_train_indices_sha256 for row in result.rows}) == 1
 
 
-def test_unlabeled_target_rows_use_only_non_evaluation_authorized_target_pool():
+def test_exact_observation_sets_are_bound_into_each_run_identity():
     data = _data()
     authority = _authority(data)
-    split = authority.restore(data)
-    evaluation = set(split.evaluation_indices.tolist())
-    source = set(split.source_train_indices.tolist())
-    protocol = _protocol(data, authority)
-    factory = AdaptiveFactory()
-
     result = run_external_qualification_case(
         data,
         authority,
-        protocol,
-        factory,
-        execution_context=_context(unlabeled_target_examples=1),
+        _protocol(data, authority),
+        LabelOnlyFactory(),
+        execution_context=_context(),
     )
 
-    assert all(row.status == "success" for row in result.rows)
-    assert all(row.unlabeled_target_examples == 1 for row in result.rows)
-    assert all(row.unlabeled_target_seconds == pytest.approx(1.25) for row in result.rows)
-    for decoder in factory.created:
-        assert len(decoder.adaptation_indices) == 1
-        assert not evaluation.intersection(decoder.adaptation_indices)
-        assert not source.intersection(decoder.adaptation_indices)
-        assert not evaluation.intersection(decoder.fit_indices)
+    # Increasing labeled calibration changes the labeled and fit authorities,
+    # while source history and untouched final assessment stay fixed.
+    assert len({row.run_contract_sha256 for row in result.rows}) == len(
+        result.rows
+    )
+    assert len({row.labeled_target_indices_sha256 for row in result.rows}) == len(
+        result.rows
+    )
+    assert len({row.fit_indices_sha256 for row in result.rows}) == len(result.rows)
+    assert len({row.source_train_indices_sha256 for row in result.rows}) == 1
+    assert len({row.evaluation_indices_sha256 for row in result.rows}) == 1
+
+
+def test_labeled_longitudinal_runner_refuses_unlabeled_target_role_conflation():
+    data = _data()
+    authority = _authority(data)
+    factory = AdaptiveFactory()
+
+    with pytest.raises(
+        ValueError,
+        match="labeled-target only.*separately frozen unlabeled-target",
+    ):
+        run_external_qualification_case(
+            data,
+            authority,
+            _protocol(data, authority),
+            factory,
+            execution_context=_context(unlabeled_target_examples=1),
+        )
+    # The authority error occurs before any external code sees data.
+    assert factory.created == []
 
 
 def test_label_only_method_keeps_probability_metrics_explicitly_unavailable():
     data = _data()
     authority = _authority(data)
-    protocol = _protocol(data, authority)
     result = run_external_qualification_case(
         data,
         authority,
-        protocol,
+        _protocol(data, authority),
         LabelOnlyFactory(),
         execution_context=_context(),
     )
@@ -348,8 +363,13 @@ def test_label_only_method_keeps_probability_metrics_explicitly_unavailable():
     assert row.score.availability["balanced_accuracy"] == "available"
     assert row.score.availability["accuracy"] == "available"
     assert row.score.metrics["brier_score"] is None
-    assert row.score.availability["brier_score"] == "unavailable_probability_output"
-    assert row.score.metrics["expected_calibration_error"] is None
+    assert (
+        row.score.availability["brier_score"]
+        == "unavailable_probability_output"
+    )
+    assert row.external_state_identity_kind == "opaque_unverified"
+    assert row.external_learned_state_sha256 is None
+    assert row.qualification_model_state_sha256 is not None
 
 
 def test_probability_method_requires_exact_fitted_class_order():
@@ -367,17 +387,26 @@ def test_probability_method_requires_exact_fitted_class_order():
     assert len(result.rows) == len(protocol.calibration_budgets_per_class)
     assert all(row.status == "failed" for row in result.rows)
     assert all(row.failure_type == "ValueError" for row in result.rows)
-    assert all("probability class order" in row.failure_reason for row in result.rows)
+    assert all(
+        "probability class order" in row.failure_reason for row in result.rows
+    )
+    # Fit succeeded before semantic output validation, so partial state evidence
+    # remains visible even though the budget row failed.
+    assert all(
+        row.external_learned_state_sha256 == STATE_SHA for row in result.rows
+    )
+    assert all(
+        row.qualification_model_state_sha256 is not None for row in result.rows
+    )
 
 
-def test_probability_method_scores_only_after_validated_class_order():
+def test_probability_method_separates_external_state_from_run_binding_state():
     data = _data()
     authority = _authority(data)
-    protocol = _protocol(data, authority)
     result = run_external_qualification_case(
         data,
         authority,
-        protocol,
+        _protocol(data, authority),
         ProbabilityFactory(),
         execution_context=_context(),
     )
@@ -390,6 +419,9 @@ def test_probability_method_scores_only_after_validated_class_order():
     assert row.score.availability["expected_calibration_error"] == "available"
     assert row.score.availability["roc_auc"] == "available"
     assert row.learned_state_addressable is True
+    assert row.external_learned_state_sha256 == STATE_SHA
+    assert row.qualification_model_state_sha256 is not None
+    assert row.qualification_model_state_sha256 != STATE_SHA
 
 
 def test_external_failures_remain_in_the_frontier_instead_of_disappearing():
@@ -426,7 +458,6 @@ def test_external_failures_remain_in_the_frontier_instead_of_disappearing():
 def test_observed_dataset_lineage_mismatch_fails_before_external_model_creation():
     data = _data()
     authority = _authority(data)
-    protocol = _protocol(data, authority)
     factory = LabelOnlyFactory()
     wrong = QualificationExecutionContext(
         observed_dataset_lineage_sha256="f" * 64,
@@ -436,7 +467,7 @@ def test_observed_dataset_lineage_mismatch_fails_before_external_model_creation(
         run_external_qualification_case(
             data,
             authority,
-            protocol,
+            _protocol(data, authority),
             factory,
             execution_context=wrong,
         )
@@ -446,7 +477,10 @@ def test_observed_dataset_lineage_mismatch_fails_before_external_model_creation(
 def test_metric_authority_mismatch_fails_before_external_model_creation():
     data = _data()
     authority = _authority(data)
-    protocol = replace(_protocol(data, authority), metric_scorecard_sha256="f" * 64)
+    protocol = replace(
+        _protocol(data, authority),
+        metric_scorecard_sha256="f" * 64,
+    )
     factory = LabelOnlyFactory()
 
     with pytest.raises(ValueError, match="metric scorecard"):
@@ -463,7 +497,6 @@ def test_metric_authority_mismatch_fails_before_external_model_creation():
 def test_processed_array_tampering_is_rejected_by_existing_case_authority():
     data = _data()
     authority = _authority(data)
-    protocol = _protocol(data, authority)
     factory = LabelOnlyFactory()
     tampered_X = data.X.copy()
     tampered_X[0, 0, 0] += 0.125
@@ -478,7 +511,7 @@ def test_processed_array_tampering_is_rejected_by_existing_case_authority():
         run_external_qualification_case(
             tampered,
             authority,
-            protocol,
+            _protocol(data, authority),
             factory,
             execution_context=_context(),
         )
@@ -508,7 +541,10 @@ def test_protocol_budget_beyond_case_authority_fails_before_fit():
 def test_runner_refuses_draft_protocol_even_when_every_other_hash_matches():
     data = _data()
     authority = _authority(data)
-    protocol = replace(_protocol(data, authority), protocol_status="draft")
+    protocol = replace(
+        _protocol(data, authority),
+        protocol_status="draft",
+    )
     with pytest.raises(ValueError, match="requires protocol_status='frozen'"):
         run_external_qualification_case(
             data,


### PR DESCRIPTION
## Why

Production NSQ v1 defines who may participate in a neural-system qualification study. This PR implements the first executable referee: neurOS controls which observations cross an external model boundary, binds the exact scientific authority around each run, validates output semantics, and preserves failures without owning the external training code.

Tracks #79 and the execution/reproduction gates in #75.

## Qualified Runner v1

- composes the existing `LongitudinalCaseAuthority` rather than creating another split engine;
- separates observed upstream dataset-lineage SHA-256 from the exact processed-array SHA-256 and requires both to match before external model creation;
- requires `protocol_status='frozen'` and the exact metric-scorecard SHA before execution;
- derives the task vocabulary from source history rather than final-assessment rows;
- requests a fresh `factory.create()` instance for every calibration budget;
- exposes only source history + the exact frozen labeled-target calibration rows to `fit()`;
- never routes final-assessment indices through fitting;
- binds full observation-set SHA-256 identities for source history, labeled target calibration, complete supervised fit, and untouched final assessment into every run contract;
- requires probability-capable methods to expose fitted probability-column class order before ROC AUC/Brier/ECE are computed;
- supports label-only methods while retaining probability-dependent metrics as explicitly unavailable;
- preserves success, unavailable, OOM, failed, skipped, and nonconverged attempts as rows rather than dropping difficult cases.

## Unlabeled adaptation boundary

The generic NSQ participation contract can describe `adapt_unlabeled(X)`, but this first `LongitudinalCaseAuthority` executor is intentionally **labeled-target only**.

An earlier draft attempted to use calibration rows not yet selected at the current labeled budget as an unlabeled pool. The dedicated runner matrix caught the resulting authority inconsistency. That design was rejected because the unlabeled observation set changed as labeled budget grew and disappeared at the maximum budget, allowing the same observation to change scientific role across the frontier.

Runner v1 now refuses nonzero unlabeled-target exposure before any external model is created. Issue #81 tracks a future adaptive authority with a separately frozen unlabeled target role rather than inferred leftover rows.

## Learned-state semantics

Two identities are kept separate:

- `external_learned_state_sha256`: exact upstream tensor/checkpoint state, when the external ecosystem can honestly provide one;
- `qualification_model_state_sha256`: NSQ binding of that learned-state record to the exact method + run authority that produced it.

For MNE/scikit-learn CSP + LDA the external state remains `opaque_unverified`; NSQ does not use pickle/joblib merely to manufacture a strong state identity. Direct upstream Braindecode exposes an exact SHA over the fitted PyTorch module state, including registered buffers.

Partial learned-state evidence remains visible when fitting succeeds but later output-semantic validation fails.

## Frozen scorecard

`ClassificationScorecardV1` has a full SHA-256 and explicit semantics for:

- balanced accuracy: macro mean recall over source-derived task classes;
- accuracy;
- binary ROC AUC with the second canonical source label as positive class;
- multiclass Brier score;
- 10-bin top-label ECE.

The runner refuses a protocol whose metric-scorecard SHA does not exactly match the supplied scorer.

## Real external proving methods

### MNE + scikit-learn

`MNECSPLDAFactory` directly composes maintained upstream `mne.decoding.CSP` and sklearn `LinearDiscriminantAnalysis`.

### Braindecode

`UpstreamBraindecodeFactory` directly constructs `braindecode.models.<model>` plus upstream `braindecode.EEGClassifier`, PyTorch cross-entropy, and AdamW. It deliberately does **not** route training through the neurOS `BraindecodeDecoder` wrapper.

## Exact-head qualification

Qualified PR head:

`3732222c18d3feb8de93d4e0d5fb8e8ee2e53177`

All six relevant repository workflows are green on that exact head:

- NSQ Runner v1;
- neurOS CI;
- neurOS real-world evidence;
- Braindecode Longitudinal Evidence;
- Ecosystem Compatibility;
- Public Trust Contracts.

The dedicated NSQ Runner workflow contains five independently green jobs on the same head:

- Runner contracts / Python 3.10;
- Runner contracts / Python 3.11;
- Runner contracts / Python 3.12;
- External MNE CSP + sklearn LDA;
- Direct upstream Braindecode.

The earlier failing runner matrix was not bypassed or weakened. Its unlabeled-role failure led to the stronger labeled-target-only executor, exact observation-set SHA authority, and the separate adaptive-authority Issue #81.

## Scope audit

The branch is based on current production `main` (`5327914b65ba65a6be79fc1e24a1036cafb41cb4`) and changes exactly six intended files:

- one dedicated CI workflow;
- one runner design/evidence document;
- the runner core;
- the external reference factories;
- runner authority tests;
- external-baseline integration tests.

## Evidence boundary

Runner v1 establishes software split/data/metric/state authority and external-package interoperability. It does not establish model superiority, physiological validity, hardware qualification, online BCI efficacy, participant benefit, or clinical validity.

The next milestone is a real frozen Kumar2024 execution with canonical DatasetLineage authority and strong upstream baselines, not another abstraction.