### PR TITLE
Release policy: separate publication eligibility from workspace membership

### DIFF
--- a/.github/workflows/packaging-contracts.yml
+++ b/.github/workflows/packaging-contracts.yml
@@ -6,7 +6,11 @@ on:
       - ".github/workflows/packaging-contracts.yml"
       - ".github/workflows/ci.yml"
       - ".github/workflows/release-candidate.yml"
+      - "release/package-policy.json"
       - "scripts/check_wheel_ownership.py"
+      - "scripts/list_release_packages.py"
+      - "scripts/list_workspace_packages.py"
+      - "tests/test_release_package_policy.py"
       - "tests/test_wheel_ownership.py"
       - "packages/*/src/neuros/__init__.py"
       - "packages/*/pyproject.toml"
@@ -17,7 +21,11 @@ on:
       - ".github/workflows/packaging-contracts.yml"
       - ".github/workflows/ci.yml"
       - ".github/workflows/release-candidate.yml"
+      - "release/package-policy.json"
       - "scripts/check_wheel_ownership.py"
+      - "scripts/list_release_packages.py"
+      - "scripts/list_workspace_packages.py"
+      - "tests/test_release_package_policy.py"
       - "tests/test_wheel_ownership.py"
       - "packages/*/src/neuros/__init__.py"
       - "packages/*/pyproject.toml"
@@ -31,7 +39,7 @@ concurrency:
 
 jobs:
   wheel-ownership-unit-contracts:
-    name: Wheel ownership unit contracts
+    name: Packaging and release-policy unit contracts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -43,5 +51,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-asyncio
-      - name: Exercise ownership normalization and fail-closed cases
-        run: pytest -q tests/test_wheel_ownership.py
+      - name: Exercise release inventory and wheel-ownership fail-closed cases
+        run: |
+          pytest -q \
+            tests/test_release_package_policy.py \
+            tests/test_wheel_ownership.py

--- a/.github/workflows/packaging-contracts.yml
+++ b/.github/workflows/packaging-contracts.yml
@@ -7,9 +7,11 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/release-candidate.yml"
       - "release/package-policy.json"
+      - "scripts/check_release_dependency_closure.py"
       - "scripts/check_wheel_ownership.py"
       - "scripts/list_release_packages.py"
       - "scripts/list_workspace_packages.py"
+      - "tests/test_release_dependency_closure.py"
       - "tests/test_release_package_policy.py"
       - "tests/test_wheel_ownership.py"
       - "packages/*/src/neuros/__init__.py"
@@ -22,9 +24,11 @@ on:
       - ".github/workflows/ci.yml"
       - ".github/workflows/release-candidate.yml"
       - "release/package-policy.json"
+      - "scripts/check_release_dependency_closure.py"
       - "scripts/check_wheel_ownership.py"
       - "scripts/list_release_packages.py"
       - "scripts/list_workspace_packages.py"
+      - "tests/test_release_dependency_closure.py"
       - "tests/test_release_package_policy.py"
       - "tests/test_wheel_ownership.py"
       - "packages/*/src/neuros/__init__.py"
@@ -50,9 +54,10 @@ jobs:
       - name: Install test tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-asyncio
-      - name: Exercise release inventory and wheel-ownership fail-closed cases
+          python -m pip install pytest pytest-asyncio packaging
+      - name: Exercise release and wheel-ownership fail-closed cases
         run: |
           pytest -q \
+            tests/test_release_dependency_closure.py \
             tests/test_release_package_policy.py \
             tests/test_wheel_ownership.py

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+env:
+  RELEASE_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  RELEASE_SOURCE_REF: ${{ github.event.pull_request.head.ref || github.ref }}
+
 concurrency:
   group: release-candidate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -34,7 +38,15 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          ref: ${{ env.RELEASE_SOURCE_SHA }}
           fetch-depth: 0
