### PR TITLE
Developer preview: make neurOS usable from the first command

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 * text=auto eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
+
+# Research notebooks are supporting documentation/experiments, not the primary
+# implementation language of the neurOS platform.
+*.ipynb linguist-documentation

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Reproducible bug report
+description: Report a neurOS runtime, packaging, replay, CLI, or evidence-contract defect
+title: "[bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping harden neurOS. Please reduce the failure to the smallest public configuration you can. Do not attach credentials, private keys, or identifiable participant data.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - CLI / project setup
+        - Runtime / configuration
+        - Recording / replay
+        - Plugin / ecosystem integration
+        - Qualification / evidence artifact
+        - ORION
+        - Packaging / installation
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: revision
+    attributes:
+      label: Exact neurOS revision or release
+      description: Prefer the full 40-character Git commit or an exact release tag.
+      placeholder: 0123456789abcdef0123456789abcdef01234567
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Smallest failing command or API call
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal configuration or code
+      description: Remove participant data, credentials, and unrelated configuration.
+      render: yaml
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: Include the complete error message or traceback when possible.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: `neuros doctor --json`
+      description: Paste the machine-readable diagnostic output when the CLI can start.
+      render: json
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Relevant compatibility information
+      description: For integration bugs, include `neuros compatibility --json` or the focused integration entry.
+      render: json
+  - type: checkboxes
+    id: boundary
+    attributes:
+      label: Data and claim safety
+      options:
+        - label: I removed credentials and identifiable participant data from this report.
+          required: true
+        - label: I have not interpreted a software-contract failure as evidence about biological, hardware, safety, or clinical performance.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support and usage questions
+    url: https://github.com/sidhulyalkar/neurOS-v1/blob/main/SUPPORT.md
+    about: Check supported workflows, diagnostics, and where to ask usage questions before opening a defect.
+  - name: Security policy
+    url: https://github.com/sidhulyalkar/neurOS-v1/blob/main/SECURITY.md
+    about: Do not report security-sensitive information in a public issue.

--- a/.github/ISSUE_TEMPLATE/ecosystem_integration.yml
+++ b/.github/ISSUE_TEMPLATE/ecosystem_integration.yml
@@ -1,6 +1,6 @@
 name: Ecosystem integration proposal
 description: Propose a thin neurOS boundary around an existing neuroscience or BCI ecosystem
- title: "[integration] "
+title: "[integration] "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/ecosystem_integration.yml
+++ b/.github/ISSUE_TEMPLATE/ecosystem_integration.yml
@@ -1,0 +1,82 @@
+name: Ecosystem integration proposal
+description: Propose a thin neurOS boundary around an existing neuroscience or BCI ecosystem
+ title: "[integration] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        neurOS prefers integration over reimplementation. A strong proposal names what the upstream project already owns and the specific qualification, replay, provenance, or deployment authority neurOS would add.
+  - type: input
+    id: upstream
+    attributes:
+      label: Upstream project or standard
+      placeholder: MNE, MOABB, Braindecode, BrainFlow, LSL, NWB, BIDS, SpikeInterface, ...
+    validations:
+      required: true
+  - type: input
+    id: upstream_version
+    attributes:
+      label: Upstream version or revision
+      description: Give an exact package version, release, or commit when possible.
+    validations:
+      required: true
+  - type: textarea
+    id: existing_owner
+    attributes:
+      label: What does the upstream ecosystem already solve?
+      description: Describe the maintained upstream responsibility we should not duplicate.
+    validations:
+      required: true
+  - type: textarea
+    id: missing_boundary
+    attributes:
+      label: What concrete boundary is missing?
+      description: Focus on reproducibility, qualification, replay, lineage, transfer, adaptation authority, hardware evidence, or another neurOS-specific seam.
+    validations:
+      required: true
+  - type: dropdown
+    id: authority
+    attributes:
+      label: neurOS authority strengthened
+      options:
+        - Runtime / timing / transport
+        - Recording / exact replay
+        - Scientific data authority
+        - Neural System Qualification
+        - Model artifact / deployment identity
+        - ORION representation / adaptation authority
+        - Hardware qualification
+        - Falsification / robustness evidence
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: falsification
+    attributes:
+      label: External falsification target
+      description: Name the public dataset, model, device, upstream test, or interoperability case that could prove this integration wrong or unnecessary.
+    validations:
+      required: true
+  - type: textarea
+    id: maintenance
+    attributes:
+      label: Maintenance cost
+      description: New dependencies, APIs, CI lanes, hardware requirements, credentials, or compatibility commitments.
+    validations:
+      required: true
+  - type: textarea
+    id: removal
+    attributes:
+      label: When should this be upstreamed, rejected, or removed?
+      description: State the condition under which neurOS should not maintain this boundary.
+    validations:
+      required: true
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope firewall
+      options:
+        - label: I checked whether a thin adapter or upstream contribution is sufficient before proposing a new neurOS subsystem.
+          required: true
+        - label: This proposal does not rely on package count or architectural novelty as evidence of value.
+          required: true

--- a/.github/ISSUE_TEMPLATE/external_method.yml
+++ b/.github/ISSUE_TEMPLATE/external_method.yml
@@ -1,0 +1,93 @@
+name: External model / method submission
+description: Bring an existing decoder, representation, or training stack to Neural System Qualification
+title: "[method] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You should not need to rewrite your model in neurOS. NSQ is designed to wrap an external method with frozen data, calibration, final-assessment, metric, failure, and provenance authority while leaving your training implementation yours.
+  - type: input
+    id: method
+    attributes:
+      label: Method name
+      placeholder: EEGNet, custom sklearn pipeline, lab model, foundation representation, ...
+    validations:
+      required: true
+  - type: input
+    id: implementation
+    attributes:
+      label: Implementation source and exact version
+      description: Package/repository plus release or commit. If private, describe the versioning scheme without exposing credentials.
+    validations:
+      required: true
+  - type: dropdown
+    id: model_type
+    attributes:
+      label: Participation type
+      options:
+        - Task decoder with fit/predict
+        - Probability-capable task decoder
+        - Frozen representation plus external readout
+        - Pretrained/foundation model
+        - Adaptive method consuming labeled target data
+        - Adaptive method requiring unlabeled target data
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: input
+    attributes:
+      label: Input contract
+      description: Axes, units, channels, sample rate/window semantics, preprocessing assumptions, and any fitted preprocessing state.
+    validations:
+      required: true
+  - type: textarea
+    id: training
+    attributes:
+      label: Training and state-selection behavior
+      description: What observations can affect fitting, validation, early stopping, checkpoint selection, calibration, thresholds, or preprocessing state?
+    validations:
+      required: true
+  - type: dropdown
+    id: probabilities
+    attributes:
+      label: Probability semantics
+      options:
+        - No probability output
+        - Uncalibrated probabilities
+        - Uncalibrated softmax scores treated as probability-shaped output
+        - Calibrated probabilities with separately identified calibration state
+    validations:
+      required: true
+  - type: textarea
+    id: learned_state
+    attributes:
+      label: Learned-state identity
+      description: Explain whether exact tensors/checkpoints can be hashed without unsafe serialization. Opaque state is allowed, but must remain explicitly unverified.
+    validations:
+      required: true
+  - type: textarea
+    id: lineage
+    attributes:
+      label: Pretraining / dataset lineage
+      description: Required for pretrained methods. Unknown lineage should be stated as unknown rather than inferred.
+  - type: textarea
+    id: benchmark
+    attributes:
+      label: Qualification target
+      description: Which frozen public study or evidence question should this method enter, and why is it a scientifically useful comparator?
+    validations:
+      required: true
+  - type: checkboxes
+    id: agreement
+    attributes:
+      label: Fair-comparison contract
+      options:
+        - label: A fresh model instance may be created for each authorized calibration frontier point.
+          required: true
+        - label: Final-assessment observations will not be used for fitting, preprocessing, adaptation, state selection, threshold selection, or hyperparameter tuning.
+          required: true
+        - label: Failed, unavailable, OOM, skipped, or nonconverged attempts may remain visible in the evidence artifact.
+          required: true
+        - label: I understand that passing software/NSQ contracts does not itself establish biological mechanism, hardware validity, safety, or clinical benefit.
+          required: true

