### PR TITLE
NSQ: bind studies to environment, raw bytes, and observation identities

### DIFF
--- a/.github/workflows/nsq-kumar2024-ci.yml
+++ b/.github/workflows/nsq-kumar2024-ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py"
       - "packages/neuros/src/neuros/evidence/**"
       - "packages/neuros/pyproject.toml"
@@ -18,6 +20,8 @@ on:
     paths:
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py"
       - "packages/neuros/src/neuros/evidence/**"
       - "packages/neuros/pyproject.toml"
@@ -61,13 +65,21 @@ jobs:
         run: |
           pytest -q \
             tests/test_moabb_epoch_evidence.py \
+            tests/test_study_materialization_authority.py \
+            tests/test_moabb_materialization_authority.py \
+            tests/test_kumar2024_materialization_roles.py \
+            tests/test_kumar2024_bundle_v2.py \
             tests/test_kumar2024_nsq_study.py \
             tests/test_neural_system_qualification_runner.py
       - name: Compile evidence surface
         run: |
           python -m compileall -q \
             packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py \
-            packages/neuros/src/neuros/evidence/kumar2024.py
+            packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py \
+            packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py \
+            packages/neuros/src/neuros/evidence/kumar2024.py \
+            packages/neuros/src/neuros/evidence/kumar2024_materialization.py \
+            packages/neuros/src/neuros/evidence/kumar2024_materialized_study.py
 
   upstream-moabb-contract:
     name: Current MOABB processed-epoch contract

--- a/.github/workflows/nsq-kumar2024-study.yml
+++ b/.github/workflows/nsq-kumar2024-study.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/qualification_baselines.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
+      - "packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py"
+      - "packages/neuros/src/neuros/evidence/kumar2024_materialization.py"
+      - "packages/neuros/src/neuros/evidence/kumar2024_materialized_study.py"
       - "packages/neuros/src/neuros/evidence/kumar2024.py"
       - ".github/workflows/nsq-kumar2024-study.yml"
 
@@ -55,9 +59,21 @@ jobs:
           manifest = json.loads((root / "study_manifest.json").read_text())
           authorities = json.loads((root / "case_authorities.json").read_text())["authorities"]
           analysis = json.loads((root / "analysis.json").read_text())
+          materialization = json.loads((root / "materialization.json").read_text())
+          observation_roles = json.loads((root / "observation_roles.json").read_text())
+          artifact_hashes = json.loads((root / "artifact_hashes.json").read_text())
           rows = list(csv.DictReader((root / "results.csv").open()))
 
+          assert artifact_hashes["schema_version"] == 2
+          assert manifest["schema_version"] == 2
+          assert manifest["bundle_generation"] == 2
           assert manifest["git_revision"] == os.environ["GITHUB_SHA"]
+          assert len(manifest["study_materialization_sha256"]) == 64
+          assert manifest["study_materialization_sha256"] == materialization["study_materialization_sha256"]
+          assert manifest["raw_materialization_sha256"] == materialization["authority"]["raw_materialization_sha256"]
+          assert len(materialization["authority"]["processed_shards"]) == 2
+          assert observation_roles["study_materialization_sha256"] == manifest["study_materialization_sha256"]
+          assert observation_roles["entries"]
           assert manifest["config"]["methods"] == ["mne-csp-lda", "pyriemann-rg-lr"]
           assert len(authorities) == 10
           assert {item["seed"] for item in authorities} == {2026}

