### PR TITLE
NSQ Kumar2024: qualify one classical promoted worker path

### DIFF
--- a/.github/workflows/nsq-kumar2024-ci.yml
+++ b/.github/workflows/nsq-kumar2024-ci.yml
@@ -3,6 +3,8 @@ name: NSQ Kumar2024 v1
 on:
   pull_request:
     paths:
+      - "requirements/nsq-kumar2024-promoted-py311.constraints.txt"
+      - "scripts/evidence/validate_promoted_environment.py"
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
@@ -16,12 +18,17 @@ on:
       - "tests/test_kumar2024_promoted_execution_authority.py"
       - "tests/test_kumar2024_promoted_binding_authority.py"
       - "tests/test_kumar2024_promoted_worker_authority.py"
+      - "tests/test_promoted_environment_validator.py"
       - "tests/test_neural_system_qualification_baselines.py"
       - "docs/NSQ_KUMAR2024_V1.md"
       - ".github/workflows/nsq-kumar2024-ci.yml"
+      - ".github/workflows/nsq-kumar2024-promoted-binding.yml"
+      - ".github/workflows/nsq-kumar2024-classical-worker-qualification.yml"
   push:
     branches: [main]
     paths:
+      - "requirements/nsq-kumar2024-promoted-py311.constraints.txt"
+      - "scripts/evidence/validate_promoted_environment.py"
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
@@ -35,9 +42,12 @@ on:
       - "tests/test_kumar2024_promoted_execution_authority.py"
       - "tests/test_kumar2024_promoted_binding_authority.py"
       - "tests/test_kumar2024_promoted_worker_authority.py"
+      - "tests/test_promoted_environment_validator.py"
       - "tests/test_neural_system_qualification_baselines.py"
       - "docs/NSQ_KUMAR2024_V1.md"
       - ".github/workflows/nsq-kumar2024-ci.yml"
+      - ".github/workflows/nsq-kumar2024-promoted-binding.yml"
+      - ".github/workflows/nsq-kumar2024-classical-worker-qualification.yml"
 
 permissions:
   contents: read
@@ -55,8 +65,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -82,6 +92,7 @@ jobs:
             tests/test_kumar2024_promoted_execution_authority.py \
             tests/test_kumar2024_promoted_binding_authority.py \
             tests/test_kumar2024_promoted_worker_authority.py \
+            tests/test_promoted_environment_validator.py \
             tests/test_neural_system_qualification_runner.py
       - name: Compile evidence surface
         run: |
@@ -95,14 +106,15 @@ jobs:
             packages/neuros/src/neuros/evidence/kumar2024_comparison.py \
             packages/neuros/src/neuros/evidence/kumar2024_promoted_execution.py \
             packages/neuros/src/neuros/evidence/kumar2024_promoted_binding.py \