--- a/.github/workflows/developer-preview.yml
+++ b/.github/workflows/developer-preview.yml
@@ -43,8 +43,8 @@ jobs:
     name: Installed-wheel external-user journey
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: pip
@@ -82,6 +82,22 @@ jobs:
           done
           "${PIP}" install "${CORE}" "${DRIVERS}" "${MODELS}" "${SDK}" "${ARENA}" "${PLUGIN}"
           "${PIP}" check
+      - name: Qualify generated starter project from installed wheel
+        run: |
+          set -euo pipefail
+          CLI="${RUNNER_TEMP}/developer-preview-env/bin/neuros"
+          STARTER="${RUNNER_TEMP}/neuros-starter"
+          "${CLI}" init "${STARTER}" --json > "${RUNNER_TEMP}/starter-init.json"
+          test -s "${STARTER}/neuros.yaml"
+          test -s "${STARTER}/README.md"
+          "${CLI}" validate "${STARTER}/neuros.yaml" --json > "${RUNNER_TEMP}/starter-validate.json"
+          "${CLI}" run "${STARTER}/neuros.yaml" --duration 0.1 --json > "${RUNNER_TEMP}/starter-run.json"
+          "${CLI}" qualify "${STARTER}/neuros.yaml" \
+            --output "${STARTER}/evidence/qualification" \
+            --duration 0.1 \
+            --json > "${RUNNER_TEMP}/starter-qualify.json"
+          "${CLI}" reproduce "${STARTER}/evidence/qualification" \
+            --json > "${RUNNER_TEMP}/starter-reproduce.json"
       - name: Run the complete installed-wheel journey
         run: |
           set -euo pipefail
@@ -108,9 +124,11 @@ jobs:
           PY
       - name: Upload developer-preview evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: neurOS-developer-preview-${{ github.sha }}
-          path: ${{ runner.temp }}/developer-preview-report
+          path: |
+            ${{ runner.temp }}/developer-preview-report
+            ${{ runner.temp }}/starter-*.json
           if-no-files-found: warn
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -1,85 +1,20 @@
 # neurOS
 
-**neurOS is an open execution and qualification layer for neural systems.**
+**The open qualification and reproducible execution layer for neural AI and BCI systems.**
 
-Most neural-interface projects can train a model. Far fewer can answer, precisely and reproducibly:
+Your model can train. Can you prove exactly **what data it saw, what calibration it consumed, what state was evaluated, what failed, and what claim the result actually supports?**
 
-- which neural observations were allowed to influence training, calibration, adaptation, or model selection;
-- whether the deployed subject/session/device was genuinely unseen under the declared data and pretraining lineage;
-- whether preprocessing or adaptation touched the final assessment set;
-- whether a model artifact is exactly the state that was qualified;
-- whether an improvement survives calibration cost, session shift, montage changes, artifacts, latency, and failure cases;
-- what part of a claim is supported by software, real data, physical hardware, closed-loop evidence, or clinical work.
+neurOS turns those questions into executable contracts and content-addressed evidence.
 
-neurOS is being built to make those questions executable rather than rhetorical.
+Bring MNE, MOABB, Braindecode, BrainFlow/LSL, a lab model, or your own Python implementation. neurOS is not trying to replace those ecosystems. It adds the missing layer around them: **runtime identity, exact replay, observation-role authority, leakage-controlled qualification, model-state provenance, calibration accounting, failure preservation, and evidence grading.**
 
-**ORION** is the complementary neural-intelligence layer. It explores tokenization, learned representations, transfer, personalization, and governed adaptation under the same evidence authority.
+**ORION** is the optional neural-intelligence plane on top: tokenization, representations, transfer, personalization, and governed adaptation tested under the same authority rather than a privileged benchmark path.
 
-> **Current status:** active research and engineering platform. Passing CI establishes specific software contracts only. It does not imply biological correctness, model superiority, hardware qualification, online BCI efficacy, safety certification, or clinical benefit.
+> **Status:** active research and engineering developer preview. Current CI proves named software contracts, not biological correctness, model superiority, physical hardware validity, online BCI efficacy, safety certification, or clinical benefit. The first frozen full real-data NSQ comparison is still being qualified.
 
-## The platform
+## Get useful evidence in minutes
 
-The public architecture is intentionally smaller than the monorepo:
-
-| Surface | Responsibility |
-| --- | --- |
-| **neurOS** | acquisition/runtime contracts, clocks, configuration, recording/replay, interoperability, deployment semantics |
-| **ORION** | neural tokenization, representations, transfer, personalization, governed adaptation |
-| **Evidence / NSQ** | frozen protocols, observation-role authority, scoring, model participation, artifacts, falsification, claim qualification |
-| **Studio** | future inspection of runtime, evidence, representations, adaptation, quality, and provenance without creating a second runtime |
-
-`neuros-arena` belongs to Evidence. It is a deterministic systems wind tunnel for finding failures across display, neural-world, device, transport, decoder, and application boundaries. Synthetic conformance is not human physiological validation.
-
-```text
-hardware / LSL / public data / replay
-                 |
-                 v
-               neurOS
- SignalFrame -> RuntimeGraph -> recording / replay / quality
-                 |
-          +------+------+
-          |             |
-          v             v
-        ORION       external methods
- representation    MNE / Braindecode /
- + adaptation      external plugins
-          \             /
-           +-----+-----+
-                 v
-                NSQ
- protocol + observation authority + scoring + artifact identity
-                 |
-                 v
-        reproducible evidence
-                 |
-                 v
-               Studio
-```
-
-## What is solid today
-
-The repository has moved beyond a prototype architecture in several important ways:
-
-- immutable canonical signal/frame and descriptor contracts;
-- config-first native runtime graphs with bounded queue policy and latency/quality telemetry;
-- deterministic recording, integrity verification, and replay;
-- causal chunk-invariant streaming DSP;
-- clean workspace wheel ownership and installed-wheel developer-preview testing;
-- out-of-tree plugin authoring through Python entry points;
-- Scientific Authority v2 for lineage, leakage, preprocessing, information roles, metrics, repeated measures, and failure preservation;
-- Model Artifact v1 for content-addressed model promotion, reconstruction, rollback, and provenance;
-- Neural System Qualification v1 plus an executable external-method runner;
-- direct proving paths for canonical MNE/scikit-learn and upstream Braindecode participation;
-- ORION adaptation/state-selection/final-assessment authority;
-- deterministic Arena falsification and counterexample tooling.
-
-The most important missing result is also clear: **the first frozen real-data NSQ study has not yet been completed.** ORION therefore does not currently claim a calibration or representation advantage.
-
-See [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) for the strict maturity map.
-
-## Quick start
-
-This is a multi-distribution Python workspace. For the standard BCI development profile:
+Until coordinated public package publishing is qualified, install from the repository:
 
 ```bash
 git clone https://github.com/sidhulyalkar/neurOS-v1.git
@@ -89,201 +24,211 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 python scripts/bootstrap.py --profile bci --test-tools
 ```
 
