### PR TITLE
NSQ Kumar2024: preserve frozen authority through CLI overrides

### DIFF
--- a/packages/neuros/src/neuros/evidence/kumar2024.py
+++ b/packages/neuros/src/neuros/evidence/kumar2024.py
@@ -1386,9 +1386,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             else args.braindecode_epochs
         ),
         braindecode_batch_size=base.braindecode_batch_size,
+        braindecode_optimizer=base.braindecode_optimizer,
         braindecode_learning_rate=base.braindecode_learning_rate,
         braindecode_weight_decay=base.braindecode_weight_decay,
-        braindecode_random_state=base.braindecode_random_state,
+        braindecode_validation_fraction=base.braindecode_validation_fraction,
+        braindecode_validation_seed=base.braindecode_validation_seed,
+        braindecode_early_stopping_patience=(
+            base.braindecode_early_stopping_patience
+        ),
+        braindecode_model_seed=base.braindecode_model_seed,
         device=base.device if args.device is None else args.device,
         analysis_bootstrap_replicates=base.analysis_bootstrap_replicates,
         analysis_seed=base.analysis_seed,

--- a/tests/test_kumar2024_nsq_study.py
+++ b/tests/test_kumar2024_nsq_study.py
@@ -316,3 +316,51 @@ def test_bundle_verification_detects_tampering_without_rerunning_training(tmp_pa
         assert "hash mismatch" in str(exc)
     else:
         raise AssertionError("tampered bundle unexpectedly verified")
+
+
+def test_cli_overrides_preserve_frozen_eegnet_authority(tmp_path: Path, monkeypatch):
+    from neuros.evidence import kumar2024 as module
+
+    captured = {}
+
+    def fake_run_study(output, *, config, preprocessing, overwrite):
+        captured["output"] = Path(output)
+        captured["config"] = config
+        captured["preprocessing"] = preprocessing
+        captured["overwrite"] = overwrite
+        return {"validated": True}
+
+    monkeypatch.setattr(module, "run_study", fake_run_study)
+    base = module.pilot_config()
+    output = tmp_path / "cli-authority"
+
+    result = module.main(
+        [
+            "--output",
+            str(output),
+            "--methods",
+            "mne-csp-lda,pyriemann-rg-lr",
+            "--braindecode-epochs",
+            "123",
+        ]
+    )
+
+    assert result == 0
+    config = captured["config"]
+    assert captured["output"] == output
+    assert config.methods == ("mne-csp-lda", "pyriemann-rg-lr")
+    assert config.braindecode_epochs == 123
+    assert config.braindecode_batch_size == base.braindecode_batch_size
+    assert config.braindecode_optimizer == base.braindecode_optimizer
+    assert config.braindecode_learning_rate == base.braindecode_learning_rate
+    assert config.braindecode_weight_decay == base.braindecode_weight_decay
+    assert config.braindecode_validation_fraction == base.braindecode_validation_fraction
+    assert config.braindecode_validation_seed == base.braindecode_validation_seed
+    assert (
+        config.braindecode_early_stopping_patience
+        == base.braindecode_early_stopping_patience
+    )
+    assert config.braindecode_model_seed == base.braindecode_model_seed
+    assert config.device == base.device
+    assert captured["preprocessing"] == module.Kumar2024PreprocessingSpec()
+    assert captured["overwrite"] is False


### PR DESCRIPTION
## Why

The first exact-main Kumar bundle-v2 study on materialization merge `c353b04092815761ee360df149fafcbdf92afe3a` failed before data/model execution because the CLI reconstruction path still referenced the pre-#95 field `braindecode_random_state`.

The failure occurred before the study downloaded/processed Kumar data, fitted a model, inspected final-assessment values, or uploaded an artifact. This is an execution seam repair, not a scientific protocol revision.

## Fix

The CLI now explicitly carries forward the complete frozen EEGNet training/state-selection authority from `pilot_config()` whenever subjects/sessions/methods/epochs/device are reconstructed:

- batch size
- optimizer
- learning rate
- weight decay
- validation fraction
- validation seed
- early-stopping patience
- model seed
- epoch ceiling
- device

This removes the stale `braindecode_random_state` reference and prevents future CLI overrides from silently depending on dataclass defaults to preserve scientific authority.

## Regression

Adds a no-data regression to the permanent Kumar study test surface. It monkeypatches `run_study`, invokes the real CLI with the exact `--methods mne-csp-lda,pyriemann-rg-lr` path plus an epoch override, and asserts that only the explicitly overridden epoch ceiling changes while every other frozen EEGNet authority field remains identical to `pilot_config()`.

The exact source tree in this PR passed:

- compileall
- `git diff --check`
- Kumar2024 study tests
- Kumar bundle-v2 tests
- Kumar observation-role/materialization tests

The branch was then reconstructed as one commit using the exact validated clean tree with durable `c353b040...` as its sole parent. No temporary workflow remains.

## Claim boundary

This PR changes no split, participant, session, budget, preprocessing, method recipe, scorecard, model state-selection policy, or statistical endpoint. It does not run promoted EEGNet final-assessment evidence.

After merge, the exact-main classical CSP+RG pilot must rerun and produce a bundle-v2 artifact bound to the new durable main SHA. That artifact will be independently verified before this materialization milestone is considered archival.