--- a/packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py
@@ -1,0 +1,717 @@
+"""Content-addressed study materialization authority for promoted NSQ evidence.
+
+This module answers a narrower question than model qualification itself:
+
+    *what exact study materialization did this result come from?*
+
+A promoted study should be able to bind the realized software environment, the
+raw files actually consumed by the data loader, the ordered human-readable
+identity of every processed observation, and the processed/preprocessing
+contract without depending on machine-local cache roots or volatile host state.
+
+The authority objects here deliberately contain no target labels. Observation
+identity is evidence metadata, not a side channel through which a model may learn
+anything about untouched final-assessment outcomes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import platform
+import re
+from dataclasses import dataclass
+from numbers import Integral
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+
+from .real_world import GroupedEvaluationData
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_DIST_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+
+def _canonical_sha256(schema: str, payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        {"schema": schema, "payload": payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _nonempty(name: str, value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{name} must be non-empty")
+    return text
+
+
+def _sha256(name: str, value: Any) -> str:
+    text = _nonempty(name, value).lower()
+    if _SHA256_RE.fullmatch(text) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return text
+
+
+def _exact_nonnegative_int(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral) or int(value) < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return int(value)
+
+
+def _processed_observation_sha256(value: Any) -> str:
+    array = np.asarray(value)
+    if not np.issubdtype(array.dtype, np.number):
+        raise ValueError("processed observation must be numeric")
+    if not np.isfinite(array).all():
+        raise ValueError("processed observation must contain only finite values")
+    contiguous = np.ascontiguousarray(array)
+    payload = {
+        "dtype": contiguous.dtype.str,
+        "shape": list(contiguous.shape),
+        "bytes_sha256": hashlib.sha256(contiguous.tobytes(order="C")).hexdigest(),
+    }
+    return _canonical_sha256("neuros.processed_observation.v1", payload)
+
+
+def _normalized_distribution_name(value: Any) -> str:
+    return _DIST_NORMALIZE_RE.sub("-", _nonempty("distribution name", value)).lower()
+
+
+def _string_pairs(name: str, values: Mapping[str, Any] | Iterable[tuple[Any, Any]]) -> tuple[tuple[str, str], ...]:
+    items = values.items() if isinstance(values, Mapping) else values
+    normalized: dict[str, str] = {}
+    for raw_key, raw_value in items:
+        key = _nonempty(f"{name} key", raw_key)
+        value = _nonempty(f"{name}[{key}]", raw_value)
+        if key in normalized and normalized[key] != value:
+            raise ValueError(f"{name} contains conflicting values for {key!r}")
+        normalized[key] = value
+    return tuple(sorted(normalized.items()))
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDistribution:
+    """One exact installed Python distribution identity."""
+
+    name: str
+    version: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("EnvironmentDistribution schema_version must be 1")
+        object.__setattr__(self, "name", _normalized_distribution_name(self.name))
+        object.__setattr__(self, "version", _nonempty("distribution version", self.version))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "name": self.name,
+            "version": self.version,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentAuthority:
+    """Canonical realized execution environment without volatile host noise.
+
+    Hostname, timestamps, process IDs, temporary paths, runner IDs, free memory,
+    and similar telemetry are intentionally absent. They may be logged elsewhere,
+    but they are not reproducibility authority.
+    """
+
+    python_implementation: str
+    python_version: str
+    platform_system: str
+    platform_machine: str
+    distributions: tuple[EnvironmentDistribution, ...]
+    source_revision: str | None = None
+    accelerator_runtime: tuple[tuple[str, str], ...] = ()
+    deterministic_flags: tuple[tuple[str, str], ...] = ()
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("EnvironmentAuthority schema_version must be 1")
+        implementation = _nonempty("python_implementation", self.python_implementation)
+        python_version = _nonempty("python_version", self.python_version)
+        system = _nonempty("platform_system", self.platform_system)
+        machine = _nonempty("platform_machine", self.platform_machine)
+        distributions = tuple(
+            sorted(self.distributions, key=lambda item: (item.name, item.version))
+        )
+        if not distributions:
+            raise ValueError("environment authority requires at least one distribution")
+        if any(not isinstance(item, EnvironmentDistribution) for item in distributions):
+            raise TypeError("distributions must contain EnvironmentDistribution objects")
+        names = [item.name for item in distributions]
+        if len(set(names)) != len(names):
+            raise ValueError("environment authority cannot contain duplicate distribution names")
+        revision = None
+        if self.source_revision is not None:
+            revision = _nonempty("source_revision", self.source_revision)
+        object.__setattr__(self, "python_implementation", implementation)
+        object.__setattr__(self, "python_version", python_version)
+        object.__setattr__(self, "platform_system", system)
+        object.__setattr__(self, "platform_machine", machine)
+        object.__setattr__(self, "distributions", distributions)
+        object.__setattr__(self, "source_revision", revision)
+        object.__setattr__(
+            self,
+            "accelerator_runtime",
+            _string_pairs("accelerator_runtime", self.accelerator_runtime),
+        )
+        object.__setattr__(
+            self,
+            "deterministic_flags",
+            _string_pairs("deterministic_flags", self.deterministic_flags),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "python": {
+                "implementation": self.python_implementation,
+                "version": self.python_version,
+            },
+            "platform": {
+                "system": self.platform_system,
+                "machine": self.platform_machine,
+            },
+            "distributions": [item.to_dict() for item in self.distributions],
+            "source_revision": self.source_revision,
+            "accelerator_runtime": dict(self.accelerator_runtime),
+            "deterministic_flags": dict(self.deterministic_flags),
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.environment_authority.v1", self.to_dict())
+
+
+def capture_environment_authority(
+    *,
+    distribution_names: Sequence[str] | None = None,
+    source_revision: str | None = None,
+    accelerator_runtime: Mapping[str, Any] | Iterable[tuple[Any, Any]] = (),
+    deterministic_flags: Mapping[str, Any] | Iterable[tuple[Any, Any]] = (),
+) -> EnvironmentAuthority:
+    """Capture a canonical Python environment authority.
+
+    When ``distribution_names`` is ``None`` every installed Python distribution
+    is captured. Promoted studies should execute in a purpose-built environment
+    so this complete realized set is scientifically meaningful rather than a
+    random workstation's package collection. A caller may provide an explicit
+    distribution set for narrower integration evidence.
+    """
+
+    distributions: list[EnvironmentDistribution] = []
+    if distribution_names is None:
+        seen: dict[str, str] = {}
+        for distribution in importlib.metadata.distributions():
+            raw_name = distribution.metadata.get("Name")
+            if raw_name is None:
+                continue
+            name = _normalized_distribution_name(raw_name)
+            version = _nonempty(f"distribution version for {name}", distribution.version)
+            previous = seen.get(name)
+            if previous is not None and previous != version:
+                raise RuntimeError(
+                    f"environment exposes conflicting installed versions for {name!r}: "
+                    f"{previous!r} versus {version!r}"
+                )
+            seen[name] = version
+        distributions = [
+            EnvironmentDistribution(name=name, version=version)
+            for name, version in sorted(seen.items())
+        ]
+    else:
+        requested = sorted({_normalized_distribution_name(name) for name in distribution_names})
+        for name in requested:
+            try:
+                version = importlib.metadata.version(name)
+            except importlib.metadata.PackageNotFoundError as exc:
+                raise ValueError(
+                    f"requested environment distribution {name!r} is not installed"
+                ) from exc
+            distributions.append(EnvironmentDistribution(name=name, version=version))
+
+    return EnvironmentAuthority(
+        python_implementation=platform.python_implementation(),
+        python_version=platform.python_version(),
+        platform_system=platform.system(),
+        platform_machine=platform.machine(),
+        distributions=tuple(distributions),
+        source_revision=source_revision,
+        accelerator_runtime=_string_pairs("accelerator_runtime", accelerator_runtime),
+        deterministic_flags=_string_pairs("deterministic_flags", deterministic_flags),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RawMaterializationFile:
+    """Path-independent identity of one raw file consumed by a study loader."""
+
+    logical_path: str
+    size_bytes: int
+    sha256: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("RawMaterializationFile schema_version must be 1")
+        path = PurePosixPath(_nonempty("logical_path", self.logical_path))
+        if path.is_absolute() or ".." in path.parts or "." in path.parts:
+            raise ValueError("logical_path must be a canonical dataset-relative path")
+        normalized = path.as_posix()
+        object.__setattr__(self, "logical_path", normalized)
+        object.__setattr__(self, "size_bytes", _exact_nonnegative_int("size_bytes", self.size_bytes))
+        object.__setattr__(self, "sha256", _sha256("raw file sha256", self.sha256))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "logical_path": self.logical_path,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RawMaterializationAuthority:
+    """Exact byte identity of the raw files materialized for one logical dataset."""
+
+    dataset_id: str
+    files: tuple[RawMaterializationFile, ...]
+    upstream_identity: tuple[tuple[str, str], ...] = ()
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("RawMaterializationAuthority schema_version must be 1")
+        dataset_id = _nonempty("dataset_id", self.dataset_id)
+        files = tuple(sorted(self.files, key=lambda item: item.logical_path))
+        if not files:
+            raise ValueError("raw materialization authority requires at least one file")
+        if any(not isinstance(item, RawMaterializationFile) for item in files):
+            raise TypeError("files must contain RawMaterializationFile objects")
+        logical_paths = [item.logical_path for item in files]
+        if len(set(logical_paths)) != len(logical_paths):
+            raise ValueError("raw materialization cannot contain duplicate logical paths")
+        object.__setattr__(self, "dataset_id", dataset_id)
+        object.__setattr__(self, "files", files)
+        object.__setattr__(
+            self,
+            "upstream_identity",
+            _string_pairs("upstream_identity", self.upstream_identity),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "upstream_identity": dict(self.upstream_identity),
+            "files": [item.to_dict() for item in self.files],
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.raw_materialization_authority.v1", self.to_dict())
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while True:
+            chunk = stream.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def hash_raw_materialization(
+    *,
+    dataset_id: str,
+    root: str | Path,
+    relative_paths: Sequence[str | Path],
+    upstream_identity: Mapping[str, Any] | Iterable[tuple[Any, Any]] = (),
+) -> RawMaterializationAuthority:
+    """Hash consumed raw files without binding a machine-local cache root."""
+
+    base = Path(root).expanduser().resolve()
+    if not base.is_dir():
+        raise ValueError("raw materialization root must be an existing directory")
+    if not relative_paths:
+        raise ValueError("relative_paths must name at least one consumed raw file")
+
+    files: list[RawMaterializationFile] = []
+    seen: set[str] = set()
+    for raw_relative in relative_paths:
+        logical = PurePosixPath(str(raw_relative).replace("\\", "/"))
+        if logical.is_absolute() or ".." in logical.parts or "." in logical.parts:
+            raise ValueError("raw paths must be canonical paths relative to root")
+        logical_text = logical.as_posix()
+        if logical_text in seen:
+            raise ValueError(f"duplicate raw logical path {logical_text!r}")
+        seen.add(logical_text)
+        resolved = (base / Path(*logical.parts)).resolve()
+        try:
+            resolved.relative_to(base)
+        except ValueError as exc:
+            raise ValueError(
+                f"raw materialization path escapes declared root: {logical_text!r}"
+            ) from exc
+        if not resolved.is_file():
+            raise ValueError(f"raw materialization file does not exist: {logical_text!r}")
+        files.append(
+            RawMaterializationFile(
+                logical_path=logical_text,
+                size_bytes=resolved.stat().st_size,
+                sha256=_file_sha256(resolved),
+            )
+        )
+
+    return RawMaterializationAuthority(
+        dataset_id=dataset_id,
+        files=tuple(files),
+        upstream_identity=_string_pairs("upstream_identity", upstream_identity),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationIdentity:
+    """Human-auditable identity for one processed observation, excluding labels."""
+
+    row_index: int
+    participant: str
+    session: str
+    run: str | None
+    local_epoch: int
+    processed_observation_sha256: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("ObservationIdentity schema_version must be 1")
+        object.__setattr__(self, "row_index", _exact_nonnegative_int("row_index", self.row_index))
+        object.__setattr__(self, "participant", _nonempty("participant", self.participant))
+        object.__setattr__(self, "session", _nonempty("session", self.session))
+        run = None if self.run is None else _nonempty("run", self.run)
+        object.__setattr__(self, "run", run)
+        object.__setattr__(self, "local_epoch", _exact_nonnegative_int("local_epoch", self.local_epoch))
+        object.__setattr__(
+            self,
+            "processed_observation_sha256",
+            _sha256("processed_observation_sha256", self.processed_observation_sha256),
+        )
+
+    @property
+    def display_id(self) -> str:
+        run = "<none>" if self.run is None else self.run
+        return (
+            f"participant={self.participant}/session={self.session}/"
+            f"run={run}/epoch={self.local_epoch}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "row_index": self.row_index,
+            "participant": self.participant,
+            "session": self.session,
+            "run": self.run,
+            "local_epoch": self.local_epoch,
+            "processed_observation_sha256": self.processed_observation_sha256,
+            "display_id": self.display_id,
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.observation_identity.v1", self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationIdentityAuthority:
+    """Ordered identity manifest for every processed observation in a study array."""
+
+    dataset_id: str
+    observations: tuple[ObservationIdentity, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("ObservationIdentityAuthority schema_version must be 1")
+        dataset_id = _nonempty("dataset_id", self.dataset_id)
+        observations = tuple(self.observations)
+        if not observations:
+            raise ValueError("observation identity authority cannot be empty")
+        if any(not isinstance(item, ObservationIdentity) for item in observations):
+            raise TypeError("observations must contain ObservationIdentity objects")
+        for expected, observation in enumerate(observations):
+            if observation.row_index != expected:
+                raise ValueError(
+                    "observation row_index must exactly match processed array order"
+                )
+        semantic = [
+            (item.participant, item.session, item.run, item.local_epoch)
+            for item in observations
+        ]
+        if len(set(semantic)) != len(semantic):
+            raise ValueError("observation identities are ambiguous or duplicated")
+        object.__setattr__(self, "dataset_id", dataset_id)
+        object.__setattr__(self, "observations", observations)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "observations": [item.to_dict() for item in self.observations],
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.observation_identity_authority.v1", self.to_dict())
+
+    def role(self, role: str, row_indices: Sequence[int]) -> "ObservationRoleAuthority":
+        indices = tuple(_exact_nonnegative_int("row index", value) for value in row_indices)
+        if len(set(indices)) != len(indices):
+            raise ValueError("observation role cannot contain duplicate row indices")
+        if any(index >= len(self.observations) for index in indices):
+            raise ValueError("observation role row index exceeds identity authority")
+        selected = tuple(self.observations[index] for index in indices)
+        return ObservationRoleAuthority(
+            dataset_id=self.dataset_id,
+            observation_identity_authority_sha256=self.sha256,
+            role=role,
+            row_indices=indices,
+            observation_sha256s=tuple(item.sha256 for item in selected),
+            display_ids=tuple(item.display_id for item in selected),
+        )
+
+
+def observation_identities_from_grouped_data(
+    data: GroupedEvaluationData,
+) -> ObservationIdentityAuthority:
+    """Derive deterministic MOABB-style identities from grouped processed rows.
+
+    Local epoch ordinals are counted within participant/session/run in processed
+    row order. Labels are deliberately not read or serialized.
+    """
+
+    if not isinstance(data, GroupedEvaluationData):
+        raise TypeError("data must be GroupedEvaluationData")
+    groups = data.groups
+    if "subject" not in groups or "session" not in groups:
+        raise ValueError(
+            "human observation identity requires subject and session groups"
+        )
+    participant = groups["subject"]
+    session = groups["session"]
+    run_values = groups.get("run")
+    counters: dict[tuple[str, str, str | None], int] = {}
+    observations: list[ObservationIdentity] = []
+    for row_index in range(len(data.X)):
+        participant_id = str(participant[row_index])
+        session_id = str(session[row_index])
+        run_id = None if run_values is None else str(run_values[row_index])
+        key = (participant_id, session_id, run_id)
+        local_epoch = counters.get(key, 0)
+        counters[key] = local_epoch + 1
+        observations.append(
+            ObservationIdentity(
+                row_index=row_index,
+                participant=participant_id,
+                session=session_id,
+                run=run_id,
+                local_epoch=local_epoch,
+                processed_observation_sha256=_processed_observation_sha256(
+                    data.X[row_index]
+                ),
+            )
+        )
+    return ObservationIdentityAuthority(
+        dataset_id=data.dataset_id,
+        observations=tuple(observations),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationRoleAuthority:
+    """Inspectable role membership for one exact ordered subset of observations."""
+
+    dataset_id: str
+    observation_identity_authority_sha256: str
+    role: str
+    row_indices: tuple[int, ...]
+    observation_sha256s: tuple[str, ...]
+    display_ids: tuple[str, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("ObservationRoleAuthority schema_version must be 1")
+        object.__setattr__(self, "dataset_id", _nonempty("dataset_id", self.dataset_id))
+        object.__setattr__(
+            self,
+            "observation_identity_authority_sha256",
+            _sha256(
+                "observation_identity_authority_sha256",
+                self.observation_identity_authority_sha256,
+            ),
+        )
+        object.__setattr__(self, "role", _nonempty("role", self.role))
+        indices = tuple(_exact_nonnegative_int("row index", value) for value in self.row_indices)
+        hashes = tuple(_sha256("observation sha256", value) for value in self.observation_sha256s)
+        display = tuple(_nonempty("display_id", value) for value in self.display_ids)
+        if len(set(indices)) != len(indices):
+            raise ValueError("observation role authority cannot duplicate rows")
+        if not (len(indices) == len(hashes) == len(display)):
+            raise ValueError("observation role fields must have identical lengths")
+        object.__setattr__(self, "row_indices", indices)
+        object.__setattr__(self, "observation_sha256s", hashes)
+        object.__setattr__(self, "display_ids", display)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "observation_identity_authority_sha256": self.observation_identity_authority_sha256,
+            "role": self.role,
+            "row_indices": list(self.row_indices),
+            "observation_sha256s": list(self.observation_sha256s),
+            "display_ids": list(self.display_ids),
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.observation_role_authority.v1", self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessedMaterializationShard:
+    """One independently loaded processed shard within a materialized study.
+
+    Longitudinal EEG studies are commonly loaded participant-by-participant.
+    Preserving that native boundary avoids manufacturing global row offsets and
+    keeps case-local NSQ indices directly compatible with the evidence manifest.
+    """
+
+    shard_id: str
+    processed_data_sha256: str
+    observation_identity: ObservationIdentityAuthority
+    preprocessing_authority_sha256s: tuple[str, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("ProcessedMaterializationShard schema_version must be 1")
+        object.__setattr__(self, "shard_id", _nonempty("shard_id", self.shard_id))
+        object.__setattr__(
+            self,
+            "processed_data_sha256",
+            _sha256("processed_data_sha256", self.processed_data_sha256),
+        )
+        if not isinstance(self.observation_identity, ObservationIdentityAuthority):
+            raise TypeError("observation_identity must be ObservationIdentityAuthority")
+        preprocessing = tuple(
+            _sha256("preprocessing authority sha256", value)
+            for value in self.preprocessing_authority_sha256s
+        )
+        if not preprocessing:
+            raise ValueError("processed shard requires preprocessing authority")
+        if len(set(preprocessing)) != len(preprocessing):
+            raise ValueError("preprocessing authorities cannot contain duplicates")
+        object.__setattr__(self, "preprocessing_authority_sha256s", preprocessing)
+
+    @property
+    def dataset_id(self) -> str:
+        return self.observation_identity.dataset_id
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "shard_id": self.shard_id,
+            "processed_data_sha256": self.processed_data_sha256,
+            "preprocessing_authority_sha256s": list(
+                self.preprocessing_authority_sha256s
+            ),
+            "observation_identity": self.observation_identity.to_dict(),
+            "observation_identity_sha256": self.observation_identity.sha256,
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.processed_materialization_shard.v1", self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class StudyMaterializationAuthority:
+    """Strict composed identity of one realized, potentially sharded study."""
+
+    environment: EnvironmentAuthority
+    raw_materialization: RawMaterializationAuthority
+    processed_shards: tuple[ProcessedMaterializationShard, ...]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("StudyMaterializationAuthority schema_version must be 1")
+        if not isinstance(self.environment, EnvironmentAuthority):
+            raise TypeError("environment must be EnvironmentAuthority")
+        if not isinstance(self.raw_materialization, RawMaterializationAuthority):
+            raise TypeError("raw_materialization must be RawMaterializationAuthority")
+        shards = tuple(sorted(self.processed_shards, key=lambda item: item.shard_id))
+        if not shards:
+            raise ValueError("study materialization requires at least one processed shard")
+        if any(not isinstance(item, ProcessedMaterializationShard) for item in shards):
+            raise TypeError("processed_shards must contain ProcessedMaterializationShard objects")
+        shard_ids = [item.shard_id for item in shards]
+        if len(set(shard_ids)) != len(shard_ids):
+            raise ValueError("processed study shards must have unique shard_id values")
+        if any(item.dataset_id != self.raw_materialization.dataset_id for item in shards):
+            raise ValueError("raw and processed shard authorities must describe one dataset_id")
+        object.__setattr__(self, "processed_shards", shards)
+
+    @property
+    def dataset_id(self) -> str:
+        return self.raw_materialization.dataset_id
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "dataset_id": self.dataset_id,
+            "environment": self.environment.to_dict(),
+            "environment_sha256": self.environment.sha256,
+            "raw_materialization": self.raw_materialization.to_dict(),
+            "raw_materialization_sha256": self.raw_materialization.sha256,
+            "processed_shards": [item.to_dict() for item in self.processed_shards],
+            "processed_shard_sha256s": [item.sha256 for item in self.processed_shards],
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _canonical_sha256("neuros.study_materialization_authority.v1", self.to_dict())
+
+
+__all__ = [
+    "EnvironmentAuthority",
+    "EnvironmentDistribution",
+    "ObservationIdentity",
+    "ObservationIdentityAuthority",
+    "ObservationRoleAuthority",
+    "ProcessedMaterializationShard",
+    "RawMaterializationAuthority",
+    "RawMaterializationFile",
+    "StudyMaterializationAuthority",
+    "capture_environment_authority",
+    "hash_raw_materialization",
+    "observation_identities_from_grouped_data",
+]

--- a/packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py
+++ b/packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py
@@ -1,0 +1,319 @@
+"""Raw-file selection authority for MOABB evidence datasets.
+
+MOABB datasets frequently download archives containing more material than a
+particular dataset adapter actually exposes. Qualification must hash the files
+that the installed loader consumes, not every byte that happens to share its
+cache directory.
+
+The Kumar2024 resolver below intentionally follows the installed MOABB
+``Kumar2024`` adapter's own directory-resolution helpers and its documented
+``*.gdf``/``*.GDF`` run selection. If that upstream contract changes, promoted
+evidence fails closed until this adapter is reviewed against the new loader.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from .materialization_authority import (
+    RawMaterializationAuthority,
+    hash_raw_materialization,
+)
+
+KUMAR2024_EXPECTED_RUNS = {
+    "0": 4,
+    "1": 4,
+    "2": 3,
+    "3": 3,
+    "4": 3,
+    "5": 3,
+}
+KUMAR2024_PAPER_DOI = "10.1093/pnasnexus/pgae076"
+KUMAR2024_DATA_DOI = "10.5281/zenodo.10694880"
+KUMAR2024_ZENODO_RECORD = "https://zenodo.org/records/10694880"
+
+
+def _nonempty(name: str, value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{name} must be non-empty")
+    return text
+
+
+def _gdf_files(session_dir: Path) -> tuple[Path, ...]:
+    files = tuple(sorted(session_dir.glob("*.gdf")))
+    if not files:
+        files = tuple(sorted(session_dir.glob("*.GDF")))
+    return files
+
+
+@dataclass(frozen=True, slots=True)
+class MOABBRawRunSelection:
+    """One raw run selected by an installed MOABB dataset adapter."""
+
+    subject: int
+    raw_subject: int
+    original_protocol: str
+    session: str
+    run: str
+    logical_path: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("MOABBRawRunSelection schema_version must be 1")
+        if isinstance(self.subject, bool) or not isinstance(self.subject, int):
+            raise ValueError("subject must be an integer")
+        if isinstance(self.raw_subject, bool) or not isinstance(self.raw_subject, int):
+            raise ValueError("raw_subject must be an integer")
+        if not 1 <= self.subject <= 18:
+            raise ValueError("Kumar2024 subject must lie in 1..18")
+        if self.raw_subject <= 0:
+            raise ValueError("raw_subject must be positive")
+        protocol = _nonempty("original_protocol", self.original_protocol)
+        if protocol not in {"GR", "PAR"}:
+            raise ValueError("original_protocol must be GR or PAR")
+        session = _nonempty("session", self.session)
+        if session not in KUMAR2024_EXPECTED_RUNS:
+            raise ValueError("unexpected Kumar2024 session")
+        run = _nonempty("run", self.run)
+        logical_path = _nonempty("logical_path", self.logical_path).replace("\\", "/")
+        if logical_path.startswith("/") or "/../" in f"/{logical_path}/":
+            raise ValueError("logical_path must be dataset-relative")
+        object.__setattr__(self, "original_protocol", protocol)
+        object.__setattr__(self, "session", session)
+        object.__setattr__(self, "run", run)
+        object.__setattr__(self, "logical_path", logical_path)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "subject": self.subject,
+            "raw_subject": self.raw_subject,
+            "original_protocol": self.original_protocol,
+            "session": self.session,
+            "run": self.run,
+            "logical_path": self.logical_path,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MOABBRawMaterializationEvidence:
+    """Byte authority plus the subject/session/run paths that produced it."""
+
+    authority: RawMaterializationAuthority
+    selections: tuple[MOABBRawRunSelection, ...]
+    loader_contract: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.schema_version, bool) or self.schema_version != 1:
+            raise ValueError("MOABBRawMaterializationEvidence schema_version must be 1")
+        if not isinstance(self.authority, RawMaterializationAuthority):
+            raise TypeError("authority must be RawMaterializationAuthority")
+        selections = tuple(self.selections)
+        if not selections:
+            raise ValueError("raw materialization evidence requires selected runs")
+        if any(not isinstance(item, MOABBRawRunSelection) for item in selections):
+            raise TypeError("selections must contain MOABBRawRunSelection objects")
+        logical_paths = [item.logical_path for item in selections]
+        if len(set(logical_paths)) != len(logical_paths):
+            raise ValueError("raw run selections cannot duplicate logical paths")
+        authority_paths = [item.logical_path for item in self.authority.files]
+        if sorted(logical_paths) != sorted(authority_paths):
+            raise ValueError("raw authority files differ from selected MOABB runs")
+        object.__setattr__(self, "selections", selections)
+        object.__setattr__(self, "loader_contract", _nonempty("loader_contract", self.loader_contract))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "loader_contract": self.loader_contract,
+            "raw_materialization_sha256": self.authority.sha256,
+            "authority": self.authority.to_dict(),
+            "selections": [item.to_dict() for item in self.selections],
+        }
+
+
+def _require_kumar2024_loader_contract(dataset: Any) -> None:
+    if dataset.__class__.__name__ != "Kumar2024":
+        raise TypeError("Kumar2024 raw materialization requires a Kumar2024 dataset instance")
+    for name in (
+        "data_path",
+        "_MOABB_TO_RAW",
+        "_find_online_subject_dir",
+        "_find_session_subdir",
+    ):
+        if not hasattr(dataset, name):
+            raise RuntimeError(
+                f"installed MOABB Kumar2024 no longer exposes required loader contract {name!r}"
+            )
+
+
+def _session_files_or_fail(
+    session_dir: Path | None,
+    *,
+    subject: int,
+    session: str,
+) -> tuple[Path, ...]:
+    if session_dir is None or not session_dir.is_dir():
+        raise FileNotFoundError(
+            f"Kumar2024 raw session directory is missing for subject={subject}, session={session}"
+        )
+    files = _gdf_files(session_dir)
+    if not files:
+        raise FileNotFoundError(
+            f"Kumar2024 raw GDF runs are missing for subject={subject}, session={session}"
+        )
+    expected = KUMAR2024_EXPECTED_RUNS[session]
+    if len(files) != expected:
+        raise RuntimeError(
+            "Kumar2024 raw run count differs from frozen bar-feedback contract: "
+            f"subject={subject}, session={session}, expected={expected}, observed={len(files)}"
+        )
+    return files
+
+
+def resolve_kumar2024_raw_materialization(
+    dataset: Any,
+    *,
+    subjects: Sequence[int],
+) -> MOABBRawMaterializationEvidence:
+    """Resolve and hash exactly the GDF files consumed by MOABB Kumar2024.
+
+    The installed dataset adapter downloads a single archive containing Offline,
+    Online, and Race material. Its `_get_single_subject_data` path, however,
+    exposes only bar-feedback GDF files under Offline/ and Online/. This function
+    mirrors that exact selection and never includes Race files in the scientific
+    raw-input authority.
+    """
+
+    _require_kumar2024_loader_contract(dataset)
+    normalized_subjects = tuple(int(subject) for subject in subjects)
+    if not normalized_subjects or len(set(normalized_subjects)) != len(normalized_subjects):
+        raise ValueError("subjects must be non-empty and unique")
+    if any(subject not in range(1, 19) for subject in normalized_subjects):
+        raise ValueError("Kumar2024 subjects must lie in 1..18")
+
+    roots: list[Path] = []
+    selections: list[MOABBRawRunSelection] = []
+    mapping = dataset._MOABB_TO_RAW
+
+    for subject in normalized_subjects:
+        try:
+            raw_subject = int(mapping[subject])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"installed Kumar2024 raw subject mapping is unavailable for subject {subject}"
+            ) from exc
+        root = Path(dataset.data_path(subject)).expanduser().resolve()
+        if not root.is_dir():
+            raise FileNotFoundError(
+                f"Kumar2024 data_path did not return an extracted directory for subject {subject}"
+            )
+        roots.append(root)
+        protocol = "GR" if raw_subject <= 9 else "PAR"
+
+        offline_subject = root / "Offline" / protocol / f"Subject_{raw_subject:02d}_Offline"
+        offline_session = dataset._find_session_subdir(
+            offline_subject, raw_subject, 1, "Offline"
+        )
+        session_files: list[tuple[str, tuple[Path, ...]]] = [
+            (
+                "0",
+                _session_files_or_fail(
+                    offline_session,
+                    subject=subject,
+                    session="0",
+                ),
+            )
+        ]
+
+        online_subject = dataset._find_online_subject_dir(
+            root / "Online" / protocol,
+            raw_subject,
+        )
+        if online_subject is None or not Path(online_subject).is_dir():
+            raise FileNotFoundError(
+                f"Kumar2024 online subject directory is missing for subject {subject}"
+            )
+        for session_number in range(2, 7):
+            moabb_session = str(session_number - 1)
+            session_dir = dataset._find_session_subdir(
+                Path(online_subject), raw_subject, session_number, "Online"
+            )
+            session_files.append(
+                (
+                    moabb_session,
+                    _session_files_or_fail(
+                        session_dir,
+                        subject=subject,
+                        session=moabb_session,
+                    ),
+                )
+            )
+
+        for moabb_session, files in session_files:
+            for run_index, path in enumerate(files):
+                resolved = path.resolve()
+                try:
+                    logical = resolved.relative_to(root).as_posix()
+                except ValueError as exc:
+                    raise RuntimeError(
+                        "Kumar2024 loader selected a GDF outside its declared extracted root"
+                    ) from exc
+                selections.append(
+                    MOABBRawRunSelection(
+                        subject=subject,
+                        raw_subject=raw_subject,
+                        original_protocol=protocol,
+                        session=moabb_session,
+                        run=str(run_index),
+                        logical_path=logical,
+                    )
+                )
+
+    first_root = roots[0]
+    if any(root != first_root for root in roots[1:]):
+        raise RuntimeError(
+            "Kumar2024 subjects resolved to different extracted roots; "
+            "promoted raw materialization requires one canonical archive materialization"
+        )
+
+    try:
+        moabb_version = importlib.metadata.version("moabb")
+    except importlib.metadata.PackageNotFoundError:
+        moabb_version = "unknown"
+    authority = hash_raw_materialization(
+        dataset_id="moabb-kumar2024",
+        root=first_root,
+        relative_paths=tuple(item.logical_path for item in selections),
+        upstream_identity={
+            "dataset_class": "moabb.datasets.Kumar2024",
+            "moabb_version": moabb_version,
+            "paper_doi": KUMAR2024_PAPER_DOI,
+            "data_doi": KUMAR2024_DATA_DOI,
+            "repository": KUMAR2024_ZENODO_RECORD,
+            "included_task": "bar_feedback_only",
+            "excluded_task": "car_racing",
+        },
+    )
+    return MOABBRawMaterializationEvidence(
+        authority=authority,
+        selections=tuple(selections),
+        loader_contract=(
+            "Kumar2024.data_path + _MOABB_TO_RAW + _find_online_subject_dir + "
+            "_find_session_subdir + sorted *.gdf fallback *.GDF"
+        ),
+    )
+
+
+__all__ = [
+    "KUMAR2024_EXPECTED_RUNS",
+    "MOABBRawMaterializationEvidence",
+    "MOABBRawRunSelection",
+    "resolve_kumar2024_raw_materialization",
+]