-Exercise the installed platform:
+Create a clean starter project:
 
 ```bash
-neuros doctor --json
-neuros plugins --json
-neuros devices --json
-neuros compatibility --json
-neuros validate configs/examples/mock_bci.yaml --json
-neuros run configs/examples/mock_bci.yaml --duration 2 --json
+neuros init my-neuros-project
+cd my-neuros-project
+
+neuros doctor
+neuros validate neuros.yaml
+neuros run neuros.yaml --duration 2
+neuros qualify neuros.yaml --output evidence/qualification --duration 1
+neuros reproduce evidence/qualification
 ```
 
-The checked-in smoke configuration is deliberately training-free. Installation checks should not hide model fitting behind the CLI.
+The starter uses a deterministic mock stream so installation, runtime, replay, and provenance failures cannot hide behind model fitting. Its qualification bundle is **software/runtime evidence only**.
 
-## Record, replay, qualify
+See [First 10 Minutes](docs/getting-started/first-10-minutes.md).
 
-A live or deterministic source can be recorded through the canonical neurOS archive and replayed through the same runtime graph:
+## Bring your own model
 
-```bash
-neuros record configs/examples/mock_bci.yaml \
-  --output /tmp/session \
-  --session-id demo \
-  --duration 10
+You do not subclass a neurOS neural network or adopt a neurOS training loop.
 
-neuros inspect /tmp/session --verify --json
+An external model participates through a deliberately small contract:
 
-neuros replay /tmp/session \
-  --config configs/examples/mock_bci.yaml \
-  --json
+```text
+ExternalDecoderMethodSpec
+        |
+factory.create() -> fresh decoder
+        |
+        +-- fit(authorized X, y)
+        +-- predict(untouched X_final)
+        +-- optional predict_proba(X_final)
+        +-- learned_state()
+        |
+        v
+       NSQ
+ observation roles + calibration budget + score semantics
+ + provenance + failures + immutable result identity
 ```
 
-The archive preserves sequence/timing/quality metadata, stream descriptors, configuration identity, Git/package provenance, runtime metrics, and per-frame integrity. NWB and Zarr are interoperability exports rather than substitutes for exact neurOS replay semantics.
+That means an sklearn pipeline, upstream Braindecode model, private lab decoder, or pretrained representation can be evaluated by the same referee without moving its training implementation into this repository.
 
-Software qualification bundles can also be sealed and independently verified:
+Start with [Bring Your Own Model](docs/getting-started/bring-your-own-model.md) and [NSQ Runner v1](docs/NSQ_RUNNER_V1.md).
 
-```bash
-neuros qualify configs/examples/mock_bci.yaml \
-  --output /tmp/qualification \
-  --duration 1.0
+## The missing ecosystem layer
 
-neuros reproduce /tmp/qualification
-```
+| Existing ecosystem | What it already does well | What neurOS adds |
+| --- | --- | --- |
+| **MNE-Python** | neurophysiology preprocessing, analysis, visualization | exact execution/replay and claim-bound provenance around the pipeline |
+| **MOABB / EEG data ecosystems** | public EEG datasets and benchmark plumbing | frozen observation roles, calibration authority, failure-preserving system qualification |
+| **Braindecode / model libraries** | maintained neural architectures and training tools | external participation under identical data, calibration, state-selection, and scoring authority |
+| **BrainFlow / LSL / device stacks** | acquisition and transport | descriptor/timing provenance, replay, measured hardware qualification, evidence boundaries |
+| **NWB / BIDS / Zarr** | interoperable data organization/storage | runtime-to-artifact identity and exact execution provenance rather than a competing file format |
+| **Your lab code** | the model or experiment you actually care about | a reproducible qualification envelope without forcing a framework rewrite |
 
-A synthetic qualification bundle cannot self-award a physical hardware claim.
+The intended value proposition is simple:
+
+> **Use neurOS when the hard problem is no longer “can I run a model?” but “can another researcher audit exactly what this neural-system claim means and reproduce the evidence boundary?”**
 
 ## Neural System Qualification
 
-NSQ is becoming the peer-facing wedge of the project.
+NSQ is the peer-facing wedge of neurOS.
 
-An external method may own its architecture, optimizer, and training implementation. neurOS owns the scientific boundary around it:
+A frozen qualification binds:
 
 ```text
-frozen dataset lineage
-      |
-frozen observation roles
-      |
-external method factory
-      |
-exact learned-state binding
-      |
-trusted scorecard semantics
-      |
-preserved success / failure rows
-      |
-immutable qualification result
+upstream dataset / revision
+        |
+processed-data authority
+        |
+source / calibration / adaptation / final observation roles
+        |
+external method identity
+        |
+fresh model execution at each authorized budget
+        |
+learned-state identity
+        |
+frozen score semantics
+        |
+success + failure rows
+        |
+content-addressed evidence artifact
 ```
 
-The next flagship study is tracked in [issue #82](https://github.com/sidhulyalkar/neurOS-v1/issues/82): a longitudinal motor-imagery comparison on MOABB Kumar2024 using MNE CSP+LDA and direct upstream Braindecode baselines under identical prospective calibration authority.
+The flagship question is not just “which decoder has the highest pooled accuracy?”
 
-The key question is not merely “which model has the highest accuracy?” It is:
+> **How much held-out neural utility does a method achieve as a function of user-specific calibration cost, under exactly the same prospective authority?**
 
-> **How much held-out neural utility does each method achieve as a function of per-user calibration cost?**
-
-ORION should compete only after that external baseline floor is frozen.
-
-See [`docs/NEURAL_SYSTEM_QUALIFICATION_V1.md`](docs/NEURAL_SYSTEM_QUALIFICATION_V1.md) and [`docs/NSQ_RUNNER_V1.md`](docs/NSQ_RUNNER_V1.md).
+The current promoted Kumar2024 work is deliberately freezing external classical and Braindecode baselines before ORION is allowed into a superiority comparison. See [issue #82](https://github.com/sidhulyalkar/neurOS-v1/issues/82).
 
 ## ORION
 
-ORION starts where provenance-rich neural data becomes a machine-native representation:
+ORION is the intelligence plane, not a shortcut around qualification:
 
 ```text
-SignalFrame(s)
-    |
-    v
+neural observations
+      |
 NeuroTokenizer
-    |
-    v
+      |
 NeuroTokenBatch
-    |
-    v
+      |
 NeuralEncoder
-    |
-    v
+      |
 RepresentationBatch
-    |
-    v
+      |
 AdaptiveDecoder