+          persist-credentials: false
+      - name: Require exact clean release source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${RELEASE_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
@@ -169,8 +181,9 @@ jobs:
 
           manifest = {
               "schema_version": 2,
-              "git_sha": os.environ["GITHUB_SHA"],
-              "git_ref": os.environ["GITHUB_REF"],
+              "source_revision": os.environ["RELEASE_SOURCE_SHA"],
+              "source_ref": os.environ["RELEASE_SOURCE_REF"],
+              "github_event_sha": os.environ["GITHUB_SHA"],
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
               "release_policy": {
@@ -244,7 +257,7 @@ jobs:
       - name: Upload immutable release-candidate bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: neurOS-release-candidate-${{ github.sha }}
+          name: neurOS-release-candidate-${{ env.RELEASE_SOURCE_SHA }}
           path: |
             ${{ runner.temp }}/neuros-release/*.whl
             ${{ runner.temp }}/neuros-release/SHA256SUMS

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install release tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build twine pyyaml mkdocs-material cffconvert
+          python -m pip install build twine packaging pyyaml mkdocs-material cffconvert
       - name: Validate public contracts, release policy, and documentation
         run: |
           python scripts/check_public_contracts.py
@@ -116,8 +116,11 @@ jobs:
           import os
           import subprocess
           import sys
+          from email.parser import Parser
           from pathlib import Path
           from zipfile import ZipFile
+          from packaging.requirements import Requirement
+          from packaging.utils import canonicalize_name
 
           selected_policy = json.loads(
               subprocess.check_output(
@@ -137,6 +140,7 @@ jobs:
           bundled_policy_path.write_bytes(policy_bytes)
 
           artifacts = []
+          metadata_by_distribution = {}
           for wheel in sorted(dist.glob("*.whl")):
               digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
               with ZipFile(wheel) as archive:
@@ -144,30 +148,46 @@ jobs:
                       name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
                   )
                   metadata = archive.read(metadata_name).decode("utf-8", errors="strict")
-              fields = {}
-              for line in metadata.splitlines():
-                  if line.startswith("Name: "):
-                      fields["name"] = line[6:]
-                  elif line.startswith("Version: "):
-                      fields["version"] = line[9:]
-                  if len(fields) == 2:
-                      break
-              if set(fields) != {"name", "version"}:
+              message = Parser().parsestr(metadata)
+              name = message.get("Name")
+              version = message.get("Version")
+              if not name or not version:
                   raise SystemExit(f"missing package metadata in {wheel.name}")
-              artifacts.append({"file": wheel.name, "sha256": digest, **fields})
+              artifacts.append({"file": wheel.name, "sha256": digest, "name": name, "version": version})
+              metadata_by_distribution[canonicalize_name(name)] = message
+
           if len(artifacts) != expected_count:
               raise SystemExit(f"expected {expected_count} wheels, found {len(artifacts)}")
-          if len({item["name"] for item in artifacts}) != expected_count:
+          if len({canonicalize_name(item["name"]) for item in artifacts}) != expected_count:
               raise SystemExit("release contains duplicate distribution names")
 
-          expected_names = {item["distribution"] for item in selected_policy["packages"]}
-          observed_names = {item["name"] for item in artifacts}
+          expected_names = {canonicalize_name(item["distribution"]) for item in selected_policy["packages"]}
+          observed_names = {canonicalize_name(item["name"]) for item in artifacts}
           if expected_names != observed_names:
               raise SystemExit(
                   "release wheel distributions differ from explicit package policy: "
                   f"missing={sorted(expected_names - observed_names)}, "
                   f"foreign={sorted(observed_names - expected_names)}"
               )
+
+          internal_runtime_dependencies = []
+          for distribution, message in sorted(metadata_by_distribution.items()):
+              for raw_requirement in message.get_all("Requires-Dist") or []:
+                  requirement = Requirement(raw_requirement)
+                  dependency = canonicalize_name(requirement.name)
+                  if dependency != "neuros" and not dependency.startswith("neuros-"):
+                      continue
+                  if requirement.marker is not None and not requirement.marker.evaluate({"extra": ""}):
+                      continue
+                  internal_runtime_dependencies.append(
+                      {"from": distribution, "requirement": raw_requirement, "to": dependency}
+                  )
+                  if dependency not in observed_names:
+                      raise SystemExit(
+                          "default release has an unsatisfied internal runtime dependency: "
+                          f"{distribution} requires {raw_requirement!r}, but {dependency!r} "
+                          "is not present in the exact release wheel set"
+                      )
 
           ownership_path = dist / "wheel-ownership.json"
           if not ownership_path.is_file():
@@ -186,6 +206,10 @@ jobs:
               "github_event_sha": os.environ["GITHUB_SHA"],
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
+              "internal_runtime_dependency_closure": {
+                  "status": "pass",
+                  "dependencies": internal_runtime_dependencies,
+              },
               "release_policy": {
                   "file": bundled_policy_path.name,
                   "source_path": str(source_policy_path),

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -9,8 +9,10 @@ on:
       - "CITATION.cff"
       - "docs/RELEASE_POLICY.md"
       - "docs/SCIENTIFIC_CLAIMS.md"
+      - "release/package-policy.json"
       - "scripts/check_public_contracts.py"
       - "scripts/check_wheel_ownership.py"
+      - "scripts/list_release_packages.py"
       - "scripts/list_workspace_packages.py"
       - "mkdocs.yml"
   workflow_dispatch:
@@ -41,17 +43,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install build twine pyyaml mkdocs-material cffconvert
-      - name: Validate public contracts and documentation
+      - name: Validate public contracts, release policy, and documentation
         run: |
           python scripts/check_public_contracts.py
+          python scripts/list_release_packages.py --all --json > "${RUNNER_TEMP}/release-package-policy.json"
           cffconvert --validate
           mkdocs build --strict --site-dir "${RUNNER_TEMP}/neuros-docs"
-      - name: Build all workspace wheels
+      - name: Build explicit default release wheels
         run: |
           set -euo pipefail
           DIST="${RUNNER_TEMP}/neuros-release"
           mkdir -p "${DIST}"
-          mapfile -t PACKAGES < <(python scripts/list_workspace_packages.py)
+          mapfile -t PACKAGES < <(python scripts/list_release_packages.py)
+          test "${#PACKAGES[@]}" -gt 0
           for package in "${PACKAGES[@]}"
           do
             python -m build --wheel --outdir "${DIST}" "${package}"
@@ -103,12 +107,18 @@ jobs:
           from pathlib import Path
           from zipfile import ZipFile
 
-          expected_count = int(
+          selected_policy = json.loads(
               subprocess.check_output(
-                  [sys.executable, "scripts/list_workspace_packages.py", "--count"],
+                  [sys.executable, "scripts/list_release_packages.py", "--json"],
                   text=True,
-              ).strip()
+              )
           )
+          expected_count = selected_policy["count"]
+          if expected_count <= 0:
+              raise SystemExit("default release package set must not be empty")
+
+          policy_path = Path("release/package-policy.json")
+          policy_sha = hashlib.sha256(policy_path.read_bytes()).hexdigest()
           dist = Path(os.environ["RUNNER_TEMP"]) / "neuros-release"
           artifacts = []
           for wheel in sorted(dist.glob("*.whl")):
@@ -134,6 +144,15 @@ jobs:
           if len({item["name"] for item in artifacts}) != expected_count:
               raise SystemExit("release contains duplicate distribution names")
 
+          expected_names = {item["distribution"] for item in selected_policy["packages"]}
+          observed_names = {item["name"] for item in artifacts}
+          if expected_names != observed_names:
+              raise SystemExit(
+                  "release wheel distributions differ from explicit package policy: "
+                  f"missing={sorted(expected_names - observed_names)}, "
+                  f"foreign={sorted(observed_names - expected_names)}"
+              )
+
           ownership_path = dist / "wheel-ownership.json"
           if not ownership_path.is_file():
               raise SystemExit("wheel ownership manifest is missing")
@@ -145,11 +164,16 @@ jobs:
           ownership_sha = hashlib.sha256(ownership_path.read_bytes()).hexdigest()
 
           manifest = {
-              "schema_version": 1,
+              "schema_version": 2,
               "git_sha": os.environ["GITHUB_SHA"],
               "git_ref": os.environ["GITHUB_REF"],
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
+              "release_policy": {
+                  "file": str(policy_path),
+                  "sha256": policy_sha,
+                  "selected": selected_policy,
+              },
               "wheel_ownership": {
                   "file": ownership_path.name,
                   "sha256": ownership_sha,
@@ -192,10 +216,6 @@ jobs:
           test -n "${MODELS_WHEEL}"
           test -n "${SDK_WHEEL}"
 
-          # Install internal public-runtime dependencies explicitly from the
-          # artifacts produced by this exact source revision. External
-          # third-party dependencies may resolve normally, but neurOS
-          # components cannot be substituted by stale package-index artifacts.
           "${PY}" -m pip install \
             "${CORE_WHEEL}" \
             "${DRIVERS_WHEEL}" \

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -80,7 +80,9 @@ jobs:
       - name: Verify internal default dependency closure
         run: |
           set -euo pipefail
-          python scripts/check_release_dependency_closure.py "${RUNNER_TEMP}/neuros-release"
+          python scripts/check_release_dependency_closure.py \
+            "${RUNNER_TEMP}/neuros-release" \
+            --output "${RUNNER_TEMP}/neuros-release/release-dependency-closure.json"
       - name: Prove component namespace without the SDK
         run: |
           set -euo pipefail
@@ -124,7 +126,6 @@ jobs:
           from email.parser import Parser
           from pathlib import Path
           from zipfile import ZipFile
-          from packaging.requirements import Requirement
           from packaging.utils import canonicalize_name
 
           selected_policy = json.loads(
@@ -145,7 +146,6 @@ jobs:
           bundled_policy_path.write_bytes(policy_bytes)
 
           artifacts = []
-          metadata_by_distribution = {}
           for wheel in sorted(dist.glob("*.whl")):
               digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
               with ZipFile(wheel) as archive:
@@ -159,15 +159,13 @@ jobs:
               if not name or not version:
                   raise SystemExit(f"missing package metadata in {wheel.name}")
               artifacts.append({"file": wheel.name, "sha256": digest, "name": name, "version": version})
-              metadata_by_distribution[canonicalize_name(name)] = message
 
           if len(artifacts) != expected_count:
               raise SystemExit(f"expected {expected_count} wheels, found {len(artifacts)}")
-          if len({canonicalize_name(item["name"]) for item in artifacts}) != expected_count:
-              raise SystemExit("release contains duplicate distribution names")
-
-          expected_names = {canonicalize_name(item["distribution"]) for item in selected_policy["packages"]}
           observed_names = {canonicalize_name(item["name"]) for item in artifacts}
+          if len(observed_names) != expected_count:
+              raise SystemExit("release contains duplicate distribution names")
+          expected_names = {canonicalize_name(item["distribution"]) for item in selected_policy["packages"]}
           if expected_names != observed_names:
               raise SystemExit(
                   "release wheel distributions differ from explicit package policy: "
@@ -175,24 +173,22 @@ jobs:
                   f"foreign={sorted(observed_names - expected_names)}"
               )
 
-          internal_runtime_dependencies = []
-          for distribution, message in sorted(metadata_by_distribution.items()):
-              for raw_requirement in message.get_all("Requires-Dist") or []:
-                  requirement = Requirement(raw_requirement)
-                  dependency = canonicalize_name(requirement.name)
-                  if dependency != "neuros" and not dependency.startswith("neuros-"):
-                      continue
-                  if requirement.marker is not None and not requirement.marker.evaluate({"extra": ""}):
-                      continue
-                  internal_runtime_dependencies.append(
-                      {"from": distribution, "requirement": raw_requirement, "to": dependency}
-                  )
-                  if dependency not in observed_names:
-                      raise SystemExit(
-                          "default release has an unsatisfied internal runtime dependency: "
-                          f"{distribution} requires {raw_requirement!r}, but {dependency!r} "
-                          "is not present in the exact release wheel set"
-                      )
+          closure_path = dist / "release-dependency-closure.json"
+          if not closure_path.is_file():
+              raise SystemExit("release dependency closure report is missing")
+          closure_payload = json.loads(closure_path.read_text(encoding="utf-8"))
+          if closure_payload.get("schema") != "neuros.release_dependency_closure.v1":
+              raise SystemExit("unexpected release dependency closure schema")
+          if closure_payload.get("status") != "pass":
+              raise SystemExit("release dependency closure is not passing")
+          closure_names = set(closure_payload.get("distributions", {}))
+          if closure_names != observed_names:
+              raise SystemExit(
+                  "release dependency closure distribution set differs from wheels: "
+                  f"missing={sorted(observed_names - closure_names)}, "
+                  f"foreign={sorted(closure_names - observed_names)}"
+              )
+          closure_sha = hashlib.sha256(closure_path.read_bytes()).hexdigest()
 
           ownership_path = dist / "wheel-ownership.json"
           if not ownership_path.is_file():
@@ -211,9 +207,13 @@ jobs:
               "github_event_sha": os.environ["GITHUB_SHA"],
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
-              "internal_runtime_dependency_closure": {
-                  "status": "pass",
-                  "dependencies": internal_runtime_dependencies,
+              "release_dependency_closure": {
+                  "file": closure_path.name,
+                  "sha256": closure_sha,
+                  "schema": closure_payload["schema"],
+                  "python_versions": closure_payload.get("python_versions", []),
+                  "target_environment_count": len(closure_payload.get("target_environments", [])),
+                  "dependency_count": len(closure_payload.get("dependencies", [])),
               },
               "release_policy": {
                   "file": bundled_policy_path.name,
@@ -236,6 +236,7 @@ jobs:
 
           checksum_lines = [
               *(f"{a['sha256']}  {a['file']}\n" for a in artifacts),
+              f"{closure_sha}  {closure_path.name}\n",
               f"{ownership_sha}  {ownership_path.name}\n",
               f"{policy_sha}  {bundled_policy_path.name}\n",
               f"{manifest_sha}  {manifest_path.name}\n",
@@ -291,6 +292,7 @@ jobs:
             ${{ runner.temp }}/neuros-release/*.whl
             ${{ runner.temp }}/neuros-release/SHA256SUMS
             ${{ runner.temp }}/neuros-release/package-policy.json
+            ${{ runner.temp }}/neuros-release/release-dependency-closure.json
             ${{ runner.temp }}/neuros-release/release-manifest.json
             ${{ runner.temp }}/neuros-release/wheel-ownership.json
           if-no-files-found: error

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -94,7 +94,7 @@ jobs:
           if not neuros.__spec__ or not neuros.__spec__.submodule_search_locations:
               raise SystemExit("component-only neuros namespace has no search locations")
           PY
-      - name: Generate component and checksum manifests
+      - name: Generate self-describing release manifest and checksums
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -117,9 +117,13 @@ jobs:
           if expected_count <= 0:
               raise SystemExit("default release package set must not be empty")
 
-          policy_path = Path("release/package-policy.json")
-          policy_sha = hashlib.sha256(policy_path.read_bytes()).hexdigest()
+          source_policy_path = Path("release/package-policy.json")
+          policy_bytes = source_policy_path.read_bytes()
+          policy_sha = hashlib.sha256(policy_bytes).hexdigest()
           dist = Path(os.environ["RUNNER_TEMP"]) / "neuros-release"
+          bundled_policy_path = dist / "package-policy.json"
+          bundled_policy_path.write_bytes(policy_bytes)
+
           artifacts = []
           for wheel in sorted(dist.glob("*.whl")):
               digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
@@ -170,7 +174,8 @@ jobs:
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
               "release_policy": {
-                  "file": str(policy_path),
+                  "file": bundled_policy_path.name,
+                  "source_path": str(source_policy_path),
                   "sha256": policy_sha,
                   "selected": selected_policy,
               },
@@ -180,15 +185,20 @@ jobs:
                   "schema": ownership_payload["schema"],
               },
           }
-          (dist / "release-manifest.json").write_text(
+          manifest_path = dist / "release-manifest.json"
+          manifest_path.write_text(
               json.dumps(manifest, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
           )
-          (dist / "SHA256SUMS").write_text(
-              "".join(f"{a['sha256']}  {a['file']}\n" for a in artifacts)
-              + f"{ownership_sha}  {ownership_path.name}\n",
-              encoding="utf-8",
-          )
+          manifest_sha = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+          checksum_lines = [
+              *(f"{a['sha256']}  {a['file']}\n" for a in artifacts),
+              f"{ownership_sha}  {ownership_path.name}\n",
+              f"{policy_sha}  {bundled_policy_path.name}\n",
+              f"{manifest_sha}  {manifest_path.name}\n",
+          ]
+          (dist / "SHA256SUMS").write_text("".join(checksum_lines), encoding="utf-8")
           PY
       - name: Verify checksums before installation
         run: |
@@ -238,6 +248,7 @@ jobs:
           path: |
             ${{ runner.temp }}/neuros-release/*.whl
             ${{ runner.temp }}/neuros-release/SHA256SUMS
+            ${{ runner.temp }}/neuros-release/package-policy.json
             ${{ runner.temp }}/neuros-release/release-manifest.json
             ${{ runner.temp }}/neuros-release/wheel-ownership.json
           if-no-files-found: error

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -11,6 +11,7 @@ on:
       - "docs/SCIENTIFIC_CLAIMS.md"
       - "release/package-policy.json"
       - "scripts/check_public_contracts.py"
+      - "scripts/check_release_dependency_closure.py"
       - "scripts/check_wheel_ownership.py"
       - "scripts/list_release_packages.py"
       - "scripts/list_workspace_packages.py"
@@ -76,6 +77,10 @@ jobs:
           python -m twine check "${DIST}"/*.whl
           python scripts/check_wheel_ownership.py "${DIST}" \
             --output "${DIST}/wheel-ownership.json"
+      - name: Verify internal default dependency closure
+        run: |
+          set -euo pipefail
+          python scripts/check_release_dependency_closure.py "${RUNNER_TEMP}/neuros-release"
       - name: Prove component namespace without the SDK
         run: |
           set -euo pipefail

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -195,24 +195,21 @@ jobs:
           set -euo pipefail
           cd "${RUNNER_TEMP}/neuros-release"
           sha256sum --check SHA256SUMS
-      - name: Smoke-install the public SDK and Arena from this exact wheel set
+      - name: Smoke-install the minimal public SDK from this exact wheel set
         run: |
           set -euo pipefail
           DIST="${RUNNER_TEMP}/neuros-release"
           python -m venv "${RUNNER_TEMP}/release-smoke"
           PY="${RUNNER_TEMP}/release-smoke/bin/python"
           NEUROS="${RUNNER_TEMP}/release-smoke/bin/neuros"
-          ARENA="${RUNNER_TEMP}/release-smoke/bin/neuros-arena"
           "${PY}" -m pip install --upgrade pip
 
           CORE_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_core-*.whl' -print -quit)"
           DRIVERS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_drivers-*.whl' -print -quit)"
-          ARENA_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_arena-*.whl' -print -quit)"
           MODELS_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros_models-*.whl' -print -quit)"
           SDK_WHEEL="$(find "${DIST}" -maxdepth 1 -name 'neuros-[0-9]*.whl' -print -quit)"
           test -n "${CORE_WHEEL}"
           test -n "${DRIVERS_WHEEL}"
-          test -n "${ARENA_WHEEL}"
           test -n "${MODELS_WHEEL}"
           test -n "${SDK_WHEEL}"
 
@@ -220,8 +217,7 @@ jobs:
             "${CORE_WHEEL}" \
             "${DRIVERS_WHEEL}" \
             "${MODELS_WHEEL}" \
-            "${SDK_WHEEL}" \
-            "${ARENA_WHEEL}"
+            "${SDK_WHEEL}"
           "${PY}" -m pip check
           "${PY}" - <<'PY'
           import neuros
@@ -235,8 +231,6 @@ jobs:
           PY
           "${NEUROS}" doctor --json
           "${NEUROS}" compatibility --json
-          "${ARENA}" --preset dual-target-smoke --output "${RUNNER_TEMP}/arena-wheel-smoke.json"
-          test -s "${RUNNER_TEMP}/arena-wheel-smoke.json"
       - name: Upload immutable release-candidate bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -8,13 +8,28 @@ The repository is a multi-distribution workspace. Individual Python distribution
 
 A platform release must record the exact versions and wheel hashes of every included distribution.
 
+## Workspace membership is not release eligibility
+
+`tool.uv.workspace.members` answers only whether a distribution is developed and validated in this monorepo. It does **not** authorize that distribution for publication.
+
+`release/package-policy.json` is the machine-readable release authority. It classifies every workspace member exactly once across two independent dimensions:
+
+- `release_tier`: whether the package is part of the default public runtime, a separately qualified integration, a research extension, or an internal preview;
+- `scientific_maturity`: what kind of evidence the package has actually earned.
+
+Only entries with `publish_candidate=true` enter the default release-candidate wheel set. The policy validator fails closed if a workspace package is unclassified, a distribution name drifts from package metadata, a non-runtime package enters the default release set, or the SDK dependency closure is missing.
+
+A package may remain fully maintained in the monorepo while intentionally not being a default publication candidate. Version number, workspace membership, test coverage, and scientific maturity are not interchangeable promotion signals.
+
+The release manifest checksum-binds the exact package-policy file and the selected package inventory so the artifact set can be reconstructed from evidence rather than inferred from repository layout.
+
 ## Distribution and namespace ownership
 
 Multiple distributions may contribute subpackages to the shared `neuros` Python namespace, but **two distributions must never own the same installed file path**.
 
 Component distributions use PEP 420 implicit namespace portions. The user-facing `neuros` SDK is the sole owner of `neuros/__init__.py` because that initializer defines the public top-level SDK API.
 
-Release qualification scans the payload of every built workspace wheel, normalizes wheel `.data/purelib` and `.data/platlib` entries to their real install destinations, and fails if any destination has multiple owners. The resulting `neuros.wheel_ownership.v1` manifest is checksum-bound into the release-candidate bundle.
+Release qualification scans the payload of every built release wheel, normalizes wheel `.data/purelib` and `.data/platlib` entries to their real install destinations, and fails if any destination has multiple owners. The resulting `neuros.wheel_ownership.v1` manifest is checksum-bound into the release-candidate bundle.
 
 This is an install-integrity requirement, not a style preference. Package managers track files per distribution; if two wheels record the same path, uninstalling either distribution can delete a file the other still requires.
 
@@ -43,11 +58,13 @@ Persisted replay/archive/qualification formats require stronger discipline. A fo
 
 Before a public release is published, CI must:
 
-- build every intended workspace wheel from the release source;
+- validate that every workspace member is explicitly classified by the release package policy;
+- build every distribution explicitly authorized for the default release set from the release source;
 - run package metadata validation (`twine check` or equivalent);
 - prove that built wheels have no overlapping installed-file ownership;
 - prove core/drivers/models work as implicit namespace portions without the SDK initializer;
 - prove the installed SDK owns and exposes the documented top-level `neuros` API;
+- checksum-bind the release package policy and selected inventory into the release manifest;
 - generate SHA-256 checksums for release artifacts and the wheel-ownership manifest;
 - smoke-install the user-facing `neuros` distribution from the built wheel set;
 - execute a minimal `neuros doctor` / compatibility smoke path;
@@ -62,6 +79,7 @@ Release notes should include:
 
 - Git tag and commit SHA;
 - component package/version manifest;
+- release package-policy SHA-256 and selected inventory;
 - SHA-256 manifest for built artifacts;
 - wheel-ownership manifest proving unique installed-file ownership;
 - strongest supported evidence tiers and important claim boundaries;

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,9 @@
+# Release authority
+
+This directory contains repository-level release policy that is intentionally independent from workspace membership and package version numbers.
+
+- `package-policy.json` classifies every maintained workspace distribution.
+- `scripts/list_release_packages.py` validates the policy fail-closed and emits the default release-candidate set.
+- `.github/workflows/release-candidate.yml` builds only that explicit set and checksum-binds the policy snapshot into the release manifest.
+
+A package can remain maintained, tested, and available to research workflows without being authorized for default publication. Scientific maturity is a separate axis from packaging eligibility.

--- a/release/package-policy.json
+++ b/release/package-policy.json
@@ -1,0 +1,94 @@
+{
+  "schema": "neuros.release_package_policy.v1",
+  "policy": {
+    "workspace_membership_means": "developed and validated in this monorepo",
+    "publish_candidate_means": "included in the default neurOS release artifact set",
+    "scientific_maturity_is_independent": true
+  },
+  "packages": [
+    {
+      "path": "packages/neuros-core",
+      "distribution": "neuros-core",
+      "release_tier": "public-runtime",
+      "scientific_maturity": "platform-core",
+      "publish_candidate": true
+    },
+    {
+      "path": "packages/neuros-drivers",
+      "distribution": "neuros-drivers",
+      "release_tier": "public-runtime",
+      "scientific_maturity": "qualified-integration",
+      "publish_candidate": true
+    },
+    {
+      "path": "packages/neuros-arena",
+      "distribution": "neuros-arena",
+      "release_tier": "public-runtime",
+      "scientific_maturity": "synthetic-validation",
+      "publish_candidate": true
+    },
+    {
+      "path": "packages/neuros-models",
+      "distribution": "neuros-models",
+      "release_tier": "public-runtime",
+      "scientific_maturity": "qualified-integration",
+      "publish_candidate": true
+    },
+    {
+      "path": "packages/neuros",
+      "distribution": "neuros",
+      "release_tier": "public-runtime",
+      "scientific_maturity": "platform-core",
+      "publish_candidate": true
+    },
+    {
+      "path": "packages/neuros-foundation",
+      "distribution": "neuros-foundation",
+      "release_tier": "qualified-integration",
+      "scientific_maturity": "research-qualified",
+      "publish_candidate": false
+    },
+    {
+      "path": "packages/neuros-mechint",
+      "distribution": "neuros-mechint",
+      "release_tier": "qualified-integration",
+      "scientific_maturity": "research-qualified",
+      "publish_candidate": false
+    },
+    {
+      "path": "packages/neuros-neurofm",
+      "distribution": "neuros-neurofm",
+      "release_tier": "research-extension",
+      "scientific_maturity": "research",
+      "publish_candidate": false
+    },
+    {
+      "path": "packages/neuros-sourceweigher",
+      "distribution": "neuros-sourceweigher",
+      "release_tier": "research-extension",
+      "scientific_maturity": "research",
+      "publish_candidate": false
+    },
+    {
+      "path": "packages/orion",
+      "distribution": "neuros-orion",
+      "release_tier": "research-extension",
+      "scientific_maturity": "research",
+      "publish_candidate": false
+    },
+    {
+      "path": "packages/neuros-ui",
+      "distribution": "neuros-ui",
+      "release_tier": "internal-preview",
+      "scientific_maturity": "prototype",
+      "publish_candidate": false
+    },
+    {
+      "path": "packages/neuros-cloud",
+      "distribution": "neuros-cloud",
+      "release_tier": "internal-preview",
+      "scientific_maturity": "prototype",
+      "publish_candidate": false
+    }
+  ]
+}

--- a/release/package-policy.json
+++ b/release/package-policy.json
@@ -23,9 +23,9 @@
     {
       "path": "packages/neuros-arena",
       "distribution": "neuros-arena",
-      "release_tier": "public-runtime",
+      "release_tier": "qualified-integration",
       "scientific_maturity": "synthetic-validation",
-      "publish_candidate": true
+      "publish_candidate": false
     },
     {
       "path": "packages/neuros-models",

--- a/scripts/check_release_dependency_closure.py
+++ b/scripts/check_release_dependency_closure.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Verify the default neurOS release wheel set is internally dependency-closed.
+
+The check is intentionally scoped to active *default* dependencies between neurOS
+distributions. Optional-extra edges do not enter the default runtime unless an
+active internal requirement explicitly requests an extra. Such requested extras
+fail closed until this verifier models their dependency propagation explicitly.
+
+External third-party requirements remain the package resolver's responsibility;
+this contract prevents a release candidate from silently fetching an omitted
+neurOS distribution from a package index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from email.parser import Parser
+from pathlib import Path
+from typing import Any
+from zipfile import BadZipFile, ZipFile
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+SCHEMA = "neuros.release_dependency_closure.v1"
+
+
+def _is_internal(name: str) -> bool:
+    canonical = canonicalize_name(name)
+    return canonical == "neuros" or canonical.startswith("neuros-")
+
+
+def _metadata(wheel: Path) -> tuple[str, str, list[str]]:
+    try:
+        with ZipFile(wheel) as archive:
+            metadata_names = [
+                name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_names) != 1:
+                raise ValueError(
+                    f"{wheel.name}: expected exactly one .dist-info/METADATA, "
+                    f"found {len(metadata_names)}"
+                )
+            text = archive.read(metadata_names[0]).decode("utf-8", errors="strict")
+    except BadZipFile as exc:
+        raise ValueError(f"invalid wheel archive: {wheel}") from exc
+    message = Parser().parsestr(text)
+    name = message.get("Name")
+    version = message.get("Version")
+    if not name or not version:
+        raise ValueError(f"{wheel.name}: METADATA must contain Name and Version")
+    try:
+        Version(str(version))
+    except InvalidVersion as exc:
+        raise ValueError(f"{wheel.name}: invalid Version metadata {version!r}") from exc
+    return str(name), str(version), list(message.get_all("Requires-Dist") or [])
+
+
+def inspect_release_dependency_closure(wheel_dir: Path) -> dict[str, Any]:
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if not wheels:
+        raise ValueError(f"no wheels found in {wheel_dir}")
+
+    distributions: dict[str, dict[str, Any]] = {}
+    requirements_by_distribution: dict[str, list[str]] = {}
+    for wheel in wheels:
+        display_name, version, requirements = _metadata(wheel)
+        canonical = canonicalize_name(display_name)
+        if canonical in distributions:
+            raise ValueError(f"duplicate distribution in release set: {display_name}")
+        distributions[canonical] = {
+            "name": display_name,
+            "version": version,
+            "wheel": wheel.name,
+        }
+        requirements_by_distribution[canonical] = requirements
+
+    dependencies: list[dict[str, Any]] = []
+    for source in sorted(distributions):
+        for raw in requirements_by_distribution[source]:
+            try:
+                requirement = Requirement(raw)
+            except InvalidRequirement as exc:
+                raise ValueError(
+                    f"{distributions[source]['wheel']}: invalid Requires-Dist {raw!r}"
+                ) from exc
+            target = canonicalize_name(requirement.name)
+            if not _is_internal(target):
+                continue
+            if requirement.marker is not None and not requirement.marker.evaluate({"extra": ""}):
+                continue
+            if requirement.extras:
+                raise ValueError(
+                    "active internal runtime dependency requests extras whose closure is not "
+                    f"modeled: {source} -> {raw}"
+                )
+            target_meta = distributions.get(target)
+            if target_meta is None:
+                raise ValueError(
+                    "unsatisfied internal runtime dependency: "
+                    f"{source} requires {raw!r}, but {target!r} is absent from release set"
+                )
+            target_version = Version(target_meta["version"])
+            if requirement.specifier and not requirement.specifier.contains(
+                target_version, prereleases=True
+            ):
+                raise ValueError(
+                    "incompatible internal runtime dependency: "
+                    f"{source} requires {raw!r}, but bundled {target}=={target_version}"
+                )
+            dependencies.append(
+                {
+                    "from": source,
+                    "requirement": raw,
+                    "to": target,
+                    "resolved_version": str(target_version),
+                }
+            )
+
+    return {
+        "schema": SCHEMA,
+        "status": "pass",
+        "distribution_count": len(distributions),
+        "distributions": dict(sorted(distributions.items())),
+        "dependencies": dependencies,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel_dir", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    try:
+        report = inspect_release_dependency_closure(args.wheel_dir.resolve())
+    except (OSError, ValueError) as exc:
+        print(f"release dependency closure: ERROR: {exc}", file=sys.stderr)
+        return 2
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(
+        "release dependency closure: PASS "
+        f"({report['distribution_count']} distributions, "
+        f"{len(report['dependencies'])} active internal edges)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_dependency_closure.py
+++ b/scripts/check_release_dependency_closure.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Verify the default neurOS release wheel set is internally dependency-closed.
 
-The check is intentionally scoped to active *default* dependencies between neurOS
-distributions. Optional-extra edges do not enter the default runtime unless an
-active internal requirement explicitly requests an extra. Such requested extras
-fail closed until this verifier models their dependency propagation explicitly.
+The check covers active *default* dependencies between neurOS distributions
+across the supported Python/runtime matrix, rather than only the CI runner that
+happened to build the wheels. Optional-extra edges do not enter the default
+runtime unless an active internal requirement explicitly requests an extra. Such
+requested extras fail closed until this verifier models their dependency
+propagation explicitly.
 
 External third-party requirements remain the package resolver's responsibility;
-this contract prevents a release candidate from silently fetching an omitted
-neurOS distribution from a package index.
+this contract prevents a release candidate from silently fetching an omitted or
+incompatible neurOS distribution from a package index.
 """
 
 from __future__ import annotations
@@ -17,20 +19,69 @@ import argparse
 import json
 import sys
 from email.parser import Parser
+from itertools import product
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 from zipfile import BadZipFile, ZipFile
 
+from packaging.markers import default_environment
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 SCHEMA = "neuros.release_dependency_closure.v1"
+SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
+_PLATFORM_TARGETS = (
+    ("linux-x86_64", "linux", "Linux", "posix", "x86_64"),
+    ("linux-aarch64", "linux", "Linux", "posix", "aarch64"),
+    ("macos-x86_64", "darwin", "Darwin", "posix", "x86_64"),
+    ("macos-arm64", "darwin", "Darwin", "posix", "arm64"),
+    ("windows-amd64", "win32", "Windows", "nt", "AMD64"),
+    ("windows-arm64", "win32", "Windows", "nt", "ARM64"),
+)
 
 
 def _is_internal(name: str) -> bool:
     canonical = canonicalize_name(name)
     return canonical == "neuros" or canonical.startswith("neuros-")
+
+
+def _target_environments() -> tuple[tuple[str, dict[str, str]], ...]:
+    targets: list[tuple[str, dict[str, str]]] = []
+    for python_version, platform in product(SUPPORTED_PYTHON_VERSIONS, _PLATFORM_TARGETS):
+        platform_id, sys_platform, platform_system, os_name, platform_machine = platform
+        environment = default_environment()
+        full_version = f"{python_version}.0"
+        environment.update(
+            {
+                "python_version": python_version,
+                "python_full_version": full_version,
+                "implementation_name": "cpython",
+                "implementation_version": full_version,
+                "platform_python_implementation": "CPython",
+                "sys_platform": sys_platform,
+                "platform_system": platform_system,
+                "os_name": os_name,
+                "platform_machine": platform_machine,
+                "extra": "",
+            }
+        )
+        targets.append((f"cp{python_version}-{platform_id}", environment))
+    return tuple(targets)
+
+
+TARGET_ENVIRONMENTS = _target_environments()
+
+
+def _active_targets(requirement: Requirement) -> tuple[str, ...]:
+    if requirement.marker is None:
+        return tuple(target_id for target_id, _ in TARGET_ENVIRONMENTS)
+    active = [
+        target_id
+        for target_id, environment in TARGET_ENVIRONMENTS
+        if requirement.marker.evaluate(environment)
+    ]
+    return tuple(active)
 
 
 def _metadata(wheel: Path) -> tuple[str, str, list[str]]:
@@ -90,18 +141,20 @@ def inspect_release_dependency_closure(wheel_dir: Path) -> dict[str, Any]:
             target = canonicalize_name(requirement.name)
             if not _is_internal(target):
                 continue
-            if requirement.marker is not None and not requirement.marker.evaluate({"extra": ""}):
+            active_targets = _active_targets(requirement)
+            if not active_targets:
                 continue
             if requirement.extras:
                 raise ValueError(
                     "active internal runtime dependency requests extras whose closure is not "
-                    f"modeled: {source} -> {raw}"
+                    f"modeled: {source} -> {raw}; active_targets={list(active_targets)}"
                 )
             target_meta = distributions.get(target)
             if target_meta is None:
                 raise ValueError(
                     "unsatisfied internal runtime dependency: "
-                    f"{source} requires {raw!r}, but {target!r} is absent from release set"
+                    f"{source} requires {raw!r}, but {target!r} is absent from release set; "
+                    f"active_targets={list(active_targets)}"
                 )
             target_version = Version(target_meta["version"])
             if requirement.specifier and not requirement.specifier.contains(
@@ -109,7 +162,8 @@ def inspect_release_dependency_closure(wheel_dir: Path) -> dict[str, Any]:
             ):
                 raise ValueError(
                     "incompatible internal runtime dependency: "
-                    f"{source} requires {raw!r}, but bundled {target}=={target_version}"
+                    f"{source} requires {raw!r}, but bundled {target}=={target_version}; "
+                    f"active_targets={list(active_targets)}"
                 )
             dependencies.append(
                 {
@@ -117,12 +171,15 @@ def inspect_release_dependency_closure(wheel_dir: Path) -> dict[str, Any]:
                     "requirement": raw,
                     "to": target,
                     "resolved_version": str(target_version),
+                    "active_targets": list(active_targets),
                 }
             )
 
     return {
         "schema": SCHEMA,
         "status": "pass",
+        "python_versions": list(SUPPORTED_PYTHON_VERSIONS),
+        "target_environments": [target_id for target_id, _ in TARGET_ENVIRONMENTS],
         "distribution_count": len(distributions),
         "distributions": dict(sorted(distributions.items())),
         "dependencies": dependencies,
@@ -148,7 +205,8 @@ def main() -> int:
     print(
         "release dependency closure: PASS "
         f"({report['distribution_count']} distributions, "
-        f"{len(report['dependencies'])} active internal edges)"
+        f"{len(report['dependencies'])} active internal edges, "
+        f"{len(report['target_environments'])} target environments)"
     )
     return 0
 

--- a/scripts/list_release_packages.py
+++ b/scripts/list_release_packages.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Validate and list the explicit neurOS release package policy.
+
+Workspace membership answers "is this developed here?". This policy separately
+answers "is this distribution part of the default release artifact set?" and
+records scientific maturity without using version numbers as a promotion signal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from list_workspace_packages import ROOT, workspace_members
+
+POLICY_FILE = ROOT / "release" / "package-policy.json"
+ALLOWED_TIERS = {
+    "public-runtime",
+    "qualified-integration",
+    "research-extension",
+    "internal-preview",
+}
+ALLOWED_MATURITY = {
+    "platform-core",
+    "qualified-integration",
+    "synthetic-validation",
+    "research-qualified",
+    "research",
+    "prototype",
+}
+
+
+def _project_name(pyproject: Path) -> str:
+    text = pyproject.read_text(encoding="utf-8")
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+        section = re.search(r"(?ms)^\[project\]\s*(.*?)(?=^\[|\Z)", text)
+        if section is None:
+            raise ValueError(f"missing [project] section: {pyproject}")
+        match = re.search(r'(?m)^name\s*=\s*"([^"\n]+)"\s*$', section.group(1))
+        if match is None:
+            raise ValueError(f"missing project.name: {pyproject}")
+        return match.group(1)
+    payload = tomllib.loads(text)
+    try:
+        name = payload["project"]["name"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(f"missing project.name: {pyproject}") from exc
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"project.name must be a non-empty string: {pyproject}")
+    return name
+
+
+def release_policy(path: Path = POLICY_FILE) -> tuple[dict[str, Any], ...]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != "neuros.release_package_policy.v1":
+        raise ValueError("unexpected release package policy schema")
+    raw = payload.get("packages")
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("release package policy must contain packages")
+
+    entries: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    seen_distributions: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"release package policy entry {index} must be an object")
+        expected_fields = {
+            "path",
+            "distribution",
+            "release_tier",
+            "scientific_maturity",
+            "publish_candidate",
+        }
+        if set(item) != expected_fields:
+            raise ValueError(
+                f"release package policy entry {index} fields differ from canonical schema"
+            )
+        member = item["path"]
+        distribution = item["distribution"]
+        tier = item["release_tier"]
+        maturity = item["scientific_maturity"]
+        publish = item["publish_candidate"]
+        if not isinstance(member, str) or not member:
+            raise ValueError("release package path must be a non-empty string")
+        if not isinstance(distribution, str) or not distribution:
+            raise ValueError("release distribution must be a non-empty string")
+        if tier not in ALLOWED_TIERS:
+            raise ValueError(f"unsupported release tier for {member}: {tier}")
+        if maturity not in ALLOWED_MATURITY:
+            raise ValueError(f"unsupported scientific maturity for {member}: {maturity}")
+        if not isinstance(publish, bool):
+            raise ValueError(f"publish_candidate must be boolean for {member}")
+        if tier == "public-runtime" and not publish:
+            raise ValueError(f"public-runtime package must be a publish candidate: {member}")
+        if tier != "public-runtime" and publish:
+            raise ValueError(
+                f"non-public-runtime package cannot enter the default release set: {member}"
+            )
+        if member in seen_paths:
+            raise ValueError(f"duplicate release package path: {member}")
+        if distribution in seen_distributions:
+            raise ValueError(f"duplicate release distribution: {distribution}")
+        seen_paths.add(member)
+        seen_distributions.add(distribution)
+
+        pyproject = ROOT / member / "pyproject.toml"
+        if not pyproject.is_file():
+            raise ValueError(f"release package has no pyproject.toml: {member}")
+        actual_name = _project_name(pyproject)
+        if actual_name != distribution:
+            raise ValueError(
+                f"release policy distribution mismatch for {member}: "
+                f"policy={distribution!r}, project={actual_name!r}"
+            )
+        entries.append(dict(item))
+
+    workspace = set(workspace_members())
+    policy_members = {item["path"] for item in entries}
+    if workspace != policy_members:
+        missing = sorted(workspace - policy_members)
+        foreign = sorted(policy_members - workspace)
+        raise ValueError(
+            "release package policy must classify every workspace member exactly once; "
+            f"missing={missing}, foreign={foreign}"
+        )
+
+    required_runtime = {
+        "packages/neuros-core",
+        "packages/neuros-drivers",
+        "packages/neuros-models",
+        "packages/neuros",
+    }
+    publish_paths = {item["path"] for item in entries if item["publish_candidate"]}
+    if not required_runtime.issubset(publish_paths):
+        raise ValueError(
+            "default release set must contain SDK dependency closure: "
+            f"missing={sorted(required_runtime - publish_paths)}"
+        )
+    return tuple(entries)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--all", action="store_true", help="list every classified workspace package")
+    parser.add_argument("--count", action="store_true", help="print only the selected package count")
+    parser.add_argument("--json", action="store_true", help="print the selected package inventory as JSON")
+    parser.add_argument("--tier", choices=sorted(ALLOWED_TIERS), help="select one release tier")
+    args = parser.parse_args()
+
+    entries = release_policy()
+    if args.all:
+        selected = entries
+    elif args.tier:
+        selected = tuple(item for item in entries if item["release_tier"] == args.tier)
+    else:
+        selected = tuple(item for item in entries if item["publish_candidate"])
+
+    if args.count:
+        print(len(selected))
+    elif args.json:
+        print(
+            json.dumps(
+                {
+                    "schema": "neuros.release_package_inventory.v1",
+                    "count": len(selected),
+                    "packages": selected,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print("\n".join(item["path"] for item in selected))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_dependency_closure.py
+++ b/tests/test_release_dependency_closure.py
@@ -11,7 +11,11 @@ SCRIPTS = ROOT / "scripts"
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-from check_release_dependency_closure import inspect_release_dependency_closure  # noqa: E402
+from check_release_dependency_closure import (  # noqa: E402
+    SUPPORTED_PYTHON_VERSIONS,
+    TARGET_ENVIRONMENTS,
+    inspect_release_dependency_closure,
+)
 
 
 def _wheel(
@@ -50,14 +54,15 @@ def test_internal_default_dependencies_must_be_present_and_version_compatible(tm
     report = inspect_release_dependency_closure(tmp_path)
     assert report["status"] == "pass"
     assert report["distribution_count"] == 2
-    assert report["dependencies"] == [
-        {
-            "from": "neuros-drivers",
-            "requirement": "neuros-core>=2.0.0",
-            "to": "neuros-core",
-            "resolved_version": "2.0.0",
-        }
-    ]
+    assert report["python_versions"] == list(SUPPORTED_PYTHON_VERSIONS)
+    assert report["target_environments"] == [item[0] for item in TARGET_ENVIRONMENTS]
+    assert len(report["dependencies"]) == 1
+    dependency = report["dependencies"][0]
+    assert dependency["from"] == "neuros-drivers"
+    assert dependency["requirement"] == "neuros-core>=2.0.0"
+    assert dependency["to"] == "neuros-core"
+    assert dependency["resolved_version"] == "2.0.0"
+    assert dependency["active_targets"] == report["target_environments"]
 
 
 def test_missing_internal_default_dependency_fails_closed(tmp_path):
@@ -81,6 +86,30 @@ def test_incompatible_internal_version_fails_closed(tmp_path):
     )
     with pytest.raises(ValueError, match="incompatible internal runtime dependency"):
         inspect_release_dependency_closure(tmp_path)
+
+
+def test_python_gated_dependency_is_checked_across_supported_versions(tmp_path):
+    _wheel(
+        tmp_path,
+        name="neuros",
+        version="2.1.0",
+        requires=('neuros-legacy>=1.0; python_version < "3.11"',),
+    )
+    with pytest.raises(ValueError, match="unsatisfied internal runtime dependency") as exc:
+        inspect_release_dependency_closure(tmp_path)
+    assert "cp3.10-" in str(exc.value)
+
+
+def test_platform_gated_dependency_is_checked_beyond_linux_runner(tmp_path):
+    _wheel(
+        tmp_path,
+        name="neuros",
+        version="2.1.0",
+        requires=('neuros-winbridge>=1.0; sys_platform == "win32"',),
+    )
+    with pytest.raises(ValueError, match="unsatisfied internal runtime dependency") as exc:
+        inspect_release_dependency_closure(tmp_path)
+    assert "windows-" in str(exc.value)
 
 
 def test_active_internal_extra_requirement_fails_until_extra_closure_is_modeled(tmp_path):

--- a/tests/test_release_dependency_closure.py
+++ b/tests/test_release_dependency_closure.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from check_release_dependency_closure import inspect_release_dependency_closure  # noqa: E402
+
+
+def _wheel(
+    root: Path,
+    *,
+    name: str,
+    version: str,
+    requires: tuple[str, ...] = (),
+) -> Path:
+    normalized = name.replace("-", "_")
+    path = root / f"{normalized}-{version}-py3-none-any.whl"
+    metadata = [
+        "Metadata-Version: 2.1",
+        f"Name: {name}",
+        f"Version: {version}",
+    ]
+    metadata.extend(f"Requires-Dist: {requirement}" for requirement in requires)
+    metadata_text = "\n".join(metadata) + "\n\n"
+    with ZipFile(path, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr(f"{normalized}/fixture.py", "VALUE = 1\n")
+        archive.writestr(
+            f"{normalized}-{version}.dist-info/METADATA",
+            metadata_text,
+        )
+    return path
+
+
+def test_internal_default_dependencies_must_be_present_and_version_compatible(tmp_path):
+    _wheel(tmp_path, name="neuros-core", version="2.0.0")
+    _wheel(
+        tmp_path,
+        name="neuros-drivers",
+        version="2.1.0",
+        requires=("neuros-core>=2.0.0", "numpy>=1.24"),
+    )
+    report = inspect_release_dependency_closure(tmp_path)
+    assert report["status"] == "pass"
+    assert report["distribution_count"] == 2
+    assert report["dependencies"] == [
+        {
+            "from": "neuros-drivers",
+            "requirement": "neuros-core>=2.0.0",
+            "to": "neuros-core",
+            "resolved_version": "2.0.0",
+        }
+    ]
+
+
+def test_missing_internal_default_dependency_fails_closed(tmp_path):
+    _wheel(
+        tmp_path,
+        name="neuros",
+        version="2.1.0",
+        requires=("neuros-models>=2.0.0",),
+    )
+    with pytest.raises(ValueError, match="unsatisfied internal runtime dependency"):
+        inspect_release_dependency_closure(tmp_path)
+
+
+def test_incompatible_internal_version_fails_closed(tmp_path):
+    _wheel(tmp_path, name="neuros-core", version="2.0.0")
+    _wheel(
+        tmp_path,
+        name="neuros-drivers",
+        version="2.1.0",
+        requires=("neuros-core>=3.0.0",),
+    )
+    with pytest.raises(ValueError, match="incompatible internal runtime dependency"):
+        inspect_release_dependency_closure(tmp_path)
+
+
+def test_active_internal_extra_requirement_fails_until_extra_closure_is_modeled(tmp_path):
+    _wheel(tmp_path, name="neuros-drivers", version="2.1.0")
+    _wheel(
+        tmp_path,
+        name="neuros",
+        version="2.1.0",
+        requires=("neuros-drivers[eeg]>=2.0.0",),
+    )
+    with pytest.raises(ValueError, match="requests extras"):
+        inspect_release_dependency_closure(tmp_path)
+
+
+def test_optional_internal_extra_edges_do_not_enter_default_runtime(tmp_path):
+    _wheel(tmp_path, name="neuros-core", version="2.0.0")
+    _wheel(
+        tmp_path,
+        name="neuros",
+        version="2.1.0",
+        requires=(
+            "neuros-core>=2.0.0",
+            'neuros-foundation>=2.0.0; extra == "research"',
+        ),
+    )
+    report = inspect_release_dependency_closure(tmp_path)
+    assert [item["to"] for item in report["dependencies"]] == ["neuros-core"]
+
+
+def test_duplicate_distribution_fails_closed(tmp_path):
+    first = _wheel(tmp_path, name="neuros-core", version="2.0.0")
+    second = tmp_path / "alternate.whl"
+    second.write_bytes(first.read_bytes())
+    with pytest.raises(ValueError, match="duplicate distribution"):
+        inspect_release_dependency_closure(tmp_path)

--- a/tests/test_release_package_policy.py
+++ b/tests/test_release_package_policy.py
@@ -33,10 +33,13 @@ def test_policy_classifies_every_workspace_member_once_and_release_set_is_explic
     assert published == {
         "neuros-core",
         "neuros-drivers",
-        "neuros-arena",
         "neuros-models",
         "neuros",
     }
+    arena = next(item for item in entries if item["distribution"] == "neuros-arena")
+    assert arena["release_tier"] == "qualified-integration"
+    assert arena["scientific_maturity"] == "synthetic-validation"
+    assert arena["publish_candidate"] is False
     assert all(
         (item["release_tier"] == "public-runtime") == item["publish_candidate"]
         for item in entries
@@ -70,6 +73,16 @@ def test_policy_fails_if_research_package_enters_default_release_set(tmp_path):
         item for item in payload["packages"] if item["release_tier"] == "research-extension"
     )
     research["publish_candidate"] = True
+    with pytest.raises(ValueError, match="non-public-runtime package cannot enter"):
+        release_policy(_write(tmp_path, payload))
+
+
+def test_policy_fails_if_qualified_integration_enters_default_release_set(tmp_path):
+    payload = _payload()
+    arena = next(
+        item for item in payload["packages"] if item["distribution"] == "neuros-arena"
+    )
+    arena["publish_candidate"] = True
     with pytest.raises(ValueError, match="non-public-runtime package cannot enter"):
         release_policy(_write(tmp_path, payload))
 

--- a/tests/test_release_package_policy.py
+++ b/tests/test_release_package_policy.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from list_release_packages import POLICY_FILE, release_policy  # noqa: E402
+from list_workspace_packages import workspace_members  # noqa: E402
+
+
+def _payload() -> dict:
+    return json.loads(POLICY_FILE.read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "package-policy.json"
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def test_policy_classifies_every_workspace_member_once_and_release_set_is_explicit():
+    entries = release_policy()
+    assert {item["path"] for item in entries} == set(workspace_members())
+    published = {item["distribution"] for item in entries if item["publish_candidate"]}
+    assert published == {
+        "neuros-core",
+        "neuros-drivers",
+        "neuros-arena",
+        "neuros-models",
+        "neuros",
+    }
+    assert all(
+        (item["release_tier"] == "public-runtime") == item["publish_candidate"]
+        for item in entries
+    )
+
+
+def test_policy_fails_if_workspace_member_is_unclassified(tmp_path):
+    payload = _payload()
+    payload["packages"] = payload["packages"][:-1]
+    with pytest.raises(ValueError, match="classify every workspace member exactly once"):
+        release_policy(_write(tmp_path, payload))
+
+
+def test_policy_fails_on_duplicate_path(tmp_path):
+    payload = _payload()
+    payload["packages"].append(deepcopy(payload["packages"][0]))
+    with pytest.raises(ValueError, match="duplicate release package path"):
+        release_policy(_write(tmp_path, payload))
+
+
+def test_policy_fails_on_distribution_metadata_drift(tmp_path):
+    payload = _payload()
+    payload["packages"][0]["distribution"] = "not-the-project-name"
+    with pytest.raises(ValueError, match="distribution mismatch"):
+        release_policy(_write(tmp_path, payload))
+
+
+def test_policy_fails_if_research_package_enters_default_release_set(tmp_path):
+    payload = _payload()
+    research = next(
+        item for item in payload["packages"] if item["release_tier"] == "research-extension"
+    )
+    research["publish_candidate"] = True
+    with pytest.raises(ValueError, match="non-public-runtime package cannot enter"):
+        release_policy(_write(tmp_path, payload))
+
+
+def test_policy_fails_if_public_runtime_is_silently_removed_from_release(tmp_path):
+    payload = _payload()
+    runtime = next(
+        item for item in payload["packages"] if item["release_tier"] == "public-runtime"
+    )
+    runtime["publish_candidate"] = False
+    with pytest.raises(ValueError, match="public-runtime package must be a publish candidate"):
+        release_policy(_write(tmp_path, payload))
+
+
+def test_policy_requires_sdk_dependency_closure(tmp_path):
+    payload = _payload()
+    drivers = next(
+        item for item in payload["packages"] if item["path"] == "packages/neuros-drivers"
+    )
+    drivers["release_tier"] = "qualified-integration"
+    drivers["publish_candidate"] = False
+    with pytest.raises(ValueError, match="SDK dependency closure"):
+        release_policy(_write(tmp_path, payload))


### PR DESCRIPTION
## Purpose

Separate publication eligibility from monorepo workspace membership and make the default neurOS release candidate a minimal, self-describing, exact-source, dependency-closed artifact set.

This PR remains **draft** and stacked on #117. It does not move frozen `main` and must not merge before the authorized Kumar2024 one-shard systems qualification is completed and independently audited.

## Default release authority

`release/package-policy.json` classifies all 12 workspace distributions independently by release tier, scientific maturity, and default publication eligibility.

Default public runtime, exactly four distributions:

- `neuros-core`
- `neuros-drivers`
- `neuros-models`
- `neuros`

Maintained but non-default:

- qualified integrations: `neuros-arena`, `neuros-foundation`, `neuros-mechint`
- research extensions: `neuros-neurofm`, `neuros-sourceweigher`, `neuros-orion`
- internal previews: `neuros-ui`, `neuros-cloud`

Arena is intentionally outside the default release because it is synthetic validation tooling, is not required by the SDK, and has an independent qualification surface.

## Fail-closed package policy

`scripts/list_release_packages.py` rejects missing/foreign/duplicate workspace classifications, package-name drift, invalid tiers/maturity values, non-runtime distributions entering the default set, public-runtime distributions silently leaving it, and loss of the SDK core/drivers/models closure.

`tests/test_release_package_policy.py` covers these failures adversarially.

## Cross-runtime internal dependency closure

`check_release_dependency_closure.py` verifies the **built wheel METADATA**, not source assumptions. For every active default dependency from one neurOS distribution to another it requires:

- the target wheel is physically present in the exact release set;
- the bundled target version satisfies the declared specifier;
- active internal requirements requesting extras fail closed until extra dependency propagation is explicitly modeled;
- optional-extra-only edges remain outside the default runtime;
- duplicate distribution identity fails.

Marker evaluation is not tied to the packaging runner. The verifier evaluates the supported Python 3.10 / 3.11 / 3.12 surface across common Linux, macOS, and Windows x86_64/ARM targets (18 target environments). A dependency active only on Python 3.10 or only on Windows therefore cannot disappear merely because release CI currently packages on Linux/Python 3.11.

`tests/test_release_dependency_closure.py` covers missing/incompatible dependencies, active internal extras, optional extras, duplicate distributions, Python-version-gated dependencies, and platform-gated dependencies.

The exact runtime-matrix report is persisted as `release-dependency-closure.json`, then checksum-bound into the final bundle.

## Release Candidate v2

The workflow:

1. explicitly checks out `${{ github.event.pull_request.head.sha || github.sha }}` and asserts exact clean source;
2. builds only the four policy-selected runtime wheels;
3. validates wheel METADATA names against the selected policy;
4. verifies wheel ownership and the unit-tested cross-runtime dependency closure;
5. proves component namespace behavior and clean minimal SDK installation;
6. bundles full `package-policy.json` and `release-dependency-closure.json` evidence;
7. records exact `source_revision`, source ref, separate GitHub event SHA, selected policy, wheel identities, dependency-closure identity, and wheel-ownership identity in `release-manifest.json` schema v2;
8. verifies all wheels plus policy, dependency closure, ownership and release manifest through `SHA256SUMS`;
9. uploads the bundle under the exact source SHA rather than the synthetic PR merge SHA.

An earlier four-wheel artifact proved package closure but used the PR merge commit as source identity. That evidence is intentionally superseded rather than reinterpreted.

All GitHub Action references remain content-addressed through #117.

## Product boundary exposed

The release cannot contract below four wheels without API migration because `neuros/__init__.py` directly re-exports `BaseModel` and `SimpleClassifier` from `neuros-models`. A later post-floor refactor should move durable decoder/artifact interfaces into the platform layer and make concrete model implementations optional. That follow-on is recorded in #89 and intentionally excluded here.

## Scientific boundary

No package deletion/version changes, no publishing, no runtime/scientific API changes, no Kumar2024 worker/model execution, no external-floor claim, and no ORION authorization. Frozen `main` is untouched.

## Current exact head

`f9bdc24a42836829b5a8598484c84b2217191ed6`

All earlier #119 evidence is superseded.

## Merge gate

1. Keep draft while the frozen one-shard authorization is active.
2. Require Packaging Contracts, Release Candidate Artifacts, Packaging Uninstall, Public Trust and core CI green on this exact head.
3. Independently audit the uploaded exact-head bundle: GitHub digest, source revision, exactly four wheels/no non-default wheels, every `SHA256SUMS` row, policy identity, 18-target dependency closure, and wheel ownership.
4. After #117 lands, retarget/requalify against resulting `main` before merge.

Related: #89, #85, #117.