--- a/packages/neuros/src/neuros/evidence/kumar2024.py
+++ b/packages/neuros/src/neuros/evidence/kumar2024.py
@@ -384,6 +384,7 @@ def build_dataset_lineage(
     config: Kumar2024StudyConfig,
     preprocessing_authority: Mapping[str, Any],
     versions: Mapping[str, str | None],
+    raw_materialization_sha256: str | None = None,
 ):
     """Construct honest partial lineage for the actual requested study corpus."""
 
@@ -455,8 +456,18 @@ def build_dataset_lineage(
             "requested_subjects": list(config.subjects),
             "expected_session_order": list(KUMAR2024_EXPECTED_SESSIONS),
             "not_a_reproduction_of_original_online_intervention": True,
+            "raw_materialization_sha256": raw_materialization_sha256,
+            "raw_materialization_scope": (
+                None
+                if raw_materialization_sha256 is None
+                else "exact consumed bar-feedback GDF files under MOABB loader authority"
+            ),
             "content_sha256_reason": (
-                "exact downloaded raw corpus bytes have not been hashed under a canonical rule"
+                "exact consumed raw bytes are bound by raw_materialization_sha256, but "
+                "DatasetLineage.content_sha256 remains unset because that composed "
+                "consumed-file authority is not a canonical upstream archive digest"
+                if raw_materialization_sha256 is not None
+                else "exact downloaded raw corpus bytes have not been hashed under a canonical rule"
             ),
         },
     )