-    |
-    v
+      |
 DecoderOutput
 ```
 
-Current tokenization research includes exact events, binned counts, relative-ISI WAIT/SPIKE representations, burst/pause/rebound tokens, synchrony packets, vector-quantized motifs, and population assemblies.
-
-```bash
-python scripts/orion/run_tokenizer_benchmark.py \
-  configs/orion/tokenization_smoke.yaml \
-  --output /tmp/orion-tokenization
-```
-
-Synthetic motif recovery is a falsification tool, not evidence that a tokenizer is better on real human neural data.
-
-The long-term ORION hypothesis is explicit and testable:
+Its long-term hypothesis is falsifiable:
 
 > Preserve or improve held-out neural utility while materially reducing user-specific calibration, without sacrificing robustness, latency, provenance, uncertainty calibration, or representation stability.
 
-Real longitudinal evidence decides whether that hypothesis survives.
+Current tokenization and adaptation contracts are research surfaces. Real deployment-disjoint evidence decides whether the hypothesis survives.
 
-## Interoperate instead of reimplement
+## What is solid today
 
-neurOS should not become a replacement for mature neuroscience ecosystems. It should make their boundaries more reproducible and their claims more auditable.
+The strongest maintained capabilities include:
 
-Current evidence-backed integration lanes include BrainFlow, Lab Streaming Layer, MNE-Python, NWB/Zarr, MOABB, Braindecode, SNAP, and a narrow ngc-learn boundary.
+- canonical signal/frame and stream-descriptor contracts;
+- config-first runtime graphs with bounded queues and latency/quality telemetry;
+- deterministic recording, integrity verification, and replay;
+- installed-wheel developer-preview qualification;
+- out-of-tree plugin discovery through Python entry points;
+- Scientific Authority for lineage, information roles, leakage, metrics, repeated measures, and failures;
+- content-addressed Model Artifact promotion/reconstruction boundaries;
+- Neural System Qualification with external model participation;
+- upstream MNE/scikit-learn, pyRiemann, and Braindecode proving paths;
+- governed ORION adaptation/state-selection/final-assessment contracts;
+- deterministic systems falsification through Arena.
 
-Examples:
+See [Project Status](docs/PROJECT_STATUS.md) for the strict maturity map.
 
-- BrainFlow / LSL for acquisition and transport rather than a giant proprietary driver catalog;
-- MNE for neurophysiology analysis/preprocessing rather than a competing preprocessing universe;
-- MOABB for public EEG access and benchmark data rather than a duplicate dataset registry;
-- Braindecode for maintained neural architectures rather than copied model implementations;
-- NWB/Zarr for interoperable export while neurOS preserves exact runtime replay semantics.
+## Record, replay, qualify
 
-See [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md) and [`docs/NEUROAI_ECOSYSTEM.md`](docs/NEUROAI_ECOSYSTEM.md).
+```bash
+neuros record neuros.yaml \
+  --output sessions/example \
+  --session-id demo \
+  --duration 10
 
-## Internal workspace map
-
-The repository still contains multiple implementation distributions. They are not twelve equal product identities.
-
-```text
-packages/
-  neuros-core/          runtime/data/replay/plugin contracts
-  neuros/               public SDK + CLI composition
-  neuros-drivers/       hardware, simulated, dataset and LSL sources
-  orion/                ORION representation/adaptation contracts
-  neuros-foundation/    external models/data + current NSQ/evidence implementation
-  neuros-models/        supporting task decoders
-  neuros-sourceweigher/ source/domain reliability research
-  neuros-mechint/       intervention/faithfulness evidence research
-  neuros-arena/         deterministic systems falsification
-  neuros-neurofm/       experimental native foundation-model R&D
-  neuros-ui/            experimental Studio substrate
-  neuros-cloud/         experimental distributed/provider integrations
+neuros inspect sessions/example --verify
+neuros replay sessions/example --config neuros.yaml
 ```
 
-The root workspace is a packaging inventory, not proof that every member has equal maturity. Experimental packages should remain visibly experimental until they earn promotion.
+The canonical archive preserves sequence/timing/quality metadata, descriptors, configuration identity, package/Git provenance, runtime evidence, and integrity hashes. NWB and Zarr remain interoperability exports rather than substitutes for exact neurOS replay semantics.
 
-## Scientific evidence hierarchy
-
-A strong result names the evidence level it actually supports:
+## Evidence levels are not interchangeable
 
 ```text
 software contract
       -> integration
-      -> deterministic replay
-      -> scientific synthetic
+      -> deterministic replay / scientific synthetic
       -> real dataset
       -> physical hardware
       -> closed loop
       -> clinical evidence
 ```
 
-A result in one tier does not silently promote another. Representation similarity is not task utility. Attribution is not mechanism. Synthetic conformance is not human performance. Hardware qualification is not closed-loop qualification. Closed-loop evidence is not clinical certification.
+A result cannot self-promote to a stronger tier because it looks persuasive. Representation similarity is not task utility. Attribution is not mechanism. Hardware interoperability is not hardware qualification. Closed-loop evidence is not clinical certification.
 
-See [`docs/SCIENTIFIC_CLAIMS.md`](docs/SCIENTIFIC_CLAIMS.md).
+See [Scientific Claims](docs/SCIENTIFIC_CLAIMS.md).
 
-## What happens next
+## Public architecture
 
-The current execution order is intentionally narrow:
+The monorepo contains multiple distributions, but the public mental model should stay small:
 