-            packages/neuros/src/neuros/evidence/kumar2024_promoted_worker.py
+            packages/neuros/src/neuros/evidence/kumar2024_promoted_worker.py \
+            scripts/evidence/validate_promoted_environment.py
 
   upstream-moabb-contract:
     name: Current MOABB processed-epoch contract
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: pip
@@ -134,8 +146,8 @@ jobs:
     name: Upstream pyRiemann RG+LR NSQ contract
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: pip
@@ -177,8 +189,8 @@ jobs:
     name: Upstream Braindecode EEGNet training authority
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/nsq-kumar2024-classical-worker-qualification.yml
+++ b/.github/workflows/nsq-kumar2024-classical-worker-qualification.yml
@@ -1,0 +1,316 @@
+name: NSQ Kumar2024 classical worker qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      binding_run_id:
+        description: "Successful exact-main promoted-binding workflow run ID"
+        required: true
+        type: string
+      binding_artifact_id:
+        description: "Immutable promoted-binding artifact ID from that run"
+        required: true
+        type: string
+      shard_spec_sha256:
+        description: "One archived classical shard_spec_sha256 from the binding"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  PROMOTED_CONSTRAINTS: requirements/nsq-kumar2024-promoted-py311.constraints.txt
+
+jobs:
+  qualify-one-classical-shard:
+    name: One classical shard / non-interpretive systems qualification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Require successful exact-main binding run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BINDING_RUN_ID: ${{ inputs.binding_run_id }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          run_id = os.environ["BINDING_RUN_ID"]
+          if not run_id.isdigit():
+              raise SystemExit("binding_run_id must be a decimal GitHub Actions run id")
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/${{ github.repository }}/actions/runs/{run_id}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request) as response:
+              payload = json.load(response)
+          expected = {
+              "event": "push",
+              "head_branch": "main",
+              "status": "completed",
+              "conclusion": "success",
+              "path": ".github/workflows/nsq-kumar2024-promoted-binding.yml",
+          }
+          drift = {
+              key: {"expected": value, "observed": payload.get(key)}
+              for key, value in expected.items()
+              if payload.get(key) != value
+          }
+          head_sha = str(payload.get("head_sha", ""))
+          if len(head_sha) != 40 or any(ch not in "0123456789abcdef" for ch in head_sha):
+              drift["head_sha"] = {"expected": "40-char lowercase git SHA", "observed": head_sha}
+          if drift:
+              raise SystemExit(f"binding run is not final exact-main authority: {drift}")
+          print(json.dumps({"verified": True, "head_sha": head_sha}, sort_keys=True))
+          PY
+
+      - name: Download immutable promoted binding artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          artifact-ids: ${{ inputs.binding_artifact_id }}
+          path: ${{ runner.temp }}/promoted-binding
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.binding_run_id }}
+
+      - name: Read binding-owned source revision
+        id: binding
+        env:
+          BINDING_ROOT: ${{ runner.temp }}/promoted-binding
+          BINDING_RUN_ID: ${{ inputs.binding_run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          root = Path(os.environ["BINDING_ROOT"])
+          manifest_path = root / "binding_manifest.json"
+          hashes_path = root / "artifact_hashes.json"
+          if not manifest_path.is_file() or not hashes_path.is_file():
+              raise SystemExit("downloaded artifact is not a promoted binding bundle")
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          hashes = json.loads(hashes_path.read_text(encoding="utf-8"))
+          revision = str(manifest.get("source_revision", ""))
+          bundle_sha = str(hashes.get("bundle_sha256", ""))
+          if len(revision) != 40 or any(ch not in "0123456789abcdef" for ch in revision):
+              raise SystemExit("binding source_revision is not an exact Git SHA")
+          if len(bundle_sha) != 64 or any(ch not in "0123456789abcdef" for ch in bundle_sha):
+              raise SystemExit("binding bundle SHA-256 is malformed")
+
+          request = urllib.request.Request(
+              f"https://api.github.com/repos/${{ github.repository }}/actions/runs/{os.environ['BINDING_RUN_ID']}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request) as response:
+              run = json.load(response)
+          if str(run.get("head_sha")) != revision:
+              raise SystemExit(
+                  "binding artifact source_revision differs from the successful main run head"
+              )
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as stream:
+              stream.write(f"source_revision={revision}\n")
+              stream.write(f"binding_bundle_sha256={bundle_sha}\n")
+          print(json.dumps({"source_revision": revision, "bundle_sha256": bundle_sha}, sort_keys=True))
+          PY
+
+      - name: Checkout binding-owned source revision
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ steps.binding.outputs.source_revision }}
+          persist-credentials: false
+
+      - name: Require clean tracked source tree
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${{ steps.binding.outputs.source_revision }}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11.16"
+          cache: pip
+          cache-dependency-path: ${{ env.PROMOTED_CONSTRAINTS }}
+
+      - name: Install pinned promoted worker environment
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check \
+            -c "${PROMOTED_CONSTRAINTS}" \
+            "pip==26.2.1" "setuptools==79.0.1" "wheel==0.48.0"
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros-core
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros-drivers
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros-models
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e "packages/neuros-foundation[evidence,braindecode-evidence]"
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/orion
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros
+          python scripts/evidence/validate_promoted_environment.py \
+            --constraints "${PROMOTED_CONSTRAINTS}"
+
+      - name: Verify binding bundle under exact worker environment
+        env:
+          BINDING_ROOT: ${{ runner.temp }}/promoted-binding
+        run: |
+          set -euo pipefail
+          python -P -s -m neuros.evidence.kumar2024_promoted_binding \
+            --verify-only \
+            --output "${BINDING_ROOT}"
+
+      - name: Require exactly one archived classical shard
+        id: shard
+        env:
+          BINDING_ROOT: ${{ runner.temp }}/promoted-binding
+          SHARD_SPEC_SHA256: ${{ inputs.shard_spec_sha256 }}
+        run: |
+          set -euo pipefail
+          python -P -s - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          requested = os.environ["SHARD_SPEC_SHA256"].strip().lower()
+          if len(requested) != 64 or any(ch not in "0123456789abcdef" for ch in requested):
+              raise SystemExit("shard_spec_sha256 must be a lowercase SHA-256 digest")
+          execution = json.loads(
+              (Path(os.environ["BINDING_ROOT"]) / "execution_plan.json").read_text(encoding="utf-8")
+          )
+          matches = [
+              shard
+              for shard in execution["template"]["shards"]
+              if shard.get("shard_spec_sha256") == requested
+          ]
+          if len(matches) != 1:
+              raise SystemExit("requested shard must occur exactly once in the promoted binding")
+          shard = matches[0]
+          method = str(shard.get("method_id"))
+          if method not in {"mne-csp-lda", "pyriemann-rg-lr"}:
+              raise SystemExit(
+                  "systems qualification is classical-only; neural/model-training shards are forbidden"
+              )
+          if tuple(shard.get("budgets_per_class", ())) != (0, 1, 2, 5, 10):
+              raise SystemExit("qualification shard does not contain the complete atomic budget frontier")
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as stream:
+              stream.write(f"method_id={method}\n")
+              stream.write(f"shard_id={shard['shard_id']}\n")
+          print(
+              json.dumps(
+                  {
+                      "verified": True,
+                      "method_id": method,
+                      "shard_id": shard["shard_id"],
+                      "budgets_per_class": shard["budgets_per_class"],
+                  },
+                  sort_keys=True,
+              )
+          )
+          PY
+
+      - name: Execute one non-headline classical worker shard
+        env:
+          BINDING_ROOT: ${{ runner.temp }}/promoted-binding
+          WORKER_ROOT: ${{ runner.temp }}/classical-worker-qualification/worker
+          SHARD_SPEC_SHA256: ${{ inputs.shard_spec_sha256 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${WORKER_ROOT}")"
+          python -P -s -m neuros.evidence.kumar2024_promoted_worker \
+            --binding "${BINDING_ROOT}" \
+            --shard-spec-sha256 "${SHARD_SPEC_SHA256}" \
+            --output "${WORKER_ROOT}" \
+            | tee "${RUNNER_TEMP}/classical-worker-qualification/worker_run.json"
+          python -P -s -m neuros.evidence.kumar2024_promoted_worker \
+            --verify-only \
+            --binding "${BINDING_ROOT}" \
+            --shard-spec-sha256 "${SHARD_SPEC_SHA256}" \
+            --output "${WORKER_ROOT}"
+
+      - name: Seal systems-qualification claim boundary
+        env:
+          QUALIFICATION_ROOT: ${{ runner.temp }}/classical-worker-qualification
+          BINDING_ROOT: ${{ runner.temp }}/promoted-binding
+          SHARD_SPEC_SHA256: ${{ inputs.shard_spec_sha256 }}
+          METHOD_ID: ${{ steps.shard.outputs.method_id }}
+          SHARD_ID: ${{ steps.shard.outputs.shard_id }}
+          SOURCE_REVISION: ${{ steps.binding.outputs.source_revision }}
+          BINDING_BUNDLE_SHA256: ${{ steps.binding.outputs.binding_bundle_sha256 }}
+          BINDING_RUN_ID: ${{ inputs.binding_run_id }}
+          BINDING_ARTIFACT_ID: ${{ inputs.binding_artifact_id }}
+        run: |
+          set -euo pipefail
+          python -P -s - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["QUALIFICATION_ROOT"])
+          worker = root / "worker"
+          worker_hashes = json.loads((worker / "artifact_hashes.json").read_text(encoding="utf-8"))
+          worker_manifest = json.loads((worker / "worker_manifest.json").read_text(encoding="utf-8"))
+          payload = {
+              "schema_version": 1,
+              "artifact_kind": "promoted_classical_worker_systems_qualification",
+              "source_revision": os.environ["SOURCE_REVISION"],
+              "binding_run_id": int(os.environ["BINDING_RUN_ID"]),
+              "binding_artifact_id": int(os.environ["BINDING_ARTIFACT_ID"]),
+              "binding_bundle_sha256": os.environ["BINDING_BUNDLE_SHA256"],
+              "shard_spec_sha256": os.environ["SHARD_SPEC_SHA256"],
+              "shard_id": os.environ["SHARD_ID"],
+              "method_id": os.environ["METHOD_ID"],
+              "worker_bundle_sha256": worker_hashes["bundle_sha256"],
+              "worker_shard_result_sha256": worker_manifest["shard_result_sha256"],
+              "numerical_result_interpretable": False,
+              "global_analysis_performed": False,
+              "external_floor_claim_generated": False,
+              "orion_comparison_permitted": False,
+              "claim_boundary": (
+                  "systems qualification of one classical artifact-consuming worker path only; "
+                  "all numerical scores are non-interpretable and cannot support efficacy, "
+                  "method-ranking, external-floor, or ORION claims"
+              ),
+          }
+          encoded = json.dumps(
+              {"schema": "neuros.promoted_classical_worker_systems_qualification.v1", "payload": payload},
+              sort_keys=True,
+              separators=(",", ":"),
+              allow_nan=False,
+          ).encode("utf-8")
+          payload["qualification_sha256"] = hashlib.sha256(encoded).hexdigest()
+          (root / "qualification_manifest.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          print(json.dumps(payload, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload sealed systems qualification evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nsq-kumar2024-classical-worker-qualification-${{ inputs.shard_spec_sha256 }}
+          path: ${{ runner.temp }}/classical-worker-qualification
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/nsq-kumar2024-classical-worker-qualification.yml
+++ b/.github/workflows/nsq-kumar2024-classical-worker-qualification.yml
@@ -29,10 +29,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     steps:
-      - name: Require successful exact-main binding run
+      - name: Require successful exact-main binding run and artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BINDING_RUN_ID: ${{ inputs.binding_run_id }}
+          BINDING_ARTIFACT_ID: ${{ inputs.binding_artifact_id }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -41,17 +42,21 @@ jobs:
           import urllib.request
 
           run_id = os.environ["BINDING_RUN_ID"]
+          artifact_id = os.environ["BINDING_ARTIFACT_ID"]
           if not run_id.isdigit():
               raise SystemExit("binding_run_id must be a decimal GitHub Actions run id")
-          request = urllib.request.Request(
+          if not artifact_id.isdigit():
+              raise SystemExit("binding_artifact_id must be a decimal GitHub Actions artifact id")
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          run_request = urllib.request.Request(
               f"https://api.github.com/repos/${{ github.repository }}/actions/runs/{run_id}",
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              },
+              headers=headers,
           )
-          with urllib.request.urlopen(request) as response:
+          with urllib.request.urlopen(run_request) as response:
               payload = json.load(response)
           expected = {
               "event": "push",
@@ -70,7 +75,43 @@ jobs:
               drift["head_sha"] = {"expected": "40-char lowercase git SHA", "observed": head_sha}
           if drift:
               raise SystemExit(f"binding run is not final exact-main authority: {drift}")
-          print(json.dumps({"verified": True, "head_sha": head_sha}, sort_keys=True))
+
+          artifact_request = urllib.request.Request(
+              f"https://api.github.com/repos/${{ github.repository }}/actions/artifacts/{artifact_id}",
+              headers=headers,
+          )
+          with urllib.request.urlopen(artifact_request) as response:
+              artifact = json.load(response)
+          workflow_run = artifact.get("workflow_run") or {}
+          artifact_drift = {}
+          if bool(artifact.get("expired")):
+              artifact_drift["expired"] = True
+          if int(workflow_run.get("id", -1)) != int(run_id):
+              artifact_drift["workflow_run_id"] = {
+                  "expected": int(run_id),
+                  "observed": workflow_run.get("id"),
+              }
+          expected_name = f"nsq-kumar2024-promoted-binding-{head_sha}"
+          if artifact.get("name") != expected_name:
+              artifact_drift["name"] = {
+                  "expected": expected_name,
+                  "observed": artifact.get("name"),
+              }
+          if artifact_drift:
+              raise SystemExit(
+                  f"artifact is not the immutable binding output of the authorized run: {artifact_drift}"
+              )
+          print(
+              json.dumps(
+                  {
+                      "verified": True,
+                      "head_sha": head_sha,
+                      "artifact_id": int(artifact_id),
+                      "artifact_digest": artifact.get("digest"),
+                  },
+                  sort_keys=True,
+              )
+          )
           PY
 
       - name: Download immutable promoted binding artifact
@@ -88,6 +129,7 @@ jobs:
           BINDING_ROOT: ${{ runner.temp }}/promoted-binding
           BINDING_RUN_ID: ${{ inputs.binding_run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -109,6 +151,11 @@ jobs:
               raise SystemExit("binding source_revision is not an exact Git SHA")
           if len(bundle_sha) != 64 or any(ch not in "0123456789abcdef" for ch in bundle_sha):
               raise SystemExit("binding bundle SHA-256 is malformed")
+          if os.environ["WORKFLOW_SHA"] != revision:
+              raise SystemExit(
+                  "qualification workflow revision differs from binding source_revision; "
+                  "regenerate exact-main binding before worker qualification"
+              )
 
           request = urllib.request.Request(
               f"https://api.github.com/repos/${{ github.repository }}/actions/runs/{os.environ['BINDING_RUN_ID']}",
@@ -141,6 +188,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "${{ steps.binding.outputs.source_revision }}"
+          test -f .github/workflows/nsq-kumar2024-classical-worker-qualification.yml
           git diff --quiet HEAD --
           git diff --cached --quiet HEAD --
 
@@ -252,7 +300,6 @@ jobs:
       - name: Seal systems-qualification claim boundary
         env:
           QUALIFICATION_ROOT: ${{ runner.temp }}/classical-worker-qualification
-          BINDING_ROOT: ${{ runner.temp }}/promoted-binding
           SHARD_SPEC_SHA256: ${{ inputs.shard_spec_sha256 }}
           METHOD_ID: ${{ steps.shard.outputs.method_id }}
           SHARD_ID: ${{ steps.shard.outputs.shard_id }}

--- a/.github/workflows/nsq-kumar2024-promoted-binding.yml
+++ b/.github/workflows/nsq-kumar2024-promoted-binding.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - "requirements/nsq-kumar2024-promoted-py311.constraints.txt"
+      - "scripts/evidence/validate_promoted_environment.py"
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py"
@@ -18,10 +19,12 @@ on:
       - "packages/neuros/src/neuros/evidence/kumar2024_promoted_binding.py"
       - "packages/neuros/src/neuros/evidence/kumar2024_promoted_worker.py"
       - ".github/workflows/nsq-kumar2024-promoted-binding.yml"
+      - ".github/workflows/nsq-kumar2024-classical-worker-qualification.yml"
   push:
     branches: [main]
     paths:
       - "requirements/nsq-kumar2024-promoted-py311.constraints.txt"
+      - "scripts/evidence/validate_promoted_environment.py"
       - "packages/neuros-foundation/pyproject.toml"
       - "packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py"
       - "packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py"
@@ -35,6 +38,7 @@ on:
       - "packages/neuros/src/neuros/evidence/kumar2024_promoted_binding.py"
       - "packages/neuros/src/neuros/evidence/kumar2024_promoted_worker.py"
       - ".github/workflows/nsq-kumar2024-promoted-binding.yml"
+      - ".github/workflows/nsq-kumar2024-classical-worker-qualification.yml"
 
 permissions:
   contents: read
@@ -58,6 +62,12 @@ jobs:
         with:
           ref: ${{ env.BINDING_SOURCE_SHA }}
           persist-credentials: false
+      - name: Require clean tracked source tree
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${BINDING_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11.16"
@@ -65,6 +75,7 @@ jobs:
           cache-dependency-path: ${{ env.PROMOTED_CONSTRAINTS }}
       - name: Install pinned promoted evidence stack
         run: |
+          set -euo pipefail
           python -m pip install --disable-pip-version-check \
             -c "${PROMOTED_CONSTRAINTS}" \
             "pip==26.2.1" "setuptools==79.0.1" "wheel==0.48.0"
@@ -82,74 +93,8 @@ jobs:
             -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros
       - name: Assert pinned external dependency frontier
         run: |
-          python - <<'PY'
-          import importlib.metadata
-          import re
-          from pathlib import Path
-
-          normalize = lambda value: re.sub(r"[-_.]+", "-", value).lower()
-          expected = {}
-          for raw in Path("requirements/nsq-kumar2024-promoted-py311.constraints.txt").read_text().splitlines():
-              line = raw.strip()
-              if not line or line.startswith("#"):
-                  continue
-              name, version = line.split("==", 1)
-              expected[normalize(name)] = version
-
-          local = {
-              "neuros",
-              "neuros-core",
-              "neuros-drivers",
-              "neuros-foundation",
-              "neuros-models",
-              "neuros-orion",
-          }
-          observed = {}
-          for distribution in importlib.metadata.distributions():
-              raw_name = distribution.metadata.get("Name")
-              if raw_name is None:
-                  continue
-              name = normalize(raw_name)
-              version = str(distribution.version)
-              previous = observed.get(name)
-              if previous is not None and previous != version:
-                  raise SystemExit(
-                      f"conflicting installed versions for {name}: {previous} versus {version}"
-                  )
-              observed[name] = version
-
-          external = {name: version for name, version in observed.items() if name not in local}
-          unexpected = sorted(set(external) - set(expected))
-          mismatched = {
-              name: {"expected": expected[name], "observed": external[name]}
-              for name in sorted(set(external) & set(expected))
-              if external[name] != expected[name]
-          }
-          required = {
-              "braindecode",
-              "mne",
-              "moabb",
-              "numpy",
-              "pip",
-              "pyriemann",
-              "scikit-learn",
-              "scipy",
-              "setuptools",
-              "torch",
-              "wheel",
-          }
-          missing_required = sorted(required - set(external))
-          if unexpected or mismatched or missing_required:
-              raise SystemExit(
-                  "promoted external dependency frontier differs: "
-                  f"unexpected={unexpected}, mismatched={mismatched}, "
-                  f"missing_required={missing_required}"
-              )
-          print(
-              f"validated {len(external)} installed external distributions against "
-              f"{len(expected)} exact constraints"
-          )
-          PY
+          python scripts/evidence/validate_promoted_environment.py \
+            --constraints "${PROMOTED_CONSTRAINTS}"
       - name: Build exact-revision no-model promoted binding
         run: |
           OUT="${RUNNER_TEMP}/nsq-kumar2024-promoted-binding"

--- a/scripts/evidence/validate_promoted_environment.py
+++ b/scripts/evidence/validate_promoted_environment.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fail-closed validator for the promoted Kumar2024 Python environment.
+
+The promoted binding and worker workflows share this executable contract so the
+scheduler cannot quietly use a looser dependency check than the binding job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+
+LOCAL_DISTRIBUTIONS = frozenset(
+    {
+        "neuros",
+        "neuros-core",
+        "neuros-drivers",
+        "neuros-foundation",
+        "neuros-models",
+        "neuros-orion",
+    }
+)
+
+REQUIRED_EXTERNAL_DISTRIBUTIONS = frozenset(
+    {
+        "braindecode",
+        "mne",
+        "moabb",
+        "numpy",
+        "pip",
+        "pyriemann",
+        "scikit-learn",
+        "scipy",
+        "setuptools",
+        "torch",
+        "wheel",
+    }
+)
+
+
+def _normalize(value: str) -> str:
+    return _NORMALIZE_RE.sub("-", value.strip()).lower()
+
+
+def load_exact_constraints(path: str | Path) -> dict[str, str]:
+    """Load an exact ``name==version`` constraint frontier."""
+
+    result: dict[str, str] = {}
+    for line_number, raw in enumerate(Path(path).read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.count("==") != 1:
+            raise ValueError(
+                f"constraint line {line_number} must be exactly name==version: {line!r}"
+            )
+        raw_name, raw_version = line.split("==", 1)
+        name = _normalize(raw_name)
+        version = raw_version.strip()
+        if not name or not version:
+            raise ValueError(f"constraint line {line_number} is incomplete")
+        previous = result.get(name)
+        if previous is not None and previous != version:
+            raise ValueError(
+                f"constraint frontier contains conflicting versions for {name!r}: "
+                f"{previous!r} versus {version!r}"
+            )
+        result[name] = version
+    if not result:
+        raise ValueError("promoted constraint frontier cannot be empty")
+    return result
+
+
+def observed_distributions() -> dict[str, str]:
+    """Return the canonical realized Python distribution map."""
+
+    observed: dict[str, str] = {}
+    for distribution in importlib.metadata.distributions():
+        raw_name = distribution.metadata.get("Name")
+        if raw_name is None:
+            continue
+        name = _normalize(raw_name)
+        version = str(distribution.version).strip()
+        previous = observed.get(name)
+        if previous is not None and previous != version:
+            raise RuntimeError(
+                f"environment exposes conflicting installed versions for {name!r}: "
+                f"{previous!r} versus {version!r}"
+            )
+        observed[name] = version
+    return observed
+
+
+def validate_promoted_environment(
+    constraints: dict[str, str],
+    *,
+    local_distributions: Iterable[str] = LOCAL_DISTRIBUTIONS,
+    required_external: Iterable[str] = REQUIRED_EXTERNAL_DISTRIBUTIONS,
+) -> dict[str, object]:
+    """Require every realized external distribution to belong to the exact frontier."""
+
+    local = {_normalize(name) for name in local_distributions}
+    required = {_normalize(name) for name in required_external}
+    observed = observed_distributions()
+    external = {name: version for name, version in observed.items() if name not in local}
+
+    unexpected = sorted(set(external) - set(constraints))
+    mismatched = {
+        name: {"expected": constraints[name], "observed": external[name]}
+        for name in sorted(set(external) & set(constraints))
+        if external[name] != constraints[name]
+    }
+    missing_required = sorted(required - set(external))
+    if unexpected or mismatched or missing_required:
+        raise RuntimeError(
+            "promoted external dependency frontier differs: "
+            f"unexpected={unexpected}, mismatched={mismatched}, "
+            f"missing_required={missing_required}"
+        )
+    return {
+        "verified": True,
+        "constraint_count": len(constraints),
+        "installed_external_count": len(external),
+        "installed_local": sorted(set(observed) & local),
+        "required_external": sorted(required),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate the realized promoted Kumar2024 Python environment."
+    )
+    parser.add_argument("--constraints", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    result = validate_promoted_environment(load_exact_constraints(args.constraints))
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_promoted_environment_validator.py
+++ b/tests/test_promoted_environment_validator.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "evidence" / "validate_promoted_environment.py"
+_SPEC = importlib.util.spec_from_file_location("_promoted_environment_validator", _SCRIPT)
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError("unable to load promoted environment validator")
+validator = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(validator)
+
+
+def test_exact_constraint_loader_is_normalized_and_fail_closed(tmp_path: Path):
+    path = tmp_path / "constraints.txt"
+    path.write_text("# fixture\nNumPy==2.4.6\nscikit_learn==1.9.0\n", encoding="utf-8")
+    assert validator.load_exact_constraints(path) == {
+        "numpy": "2.4.6",
+        "scikit-learn": "1.9.0",
+    }
+
+    path.write_text("numpy>=2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="exactly name==version"):
+        validator.load_exact_constraints(path)
+
+
+def test_promoted_environment_accepts_only_exact_external_frontier(monkeypatch):
+    monkeypatch.setattr(
+        validator,
+        "observed_distributions",
+        lambda: {
+            "neuros": "2.1.0",
+            "numpy": "2.4.6",
+            "torch": "2.13.0",
+        },
+    )
+    result = validator.validate_promoted_environment(
+        {"numpy": "2.4.6", "torch": "2.13.0"},
+        local_distributions={"neuros"},
+        required_external={"numpy", "torch"},
+    )
+    assert result["verified"] is True
+    assert result["installed_external_count"] == 2
+
+
+def test_promoted_environment_rejects_unexpected_distribution(monkeypatch):
+    monkeypatch.setattr(
+        validator,
+        "observed_distributions",
+        lambda: {"numpy": "2.4.6", "foreign": "1"},
+    )
+    with pytest.raises(RuntimeError, match="unexpected=.*foreign"):
+        validator.validate_promoted_environment(
+            {"numpy": "2.4.6"},
+            local_distributions=set(),
+            required_external={"numpy"},
+        )
+
+
+def test_promoted_environment_rejects_version_drift(monkeypatch):
+    monkeypatch.setattr(
+        validator,
+        "observed_distributions",
+        lambda: {"numpy": "2.4.7"},
+    )
+    with pytest.raises(RuntimeError, match="mismatched=.*2.4.6"):
+        validator.validate_promoted_environment(
+            {"numpy": "2.4.6"},
+            local_distributions=set(),
+            required_external={"numpy"},
+        )
+
+
+def test_promoted_environment_rejects_missing_required_distribution(monkeypatch):
+    monkeypatch.setattr(validator, "observed_distributions", lambda: {"numpy": "2.4.6"})
+    with pytest.raises(RuntimeError, match="missing_required=.*torch"):
+        validator.validate_promoted_environment(
+            {"numpy": "2.4.6", "torch": "2.13.0"},
+            local_distributions=set(),
+            required_external={"numpy", "torch"},
+        )


### PR DESCRIPTION
## Why

PR #100 establishes the artifact-consuming promoted worker. PR #101 freezes the promoted Python execution recipe and makes exact-revision no-model bindings available on PR heads. This stacked PR closes the next operational gap: the repository currently has no narrow, auditable transport for exercising exactly one bound worker shard without allowing the scheduler to redefine the experiment.

This PR deliberately does **not** create the 1,350-shard fleet launcher. It creates only the systems-qualification path required before a fleet should exist.

## Classical-only qualification transport

The manual workflow accepts only three transport identifiers:

- a successful promoted-binding workflow run ID;
- the immutable artifact ID produced by that run;
- one archived `shard_spec_sha256`.

It does not accept participant, session, split seed, model seed, calibration budget, decoder hyperparameters, preprocessing, or outcome-selection inputs.

Before execution the workflow requires that the supplied binding run:

- came from a `push` event;
- targeted `main`;
- completed successfully;
- used `.github/workflows/nsq-kumar2024-promoted-binding.yml`;
- has a 40-character exact `head_sha`.

It separately resolves the supplied GitHub artifact ID and requires that artifact to:

- be unexpired;
- belong to the supplied binding workflow run;
- have the exact name `nsq-kumar2024-promoted-binding-<run-head-sha>`.

After download, the workflow requires all three revision identities to be identical:

1. the successful main binding run `head_sha`;
2. the binding bundle's archived `source_revision`;
3. `github.workflow_sha`, the commit containing the qualification workflow being executed.

That last equality closes the rollback hole where a newer worker transport could otherwise consume an older successful authorization artifact. A scheduler revision is therefore not allowed to outrun its binding authority.

The workflow then checks out the binding-owned revision, requires a clean tracked source tree, recreates CPython 3.11.16 under the promoted constraint frontier, invokes the same shared environment validator as the binding producer, verifies the complete binding bundle, and resolves the requested shard from the archived execution plan.

For this qualification stage, only `mne-csp-lda` and `pyriemann-rg-lr` are permitted. EEGNet and any future trainable/neural method fail before execution. The selected shard must preserve the complete `(0, 1, 2, 5, 10)` atomic budget frontier.

## Evidence quarantine

The worker emits and seals its normal evidence bundle, but the workflow wraps it in a separate `qualification_manifest.json` that explicitly declares:

- `numerical_result_interpretable = false`
- `global_analysis_performed = false`
- `external_floor_claim_generated = false`
- `orion_comparison_permitted = false`

The qualification manifest is independently content-addressed and names the exact binding run, binding artifact, binding bundle, source revision, worker bundle, worker shard result, method, and shard.

## One environment contract

The dependency-frontier check introduced in #101 is centralized in `scripts/evidence/validate_promoted_environment.py` and adversarially tested. Both the binding producer and qualification consumer invoke that same executable contract, preventing producer/consumer validation drift.

The validator fails closed on:

- non-exact constraint syntax;
- unexpected external distributions;
- external package-version drift;
- missing required scientific/runtime distributions;
- conflicting realized distribution versions.

## Scientific ownership and CI

The Kumar2024 scientific ownership surface now includes:

- the promoted constraints frontier;
- the shared environment validator;
- its adversarial tests;
- the promoted binding workflow;
- this classical worker qualification workflow.

The three-version Kumar2024 authority matrix executes the new validator tests and uses immutable checkout/setup-python action commits. The promoted binding workflow separately watches the validator and this qualification workflow, so changing the transport necessarily forces a new exact-revision no-model binding.

The intended final promoted authorization must therefore contain the exact worker implementation, execution recipe, and one-shard orchestration path used for qualification.

## Explicit non-claims

This PR does not execute a real worker merely by merging or testing the PR, does not schedule any promoted shard automatically, does not create a fleet, does not generate an external-floor claim, does not compare ORION, and does not alter the preregistered scientific graph.

This PR is intentionally stacked on #101. The promotion order is #100 -> #101 -> this PR, with exact-head qualification and SHA-locked merges at each boundary. Only the new successful exact-main binding produced after the complete stack lands is eligible for the one-shard systems qualification.