@@ -1008,7 +1019,15 @@ def _render_report(
 def _prepare_output(output: Path, *, overwrite: bool) -> Path:
     output = output.resolve()
     output.mkdir(parents=True, exist_ok=True)
-    managed = [output / name for name in (*_BUNDLE_FILES, "artifact_hashes.json")]
+    managed = [
+        output / name
+        for name in (
+            *_BUNDLE_FILES,
+            "materialization.json",
+            "observation_roles.json",
+            "artifact_hashes.json",
+        )
+    ]
     existing = [path for path in managed if path.exists()]
     if existing and not overwrite:
         raise FileExistsError(
@@ -1036,6 +1055,10 @@ def verify_bundle(output: str | Path) -> dict[str, Any]:
     root = Path(output).resolve()
     manifest_path = root / "artifact_hashes.json"
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") == 2:
+        from neuros.evidence.kumar2024_materialized_study import verify_bundle_v2
+
+        return verify_bundle_v2(root, payload=payload)
     if payload.get("schema_version") != 1 or not isinstance(payload.get("files"), dict):
         raise ValueError("invalid Kumar2024 artifact hash manifest")
     actual: dict[str, str] = {}
@@ -1059,7 +1082,7 @@ def verify_bundle(output: str | Path) -> dict[str, Any]:
     }
 
 
-def run_study(
+def _run_study_v1(
     output: str | Path,
     *,
     config: Kumar2024StudyConfig | None = None,
@@ -1282,6 +1305,25 @@ def run_study(
         "verified": verified["verified"],
         "output": str(output_path),
     }
+
+
+def run_study(
+    output: str | Path,
+    *,
+    config: Kumar2024StudyConfig | None = None,
+    preprocessing: Kumar2024PreprocessingSpec | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Execute the materialization-aware generation-v2 Kumar2024 bundle."""
+
+    from neuros.evidence.kumar2024_materialized_study import run_materialized_study
+
+    return run_materialized_study(
+        output,
+        config=config,
+        preprocessing=preprocessing,
+        overwrite=overwrite,
+    )
 
 
 def _parse_ints(value: str) -> tuple[int, ...]:

--- a/packages/neuros/src/neuros/evidence/kumar2024_materialization.py
+++ b/packages/neuros/src/neuros/evidence/kumar2024_materialization.py
@@ -1,0 +1,306 @@
+"""Kumar2024 composition helpers for NSQ study materialization authority.
+
+The generic authority types live in ``neuros-foundation``. This module is the
+study-specific bridge that turns a processed participant shard and a frozen
+longitudinal case into reviewer-facing observation-role evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from neuros.foundation_models.longitudinal_authority import (
+    LongitudinalCaseAuthority,
+    processed_data_sha256,
+)
+from neuros.foundation_models.materialization_authority import (
+    ObservationIdentityAuthority,
+    ProcessedMaterializationShard,
+    StudyMaterializationAuthority,
+    observation_identities_from_grouped_data,
+)
+from neuros.foundation_models.qualification_runner import QualificationCaseResult
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+
+def _identity_sha256(schema: str, payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        {"schema": schema, "payload": payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def qualification_observation_set_sha256(
+    role: str,
+    processed_sha256: str,
+    indices: Sequence[int] | np.ndarray,
+) -> str:
+    """Recompute the public NSQ observation-set identity used by result rows."""
+
+    values = np.asarray(indices)
+    if values.ndim != 1 or values.dtype == np.bool_:
+        raise ValueError(f"{role} indices must be a one-dimensional integer sequence")
+    integer = values.astype(np.int64)
+    if not np.array_equal(values, integer):
+        raise ValueError(f"{role} indices must be integers without coercion")
+    return _identity_sha256(
+        "neuros.qualification_observation_set.v1",
+        {
+            "role": str(role),
+            "processed_data_sha256": str(processed_sha256),
+            "indices": [int(value) for value in integer.tolist()],
+        },
+    )
+
+
+def build_processed_subject_shard(
+    data: GroupedEvaluationData,
+    *,
+    subject: int,
+    preprocessing_authority_sha256: str,
+) -> ProcessedMaterializationShard:
+    """Build the immutable processed participant shard used by later cases."""
+
+    if "subject" not in data.groups:
+        raise ValueError("Kumar2024 processed shard requires subject group identity")
+    observed = set(np.asarray(data.groups["subject"]).astype(str).tolist())
+    expected = {str(int(subject))}
+    if observed != expected:
+        raise ValueError(
+            f"processed shard subject identity mismatch: expected={expected}, observed={observed}"
+        )
+    return ProcessedMaterializationShard(
+        shard_id=f"subject={int(subject)}",
+        processed_data_sha256=processed_data_sha256(data),
+        observation_identity=observation_identities_from_grouped_data(data),
+        preprocessing_authority_sha256s=(preprocessing_authority_sha256,),
+    )
+
+
+def verify_processed_subject_shard(
+    data: GroupedEvaluationData,
+    shard: ProcessedMaterializationShard,
+    *,
+    subject: int,
+) -> ObservationIdentityAuthority:
+    """Fail closed if a second materialization differs from the frozen first pass."""
+
+    expected_id = f"subject={int(subject)}"
+    if shard.shard_id != expected_id:
+        raise ValueError(
+            f"processed shard id mismatch: expected={expected_id!r}, observed={shard.shard_id!r}"
+        )
+    actual_processed = processed_data_sha256(data)
+    if actual_processed != shard.processed_data_sha256:
+        raise ValueError(
+            "second-pass processed neural array differs from frozen materialization shard"
+        )
+    identities = observation_identities_from_grouped_data(data)
+    if identities.sha256 != shard.observation_identity.sha256:
+        raise ValueError(
+            "second-pass human observation identity differs from frozen materialization shard"
+        )
+    return identities
+
+
+def _calibration_indices(
+    authority: LongitudinalCaseAuthority,
+    budget: int,
+) -> np.ndarray:
+    amount = int(budget)
+    if amount < 0:
+        raise ValueError("calibration budget must be non-negative")
+    max_budget = min(len(values) for values in authority.calibration_order_by_class.values())
+    if amount > max_budget:
+        raise ValueError(
+            f"budget {amount} exceeds balanced maximum {max_budget} for case {authority.case_id}"
+        )
+    if amount == 0:
+        return np.asarray([], dtype=np.int64)
+    selected = [
+        np.asarray(values[:amount], dtype=np.int64)
+        for _, values in sorted(authority.calibration_order_by_class.items())
+    ]
+    return np.sort(np.concatenate(selected))
+
+
+def _fit_indices(
+    authority: LongitudinalCaseAuthority,
+    budget: int,
+) -> np.ndarray:
+    calibration = _calibration_indices(authority, budget)
+    source = np.asarray(authority.source_train_indices, dtype=np.int64)
+    if len(calibration) == 0:
+        return source.copy()
+    return np.sort(np.concatenate([source, calibration]))
+
+
+def _role_payload(
+    shard: ProcessedMaterializationShard,
+    *,
+    role: str,
+    indices: Sequence[int] | np.ndarray,
+) -> dict[str, Any]:
+    role_authority = shard.observation_identity.role(role, indices)
+    payload = role_authority.to_dict()
+    payload["authority_sha256"] = role_authority.sha256
+    payload["nsq_observation_set_sha256"] = qualification_observation_set_sha256(
+        role,
+        shard.processed_data_sha256,
+        role_authority.row_indices,
+    )
+    return payload
+
+
+def _validate_row_role_hashes(
+    row: Any,
+    roles: Mapping[str, Mapping[str, Any]],
+) -> None:
+    expected = {
+        "supervised_source_history": row.source_train_indices_sha256,
+        "labeled_target_calibration": row.labeled_target_indices_sha256,
+        "supervised_fit": row.fit_indices_sha256,
+        "untouched_final_assessment": row.evaluation_indices_sha256,
+    }
+    for role, row_sha in expected.items():
+        observed = roles[role]["nsq_observation_set_sha256"]
+        if observed != row_sha:
+            raise RuntimeError(
+                f"human observation role {role!r} does not reconcile with NSQ row identity"
+            )
+
+
+def _internal_state_roles(
+    row: Any,
+    shard: ProcessedMaterializationShard,
+    fit_indices: np.ndarray,
+) -> dict[str, Any]:
+    state = row.qualification_model_state
+    if state is None:
+        return {}
+    metadata = state.learned_state.metadata
+    raw_validation = metadata.get("validation_relative_indices")
+    if raw_validation is None:
+        return {}
+    relative = np.asarray(tuple(raw_validation), dtype=np.int64)
+    if relative.ndim != 1 or len(set(relative.tolist())) != len(relative):
+        raise RuntimeError("learned-state validation membership is malformed")
+    if np.any(relative < 0) or np.any(relative >= len(fit_indices)):
+        raise RuntimeError("learned-state validation membership escapes authorized fit set")
+    validation_indices = fit_indices[relative]
+    validation_set = set(int(value) for value in relative.tolist())
+    training_relative = np.asarray(
+        [index for index in range(len(fit_indices)) if index not in validation_set],
+        dtype=np.int64,
+    )
+    training_indices = fit_indices[training_relative]
+    return {
+        "internal_model_validation": _role_payload(
+            shard,
+            role="internal_model_validation",
+            indices=validation_indices,
+        ),
+        "internal_model_training": _role_payload(
+            shard,
+            role="internal_model_training",
+            indices=training_indices,
+        ),
+    }
+
+
+def build_case_result_observation_roles(
+    *,
+    authority: LongitudinalCaseAuthority,
+    shard: ProcessedMaterializationShard,
+    result: QualificationCaseResult,
+) -> list[dict[str, Any]]:
+    """Render human-auditable observation membership for every NSQ result row."""
+
+    if authority.processed_data_sha256 != shard.processed_data_sha256:
+        raise ValueError("case authority and materialization shard processed hashes differ")
+    if result.case_authority_sha256 != authority.authority_sha256:
+        raise ValueError("case result does not belong to supplied longitudinal authority")
+
+    source_indices = np.asarray(authority.source_train_indices, dtype=np.int64)
+    evaluation_indices = np.asarray(authority.evaluation_indices, dtype=np.int64)
+    rendered: list[dict[str, Any]] = []
+    for row in result.rows:
+        calibration = _calibration_indices(authority, row.calibration_per_class)
+        fit = _fit_indices(authority, row.calibration_per_class)
+        roles: dict[str, Any] = {
+            "supervised_source_history": _role_payload(
+                shard,
+                role="supervised_source_history",
+                indices=source_indices,
+            ),
+            "labeled_target_calibration": _role_payload(
+                shard,
+                role="labeled_target_calibration",
+                indices=calibration,
+            ),
+            "supervised_fit": _role_payload(
+                shard,
+                role="supervised_fit",
+                indices=fit,
+            ),
+            "untouched_final_assessment": _role_payload(
+                shard,
+                role="untouched_final_assessment",
+                indices=evaluation_indices,
+            ),
+        }
+        _validate_row_role_hashes(row, roles)
+        internal = _internal_state_roles(row, shard, fit)
+        if internal:
+            final_set = set(int(value) for value in evaluation_indices.tolist())
+            for name, payload in internal.items():
+                if final_set.intersection(payload["row_indices"]):
+                    raise RuntimeError(
+                        f"{name} overlaps untouched final assessment for case {authority.case_id}"
+                    )
+            roles.update(internal)
+
+        rendered.append(
+            {
+                "schema_version": 1,
+                "case_id": authority.case_id,
+                "method_id": row.method_id,
+                "calibration_per_class": row.calibration_per_class,
+                "qualification_result_row_sha256": row.sha256,
+                "processed_shard_id": shard.shard_id,
+                "processed_shard_sha256": shard.sha256,
+                "roles": roles,
+            }
+        )
+    return rendered
+
+
+def materialization_manifest(
+    study: StudyMaterializationAuthority,
+    *,
+    raw_selection: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Serializable top-level authority payload stored in the study bundle."""
+
+    return {
+        "schema_version": 1,
+        "study_materialization_sha256": study.sha256,
+        "authority": study.to_dict(),
+        "raw_selection": dict(raw_selection),
+    }
+
+
+__all__ = [
+    "build_case_result_observation_roles",
+    "build_processed_subject_shard",
+    "materialization_manifest",
+    "qualification_observation_set_sha256",
+    "verify_processed_subject_shard",
+]

--- a/packages/neuros/src/neuros/evidence/kumar2024_materialized_study.py
+++ b/packages/neuros/src/neuros/evidence/kumar2024_materialized_study.py
@@ -1,0 +1,498 @@
+"""Materialization-aware execution for the canonical Kumar2024 NSQ study.
+
+Bundle generation v2 preserves the frozen scientific protocol while binding
+the exact realized Python environment, consumed raw GDF bytes, participant-
+native processed shards, and reviewer-facing observation-role manifests.
+
+Execution is deliberately two-pass. Pass one freezes every processed shard
+and the global study materialization root. Pass two reloads each participant
+and must reproduce the frozen processed SHA and human observation identities
+before any model may execute.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import platform
+from pathlib import Path
+from typing import Any, Mapping
+
+from . import kumar2024 as base
+from .kumar2024_materialization import (
+    build_case_result_observation_roles,
+    build_processed_subject_shard,
+    materialization_manifest,
+    verify_processed_subject_shard,
+)
+from neuros.foundation_models.materialization_authority import (
+    StudyMaterializationAuthority,
+    capture_environment_authority,
+)
+from neuros.foundation_models.moabb_materialization import (
+    resolve_kumar2024_raw_materialization,
+)
+
+BUNDLE_FILES_V2 = (
+    *base._BUNDLE_FILES,
+    "materialization.json",
+    "observation_roles.json",
+)
+
+
+def _runtime_authority(config: base.Kumar2024StudyConfig):
+    accelerator_runtime: dict[str, str] = {"requested_device": str(config.device)}
+    deterministic_flags: dict[str, str] = {}
+    try:
+        import torch
+    except ImportError:
+        accelerator_runtime["torch"] = "unavailable"
+    else:
+        accelerator_runtime.update(
+            {
+                "torch": str(torch.__version__),
+                "cuda_runtime": str(torch.version.cuda or "none"),
+                "cudnn_runtime": str(torch.backends.cudnn.version() or "none"),
+            }
+        )
+        deterministic_flags.update(
+            {
+                "torch_deterministic_algorithms": str(
+                    torch.are_deterministic_algorithms_enabled()
+                ).lower(),
+                "cudnn_deterministic": str(
+                    bool(torch.backends.cudnn.deterministic)
+                ).lower(),
+                "cudnn_benchmark": str(
+                    bool(torch.backends.cudnn.benchmark)
+                ).lower(),
+            }
+        )
+    return capture_environment_authority(
+        source_revision=base._git_revision(),
+        accelerator_runtime=accelerator_runtime,
+        deterministic_flags=deterministic_flags,
+    )
+
+
+def _seal_bundle_v2(output: Path) -> dict[str, Any]:
+    files = {name: base._file_sha256(output / name) for name in BUNDLE_FILES_V2}
+    root = base._identity_sha256(
+        "neuros.nsq_kumar2024_bundle.v2", {"files": files}
+    )
+    payload = {
+        "schema_version": 2,
+        "files": files,
+        "bundle_sha256": root,
+    }
+    base._json_dump(output / "artifact_hashes.json", payload)
+    return payload
+
+
+def verify_bundle_v2(
+    output: str | Path,
+    *,
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Verify a generation-v2 bundle without rerunning the study."""
+
+    root = Path(output).resolve()
+    if payload is None:
+        payload = json.loads(
+            (root / "artifact_hashes.json").read_text(encoding="utf-8")
+        )
+    if payload.get("schema_version") != 2 or not isinstance(
+        payload.get("files"), Mapping
+    ):
+        raise ValueError("invalid Kumar2024 bundle-v2 hash manifest")
+    declared = dict(payload["files"])
+    if set(declared) != set(BUNDLE_FILES_V2):
+        raise ValueError(
+            "Kumar2024 bundle-v2 file set differs from the frozen evidence contract"
+        )
+    actual: dict[str, str] = {}
+    for name in BUNDLE_FILES_V2:
+        path = root / name
+        if not path.is_file():
+            raise FileNotFoundError(f"missing Kumar2024 bundle-v2 file: {name}")
+        digest = base._file_sha256(path)
+        if digest != declared[name]:
+            raise ValueError(f"Kumar2024 bundle hash mismatch for {name}")
+        actual[name] = digest
+    expected_root = base._identity_sha256(
+        "neuros.nsq_kumar2024_bundle.v2", {"files": actual}
+    )
+    if payload.get("bundle_sha256") != expected_root:
+        raise ValueError("Kumar2024 bundle-v2 root SHA-256 does not match file manifest")
+    return {
+        "verified": True,
+        "schema_version": 2,
+        "bundle_sha256": expected_root,
+        "files": actual,
+    }
+
+
+def _render_report_v2(
+    *,
+    config: base.Kumar2024StudyConfig,
+    lineage: Any,
+    protocol: Any,
+    preprocessing_authority: Mapping[str, Any],
+    rows: list[dict[str, Any]],
+    analysis: Mapping[str, Any],
+    materialization: StudyMaterializationAuthority,
+) -> str:
+    report = base._render_report(
+        config=config,
+        lineage=lineage,
+        protocol=protocol,
+        preprocessing_authority=preprocessing_authority,
+        rows=rows,
+        analysis=analysis,
+    )
+    return report + (
+        "\n## Materialization authority\n\n"
+        f"- Bundle generation: `2`\n"
+        f"- Study materialization SHA-256: `{materialization.sha256}`\n"
+        f"- Environment authority SHA-256: `{materialization.environment.sha256}`\n"
+        f"- Raw materialization SHA-256: `{materialization.raw_materialization.sha256}`\n"
+        f"- Processed participant shards: `{len(materialization.processed_shards)}`\n\n"
+        "Every participant was processed once to freeze this authority, then loaded "
+        "again before model execution. The second pass was required to reproduce the "
+        "same processed-data and label-free observation-identity hashes exactly.\n"
+    )
+
+
+def run_materialized_study(
+    output: str | Path,
+    *,
+    config: base.Kumar2024StudyConfig | None = None,
+    preprocessing: base.Kumar2024PreprocessingSpec | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    from neuros.foundation_models.longitudinal import ordered_group_values
+    from neuros.foundation_models.moabb_epochs import collect_moabb_epochs
+    from neuros.foundation_models.moabb_longitudinal import (
+        build_moabb_longitudinal_dataset,
+        validate_observed_sessions,
+    )
+    from neuros.foundation_models.qualification_runner import (
+        QualificationExecutionContext,
+        run_external_qualification_case,
+    )
+
+    config = config or base.pilot_config()
+    preprocessing = preprocessing or base.Kumar2024PreprocessingSpec()
+    output_path = base._prepare_output(Path(output), overwrite=overwrite)
+    versions = base._runtime_versions()
+    dataset_spec, dataset, paradigm = build_moabb_longitudinal_dataset(
+        base.KUMAR2024_DATASET_KEY,
+        fmin=preprocessing.fmin_hz,
+        fmax=preprocessing.fmax_hz,
+        resample=preprocessing.resample_hz,
+    )
+
+    raw_evidence = resolve_kumar2024_raw_materialization(
+        dataset,
+        subjects=config.subjects,
+    )
+    environment = _runtime_authority(config)
+
+    first_descriptor = None
+    preprocessing_authority = None
+    frozen_shards = []
+    shards_by_subject = {}
+    subject_descriptors: dict[str, Any] = {}
+
+    # Pass 1: freeze processed participant shards without retaining the arrays.
+    for subject in config.subjects:
+        data, descriptor = collect_moabb_epochs(
+            dataset,
+            paradigm,
+            subjects=[subject],
+            dataset_id=base.KUMAR2024_DATASET_ID,
+        )
+        observed = validate_observed_sessions(
+            dataset_spec,
+            ordered_group_values(data, split_unit="session"),
+        )
+        if observed != base.KUMAR2024_EXPECTED_SESSIONS:
+            raise RuntimeError(
+                f"Kumar2024 chronology changed for subject {subject}: {observed}"
+            )
+        if first_descriptor is None:
+            first_descriptor = descriptor
+            preprocessing_authority = base._preprocessing_authority(
+                preprocessing,
+                descriptor,
+                versions,
+            )
+        elif descriptor.signal_contract_sha256 != first_descriptor.signal_contract_sha256:
+            raise RuntimeError(
+                "processed MOABB signal contract changed across participants: "
+                f"subject={subject}, reference={first_descriptor.signal_contract_sha256}, "
+                f"observed={descriptor.signal_contract_sha256}"
+            )
+        assert preprocessing_authority is not None
+        shard = build_processed_subject_shard(
+            data,
+            subject=subject,
+            preprocessing_authority_sha256=preprocessing_authority["sha256"],
+        )
+        frozen_shards.append(shard)
+        shards_by_subject[int(subject)] = shard
+        subject_descriptors[str(subject)] = {
+            **descriptor.to_dict(),
+            "descriptor_sha256": descriptor.sha256,
+        }
+        del data
+        gc.collect()
+
+    if first_descriptor is None or preprocessing_authority is None:
+        raise RuntimeError("Kumar2024 study produced no processed participant shards")
+
+    materialization = StudyMaterializationAuthority(
+        environment=environment,
+        raw_materialization=raw_evidence.authority,
+        processed_shards=tuple(frozen_shards),
+    )
+    lineage = base.build_dataset_lineage(
+        config=config,
+        preprocessing_authority=preprocessing_authority,
+        versions=versions,
+        raw_materialization_sha256=raw_evidence.authority.sha256,
+    )
+    protocol = base.build_protocol(
+        config=config,
+        dataset_lineage=lineage,
+        preprocessing_authority_sha256=preprocessing_authority["sha256"],
+    )
+    context = QualificationExecutionContext(
+        observed_dataset_lineage_sha256=lineage.lineage_sha256,
+        preprocessing_authority_sha256s=(preprocessing_authority["sha256"],),
+        metadata={
+            "study": "nsq-kumar2024-v1",
+            "bundle_generation": 2,
+            "moabb_version": versions.get("moabb"),
+            "mne_version": versions.get("mne"),
+            "processed_signal_contract_sha256": first_descriptor.signal_contract_sha256,
+            "study_materialization_sha256": materialization.sha256,
+            "environment_authority_sha256": environment.sha256,
+            "raw_materialization_sha256": raw_evidence.authority.sha256,
+        },
+    )
+    factories = base._method_factories(
+        config=config,
+        sample_rate_hz=first_descriptor.sampling_rate_hz,
+    )
+
+    authorities: list[Any] = []
+    case_results: list[dict[str, Any]] = []
+    flat_rows: list[dict[str, Any]] = []
+    observation_roles: list[dict[str, Any]] = []
+
+    # Pass 2: reload, verify exact materialization, then execute models.
+    for subject in config.subjects:
+        data, descriptor = collect_moabb_epochs(
+            dataset,
+            paradigm,
+            subjects=[subject],
+            dataset_id=base.KUMAR2024_DATASET_ID,
+        )
+        frozen_descriptor = subject_descriptors[str(subject)]
+        if descriptor.sha256 != frozen_descriptor["descriptor_sha256"]:
+            raise RuntimeError(
+                f"second-pass MOABB epoch descriptor changed for subject {subject}"
+            )
+        shard = shards_by_subject[int(subject)]
+        verify_processed_subject_shard(data, shard, subject=subject)
+        observed = validate_observed_sessions(
+            dataset_spec,
+            ordered_group_values(data, split_unit="session"),
+        )
+        if observed != base.KUMAR2024_EXPECTED_SESSIONS:
+            raise RuntimeError(
+                f"Kumar2024 chronology changed on execution pass for subject {subject}: {observed}"
+            )
+
+        for target_session in config.target_sessions:
+            authority = base._make_case_authority(
+                data=data,
+                dataset_spec=dataset_spec,
+                subject=subject,
+                target_session=target_session,
+                config=config,
+            )
+            authorities.append(authority)
+            for factory in factories:
+                result = run_external_qualification_case(
+                    data,
+                    authority,
+                    protocol,
+                    factory,
+                    execution_context=context,
+                )
+                case_results.append(
+                    {
+                        "subject": subject,
+                        "original_protocol": authority.case_metadata["original_protocol"],
+                        "held_out_session": target_session,
+                        "method_spec": {
+                            **factory.method_spec.to_dict(),
+                            "method_spec_sha256": factory.method_spec.sha256,
+                        },
+                        "result": result.to_dict(),
+                    }
+                )
+                flat_rows.extend(
+                    base._flatten_result_row(row, authority) for row in result.rows
+                )
+                observation_roles.extend(
+                    build_case_result_observation_roles(
+                        authority=authority,
+                        shard=shard,
+                        result=result,
+                    )
+                )
+        del data
+        gc.collect()
+
+    analysis = base.summarize_rows(flat_rows, config=config)
+    method_specs = []
+    for factory in factories:
+        spec = factory.method_spec
+        method_specs.append(
+            {**spec.to_dict(), "method_spec_sha256": spec.sha256}
+        )
+    study_identity_payload = {
+        "config_sha256": config.sha256,
+        "dataset_lineage_sha256": lineage.lineage_sha256,
+        "protocol_sha256": protocol.sha256,
+        "preprocessing_authority_sha256": preprocessing_authority["sha256"],
+        "study_materialization_sha256": materialization.sha256,
+        "method_spec_sha256s": [
+            item["method_spec_sha256"] for item in method_specs
+        ],
+        "case_authority_sha256s": [
+            item.authority_sha256 for item in authorities
+        ],
+    }
+    manifest = {
+        "schema_version": 2,
+        "study": "nsq-kumar2024-v1",
+        "evidence_tier": "real_dataset",
+        "bundle_generation": 2,
+        "study_sha256": base._identity_sha256(
+            "neuros.nsq_kumar2024_study.v2",
+            study_identity_payload,
+        ),
+        "study_materialization_sha256": materialization.sha256,
+        "environment_authority_sha256": environment.sha256,
+        "raw_materialization_sha256": raw_evidence.authority.sha256,
+        "config": config.to_dict(),
+        "config_sha256": config.sha256,
+        "preprocessing_authority": preprocessing_authority,
+        "dataset_lineage": lineage.to_dict(),
+        "protocol": {
+            **protocol.to_dict(),
+            "protocol_sha256": protocol.sha256,
+        },
+        "execution_context": {
+            **context.to_dict(),
+            "execution_context_sha256": context.sha256,
+        },
+        "method_specs": method_specs,
+        "case_authority_sha256s": [
+            item.authority_sha256 for item in authorities
+        ],
+        "case_result_sha256s": [
+            item["result"]["result_sha256"] for item in case_results
+        ],
+        "subject_epoch_descriptors": subject_descriptors,
+        "package_versions": versions,
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "git_revision": base._git_revision(),
+        "claim_boundary": (
+            "offline comparative evidence for this exact materialized MOABB "
+            "bar-feedback subset and prospective longitudinal protocol only"
+        ),
+        "not_claimed": [
+            "reproduction of the original online GR/PAR intervention",
+            "physiological mechanism",
+            "hardware qualification",
+            "online BCI efficacy",
+            "clinical benefit",
+            "ORION superiority",
+        ],
+    }
+
+    raw_selection = {
+        "schema_version": raw_evidence.schema_version,
+        "loader_contract": raw_evidence.loader_contract,
+        "selections": [item.to_dict() for item in raw_evidence.selections],
+    }
+    base._json_dump(output_path / "study_manifest.json", manifest)
+    base._json_dump(
+        output_path / "case_authorities.json",
+        {
+            "schema_version": 1,
+            "authorities": [item.to_dict() for item in authorities],
+        },
+    )
+    base._json_dump(
+        output_path / "case_results.json",
+        {"schema_version": 1, "case_results": case_results},
+    )
+    base._write_csv(output_path / "results.csv", flat_rows)
+    base._json_dump(output_path / "analysis.json", analysis)
+    base._json_dump(
+        output_path / "materialization.json",
+        materialization_manifest(
+            materialization,
+            raw_selection=raw_selection,
+        ),
+    )
+    base._json_dump(
+        output_path / "observation_roles.json",
+        {
+            "schema_version": 1,
+            "study_materialization_sha256": materialization.sha256,
+            "entries": observation_roles,
+        },
+    )
+    (output_path / "report.md").write_text(
+        _render_report_v2(
+            config=config,
+            lineage=lineage,
+            protocol=protocol,
+            preprocessing_authority=preprocessing_authority,
+            rows=flat_rows,
+            analysis=analysis,
+            materialization=materialization,
+        ),
+        encoding="utf-8",
+    )
+    sealed = _seal_bundle_v2(output_path)
+    verified = verify_bundle_v2(output_path)
+    return {
+        "study_sha256": manifest["study_sha256"],
+        "bundle_sha256": sealed["bundle_sha256"],
+        "bundle_schema_version": 2,
+        "study_materialization_sha256": materialization.sha256,
+        "environment_authority_sha256": environment.sha256,
+        "raw_materialization_sha256": raw_evidence.authority.sha256,
+        "protocol_sha256": protocol.sha256,
+        "dataset_lineage_sha256": lineage.lineage_sha256,
+        "cases": len(authorities),
+        "result_rows": len(flat_rows),
+        "verified": verified["verified"],
+        "output": str(output_path),
+    }
+
+
+__all__ = [
+    "BUNDLE_FILES_V2",
+    "run_materialized_study",
+    "verify_bundle_v2",
+]

--- a/tests/test_kumar2024_bundle_v2.py
+++ b/tests/test_kumar2024_bundle_v2.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from neuros.evidence.kumar2024 import (
+    Kumar2024PreprocessingSpec,
+    _identity_sha256,
+    _preprocessing_authority,
+    build_dataset_lineage,
+    pilot_config,
+    verify_bundle,
+)
+from neuros.evidence.kumar2024_materialized_study import BUNDLE_FILES_V2
+from neuros.foundation_models.moabb_epochs import MOABBEpochDescriptor
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _descriptor() -> MOABBEpochDescriptor:
+    return MOABBEpochDescriptor(
+        channel_names=("C3", "Cz", "C4"),
+        channel_types=("eeg", "eeg", "eeg"),
+        sampling_rate_hz=512.0,
+        n_times=2560,
+        epoch_start_s=0.0,
+        epoch_end_s=2559 / 512.0,
+        event_id=(("left_hand", 1), ("right_hand", 2)),
+        n_trials=80,
+    )
+
+
+def test_lineage_binds_raw_materialization_without_mislabeling_archive_content_hash():
+    versions = {"moabb": "1.5.0", "mne": "1.6.0"}
+    preprocessing = _preprocessing_authority(
+        Kumar2024PreprocessingSpec(),
+        _descriptor(),
+        versions,
+    )
+    lineage = build_dataset_lineage(
+        config=pilot_config(),
+        preprocessing_authority=preprocessing,
+        versions=versions,
+        raw_materialization_sha256="a" * 64,
+    )
+    assert lineage.content_sha256 is None
+    assert lineage.metadata["raw_materialization_sha256"] == "a" * 64
+    assert "exact consumed" in lineage.metadata["raw_materialization_scope"]
+    assert "not a canonical upstream archive digest" in lineage.metadata[
+        "content_sha256_reason"
+    ]
+
+
+def test_bundle_v2_verifies_and_preserves_strict_file_set(tmp_path: Path):
+    for index, name in enumerate(BUNDLE_FILES_V2):
+        (tmp_path / name).write_text(f"fixture-v2-{index}\n", encoding="utf-8")
+    files = {name: _sha(tmp_path / name) for name in BUNDLE_FILES_V2}
+    bundle_sha = _identity_sha256(
+        "neuros.nsq_kumar2024_bundle.v2", {"files": files}
+    )
+    (tmp_path / "artifact_hashes.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "files": files,
+                "bundle_sha256": bundle_sha,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    verified = verify_bundle(tmp_path)
+    assert verified["verified"] is True
+    assert verified["schema_version"] == 2
+    assert verified["bundle_sha256"] == bundle_sha
+
+    payload = json.loads((tmp_path / "artifact_hashes.json").read_text())
+    payload["files"].pop("observation_roles.json")
+    payload["bundle_sha256"] = _identity_sha256(
+        "neuros.nsq_kumar2024_bundle.v2", {"files": payload["files"]}
+    )
+    (tmp_path / "artifact_hashes.json").write_text(
+        json.dumps(payload, sort_keys=True), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="file set"):
+        verify_bundle(tmp_path)
+
+
+def test_bundle_v2_detects_tampering(tmp_path: Path):
+    for index, name in enumerate(BUNDLE_FILES_V2):
+        (tmp_path / name).write_text(f"fixture-v2-{index}\n", encoding="utf-8")
+    files = {name: _sha(tmp_path / name) for name in BUNDLE_FILES_V2}
+    bundle_sha = _identity_sha256(
+        "neuros.nsq_kumar2024_bundle.v2", {"files": files}
+    )
+    (tmp_path / "artifact_hashes.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "files": files,
+                "bundle_sha256": bundle_sha,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "materialization.json").write_text("tampered\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="hash mismatch"):
+        verify_bundle(tmp_path)

--- a/tests/test_kumar2024_materialization_roles.py
+++ b/tests/test_kumar2024_materialization_roles.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from neuros.evidence.kumar2024_materialization import (
+    build_case_result_observation_roles,
+    build_processed_subject_shard,
+)
+from neuros.foundation_models.longitudinal_authority import (
+    LongitudinalCaseAuthority,
+    processed_data_sha256,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+
+def _runner_observation_hash(role: str, processed_sha256: str, indices) -> str:
+    payload = {
+        "schema": "neuros.qualification_observation_set.v1",
+        "payload": {
+            "role": role,
+            "processed_data_sha256": processed_sha256,
+            "indices": [int(value) for value in indices],
+        },
+    }
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _data() -> GroupedEvaluationData:
+    X = np.arange(10 * 2 * 4, dtype=np.float32).reshape(10, 2, 4)
+    y = np.asarray([
+        "left", "right", "left", "right", "left",
+        "right", "left", "right", "left", "right",
+    ])
+    return GroupedEvaluationData(
+        dataset_id="moabb-kumar2024",
+        X=X,
+        y=y,
+        groups={
+            "subject": np.asarray(["1"] * 10),
+            "session": np.asarray(["0", "0", "0", "0", "1", "1", "1", "1", "1", "1"]),
+            "run": np.asarray(["0", "0", "1", "1", "0", "0", "1", "1", "2", "2"]),
+        },
+        metadata=tuple({"row": index} for index in range(10)),
+    )
+
+
+def _authority(data: GroupedEvaluationData) -> LongitudinalCaseAuthority:
+    return LongitudinalCaseAuthority(
+        dataset_id=data.dataset_id,
+        case_id="kumar2024/subject-1/session-1/split-2026",
+        split_unit="session",
+        held_out_values=("1",),
+        history_policy="prior",
+        observed_group_order=("0", "1"),
+        source_group_values=("0",),
+        source_train_indices=(0, 1, 2, 3),
+        evaluation_indices=(8, 9),
+        calibration_order_by_class={
+            "left": (4, 6),
+            "right": (5, 7),
+        },
+        evaluation_fraction=0.5,
+        seed=2026,
+        partition_fingerprint="partition-fixture",
+        calibration_split_fingerprint="calibration-fixture",
+        processed_data_sha256=processed_data_sha256(data),
+        n_samples=len(data.X),
+        input_shape=tuple(int(value) for value in data.X.shape),
+        case_metadata={"subject": 1},
+    )
+
+
+def _row(authority, *, budget: int, calibration, fit, state=None, source_sha=None):
+    processed = authority.processed_data_sha256
+    source = authority.source_train_indices
+    evaluation = authority.evaluation_indices
+    return SimpleNamespace(
+        calibration_per_class=budget,
+        method_id="fixture-eegnet",
+        source_train_indices_sha256=(
+            source_sha
+            if source_sha is not None
+            else _runner_observation_hash("supervised_source_history", processed, source)
+        ),
+        labeled_target_indices_sha256=_runner_observation_hash(
+            "labeled_target_calibration", processed, calibration
+        ),
+        fit_indices_sha256=_runner_observation_hash(
+            "supervised_fit", processed, fit
+        ),
+        evaluation_indices_sha256=_runner_observation_hash(
+            "untouched_final_assessment", processed, evaluation
+        ),
+        qualification_model_state=state,
+        sha256=f"fixture-row-{budget}",
+    )
+
+
+def test_roles_reconcile_with_runner_hashes_and_zero_budget_is_signed():
+    data = _data()
+    authority = _authority(data)
+    shard = build_processed_subject_shard(
+        data,
+        subject=1,
+        preprocessing_authority_sha256="b" * 64,
+    )
+
+    zero_fit = np.asarray(authority.source_train_indices, dtype=np.int64)
+    one_calibration = np.asarray([4, 5], dtype=np.int64)
+    one_fit = np.asarray([0, 1, 2, 3, 4, 5], dtype=np.int64)
+    neural_state = SimpleNamespace(
+        learned_state=SimpleNamespace(
+            metadata={"validation_relative_indices": [1, 4]}
+        )
+    )
+    result = SimpleNamespace(
+        case_authority_sha256=authority.authority_sha256,
+        rows=(
+            _row(
+                authority,
+                budget=0,
+                calibration=np.asarray([], dtype=np.int64),
+                fit=zero_fit,
+            ),
+            _row(
+                authority,
+                budget=1,
+                calibration=one_calibration,
+                fit=one_fit,
+                state=neural_state,
+            ),
+        ),
+    )
+
+    rendered = build_case_result_observation_roles(
+        authority=authority,
+        shard=shard,
+        result=result,
+    )
+
+    zero_roles = rendered[0]["roles"]
+    assert zero_roles["labeled_target_calibration"]["row_indices"] == []
+    assert zero_roles["labeled_target_calibration"]["display_ids"] == []
+    assert zero_roles["labeled_target_calibration"]["observation_sha256s"] == []
+    assert zero_roles["labeled_target_calibration"]["nsq_observation_set_sha256"] == (
+        _runner_observation_hash(
+            "labeled_target_calibration",
+            authority.processed_data_sha256,
+            [],
+        )
+    )
+
+    one_roles = rendered[1]["roles"]
+    expected = {
+        "supervised_source_history": [0, 1, 2, 3],
+        "labeled_target_calibration": [4, 5],
+        "supervised_fit": [0, 1, 2, 3, 4, 5],
+        "untouched_final_assessment": [8, 9],
+    }
+    for role, indices in expected.items():
+        assert one_roles[role]["row_indices"] == indices
+        assert one_roles[role]["nsq_observation_set_sha256"] == (
+            _runner_observation_hash(
+                role,
+                authority.processed_data_sha256,
+                indices,
+            )
+        )
+
+    assert one_roles["internal_model_validation"]["row_indices"] == [1, 4]
+    assert one_roles["internal_model_training"]["row_indices"] == [0, 2, 3, 5]
+    assert not set(one_roles["internal_model_validation"]["row_indices"]) & {8, 9}
+    serialized = json.dumps(rendered, sort_keys=True)
+    assert '"left"' not in serialized
+    assert '"right"' not in serialized
+
+
+def test_role_reconciliation_fails_closed_on_runner_hash_mismatch():
+    data = _data()
+    authority = _authority(data)
+    shard = build_processed_subject_shard(
+        data,
+        subject=1,
+        preprocessing_authority_sha256="b" * 64,
+    )
+    result = SimpleNamespace(
+        case_authority_sha256=authority.authority_sha256,
+        rows=(
+            _row(
+                authority,
+                budget=0,
+                calibration=[],
+                fit=authority.source_train_indices,
+                source_sha="0" * 64,
+            ),
+        ),
+    )
+    with pytest.raises(RuntimeError, match="does not reconcile"):
+        build_case_result_observation_roles(
+            authority=authority,
+            shard=shard,
+            result=result,
+        )
+
+
+def test_internal_validation_membership_cannot_escape_authorized_fit_set():
+    data = _data()
+    authority = _authority(data)
+    shard = build_processed_subject_shard(
+        data,
+        subject=1,
+        preprocessing_authority_sha256="b" * 64,
+    )
+    calibration = np.asarray([4, 5], dtype=np.int64)
+    fit = np.asarray([0, 1, 2, 3, 4, 5], dtype=np.int64)
+    invalid_state = SimpleNamespace(
+        learned_state=SimpleNamespace(
+            metadata={"validation_relative_indices": [0, len(fit)]}
+        )
+    )
+    result = SimpleNamespace(
+        case_authority_sha256=authority.authority_sha256,
+        rows=(
+            _row(
+                authority,
+                budget=1,
+                calibration=calibration,
+                fit=fit,
+                state=invalid_state,
+            ),
+        ),
+    )
+    with pytest.raises(RuntimeError, match="escapes authorized fit set"):
+        build_case_result_observation_roles(
+            authority=authority,
+            shard=shard,
+            result=result,
+        )

--- a/tests/test_moabb_materialization_authority.py
+++ b/tests/test_moabb_materialization_authority.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from neuros.foundation_models.moabb_materialization import (
+    KUMAR2024_EXPECTED_RUNS,
+    resolve_kumar2024_raw_materialization,
+)
+
+
+class Kumar2024:
+    """Filesystem-only fixture mirroring the upstream loader path helpers."""
+
+    _MOABB_TO_RAW = {i: i for i in range(1, 10)}
+    _MOABB_TO_RAW.update({i: i + 1 for i in range(10, 19)})
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    def data_path(self, subject):
+        return self.root
+
+    @staticmethod
+    def _find_online_subject_dir(online_group_dir, raw_subj):
+        if not online_group_dir.is_dir():
+            return None
+        for pattern in [
+            f"Subject_{raw_subj:02d}_Online",
+            f"Subject_{raw_subj:03d}_Online",
+            f"Subject_{raw_subj}_Online",
+        ]:
+            candidate = online_group_dir / pattern
+            if candidate.is_dir():
+                return candidate
+        for child in sorted(online_group_dir.iterdir()):
+            if child.is_dir():
+                match = re.match(r"Subject_0*(\d+)_Online", child.name)
+                if match and int(match.group(1)) == raw_subj:
+                    return child
+        return None
+
+    @staticmethod
+    def _find_session_subdir(parent_dir, raw_subj, sess_num, suffix):
+        if parent_dir is None or not parent_dir.is_dir():
+            return None
+        for subject_format in [
+            f"{raw_subj:02d}",
+            f"{raw_subj:03d}",
+            str(raw_subj),
+        ]:
+            candidate = (
+                parent_dir
+                / f"Subject_{subject_format}_Session_{sess_num:03d}_{suffix}"
+            )
+            if candidate.is_dir():
+                return candidate
+        for child in sorted(parent_dir.iterdir()):
+            if child.is_dir():
+                match = re.search(r"Session_0*(\d+)", child.name)
+                if match and int(match.group(1)) == sess_num:
+                    return child
+        return None
+
+
+def _write_subject(root: Path, *, subject: int) -> None:
+    raw_subject = Kumar2024._MOABB_TO_RAW[subject]
+    protocol = "GR" if raw_subject <= 9 else "PAR"
+
+    offline_subject = root / "Offline" / protocol / f"Subject_{raw_subject:02d}_Offline"
+    offline_session = (
+        offline_subject
+        / f"Subject_{raw_subject:02d}_Session_001_Offline"
+    )
+    offline_session.mkdir(parents=True)
+    for run in range(KUMAR2024_EXPECTED_RUNS["0"]):
+        (offline_session / f"bar_{run:02d}.gdf").write_bytes(
+            f"subject={subject};session=0;run={run}".encode()
+        )
+
+    # Exercise the upstream 3-digit PAR naming variation for subject 10 -> raw 11.
+    subject_width = 3 if raw_subject >= 10 else 2
+    online_subject = (
+        root
+        / "Online"
+        / protocol
+        / f"Subject_{raw_subject:0{subject_width}d}_Online"
+    )
+    for session_number in range(2, 7):
+        moabb_session = str(session_number - 1)
+        session_dir = (
+            online_subject
+            / f"Subject_{raw_subject:0{subject_width}d}_Session_{session_number:03d}_Online"
+        )
+        session_dir.mkdir(parents=True)
+        extension = "GDF" if moabb_session == "5" else "gdf"
+        for run in range(KUMAR2024_EXPECTED_RUNS[moabb_session]):
+            (session_dir / f"bar_{run:02d}.{extension}").write_bytes(
+                f"subject={subject};session={moabb_session};run={run}".encode()
+            )
+
+    # This file exists in the extracted archive but must never enter bar authority.
+    race = root / "Race" / protocol / f"Subject_{raw_subject:02d}" / "race.gdf"
+    race.parent.mkdir(parents=True)
+    race.write_bytes(b"not consumed by MOABB Kumar2024 bar loader")
+
+
+def _fixture_root(tmp_path: Path) -> Path:
+    root = tmp_path / "Kumar2024"
+    _write_subject(root, subject=1)
+    _write_subject(root, subject=10)
+    return root
+
+
+def test_kumar_materialization_selects_only_exact_bar_feedback_runs(tmp_path: Path):
+    root = _fixture_root(tmp_path)
+    evidence = resolve_kumar2024_raw_materialization(
+        Kumar2024(root),
+        subjects=(1, 10),
+    )
+
+    expected_per_subject = sum(KUMAR2024_EXPECTED_RUNS.values())
+    assert len(evidence.selections) == 2 * expected_per_subject
+    assert len(evidence.authority.files) == 2 * expected_per_subject
+    assert all("Race/" not in item.logical_path for item in evidence.selections)
+    assert all("Race/" not in item.logical_path for item in evidence.authority.files)
+    assert {item.subject for item in evidence.selections} == {1, 10}
+    raw_by_subject = {
+        subject: {item.raw_subject for item in evidence.selections if item.subject == subject}
+        for subject in (1, 10)
+    }
+    assert raw_by_subject == {1: {1}, 10: {11}}
+    assert {
+        (item.subject, item.session): sum(
+            1
+            for other in evidence.selections
+            if other.subject == item.subject and other.session == item.session
+        )
+        for item in evidence.selections
+    } == {
+        (subject, session): count
+        for subject in (1, 10)
+        for session, count in KUMAR2024_EXPECTED_RUNS.items()
+    }
+    assert evidence.authority.to_dict()["upstream_identity"]["included_task"] == (
+        "bar_feedback_only"
+    )
+    assert evidence.authority.to_dict()["upstream_identity"]["excluded_task"] == (
+        "car_racing"
+    )
+
+
+def test_kumar_materialization_is_root_independent_and_byte_sensitive(tmp_path: Path):
+    first_root = _fixture_root(tmp_path / "one")
+    second_root = _fixture_root(tmp_path / "two")
+    first = resolve_kumar2024_raw_materialization(
+        Kumar2024(first_root), subjects=(1, 10)
+    )
+    second = resolve_kumar2024_raw_materialization(
+        Kumar2024(second_root), subjects=(1, 10)
+    )
+    assert first.authority.sha256 == second.authority.sha256
+
+    selected = second_root / first.selections[0].logical_path
+    selected.write_bytes(selected.read_bytes() + b"changed")
+    changed = resolve_kumar2024_raw_materialization(
+        Kumar2024(second_root), subjects=(1, 10)
+    )
+    assert first.authority.sha256 != changed.authority.sha256
+
+
+def test_kumar_materialization_fails_if_frozen_bar_run_count_changes(tmp_path: Path):
+    root = _fixture_root(tmp_path)
+    first_session = next(
+        path
+        for path in root.rglob("*")
+        if path.is_dir() and "Session_001_Offline" in path.name
+    )
+    (first_session / "unexpected-extra.gdf").write_bytes(b"unexpected")
+    with pytest.raises(RuntimeError, match="run count differs"):
+        resolve_kumar2024_raw_materialization(Kumar2024(root), subjects=(1,))
+
+
+def test_kumar_materialization_fails_when_one_consumed_session_is_missing(tmp_path: Path):
+    root = _fixture_root(tmp_path)
+    target = next(
+        path
+        for path in root.rglob("*")
+        if path.is_dir() and "Session_006_Online" in path.name
+    )
+    for child in target.iterdir():
+        child.unlink()
+    target.rmdir()
+    with pytest.raises(FileNotFoundError, match="session=5"):
+        resolve_kumar2024_raw_materialization(Kumar2024(root), subjects=(1,))
+
+
+def test_kumar_materialization_rejects_non_kumar_loader(tmp_path: Path):
+    class OtherDataset:
+        pass
+
+    with pytest.raises(TypeError, match="Kumar2024 dataset instance"):
+        resolve_kumar2024_raw_materialization(OtherDataset(), subjects=(1,))

--- a/tests/test_study_materialization_authority.py
+++ b/tests/test_study_materialization_authority.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuros.foundation_models.materialization_authority import (
+    EnvironmentAuthority,
+    EnvironmentDistribution,
+    ObservationIdentity,
+    ObservationIdentityAuthority,
+    ProcessedMaterializationShard,
+    StudyMaterializationAuthority,
+    hash_raw_materialization,
+    observation_identities_from_grouped_data,
+)
+from neuros.foundation_models.real_world import GroupedEvaluationData
+
+
+def _environment(*, numpy_version: str = "2.0.0") -> EnvironmentAuthority:
+    # Deliberately supplied out of order. Canonical identity must not depend on
+    # installation/enumeration ordering.
+    return EnvironmentAuthority(
+        python_implementation="CPython",
+        python_version="3.11.9",
+        platform_system="Linux",
+        platform_machine="x86_64",
+        distributions=(
+            EnvironmentDistribution("scikit_learn", "1.6.0"),
+            EnvironmentDistribution("NumPy", numpy_version),
+        ),
+        source_revision="abc123",
+        accelerator_runtime=(
+            ("device", "cpu"),
+            ("torch", "2.8.0"),
+        ),
+        deterministic_flags=(("cudnn_deterministic", "true"),),
+    )
+
+
+def _grouped() -> GroupedEvaluationData:
+    X = np.arange(6 * 2 * 4, dtype=np.float32).reshape(6, 2, 4)
+    y = np.asarray(["left", "right", "left", "right", "left", "right"])
+    return GroupedEvaluationData(
+        dataset_id="moabb-kumar2024",
+        X=X,
+        y=y,
+        groups={
+            "subject": np.asarray(["1", "1", "1", "1", "1", "1"]),
+            "session": np.asarray(["0", "0", "0", "1", "1", "1"]),
+            "run": np.asarray(["0", "0", "1", "0", "0", "0"]),
+        },
+        metadata=tuple({"note": f"row-{index}"} for index in range(6)),
+    )
+
+
+def _materialization(tmp_path: Path) -> StudyMaterializationAuthority:
+    root = tmp_path / "raw"
+    (root / "subject-1").mkdir(parents=True)
+    (root / "subject-1" / "session-0.bin").write_bytes(b"abc")
+    (root / "subject-1" / "session-1.bin").write_bytes(b"def")
+    raw = hash_raw_materialization(
+        dataset_id="moabb-kumar2024",
+        root=root,
+        relative_paths=(
+            "subject-1/session-1.bin",
+            "subject-1/session-0.bin",
+        ),
+        upstream_identity={
+            "paper_doi": "10.1093/pnasnexus/pgae076",
+            "data_doi": "10.5281/zenodo.10694880",
+        },
+    )
+    shard = ProcessedMaterializationShard(
+        shard_id="subject=1",
+        processed_data_sha256="a" * 64,
+        observation_identity=observation_identities_from_grouped_data(_grouped()),
+        preprocessing_authority_sha256s=("b" * 64,),
+    )
+    return StudyMaterializationAuthority(
+        environment=_environment(),
+        raw_materialization=raw,
+        processed_shards=(shard,),
+    )
+
+
+def test_environment_identity_is_order_independent_but_version_sensitive():
+    first = _environment()
+    reordered = EnvironmentAuthority(
+        python_implementation="CPython",
+        python_version="3.11.9",
+        platform_system="Linux",
+        platform_machine="x86_64",
+        distributions=tuple(reversed(first.distributions)),
+        source_revision="abc123",
+        accelerator_runtime=tuple(reversed(first.accelerator_runtime)),
+        deterministic_flags=first.deterministic_flags,
+    )
+    changed = _environment(numpy_version="2.0.1")
+
+    assert first.sha256 == reordered.sha256
+    assert first.sha256 != changed.sha256
+    payload = first.to_dict()
+    assert "hostname" not in payload
+    assert "timestamp" not in payload
+    assert [item["name"] for item in payload["distributions"]] == [
+        "numpy",
+        "scikit-learn",
+    ]
+
+
+def test_environment_rejects_conflicting_duplicate_distribution_names():
+    with pytest.raises(ValueError, match="duplicate distribution"):
+        EnvironmentAuthority(
+            python_implementation="CPython",
+            python_version="3.11.9",
+            platform_system="Linux",
+            platform_machine="x86_64",
+            distributions=(
+                EnvironmentDistribution("scikit-learn", "1.5"),
+                EnvironmentDistribution("scikit_learn", "1.6"),
+            ),
+        )
+
+
+def test_raw_materialization_is_cache_root_independent_and_byte_sensitive(tmp_path: Path):
+    roots = (tmp_path / "cache-a", tmp_path / "cache-b")
+    for root in roots:
+        (root / "nested").mkdir(parents=True)
+        (root / "nested" / "recording.bin").write_bytes(b"same-bytes")
+
+    first = hash_raw_materialization(
+        dataset_id="fixture",
+        root=roots[0],
+        relative_paths=("nested/recording.bin",),
+        upstream_identity={"version": "1"},
+    )
+    second = hash_raw_materialization(
+        dataset_id="fixture",
+        root=roots[1],
+        relative_paths=("nested/recording.bin",),
+        upstream_identity={"version": "1"},
+    )
+    assert first.sha256 == second.sha256
+    assert str(roots[0]) not in str(first.to_dict())
+    assert first.files[0].logical_path == "nested/recording.bin"
+
+    (roots[1] / "nested" / "recording.bin").write_bytes(b"changed")
+    changed = hash_raw_materialization(
+        dataset_id="fixture",
+        root=roots[1],
+        relative_paths=("nested/recording.bin",),
+        upstream_identity={"version": "1"},
+    )
+    assert first.sha256 != changed.sha256
+
+
+def test_raw_materialization_rejects_escape_missing_and_duplicate_paths(tmp_path: Path):
+    root = tmp_path / "raw"
+    root.mkdir()
+    (root / "file.bin").write_bytes(b"x")
+
+    with pytest.raises(ValueError, match="canonical paths"):
+        hash_raw_materialization(
+            dataset_id="fixture",
+            root=root,
+            relative_paths=("../escape.bin",),
+        )
+    with pytest.raises(ValueError, match="does not exist"):
+        hash_raw_materialization(
+            dataset_id="fixture",
+            root=root,
+            relative_paths=("missing.bin",),
+        )
+    with pytest.raises(ValueError, match="duplicate raw logical path"):
+        hash_raw_materialization(
+            dataset_id="fixture",
+            root=root,
+            relative_paths=("file.bin", "file.bin"),
+        )
+
+
+def test_grouped_observation_identities_are_human_auditable_and_label_free():
+    authority = observation_identities_from_grouped_data(_grouped())
+
+    assert [item.local_epoch for item in authority.observations] == [0, 1, 0, 0, 1, 2]
+    assert authority.observations[2].display_id == (
+        "participant=1/session=0/run=1/epoch=0"
+    )
+    serialized = authority.to_dict()
+    text = str(serialized)
+    assert "left" not in text
+    assert "right" not in text
+    assert len(authority.sha256) == 64
+
+
+def test_observation_row_reorder_changes_authority():
+    data = _grouped()
+    first = observation_identities_from_grouped_data(data)
+    order = np.asarray([1, 0, 2, 3, 4, 5])
+    reordered = GroupedEvaluationData(
+        dataset_id=data.dataset_id,
+        X=data.X[order],
+        y=data.y[order],
+        groups={key: values[order] for key, values in data.groups.items()},
+        metadata=tuple(data.metadata[index] for index in order),
+    )
+    second = observation_identities_from_grouped_data(reordered)
+    assert first.sha256 != second.sha256
+
+
+def test_explicit_ambiguous_observation_identity_fails_closed():
+    with pytest.raises(ValueError, match="ambiguous or duplicated"):
+        ObservationIdentityAuthority(
+            dataset_id="fixture",
+            observations=(
+                ObservationIdentity(0, "p1", "s1", "r1", 0, "a" * 64),
+                ObservationIdentity(1, "p1", "s1", "r1", 0, "b" * 64),
+            ),
+        )
+
+
+def test_role_authority_maps_execution_rows_to_human_identities_without_labels():
+    observations = observation_identities_from_grouped_data(_grouped())
+    source = observations.role(
+        "source_history", np.asarray([0, 2, 4], dtype=np.int64)
+    )
+    reversed_source = observations.role("source_history", (4, 2, 0))
+
+    assert source.row_indices == (0, 2, 4)
+    assert source.display_ids == tuple(
+        observations.observations[index].display_id for index in (0, 2, 4)
+    )
+    assert source.observation_identity_authority_sha256 == observations.sha256
+    assert source.sha256 != reversed_source.sha256
+    assert "left" not in str(source.to_dict())
+    assert "right" not in str(source.to_dict())
+
+
+def test_study_materialization_composes_all_major_authorities(tmp_path: Path):
+    study = _materialization(tmp_path)
+    payload = study.to_dict()
+    shard = study.processed_shards[0]
+
+    assert study.dataset_id == "moabb-kumar2024"
+    assert payload["environment_sha256"] == study.environment.sha256
+    assert payload["raw_materialization_sha256"] == study.raw_materialization.sha256
+    assert payload["processed_shard_sha256s"] == [shard.sha256]
+    assert shard.to_dict()["observation_identity_sha256"] == shard.observation_identity.sha256
+    assert len(study.sha256) == 64
+
+    changed_environment = StudyMaterializationAuthority(
+        environment=_environment(numpy_version="2.0.1"),
+        raw_materialization=study.raw_materialization,
+        processed_shards=study.processed_shards,
+    )
+    assert study.sha256 != changed_environment.sha256
+
+
+def test_study_materialization_shard_order_is_canonical(tmp_path: Path):
+    study = _materialization(tmp_path)
+    first = study.processed_shards[0]
+    second = ProcessedMaterializationShard(
+        shard_id="subject=2",
+        processed_data_sha256="c" * 64,
+        observation_identity=ObservationIdentityAuthority(
+            dataset_id=first.dataset_id,
+            observations=(
+                ObservationIdentity(0, "2", "0", "0", 0, "d" * 64),
+            ),
+        ),
+        preprocessing_authority_sha256s=first.preprocessing_authority_sha256s,
+    )
+    forward = StudyMaterializationAuthority(
+        environment=study.environment,
+        raw_materialization=study.raw_materialization,
+        processed_shards=(first, second),
+    )
+    reversed_order = StudyMaterializationAuthority(
+        environment=study.environment,
+        raw_materialization=study.raw_materialization,
+        processed_shards=(second, first),
+    )
+    assert forward.sha256 == reversed_order.sha256
+    assert [item.shard_id for item in forward.processed_shards] == ["subject=1", "subject=2"]
+
+
+def test_study_materialization_refuses_cross_dataset_composition(tmp_path: Path):
+    study = _materialization(tmp_path)
+    shard = study.processed_shards[0]
+    wrong_observations = ObservationIdentityAuthority(
+        dataset_id="different-dataset",
+        observations=shard.observation_identity.observations,
+    )
+    wrong_shard = ProcessedMaterializationShard(
+        shard_id=shard.shard_id,
+        processed_data_sha256=shard.processed_data_sha256,
+        observation_identity=wrong_observations,
+        preprocessing_authority_sha256s=shard.preprocessing_authority_sha256s,
+    )
+    with pytest.raises(ValueError, match="one dataset_id"):
+        StudyMaterializationAuthority(
+            environment=study.environment,
+            raw_materialization=study.raw_materialization,
+            processed_shards=(wrong_shard,),
+        )


### PR DESCRIPTION
## Why

NSQ already freezes protocol, splits, preprocessing, model state, scorecard semantics, and failure-preserving results. The remaining gap before any promoted neural efficacy run is the **materialized study itself**: exactly which raw bytes, processed observations, realized environment, and human-auditable role memberships produced the result.

This PR implements #93 as a reusable Study Materialization Authority and wires it into Kumar2024 before any promoted EEGNet final-assessment result is generated.

The prerequisite EEGNet authority from #92 was merged through qualified replacement PR #95. This PR is now directly based on durable `main` merge `33993ff97e132e3063351f89dd3d482616e2853f`.

Final candidate head: `38a50ab4c69e0aba77ffc86fc653531ff08f7a52`.

## Reusable authority

Adds typed, content-addressed authority for:

- the realized Python environment and deterministic runtime flags;
- exact raw files consumed by a study loader, hashed by bytes and canonical dataset-relative path rather than cache root;
- label-free processed observation identities (`participant/session/run/local_epoch`) bound to each processed signal row;
- human-readable observation role manifests that independently reconcile with NSQ's machine-index hashes;
- participant-native processed shards;
- a composed `study_materialization_sha256` root.

Volatile host information such as hostname, PID, timestamps, runner IDs, temp paths, and free memory does not enter the materialization identity.

For promoted execution, the environment authority captures the complete realized Python distribution set plus source revision and accelerator/determinism settings. This intentionally makes the identity strict and assumes promoted studies run in purpose-built environments rather than arbitrary developer workstations.

## Kumar2024 raw authority

The resolver mirrors the installed MOABB Kumar2024 loader rather than hashing the entire cache. It binds only the bar-feedback GDF files actually consumed by the study and excludes Race material shipped in the same extraction.

It preserves the upstream subject mapping, including MOABB participant 10 -> raw participant 11, directory-padding quirks, `.gdf`/`.GDF` fallback, and the frozen session run counts `4/4/3/3/3/3`.

Same bytes under another cache root produce the same raw authority. A changed byte, missing run, extra consumed run, changed subject mapping, or inconsistent archive root fails closed.

## Human observation authority

Every processed row is represented by a label-free human identity plus a processed-observation SHA. For each NSQ result row the bundle exposes:

- `supervised_source_history`
- `labeled_target_calibration`
- `supervised_fit`
- `untouched_final_assessment`
- `internal_model_training`, when a model performs internal state selection
- `internal_model_validation`, when present

The first four are independently hashed using the same `neuros.qualification_observation_set.v1` identity domain as the production runner and must exactly equal the NSQ result-row hashes or artifact construction fails.

Budget 0 is represented by a signed empty calibration role. EEGNet relative validation membership is mapped through the exact authorized fit set back to original participant/session/run/epoch identities and is checked not to overlap final assessment.

No target labels are serialized in observation-identity or role surfaces.

## Two-pass materialization

Kumar2024 study execution is deliberately two-pass:

1. Process each participant and freeze its processed-data SHA, epoch descriptor, and label-free observation identity.
2. Release the participant array and compose the global environment/raw/processed materialization root after all shards are frozen.
3. Reload each participant before model execution.
4. Require the second pass to reproduce the frozen descriptor, processed-data SHA, and observation-identity SHA exactly.
5. Only then execute NSQ cases under an execution context bound to the global materialization root.

This turns preprocessing/materialization determinism into an enforced invariant without requiring all 18 participant arrays to remain resident simultaneously.

## Kumar evidence bundle generation v2

The public `run_study()` path now emits generation-v2 evidence containing the historical files plus:

- `materialization.json`
- `observation_roles.json`

`study_manifest.json` binds the environment, raw materialization, and composed study roots. `artifact_hashes.json` uses the `neuros.nsq_kumar2024_bundle.v2` identity domain and requires the exact frozen v2 file set.

Historical bundle-v1 verification remains supported. This PR does not redefine previously sealed evidence.

`DatasetLineage.content_sha256` deliberately remains unset. The new raw-materialization SHA identifies the exact consumed extracted GDF set, but that composed consumed-file authority is not misrepresented as a canonical digest of the upstream Zenodo archive. Lineage therefore remains conservatively partial.

## CI and exact-main study contract

Kumar CI now covers materialization authority, raw resolver, role reconciliation, bundle-v2 verification, existing Kumar contracts, and production NSQ runner behavior.

The exact-main classical pilot will refuse upload unless the artifact is schema v2 and binds:

- exact durable main revision;
- materialization root;
- environment authority;
- raw-file authority;
- participant processed shards;
- observation-role evidence.

The real-data workflow remains classical only (`mne-csp-lda` and `pyriemann-rg-lr`). This PR does **not** generate promoted EEGNet final-assessment results.

## Validation

The exact source tree in this PR passed a focused authority gate before history cleanup:

- compileall;
- `git diff --check`;
- **43 targeted tests** spanning study materialization, MOABB raw resolution, observation-role reconciliation, bundle-v2 verification, Kumar2024 study contracts, and the production NSQ runner.

Implementation scaffolding was then removed and the branch was reconstructed from the exact tested Git tree SHA. After #95 merged, the same tree was reparented onto durable `main` without changing source bytes. The final PR therefore has one permanent commit and no temporary workflow files.

A fresh exact-head PR matrix is required on `38a50ab4c69e0aba77ffc86fc653531ff08f7a52` before merge.

## Non-claims and remaining gates

This PR does not claim model superiority, physiological mechanism, hardware validity, online BCI efficacy, or clinical benefit. It does not promote EEGConformer or ORION.

After this materialization authority is durable, #27 still owns the remaining multi-split/model-seed statistical authority. Only after that gate is frozen should promoted EEGNet final-assessment execution occur. ORION should enter only after the external floor is qualified under identical NSQ authority.

Closes #93.