-1. finish the first frozen real-data NSQ study (#82);
-2. run ORION and competitive foundation/transfer methods against that exact authority;
-3. add adaptive NSQ observation-role authority for unlabeled target adaptation (#81);
-4. qualify one named physical EEG system end to end;
-5. recruit independent users to reproduce the public qualification workflow;
-6. resume the parked Arena v2 stack only against concrete real-data/hardware falsification targets (#83);
-7. build Studio and stronger closed-loop safety only after the evidence plane earns the need.
+| Surface | Responsibility |
+| --- | --- |
+| **neurOS** | runtime, clocks, configuration, recording/replay, interoperability, qualification composition |
+| **ORION** | neural tokenization, representation, transfer, personalization, governed adaptation |
+| **Evidence / NSQ** | frozen scientific authority, external participation, scoring, artifacts, falsification, claim boundaries |
+| **Studio** | future evidence/runtime inspection surface that must not create a second authority |
 
-See [`ROADMAP.md`](ROADMAP.md).
+Internal packages are implementation boundaries, not twelve separate products. Experimental packages should remain visibly experimental until they earn promotion.
 
 ## Contributing
 
-New subsystems should pass a build-vs-integrate test before becoming maintained code: identify the established ecosystem owner, explain why a thin adapter or upstream contribution is insufficient, state the unique neurOS authority being added, define an external falsification target, quantify maintenance cost, and name the condition under which the work should be removed or upstreamed.
+The project needs external models, datasets, integrations, falsification cases, and independent reproduction more than it needs another internal subsystem.
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`GOVERNANCE.md`](GOVERNANCE.md).
+Use the GitHub issue forms for:
+
+- reproducible defects;
+- ecosystem integration proposals;
+- external model/method participation.
+
+New maintained subsystems must answer a build-vs-integrate test: who already owns the adjacent capability, why a thin adapter/upstream contribution is insufficient, what unique neurOS authority is added, how it can be externally falsified, what it costs to maintain, and when it should be removed.
+
+See [Contributing](CONTRIBUTING.md), [Governance](GOVERNANCE.md), and the [Roadmap](ROADMAP.md).
+
+## Near-term release gates
+
+Before calling neurOS a broadly usable public release, the project should earn all of the following:
+
+1. a clean package install path that does not require understanding the monorepo;
+2. a tagged developer-preview release with built wheels and reproducible artifacts;
+3. a frozen public NSQ benchmark slice reproducible in one command;
+4. at least one external model submitted without editing neurOS internals;
+5. independent reproduction by researchers outside the implementation loop;
+6. a stable protected `main` check surface;
+7. public documentation/discussion channels that are maintained like product infrastructure.
+
+Stars are not the primary target. **Independent researchers relying on neurOS because it makes their claims harder to accidentally overstate is the target.** Popularity should follow utility and trust.
 
 ## License
 
-MIT. See [`LICENSE`](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/docs/getting-started/bring-your-own-model.md
+++ b/docs/getting-started/bring-your-own-model.md
@@ -1,0 +1,210 @@
+# Bring Your Own Model
+
+You do **not** need neurOS to train your model.
+
+That is the point of Neural System Qualification (NSQ): your code owns the architecture, optimizer, features, representation, and fitting procedure; neurOS owns the evidence boundary around the comparison.
+
+The smallest useful mental model is:
+
+```text
+your model factory
+      |
+      v
+fresh decoder instance
+      |
+      +-- fit(authorized X, y)
+      |
+      +-- predict(untouched X_final)
+      |
+      +-- optional predict_proba(X_final)
+      |
+      v
+neurOS validates observation roles, outputs,
+metrics, failure states, provenance, and identity
+```
+
+## The contract is intentionally small
+
+A normal supervised decoder needs:
+
+1. an `ExternalDecoderMethodSpec` describing the algorithm/configuration identity;
+2. a factory with a `method_spec` property and `create()` method;
+3. a fresh decoder exposing `fit(X, y)` and `predict(X)`;
+4. `learned_state()` describing how strongly the fitted state can be identified.
+
+If the method declares probability output, also provide:
+
+- `predict_proba(X)`;
+- `probability_class_labels()` after fitting, so neurOS does not guess which probability column belongs to which task class.
+
+You do not subclass a neurOS model class.
+
+## Minimal sklearn example
+
+The example below deliberately keeps the external implementation ordinary. Flattening is declared as part of the method identity so it is not hidden benchmark behavior.
+
+```python
+from __future__ import annotations
+
+import importlib.metadata
+from dataclasses import dataclass
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+from neuros.foundation_models.qualification import (
+    ExternalDecoderMethodSpec,
+    ExternalLearnedState,
+)
+
+
+class MyDecoder:
+    def __init__(self) -> None:
+        self.model = LogisticRegression(max_iter=1000)
+
+    @staticmethod
+    def _features(X: np.ndarray) -> np.ndarray:
+        X = np.asarray(X)
+        if X.ndim != 3:
+            raise ValueError("expected X=(sample, channel, time)")
+        return X.reshape(len(X), -1)
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        self.model.fit(self._features(X), np.asarray(y))
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        return np.asarray(self.model.predict(self._features(X)))
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        return np.asarray(self.model.predict_proba(self._features(X)), dtype=np.float64)
+
+    def probability_class_labels(self) -> tuple[str, ...]:
+        return tuple(str(value) for value in self.model.classes_)
+
+    def learned_state(self) -> ExternalLearnedState:
+        # Participation does not require pretending arbitrary sklearn state has a
+        # qualified tensor/checkpoint serializer. Be explicit when state identity
+        # is weaker.
+        return ExternalLearnedState(
+            state_identity_kind="opaque_unverified",
+            metadata={"reason": "example_sklearn_state_serializer_not_qualified"},
+        )
+
+
+@dataclass(frozen=True)
+class MyFactory:
+    @property
+    def method_spec(self) -> ExternalDecoderMethodSpec:
+        return ExternalDecoderMethodSpec(
+            method_id="example-logistic-regression",
+            implementation="sklearn.linear_model.LogisticRegression",
+            implementation_version=(
+                f"scikit-learn={importlib.metadata.version('scikit-learn')}"
+            ),
+            input_axes=("sample", "channel", "time"),
+            probability_semantics="uncalibrated_probability",
+            target_adaptation_mode="none",
+            source_reference="your repository, paper, or method URL",
+            metadata={
+                "feature_transform": "flatten-channel-time",
+                "solver": "lbfgs",
+                "max_iter": 1000,
+            },
+        )
+
+    def create(self) -> MyDecoder:
+        return MyDecoder()
+```
+
+The factory is the key boundary. NSQ calls `create()` again for each authorized calibration point rather than warm-starting the previous fitted state.
+
+## What neurOS controls
+
+Under a frozen qualification study, the runner controls and content-addresses:
+
+- the upstream dataset/revision identity;
+- the exact processed data authority;
+- source-history observations;
+- labeled target calibration observations;
+- untouched final-assessment observations;
+- the calibration budget;
+- preprocessing/calibration authorities declared by the study;
+- metric scorecard semantics;
+- the method specification SHA;
+- the run contract and fitted-state binding;
+- success, failure, unavailable, OOM, skipped, and nonconverged attempts.
+
+This is what lets a custom lab model, an sklearn baseline, Braindecode, a foundation model, and eventually ORION enter the **same scientific referee** without sharing training code.
+
+## What your adapter controls
+
+Your adapter owns:
+
+- architecture and feature computation;
+- optimizer/training loop;
+- deterministic transforms internal to the method;
+- fitted preprocessing that is learned only from the authorized fit observations;
+- prediction behavior;
+- probability behavior, if declared;
+- learned-state serialization/hash semantics, when you can provide them honestly.
+
+Anything that affects the method result should be represented in `method_spec` metadata or a separately governed preprocessing/model-lineage authority. Do not hide favorable preprocessing inside an unnamed wrapper.
+
+## Probability output is optional
+
+If your method only emits labels, set:
+
+```python
+probability_semantics="unavailable"
+```
+
+Then omit `predict_proba()` and probability class order. Balanced accuracy and accuracy can still participate; probability-dependent metrics remain explicitly unavailable rather than being fabricated.
+
+If your method emits probabilities, neurOS validates shape, finite values, `[0, 1]` bounds, row sums, and the fitted class-column order. It will not renormalize malformed output or guess class ordering for you.
+
+## Pretrained and foundation models
+
+A pretrained model adds one hard question: **what data has already influenced the representation?**
+
+Provide model/pretraining lineage where it is known. If overlap with the evaluation corpus cannot be established, the correct verdict is unknown, not deployment-disjoint.
+
+A foundation representation can still participate, but its claim language must respect that lineage uncertainty.
+
+## Unlabeled target adaptation
+
+Do not route target-session observations through an `adapt()` method just because they lack labels.
+
+The study must first freeze a scientifically distinct unlabeled-target observation role. The current v1 longitudinal executor intentionally refuses to manufacture an unlabeled pool from “whatever calibration rows are left.”
+
+This keeps an observation from changing roles as calibration budget changes.
+
+## Before opening a model-submission issue
+
+Be ready to state:
+
+- exact implementation/version;
+- input axes, units, channel and sampling assumptions;
+- fixed and fitted preprocessing;
+- validation/early-stopping/checkpoint-selection behavior;
+- probability semantics;
+- learned-state identity strength;
+- pretraining lineage, if applicable;
+- the frozen benchmark/study the method should enter.
+
+Use the **External model / method submission** GitHub issue form. The goal is not to make your implementation neurOS-native. The goal is to make its evidence comparable and auditable.
+
+## Reference implementations
+
+The repository already proves this boundary with maintained upstream methods rather than reimplementations:
+
+- MNE CSP + scikit-learn LDA;
+- pyRiemann covariance + tangent-space logistic regression;
+- direct upstream Braindecode models.
+
+See [NSQ Runner v1](../NSQ_RUNNER_V1.md) for the complete authority chain and failure semantics.
+
+## Claim boundary
+
+Passing the adapter and NSQ contracts can establish that an external method was evaluated under a specific frozen data, calibration, scoring, and provenance authority.
+
+It does **not** by itself establish physiological mechanism, general superiority, physical hardware validity, closed-loop safety, or clinical benefit.

--- a/docs/getting-started/first-10-minutes.md
+++ b/docs/getting-started/first-10-minutes.md
@@ -1,10 +1,12 @@
 # First 10 Minutes
 
-This path is designed to answer one question quickly: **does the neurOS execution and evidence stack work correctly on this machine before I connect real hardware or train a model?**
+The fastest way to understand neurOS is to make it produce an evidence artifact.
 
-It deliberately uses the mock source and a training-free decoder so installation, runtime, recording, replay, and provenance failures cannot hide behind model fitting.
+The starter path deliberately uses a deterministic mock neural stream and a training-free decoder. That keeps installation, runtime, recording, replay, and provenance failures visible instead of hiding them behind a model-training job.
 
-## 1. Create an isolated environment
+## 1. Install the current developer preview
+
+Until coordinated public package publishing is enabled and qualified, the repository checkout is the authoritative installation path:
 
 ```bash
 git clone https://github.com/sidhulyalkar/neurOS-v1.git
@@ -14,127 +16,121 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 python scripts/bootstrap.py --profile bci --test-tools
 ```
 
-The repository is currently the authoritative development install until coordinated public package publishing is enabled and qualified.
+A public release should eventually reduce this to a normal package install. Do not treat the monorepo bootstrap as the final onboarding design.
 
-## 2. Inspect what is actually installed
-
-```bash
-neuros doctor --json
-neuros plugins --json
-neuros devices --json
-neuros compatibility --json
-```
-
-`compatibility` is an evidence registry, not a package-detection banner. A planned integration has no qualification tier. An experimental integration states exactly which upstream surface has executable evidence.
-
-Useful focused checks include:
+## 2. Create a clean project
 
 ```bash
-neuros compatibility mne --json
-neuros compatibility braindecode --json
-neuros compatibility snap --json
-neuros compatibility ngclearn --json
+neuros init my-neuros-project
+cd my-neuros-project
 ```
 
-## 3. Validate and run a complete graph
+The generated project contains only:
+
+```text
+my-neuros-project/
+  neuros.yaml
+  README.md
+  .gitignore
+```
+
+It is intentionally not a framework generator. The point is to create the smallest configuration that exercises the maintained runtime and evidence boundary.
+
+`neuros init` will not overwrite its managed starter files unless `--force` is supplied, and even then it preserves unrelated user files.
+
+## 3. Inspect the environment
 
 ```bash
-neuros validate configs/examples/mock_bci.yaml --json
-neuros run configs/examples/mock_bci.yaml --duration 2 --json
+neuros doctor
+neuros plugins
+neuros devices
+neuros compatibility
 ```
 
-This exercises the same `SignalFrame -> RuntimeGraph -> DecoderOutput` path used by maintained live/replay execution. Runtime edges have bounded queues and explicit overload policy rather than unmeasured buffering.
+`compatibility` is an evidence registry, not a marketing banner. An integration is allowed to be experimental or planned; the command should tell you what has actually been exercised.
 
-## 4. Prove that input can be replayed
+## 4. Validate and execute the runtime
 
 ```bash
-SESSION=/tmp/neuros-first-session
-
-neuros record configs/examples/mock_bci.yaml \
-  --output "${SESSION}" \
-  --session-id first-10-minutes \
-  --duration 2 \
-  --json
-
-neuros inspect "${SESSION}" --verify --json
-
-neuros replay "${SESSION}" \
-  --config configs/examples/mock_bci.yaml \
-  --json
+neuros validate neuros.yaml
+neuros run neuros.yaml --duration 2
 ```
 
-The canonical archive preserves stream/sequence identity, timing domains, quality metadata, configuration/provenance, runtime information, and frame integrity hashes. NWB/Zarr are interoperability exports rather than replacements for exact neurOS replay semantics.
+This uses the same config resolution, plugin registry, bounded runtime graph, and decoder-output path used by maintained live and replay execution.
 
-## 5. Produce a reproducible qualification bundle
+## 5. Seal a reproducible software qualification
 
 ```bash
-QUAL=/tmp/neuros-qualification
+neuros qualify neuros.yaml \
+  --output evidence/qualification \
+  --duration 1
 
-neuros qualify configs/examples/mock_bci.yaml \
-  --output "${QUAL}" \
-  --duration 1.0
-
-neuros reproduce "${QUAL}"
+neuros reproduce evidence/qualification
 ```
 
-The resulting bundle seals configuration, environment, compatibility, runtime, device/clock/model metadata, decoder output evidence, session data, file hashes, and a root artifact identity.
+The qualification bundle binds the exact software path that ran, its configuration and environment identity, runtime evidence, recording integrity, decoder output evidence, file hashes, and a root artifact identity.
 
-This proves a **runtime record/replay software qualification boundary**. It does not turn a mock source into physical hardware evidence.
+This establishes a **software/runtime evidence boundary only**. The mock source does not become real EEG. A software qualification is not hardware validation, decoder efficacy, closed-loop safety, or clinical evidence.
 
-## 6. Know the claim boundary
+## 6. Record and replay explicitly
 
-The public evidence ladder is:
+When exact session replay is the thing you care about:
+
+```bash
+neuros record neuros.yaml \
+  --output sessions/example \
+  --session-id example \
+  --duration 2
+
+neuros inspect sessions/example --verify
+neuros replay sessions/example --config neuros.yaml
+```
+
+The canonical archive preserves sequence and timing identity, stream descriptors, quality metadata, configuration/provenance, runtime information, and per-frame integrity. NWB and Zarr remain interoperability exports rather than replacements for exact neurOS replay semantics.
+
+## 7. Choose the lane that matches your actual problem
+
+### I already have a model
+
+Do not rewrite it in neurOS. Bring it through the external model/plugin and Neural System Qualification boundary so it can be evaluated under the same observation roles, preprocessing authority, calibration budget, score semantics, and failure preservation as competing methods.
+
+Start with [Neural System Qualification](../NEURAL_SYSTEM_QUALIFICATION_V1.md) and [Plugin Authoring](../PLUGIN_AUTHORING.md).
+
+### I already have MNE/MOABB/Braindecode code
+
+Keep using those projects for the work they already do well. neurOS should add execution, replay, provenance, qualification, and claim authority around them rather than replace their preprocessing, dataset, or model ecosystems.
+
+See [Ecosystem Compatibility](../COMPATIBILITY.md).
+
+### I want to compare neural representations or reduce calibration
+
+That is where ORION belongs. ORION is the intelligence plane for tokenization, representations, transfer, personalization, and governed adaptation. It should compete under the same external qualification authority rather than receive privileged benchmark access.
+
+See [ORION Adaptation Authority](../ADAPTATION_AUTHORITY.md).
+
+### I want to use physical EEG hardware
+
+Start with a maintained BrainFlow, LSL, or device boundary. Do not describe a path as hardware-qualified until a named device, firmware, transport, host, timing, packet-loss, and replay configuration has physical evidence bound to a verified qualification artifact.
+
+See [Hardware Qualification](../HARDWARE_QUALIFICATION.md).
+
+## 8. Understand the evidence ladder
 
 ```text
 software contract
       -> integration
-      -> replay / scientific synthetic
+      -> deterministic replay / scientific synthetic
       -> real dataset
-      -> hardware
+      -> physical hardware
       -> closed loop
-      -> clinical
+      -> clinical evidence
 ```
 
-See [Scientific Claims](../SCIENTIFIC_CLAIMS.md) before interpreting a benchmark or compatibility label. The important discipline is simple: stronger language requires stronger evidence.
+A result does not silently jump tiers because it looks convincing. See [Scientific Claims](../SCIENTIFIC_CLAIMS.md).
 
-## 7. Choose the next path
+## If something fails
 
-### Existing MNE data
-
-Install the optional bridge and convert an existing `Raw` object without hidden resampling or channel reordering:
-
-```bash
-pip install -e "packages/neuros[interop-mne]"
-```
-
-See [Ecosystem Compatibility](../COMPATIBILITY.md).
-
-### Model benchmarking
-
-Use the neural-window/Braindecode and longitudinal EEG evidence paths when the question is decoder or representation performance. Keep subject/session/device evaluation authority explicit rather than randomizing trials across the deployment unit you intend to generalize to.
-
-### NeuroAI / representation research
-
-See [NeuroAI Ecosystem](../NEUROAI_ECOSYSTEM.md) for SNAP-derived spectral evidence and the optional ngc-learn bridge. Their current evidence tiers are intentionally narrower than their broader research ecosystems.
-
-### ORION
-
-```bash
-python scripts/bootstrap.py --profile orion --test-tools
-python scripts/orion/run_tokenizer_benchmark.py \
-  configs/orion/tokenization_smoke.yaml \
-  --output /tmp/orion-tokenization
-```
-
-Synthetic tokenization evidence is a falsification surface, not proof of superior real-human transfer. ORION promotion requires leakage-controlled, deployment-unit-disjoint evidence.
-
-### Physical hardware
-
-Start from a maintained driver/BrainFlow/LSL boundary, but do not describe it as hardware-qualified until a named device + firmware + transport + host configuration has physical evidence bound to a verified qualification bundle.
-
-## A useful issue report
-
-If any step above fails, capture:
+Include the following in an issue:
 
 ```bash
 neuros doctor --json
@@ -142,6 +138,6 @@ neuros compatibility --json
 python --version
 ```
 
-and include the exact Git commit, operating system, failing command, and smallest reproducible configuration. Do not attach credentials or identifiable participant data to a public issue.
+Also include the exact Git commit, operating system, command, and smallest reproducible `neuros.yaml`. Never attach credentials or identifiable participant data to a public issue.
 
-The full contributor/development path is documented in [Installation](installation.md) and the repository `SUPPORT.md`.
+For the stricter installed-wheel qualification path, see [Developer Preview Journey](developer-preview.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - First 10 Minutes: getting-started/first-10-minutes.md
+      - Bring Your Own Model: getting-started/bring-your-own-model.md
       - Developer Preview Journey: getting-started/developer-preview.md
       - Installation: getting-started/installation.md
   - Platform:
@@ -78,6 +79,8 @@ nav:
       - Architecture: ARCHITECTURE.md
       - Project Status: PROJECT_STATUS.md
   - Scientific Trust:
+      - Neural System Qualification: NEURAL_SYSTEM_QUALIFICATION_V1.md
+      - NSQ Runner: NSQ_RUNNER_V1.md
       - Scientific Claims: SCIENTIFIC_CLAIMS.md
       - Scientific Validation Policy: SCIENTIFIC_VALIDATION_POLICY.md
       - Release Policy: RELEASE_POLICY.md

--- a/packages/neuros/pyproject.toml
+++ b/packages/neuros/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
 ]
 
 [project.scripts]
-neuros = "neuros.cli:main"
+neuros = "neuros.cli.entrypoint:main"
 neuros-nsq-kumar2024 = "neuros.evidence.kumar2024:main"
 
 [project.urls]

--- a/packages/neuros/src/neuros/cli/entrypoint.py
+++ b/packages/neuros/src/neuros/cli/entrypoint.py
@@ -1,0 +1,79 @@
+"""Stable public CLI entrypoint with a narrow developer on-ramp."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from neuros.errors import ConfigurationError
+
+from .project_commands import SUPPORTED_PROJECT_TEMPLATES, init_project
+
+
+def _init_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="neuros init",
+        description="Create a minimal runnable neurOS project",
+    )
+    parser.add_argument(
+        "destination",
+        nargs="?",
+        default="neuros-project",
+        help="Project directory to create (default: neuros-project)",
+    )
+    parser.add_argument(
+        "--template",
+        choices=SUPPORTED_PROJECT_TEMPLATES,
+        default="mock-bci",
+        help="Starter project template",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace neurOS-managed starter files but preserve unrelated files",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser
+
+
+def _run_init(argv: Sequence[str]) -> int:
+    args = _init_parser().parse_args(list(argv))
+    try:
+        result = init_project(
+            args.destination,
+            template=args.template,
+            force=args.force,
+        )
+    except ConfigurationError as exc:
+        print(f"configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    print(f"Created neurOS project: {result['project_root']}")
+    print(f"Template: {result['template']}")
+    print("Next:")
+    print(f"  cd {result['project_root']}")
+    for command in result["next_commands"]:
+        print(f"  {command}")
+    print()
+    print(f"Evidence boundary: {result['evidence_boundary']}")
+    return 0
+
+
+def main() -> None:
+    """Dispatch the new-user on-ramp, then delegate every existing command."""
+
+    if len(sys.argv) > 1 and sys.argv[1] == "init":
+        raise SystemExit(_run_init(sys.argv[2:]))
+
+    from .app import main as runtime_main
+
+    runtime_main()
+
+
+__all__ = ["main"]

--- a/packages/neuros/src/neuros/cli/project_commands.py
+++ b/packages/neuros/src/neuros/cli/project_commands.py
@@ -1,0 +1,166 @@
+"""Project scaffolding for the supported neurOS developer on-ramp."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from neuros.errors import ConfigurationError
+
+
+SUPPORTED_PROJECT_TEMPLATES = ("mock-bci",)
+
+_MOCK_BCI_CONFIG = """schema_version: 1
+
+metadata:
+  name: neurOS-starter
+  purpose: deterministic local runtime and qualification starter
+
+streams:
+  - id: eeg
+    source:
+      plugin: mock
+      options:
+        sampling_rate: 250.0
+        channels: 8
+    transforms:
+      - plugin: smoothing
+        options:
+          window_size: 3
+
+decoder:
+  plugin: threshold
+  options:
+    threshold: 0.0
+
+runtime:
+  queue_capacity: 16
+  overflow_policy: drop_oldest
+
+sinks: []
+monitors: []
+"""
+
+_PROJECT_README = """# neurOS starter project
+
+This project is deliberately small. It exercises the maintained neurOS runtime,
+record/replay path, and software-qualification boundary without downloading a
+dataset, training a model, or implying a biological or hardware claim.
+
+## 1. Inspect the environment
+
+```bash
+neuros doctor
+neuros compatibility
+```
+
+## 2. Validate and run
+
+```bash
+neuros validate neuros.yaml
+neuros run neuros.yaml --duration 2
+```
+
+## 3. Produce a reproducible software-evidence bundle
+
+```bash
+neuros qualify neuros.yaml --output evidence/qualification --duration 1
+neuros reproduce evidence/qualification
+```
+
+The qualification bundle is software evidence. It does not establish neural
+model efficacy, hardware validity, closed-loop performance, safety, or clinical
+benefit.
+
+## Next steps
+
+- Replace the mock source through a maintained BrainFlow, LSL, replay, or dataset
+  integration rather than editing the neurOS kernel.
+- Add an external decoder through the plugin/qualification interfaces.
+- Use NSQ for leakage-controlled comparative neural-system evidence.
+- Use ORION only when you need governed neural representations, tokenization, or
+  adaptation on top of the same evidence authority.
+
+Project documentation: https://github.com/sidhulyalkar/neurOS-v1
+"""
+
+_PROJECT_GITIGNORE = """.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+evidence/
+sessions/
+artifacts/
+"""
+
+
+def _template_files(template: str) -> dict[str, str]:
+    if template != "mock-bci":
+        raise ConfigurationError(
+            f"Unsupported project template {template!r}; "
+            f"choose one of {', '.join(SUPPORTED_PROJECT_TEMPLATES)}"
+        )
+    return {
+        "neuros.yaml": _MOCK_BCI_CONFIG,
+        "README.md": _PROJECT_README,
+        ".gitignore": _PROJECT_GITIGNORE,
+    }
+
+
+def init_project(
+    destination: str | Path,
+    *,
+    template: str = "mock-bci",
+    force: bool = False,
+) -> dict[str, Any]:
+    """Create a minimal, runnable neurOS project without deleting user files.
+
+    ``force`` permits replacement of neurOS-managed starter files only. Unrelated
+    files in an existing directory are preserved.
+    """
+
+    root = Path(destination).expanduser().resolve()
+    files = _template_files(template)
+
+    if root.exists() and not root.is_dir():
+        raise ConfigurationError(f"Project destination is not a directory: {root}")
+
+    existing_managed = [name for name in files if (root / name).exists()]
+    if existing_managed and not force:
+        joined = ", ".join(sorted(existing_managed))
+        raise ConfigurationError(
+            f"Project destination already contains neurOS starter files: {joined}. "
+            "Use --force to replace only those managed files."
+        )
+
+    root.mkdir(parents=True, exist_ok=True)
+    created: list[str] = []
+    replaced: list[str] = []
+    for relative, content in files.items():
+        path = root / relative
+        existed = path.exists()
+        path.write_text(content, encoding="utf-8")
+        (replaced if existed else created).append(relative)
+
+    return {
+        "schema_version": 1,
+        "project_root": str(root),
+        "template": template,
+        "config": str(root / "neuros.yaml"),
+        "created": sorted(created),
+        "replaced": sorted(replaced),
+        "next_commands": [
+            "neuros doctor",
+            "neuros validate neuros.yaml",
+            "neuros run neuros.yaml --duration 2",
+            "neuros qualify neuros.yaml --output evidence/qualification --duration 1",
+            "neuros reproduce evidence/qualification",
+        ],
+        "evidence_boundary": (
+            "starter workflow produces software/runtime evidence only; it does not "
+            "qualify neural efficacy, hardware, closed-loop behavior, safety, or clinical benefit"
+        ),
+    }
+
+
+__all__ = ["SUPPORTED_PROJECT_TEMPLATES", "init_project"]

--- a/tests/test_cli_v3.py
+++ b/tests/test_cli_v3.py
@@ -8,6 +8,9 @@ import pytest
 from neuros.cli import _parse_args
 from neuros.cli.config_commands import execute_config, validate_config
 from neuros.cli.diagnostics import doctor, plugin_inventory
+from neuros.cli.entrypoint import _run_init
+from neuros.cli.project_commands import init_project
+from neuros.errors import ConfigurationError
 
 
 CONFIG = Path("configs/examples/mock_bci.yaml")
@@ -49,3 +52,47 @@ def test_doctor_and_plugin_inventory_are_machine_readable():
     plugins = plugin_inventory()
     assert any(item["kind"] == "source" and item["name"] == "mock" for item in plugins)
     assert any(item["kind"] == "decoder" and item["name"] == "threshold" for item in plugins)
+
+
+def test_init_project_creates_a_production_validated_starter(tmp_path: Path):
+    root = tmp_path / "starter"
+    result = init_project(root)
+
+    assert result["template"] == "mock-bci"
+    assert result["replaced"] == []
+    assert set(result["created"]) == {".gitignore", "README.md", "neuros.yaml"}
+    assert "software/runtime evidence only" in result["evidence_boundary"]
+
+    resolved = validate_config(root / "neuros.yaml")
+    assert resolved["decoder"] == "threshold"
+    assert resolved["streams"] == ["eeg"]
+    assert "neuros qualify neuros.yaml" in (root / "README.md").read_text(encoding="utf-8")
+
+
+def test_init_project_refuses_to_replace_managed_files_without_force(tmp_path: Path):
+    root = tmp_path / "starter"
+    init_project(root)
+    original = (root / "README.md").read_text(encoding="utf-8")
+    (root / "unrelated.txt").write_text("keep me", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="--force"):
+        init_project(root)
+
+    assert (root / "README.md").read_text(encoding="utf-8") == original
+    assert (root / "unrelated.txt").read_text(encoding="utf-8") == "keep me"
+
+    result = init_project(root, force=True)
+    assert set(result["replaced"]) == {".gitignore", "README.md", "neuros.yaml"}
+    assert (root / "unrelated.txt").read_text(encoding="utf-8") == "keep me"
+
+
+def test_init_entrypoint_emits_machine_readable_project_manifest(tmp_path: Path, capsys):
+    root = tmp_path / "starter"
+    code = _run_init([str(root), "--json"])
+    assert code == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == 1
+    assert payload["project_root"] == str(root.resolve())
+    assert payload["config"] == str((root / "neuros.yaml").resolve())
+    assert payload["next_commands"][0] == "neuros doctor"


### PR DESCRIPTION
## Why

neurOS has strong scientific and execution contracts, but the public repository still asks a new user to understand a large research monorepo before they can produce anything useful. This PR creates a narrow external-user funnel without touching promoted NSQ scientific authority or ORION research logic.

The product thesis is sharper: neurOS should be the open qualification and reproducible execution layer around existing neural/BCI ecosystems, not another replacement for MNE, MOABB, Braindecode, BrainFlow/LSL, or a lab's own model code.

## Project-first onboarding

Adds a thin public CLI entrypoint and `neuros init`:

```bash
neuros init my-neuros-project
cd my-neuros-project
neuros doctor
neuros validate neuros.yaml
neuros run neuros.yaml --duration 2
neuros qualify neuros.yaml --output evidence/qualification --duration 1
neuros reproduce evidence/qualification
```

The generated starter is deliberately tiny: `neuros.yaml`, `README.md`, and `.gitignore`. It uses the existing mock source and training-free threshold decoder so software/runtime failures cannot hide behind a training job.

`--force` replaces only neurOS-managed starter files and preserves unrelated user files.

## Installed-wheel qualification

The existing Developer Preview Journey now builds the SDK wheel, installs it into a fresh environment, runs `neuros init`, and validates/runs/qualifies/reproduces the generated project before the broader installed-wheel journey proceeds. The on-ramp is therefore tested as an installed product surface rather than an editable-monorepo convenience.

The new entrypoint intercepts only `init` and delegates every existing command to the current CLI unchanged.

## Bring your own model

Adds a first-class guide showing the actual NSQ participation boundary:

- `ExternalDecoderMethodSpec`;
- factory `create()` returning a fresh decoder;
- `fit(X, y)` and `predict(X)`;
- `learned_state()`;
- optional `predict_proba(X)` plus explicit probability-class ordering.

The guide uses a normal sklearn example and makes clear that external researchers do not need to adopt neurOS training code. It also documents probability semantics, fitted preprocessing, pretrained lineage, and the current refusal to invent an unlabeled-target role.

## Public repository surface

- rewrites the README around the qualification/reproducibility wedge rather than package inventory;
- adds a project-first First 10 Minutes path;
- surfaces Bring Your Own Model and NSQ prominently in MkDocs navigation;
- adds structured GitHub issue forms for reproducible bugs, ecosystem integrations, and external model/method submissions;
- routes support/security questions away from unstructured blank issues;
- marks research notebooks as Linguist documentation so GitHub language statistics better reflect the Python implementation.

## Claim boundary

This PR changes onboarding, packaging entrypoint, documentation, community forms, and developer-preview qualification only. It does not alter:

- Kumar2024 data/protocol/case/method authority;
- promoted worker or execution semantics;
- calibration budgets or model seeds;
- scientific metrics or final-assessment logic;
- ORION model/tokenization/adaptation algorithms;
- any efficacy result or scientific claim.

The starter qualification is explicitly software/runtime evidence only.

## Follow-up gates

This PR does not pretend the public-product job is finished. Major remaining adoption blockers include coordinated package publishing, a tagged developer-preview release, protected `main`, stable required checks, GitHub topics/homepage/Discussions, a one-command frozen public NSQ slice, and independent external reproduction.

Squash merge is preferred after exact-head CI is green so the public-onboarding change lands as one coherent product commit.