### PR TITLE
Validation: qualify the installed-wheel product across platforms and adversarial failures

### DIFF
--- a/.github/workflows/full-package-qualification.yml
+++ b/.github/workflows/full-package-qualification.yml
@@ -1,0 +1,217 @@
+name: Whole Package Qualification
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/full-package-qualification.yml"
+      - "scripts/run_full_package_qualification.py"
+      - "scripts/list_release_packages.py"
+      - "scripts/list_workspace_packages.py"
+      - "scripts/check_release_dependency_closure.py"
+      - "scripts/check_wheel_ownership.py"
+      - "release/package-policy.json"
+      - "validation_tests/**"
+      - "tests/test_full_package_qualification_harness.py"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "packages/neuros-models/**"
+      - "packages/neuros/**"
+      - "packages/neuros-arena/**"
+      - "packages/neuros-foundation/**"
+      - "packages/neuros-mechint/**"
+      - "packages/neuros-neurofm/**"
+      - "packages/neuros-sourceweigher/**"
+      - "packages/orion/**"
+      - "packages/neuros-ui/**"
+      - "packages/neuros-cloud/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/full-package-qualification.yml"
+      - "scripts/run_full_package_qualification.py"
+      - "scripts/list_release_packages.py"
+      - "scripts/list_workspace_packages.py"
+      - "scripts/check_release_dependency_closure.py"
+      - "scripts/check_wheel_ownership.py"
+      - "release/package-policy.json"
+      - "validation_tests/**"
+      - "tests/test_full_package_qualification_harness.py"
+      - "packages/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  QUALIFICATION_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+concurrency:
+  group: whole-package-qualification-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clean-room-product:
+    name: Clean room ${{ matrix.os }} / Python ${{ matrix.python }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+          - windows-2025
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.QUALIFICATION_SOURCE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require exact clean qualification source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - name: Install qualification tooling only
+        run: python -m pip install --upgrade pip build packaging
+      - name: Exercise exact installed-wheel product and adversarial boundaries
+        run: >-
+          python scripts/run_full_package_qualification.py
+          --repo-root .
+          --output "${{ runner.temp }}/full-package-qualification"
+          --source-revision "${{ env.QUALIFICATION_SOURCE_SHA }}"
+          --duration 0.20
+          --soak-iterations 8
+      - name: Upload clean-room qualification evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: neurOS-full-package-${{ env.QUALIFICATION_SOURCE_SHA }}-${{ matrix.os }}-py${{ matrix.python }}
+          path: ${{ runner.temp }}/full-package-qualification
+          if-no-files-found: warn
+          retention-days: 30
+
+  property-contracts:
+    name: Property and corruption contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.QUALIFICATION_SOURCE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require exact clean qualification source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install property-test environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ./packages/neuros-core pytest hypothesis
+      - name: Exercise generated signal/archive invariants
+        run: pytest -q validation_tests/test_signal_contract_properties.py
+
+  workspace-wheel-audit:
+    name: All workspace distributions build without file-ownership ambiguity
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.QUALIFICATION_SOURCE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require exact clean qualification source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Build every maintained workspace distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build twine
+          DIST="${RUNNER_TEMP}/workspace-wheels"
+          mkdir -p "${DIST}"
+          mapfile -t PACKAGES < <(python scripts/list_workspace_packages.py)
+          test "${#PACKAGES[@]}" -gt 0
+          for package in "${PACKAGES[@]}"
+          do
+            python -m build --wheel --outdir "${DIST}" "${package}"
+          done
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq "${#PACKAGES[@]}"
+          python -m twine check "${DIST}"/*.whl
+          python scripts/check_wheel_ownership.py "${DIST}" \
+            --output "${RUNNER_TEMP}/workspace-wheel-ownership.json"
+          python scripts/list_workspace_packages.py --json > "${RUNNER_TEMP}/workspace-packages.json"
+      - name: Upload workspace build evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: neurOS-workspace-wheel-audit-${{ env.QUALIFICATION_SOURCE_SHA }}
+          path: |
+            ${{ runner.temp }}/workspace-wheel-ownership.json
+            ${{ runner.temp }}/workspace-packages.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  harness-unit-contracts:
+    name: Qualification harness contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.QUALIFICATION_SOURCE_SHA }}
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install harness test tooling
+        run: python -m pip install --upgrade pip pytest packaging
+      - name: Prove qualification helpers fail closed
+        run: pytest -q tests/test_full_package_qualification_harness.py
+
+  whole-package-qualification:
+    name: Whole Package Qualification
+    if: always()
+    needs:
+      - clean-room-product
+      - property-contracts
+      - workspace-wheel-audit
+      - harness-unit-contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require every qualification layer to pass
+        env:
+          CLEAN_ROOM_RESULT: ${{ needs.clean-room-product.result }}
+          PROPERTY_RESULT: ${{ needs.property-contracts.result }}
+          WORKSPACE_RESULT: ${{ needs.workspace-wheel-audit.result }}
+          HARNESS_RESULT: ${{ needs.harness-unit-contracts.result }}
+        run: |
+          set -euo pipefail
+          test "${CLEAN_ROOM_RESULT}" = "success"
+          test "${PROPERTY_RESULT}" = "success"
+          test "${WORKSPACE_RESULT}" = "success"
+          test "${HARNESS_RESULT}" = "success"
+          echo "Whole Package Qualification: PASS"

--- a/.github/workflows/full-package-qualification.yml
+++ b/.github/workflows/full-package-qualification.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install property-test environment
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ./packages/neuros-core pytest hypothesis
+          python -m pip install ./packages/neuros-core pytest pytest-asyncio hypothesis
       - name: Exercise generated signal/archive invariants
         run: pytest -q validation_tests/test_signal_contract_properties.py
 
@@ -188,7 +188,7 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install harness test tooling
-        run: python -m pip install --upgrade pip pytest packaging
+        run: python -m pip install --upgrade pip pytest pytest-asyncio packaging
       - name: Prove qualification helpers fail closed
         run: pytest -q tests/test_full_package_qualification_harness.py
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,201 @@
+# neurOS Validation Program
+
+neurOS is not considered validated because one test suite is green. Different
+claims require different evidence, and stronger evidence must not be inferred
+from weaker evidence.
+
+The validation program therefore treats software correctness, reproducibility,
+scientific validity, hardware validity, and deployment validity as separate
+promotion layers.
+
+## Validation principle
+
+A useful neurOS result should answer four questions independently:
+
+1. **Did the software behave according to its contracts?**
+2. **Can the exact computational result be reproduced from identified inputs and artifacts?**
+3. **Does the study design support the scientific claim being made?**
+4. **Does the evidence cover the real hardware, users, and deployment conditions named by the claim?**
+
+Passing one layer never automatically promotes the next.
+
+## Evidence ladder
+
+| Layer | Primary question | Representative evidence | What it does **not** prove |
+| --- | --- | --- | --- |
+| Contract/unit | Are local invariants correct? | typed contract tests, deterministic identities, parser/config tests | installed-package usability, integration, neural efficacy |
+| Property/adversarial | Do invariants survive generated edge cases and corruption? | Hypothesis-generated signals, invalid metadata, byte tampering | real-world performance |
+| Clean-room product | Can a user install and use the default product from exact wheels? | wheel hashes, fresh venv, public CLI journey | non-default research packages, hardware, efficacy |
+| Workspace integrity | Can every maintained distribution build without packaging collisions? | all workspace wheels, `twine check`, wheel ownership | that every package belongs in the default release |
+| Runtime resilience | Does execution stop, recover, and fail closed under stress? | repeated lifecycle runs, queue/failure tests, cancellation tests | biological validity |
+| Recording/replay | Are recorded observations integrity-bound and replayable? | payload hashes, descriptor fingerprints, semantic replay identity | device clock accuracy or signal quality |
+| Qualification bundle | Does a sealed computational artifact reproduce exactly? | exact artifact set, bundle SHA-256, externally pinned root, replay digest | real-dataset, hardware, closed-loop, safety, clinical claims |
+| Interoperability | Do integrations preserve neurOS contracts at ecosystem boundaries? | MNE/Braindecode/MOABB/BrainFlow/LSL/NWB/Zarr compatibility evidence | general scientific efficacy |
+| Scientific qualification | Does the protocol support a specific neural-system claim? | subject-disjoint NSQ, calibration authority, untouched final assessment, failure preservation | hardware safety or clinical benefit |
+| Real-data external floor | Does the method survive a frozen public neural dataset under the same referee? | promoted Kumar2024 authority and independently audited execution artifacts | broad population generalization |
+| Hardware qualification | Does measured physical hardware meet explicit gates? | clock, loss, latency, reliability and device evidence | neural efficacy unless paired with a qualified study |
+| Independent reproduction | Can another environment/team reproduce the evidence without repository-local assumptions? | release artifacts, hashes, documented commands, external rerun | universal validity |
+
+## Whole Package Qualification
+
+`.github/workflows/full-package-qualification.yml` is the umbrella software gate.
+It intentionally validates both the default product and the larger development
+workspace without conflating them.
+
+### Default product matrix
+
+The default public runtime is installed from exact wheels in fresh virtual
+environments across:
+
+- Ubuntu 24.04 x86-64;
+- Windows 2025 x86-64;
+- macOS 14 ARM64;
+- Python 3.10, 3.11, and 3.12 on each operating system.
+
+Every matrix job builds the release-policy-selected wheels and requires the
+installed artifacts to resolve outside the repository checkout. The installed
+wheel SHA-256 identities are checked against the wheels produced by that exact
+source revision.
+
+The clean-room path exercises:
+
+- `neuros doctor`;
+- compatibility and plugin discovery;
+- `neuros init` and overwrite refusal;
+- config validation and invalid-plugin rejection;
+- runtime execution and lifecycle cleanup;
+- recording, verified inspection, and replay;
+- recording overwrite refusal;
+- qualification and repeated reproduction;
+- externally pinned qualification-root verification;
+- incorrect external-root rejection;
+- qualification overwrite refusal;
+- bounded repeated runtime lifecycle/soak execution.
+
+The runtime gate requires stopped execution, zero node failures, zero dropped
+edges, and non-zero processed work for the maintained deterministic starter.
+Timing fields are observed but are not incorrectly treated as deterministic
+semantic output identity.
+
+### Direct corruption attacks
+
+The qualification does not merely ask whether valid artifacts work.
+
+For a recorded session it copies the archive, flips one byte in an actual neural
+`.npy` frame payload, and requires both:
+
+```text
+neuros inspect <archive> --verify
+neuros replay <archive> --config <config>
+```
+
+to reject the corrupted archive.
+
+For a sealed qualification bundle it mutates a checksum-bound artifact and
+requires both normal and externally pinned `neuros reproduce` paths to reject the
+bundle.
+
+This directly tests the integrity boundary rather than mocking the verifier.
+
+### Property-based contracts
+
+`validation_tests/test_signal_contract_properties.py` generates finite neural
+arrays and metadata combinations with Hypothesis. It checks:
+
+- immutable, caller-detached `SignalFrame` sample ownership;
+- exact archive data/dtype round-trip;
+- descriptor fingerprint stability under mapping-order changes;
+- rejection of non-finite/non-positive declared sampling rates;
+- rejection of descriptor/frame channel-geometry contradictions;
+- payload hash failure after direct byte mutation.
+
+These tests intentionally live outside the ordinary unit-test directory because
+property-test dependencies are validation tooling, not runtime dependencies.
+
+### Workspace wheel audit
+
+Every maintained workspace distribution is also built on the umbrella workflow.
+The audit runs package metadata validation and checks that shared `neuros`
+namespace portions do not own overlapping installed files.
+
+A package passing this audit means it is buildable and packaging-compatible. It
+does **not** mean the package is automatically part of the default neurOS
+release or has earned a scientific claim.
+
+## Required future validation
+
+Whole Package Qualification is deliberately not the final validation state.
+The strongest remaining gaps are:
+
+### Exact installed-artifact provenance in ordinary qualification
+
+The v1 runtime qualification bundle records package versions, but versions alone
+are weaker than exact wheel/container identities. A later qualification schema
+should bind the installed distribution artifact digest or a stronger environment
+authority rather than assuming that equal version strings imply equal code.
+
+### Runtime fault injection
+
+Add deterministic tests for:
+
+- source failure during startup and mid-stream;
+- decoder/transform exceptions;
+- cancellation during recording and qualification staging;
+- queue saturation and each overflow policy;
+- interrupted writes and orphan temporary files;
+- repeated start/stop and task cleanup;
+- resource growth over longer bounded runs.
+
+Failures must be preserved as evidence, not converted into successful numerical
+rows.
+
+### Longer resource soak
+
+Short CI lifecycle loops catch cleanup regressions but not slow leaks. Release
+qualification should eventually include a longer scheduled soak measuring:
+
+- resident-memory growth;
+- open file descriptors/handles;
+- task/thread counts;
+- queue depth;
+- frame/decoder throughput;
+- latency distributions;
+- data loss.
+
+Thresholds should be established from measured stable baselines, not invented to
+make CI green.
+
+### External clean-room reproduction
+
+At least one release candidate should be reproduced from downloadable artifacts
+without using a local repository checkout for package code. The reproduction
+should verify wheel/container digests, execute the public starter workflow, and
+compare evidence roots.
+
+### Real neural data
+
+Software validation cannot establish neural decoding efficacy. Promoted neural
+claims require the frozen NSQ authority, subject-disjoint evaluation, declared
+calibration budgets, untouched final assessment, model-state identity, and
+failure-preserving evidence.
+
+The Kumar2024 promoted study is the current external-floor program. ORION must
+remain outside favorable comparison until the external floor and execution
+transport are fully qualified.
+
+### Physical hardware
+
+Synthetic drivers, replay, and Arena are useful systems tests but are not device
+qualification. Physical BCI hardware claims require measured acquisition loss,
+clock behavior, drift/uncertainty, end-to-end latency, reconnect/recovery,
+long-duration stability, montage/electrode behavior where applicable, and an
+explicit hardware evidence authority.
+
+## Promotion rule
+
+A release or scientific claim should name the strongest evidence layer actually
+completed and preserve the lower layers that support it.
+
+The target is not "100% tested." The target is a traceable chain in which every
+important claim has an appropriate adversary and every stronger promotion
+requires evidence that the weaker layer could not provide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Architecture: ARCHITECTURE.md
       - Project Status: PROJECT_STATUS.md
   - Scientific Trust:
+      - Validation Program: VALIDATION.md
       - Neural System Qualification: NEURAL_SYSTEM_QUALIFICATION_V1.md
       - NSQ Runner: NSQ_RUNNER_V1.md
       - Scientific Claims: SCIENTIFIC_CLAIMS.md

--- a/scripts/run_full_package_qualification.py
+++ b/scripts/run_full_package_qualification.py
@@ -1,0 +1,909 @@
+#!/usr/bin/env python3
+"""Clean-room qualification of the default neurOS installed-wheel product path.
+
+This harness deliberately sits above unit/integration tests.  It builds the
+policy-selected default release wheels, installs them into a fresh virtual
+environment, then exercises public CLI and contract surfaces from outside the
+repository checkout.  It also mutates authority-bearing bytes and requires the
+public verification/reproduction paths to fail closed.
+
+The output is a machine-readable evidence report.  Passing this harness proves a
+software packaging/runtime/replay integrity boundary only; it does not establish
+real neural efficacy, hardware validity, closed-loop safety, or clinical value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import time
+import venv
+from dataclasses import dataclass
+from email.parser import Parser
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+from zipfile import ZipFile
+
+SCHEMA = "neuros.full_package_qualification.v1"
+REQUIRED_DISTRIBUTIONS = (
+    "neuros-core",
+    "neuros-drivers",
+    "neuros-models",
+    "neuros",
+)
+NONDEFAULT_DISTRIBUTIONS = (
+    "neuros-arena",
+    "neuros-foundation",
+    "neuros-mechint",
+    "neuros-neurofm",
+    "neuros-sourceweigher",
+    "neuros-orion",
+    "neuros-ui",
+    "neuros-cloud",
+)
+
+
+@dataclass(slots=True)
+class CommandResult:
+    name: str
+    argv: list[str]
+    returncode: int
+    elapsed_s: float
+    stdout: str
+    stderr: str
+    expected: str
+    parsed_json: Any | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "argv": self.argv,
+            "returncode": self.returncode,
+            "elapsed_s": self.elapsed_s,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "expected": self.expected,
+            "parsed_json": self.parsed_json,
+        }
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_name(value: str) -> str:
+    return value.lower().replace("_", "-").replace(".", "-")
+
+
+def _wheel_metadata(path: Path) -> dict[str, Any]:
+    with ZipFile(path) as archive:
+        names = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+        if len(names) != 1:
+            raise RuntimeError(f"{path.name}: expected one METADATA file, found {len(names)}")
+        message = Parser().parsestr(archive.read(names[0]).decode("utf-8", errors="strict"))
+    name = message.get("Name")
+    version = message.get("Version")
+    if not name or not version:
+        raise RuntimeError(f"{path.name}: missing Name/Version metadata")
+    return {
+        "name": str(name),
+        "canonical_name": _canonical_name(str(name)),
+        "version": str(version),
+        "file": path.name,
+        "sha256": _sha256_file(path),
+        "bytes": path.stat().st_size,
+    }
+
+
+def _python_in_venv(root: Path) -> Path:
+    return root / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _console_script(name: str) -> Path:
+    scripts = sysconfig.get_path("scripts")
+    if not scripts:
+        raise RuntimeError("active environment does not expose a scripts directory")
+    suffix = ".exe" if os.name == "nt" else ""
+    path = Path(scripts) / f"{name}{suffix}"
+    if not path.is_file():
+        raise RuntimeError(f"required console script is missing: {path}")
+    return path
+
+
+def _run(
+    results: list[CommandResult],
+    name: str,
+    argv: Sequence[str | Path],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    expect_json: bool = False,
+    expected_codes: Iterable[int] = (0,),
+) -> Any | None:
+    rendered = [str(value) for value in argv]
+    expected = tuple(int(value) for value in expected_codes)
+    started = time.perf_counter()
+    proc = subprocess.run(
+        rendered,
+        cwd=None if cwd is None else str(cwd),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.perf_counter() - started
+    parsed: Any | None = None
+    if expect_json and proc.returncode == 0:
+        try:
+            parsed = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"{name} returned success without valid JSON: {exc}; stdout={proc.stdout!r}"
+            ) from exc
+    result = CommandResult(
+        name=name,
+        argv=rendered,
+        returncode=proc.returncode,
+        elapsed_s=elapsed,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        expected="return code in " + repr(expected),
+        parsed_json=parsed,
+    )
+    results.append(result)
+    if proc.returncode not in expected:
+        raise RuntimeError(
+            f"{name} returned {proc.returncode}, expected one of {expected}\n"
+            f"command: {' '.join(rendered)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return parsed
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _flip_one_byte(path: Path) -> dict[str, Any]:
+    payload = bytearray(path.read_bytes())
+    if not payload:
+        raise RuntimeError(f"cannot tamper with empty file: {path}")
+    index = len(payload) // 2
+    before = hashlib.sha256(payload).hexdigest()
+    payload[index] ^= 0x01
+    path.write_bytes(payload)
+    after = hashlib.sha256(payload).hexdigest()
+    _require(before != after, "tamper helper did not change file identity")
+    return {"path": str(path), "byte_offset": index, "sha256_before": before, "sha256_after": after}
+
+
+def _append_tamper(path: Path) -> dict[str, Any]:
+    before = _sha256_file(path)
+    with path.open("ab") as handle:
+        handle.write(b" \n")
+    after = _sha256_file(path)
+    _require(before != after, "tamper helper did not change file identity")
+    return {"path": str(path), "sha256_before": before, "sha256_after": after}
+
+
+def _distribution_identity(name: str, repo_root: Path, expected_sha256: str) -> dict[str, Any]:
+    dist = metadata.distribution(name)
+    location = Path(dist.locate_file("")).resolve()
+    try:
+        location.relative_to(repo_root)
+    except ValueError:
+        pass
+    else:
+        raise RuntimeError(f"{name} resolves inside the repository checkout: {location}")
+
+    direct_url_text = dist.read_text("direct_url.json")
+    if not direct_url_text:
+        raise RuntimeError(f"{name} has no direct_url.json; exact wheel origin is not observable")
+    direct_url = json.loads(direct_url_text)
+    archive_info = direct_url.get("archive_info", {})
+    hashes = archive_info.get("hashes", {})
+    observed_sha = hashes.get("sha256")
+    if observed_sha is None:
+        legacy = archive_info.get("hash")
+        if isinstance(legacy, str) and legacy.startswith("sha256="):
+            observed_sha = legacy.split("=", 1)[1]
+    if observed_sha != expected_sha256:
+        raise RuntimeError(
+            f"{name} installed wheel digest differs from built artifact: "
+            f"expected {expected_sha256}, observed {observed_sha}"
+        )
+
+    return {
+        "name": str(dist.metadata["Name"]),
+        "version": dist.version,
+        "location": str(location),
+        "editable": bool(direct_url.get("dir_info", {}).get("editable")),
+        "wheel_sha256": observed_sha,
+        "direct_url": direct_url,
+    }
+
+
+def _runtime_semantics(snapshot: dict[str, Any]) -> dict[str, Any]:
+    nodes = snapshot.get("nodes", {})
+    edges = snapshot.get("edges", {})
+    return {
+        "state": snapshot.get("state"),
+        "node_processed": {
+            str(name): int(value.get("processed", 0)) for name, value in sorted(nodes.items())
+        },
+        "node_failed": {
+            str(name): int(value.get("failed", 0)) for name, value in sorted(nodes.items())
+        },
+        "edge_accepted": {
+            str(name): int(value.get("accepted", 0)) for name, value in sorted(edges.items())
+        },
+        "edge_dropped": {
+            str(name): int(value.get("dropped", 0)) for name, value in sorted(edges.items())
+        },
+    }
+
+
+def _assert_clean_runtime(snapshot: dict[str, Any], *, label: str) -> None:
+    semantics = _runtime_semantics(snapshot)
+    _require(semantics["state"] == "stopped", f"{label} did not stop cleanly")
+    _require(
+        all(value == 0 for value in semantics["node_failed"].values()),
+        f"{label} contains node failures",
+    )
+    _require(
+        all(value == 0 for value in semantics["edge_dropped"].values()),
+        f"{label} dropped runtime items",
+    )
+    _require(
+        sum(semantics["node_processed"].values()) > 0,
+        f"{label} processed no runtime items",
+    )
+
+
+def _contract_checks() -> dict[str, Any]:
+    import numpy as np
+    from neuros.contracts import ClockDomain, SignalFrame, StreamDescriptor
+
+    original = np.arange(24, dtype=np.float32).reshape(3, 8)
+    frame = SignalFrame(
+        stream_id="contract-check",
+        sequence_id=1,
+        data=original,
+        sample_rate_hz=250.0,
+        host_receive_time_ns=10,
+        clock_domain=ClockDomain.HOST_MONOTONIC,
+        metadata={"nested": {"values": [1, 2, 3]}},
+    )
+    original[:] = -999.0
+    _require(not np.all(frame.data == -999.0), "SignalFrame aliases caller-owned sample memory")
+    _require(frame.data.flags.writeable is False, "SignalFrame data remains writeable")
+
+    descriptor_a = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=250.0,
+        channel_names=("C3", "C4"),
+        metadata={"b": 2, "a": {"y": 2, "x": 1}},
+    )
+    descriptor_b = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=250.0,
+        channel_names=("C3", "C4"),
+        metadata={"a": {"x": 1, "y": 2}, "b": 2},
+    )
+    _require(
+        descriptor_a.fingerprint() == descriptor_b.fingerprint(),
+        "StreamDescriptor fingerprint depends on mapping insertion order",
+    )
+    return {
+        "signal_frame_copies_input": True,
+        "signal_frame_read_only": True,
+        "descriptor_fingerprint_mapping_order_invariant": True,
+        "descriptor_sha256": descriptor_a.fingerprint(),
+    }
+
+
+def _inside_environment(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    output = Path(args.output).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    wheel_manifest = json.loads(Path(args.wheel_manifest).read_text(encoding="utf-8"))
+    wheel_by_name = {
+        _canonical_name(item["name"]): item for item in wheel_manifest.get("wheels", [])
+    }
+    results: list[CommandResult] = []
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "source_revision": args.source_revision,
+        "environment": {
+            "python": sys.version,
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "executable": sys.executable,
+            "prefix": sys.prefix,
+        },
+        "commands": [],
+        "checks": {},
+        "tamper_tests": {},
+    }
+
+    try:
+        identities: dict[str, Any] = {}
+        for name in REQUIRED_DISTRIBUTIONS:
+            expected = wheel_by_name.get(_canonical_name(name))
+            _require(expected is not None, f"wheel manifest is missing {name}")
+            identities[name] = _distribution_identity(name, repo_root, expected["sha256"])
+            _require(identities[name]["editable"] is False, f"{name} is installed editable")
+        report["distributions"] = identities
+
+        installed_neuros = sorted(
+            _canonical_name(str(dist.metadata.get("Name", "")))
+            for dist in metadata.distributions()
+            if _canonical_name(str(dist.metadata.get("Name", ""))) == "neuros"
+            or _canonical_name(str(dist.metadata.get("Name", ""))).startswith("neuros-")
+        )
+        _require(
+            installed_neuros == sorted(_canonical_name(name) for name in REQUIRED_DISTRIBUTIONS),
+            f"clean-room environment contains unexpected neurOS distributions: {installed_neuros}",
+        )
+        report["checks"]["only_default_neuros_distributions_installed"] = True
+
+        for name in NONDEFAULT_DISTRIBUTIONS:
+            try:
+                metadata.version(name)
+            except metadata.PackageNotFoundError:
+                continue
+            raise RuntimeError(f"non-default distribution leaked into clean-room install: {name}")
+
+        import neuros
+
+        required_exports = {"SignalFrame", "Pipeline", "BaseDriver", "BaseModel", "load_plugin"}
+        missing_exports = sorted(name for name in required_exports if not hasattr(neuros, name))
+        _require(not missing_exports, f"SDK root is missing exports: {missing_exports}")
+        neuros_path = Path(neuros.__file__).resolve() if neuros.__file__ else None
+        _require(neuros_path is not None, "SDK root has no __file__")
+        try:
+            neuros_path.relative_to(repo_root)
+        except ValueError:
+            pass
+        else:
+            raise RuntimeError(f"SDK import leaked from repository checkout: {neuros_path}")
+        report["checks"]["sdk_import_outside_repo"] = str(neuros_path)
+        report["checks"]["contracts"] = _contract_checks()
+
+        neuros_cli = _console_script("neuros")
+        work = output / "work"
+        work.mkdir(parents=True, exist_ok=False)
+        starter = work / "starter"
+
+        doctor = _run(results, "doctor", [neuros_cli, "doctor", "--json"], cwd=work, expect_json=True)
+        _require(isinstance(doctor, dict) and doctor.get("healthy") is True, "neuros doctor is unhealthy")
+        _run(results, "compatibility", [neuros_cli, "compatibility", "--json"], cwd=work, expect_json=True)
+        plugins = _run(results, "plugins", [neuros_cli, "plugins", "--json"], cwd=work, expect_json=True)
+        _require(isinstance(plugins, list) and plugins, "plugin inventory is empty")
+
+        init_result = _run(
+            results,
+            "init",
+            [neuros_cli, "init", starter, "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        _require(isinstance(init_result, dict) and init_result.get("template") == "mock-bci", "starter init failed")
+        config = starter / "neuros.yaml"
+        _require(config.is_file(), "starter configuration was not created")
+
+        _run(
+            results,
+            "init-refuses-overwrite",
+            [neuros_cli, "init", starter, "--json"],
+            cwd=work,
+            expected_codes=(2,),
+        )
+        _run(results, "validate", [neuros_cli, "validate", config, "--json"], cwd=work, expect_json=True)
+        run_result = _run(
+            results,
+            "run",
+            [neuros_cli, "run", config, "--duration", str(args.duration), "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        _require(isinstance(run_result, dict), "runtime did not emit a JSON snapshot")
+        _assert_clean_runtime(run_result, label="clean-room run")
+
+        invalid_config = work / "invalid.yaml"
+        invalid_config.write_text(
+            """schema_version: 1\nstreams:\n  - id: eeg\n    source:\n      plugin: definitely_missing_source\ndecoder:\n  plugin: threshold\nruntime:\n  queue_capacity: 4\n  overflow_policy: drop_oldest\nsinks: []\nmonitors: []\n""",
+            encoding="utf-8",
+        )
+        _run(
+            results,
+            "invalid-config-rejected",
+            [neuros_cli, "validate", invalid_config, "--json"],
+            cwd=work,
+            expected_codes=(2, 3),
+        )
+
+        session = work / "session"
+        record_result = _run(
+            results,
+            "record",
+            [
+                neuros_cli,
+                "record",
+                config,
+                "--output",
+                session,
+                "--session-id",
+                "full-package",
+                "--duration",
+                str(args.duration),
+                "--json",
+            ],
+            cwd=work,
+            expect_json=True,
+        )
+        _require(isinstance(record_result, dict) and record_result.get("status") == "complete", "record did not complete")
+        frame_files = sorted(session.glob("streams/*/frames/*.npy"))
+        _require(frame_files, "recording produced no frame payloads")
+        inspect_result = _run(
+            results,
+            "inspect-verified",
+            [neuros_cli, "inspect", session, "--verify", "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        _require(inspect_result.get("integrity") == "verified", "recording integrity was not verified")
+        replay_result = _run(
+            results,
+            "replay",
+            [neuros_cli, "replay", session, "--config", config, "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        _assert_clean_runtime(replay_result, label="clean-room replay")
+        _run(
+            results,
+            "record-refuses-overwrite",
+            [
+                neuros_cli,
+                "record",
+                config,
+                "--output",
+                session,
+                "--session-id",
+                "full-package",
+                "--duration",
+                str(args.duration),
+                "--json",
+            ],
+            cwd=work,
+            expected_codes=(5,),
+        )
+
+        tampered_session = work / "session-tampered"
+        shutil.copytree(session, tampered_session)
+        tampered_frames = sorted(tampered_session.glob("streams/*/frames/*.npy"))
+        report["tamper_tests"]["recording_payload"] = _flip_one_byte(tampered_frames[0])
+        _run(
+            results,
+            "tampered-recording-inspect-rejected",
+            [neuros_cli, "inspect", tampered_session, "--verify", "--json"],
+            cwd=work,
+            expected_codes=(5,),
+        )
+        _run(
+            results,
+            "tampered-recording-replay-rejected",
+            [neuros_cli, "replay", tampered_session, "--config", config, "--json"],
+            cwd=work,
+            expected_codes=(5,),
+        )
+
+        qualification = work / "qualification"
+        qualify_result = _run(
+            results,
+            "qualify",
+            [
+                neuros_cli,
+                "qualify",
+                config,
+                "--output",
+                qualification,
+                "--session-id",
+                "full-package",
+                "--duration",
+                str(args.duration),
+                "--json",
+            ],
+            cwd=work,
+            expect_json=True,
+        )
+        _require(isinstance(qualify_result, dict), "qualification result is not JSON")
+        root_sha = qualify_result.get("bundle_sha256")
+        _require(isinstance(root_sha, str) and len(root_sha) == 64, "qualification bundle SHA is missing")
+        boundary = qualify_result.get("claim_boundary", {})
+        _require(boundary.get("runtime_record_replay_qualified") is True, "runtime qualification claim is absent")
+        for key in ("real_dataset_qualified", "hardware_qualified", "closed_loop_qualified", "clinical_qualified"):
+            _require(boundary.get(key) is False, f"qualification overclaims {key}")
+
+        reproduction_1 = _run(
+            results,
+            "reproduce",
+            [neuros_cli, "reproduce", qualification, "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        reproduction_2 = _run(
+            results,
+            "reproduce-second-pass",
+            [neuros_cli, "reproduce", qualification, "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        pinned = _run(
+            results,
+            "reproduce-pinned",
+            [neuros_cli, "reproduce", qualification, "--expected-sha256", root_sha, "--json"],
+            cwd=work,
+            expect_json=True,
+        )
+        for item in (reproduction_1, reproduction_2, pinned):
+            _require(item.get("reproduced") is True, "qualification reproduction did not complete")
+            _require(item.get("bundle_sha256") == root_sha, "qualification root changed during reproduction")
+        _require(
+            reproduction_1.get("decoder_outputs") == reproduction_2.get("decoder_outputs"),
+            "repeated qualification reproductions changed semantic decoder output identity",
+        )
+        _run(
+            results,
+            "wrong-external-pin-rejected",
+            [neuros_cli, "reproduce", qualification, "--expected-sha256", "0" * 64, "--json"],
+            cwd=work,
+            expected_codes=(5,),
+        )
+        _run(
+            results,
+            "qualification-refuses-overwrite",
+            [
+                neuros_cli,
+                "qualify",
+                config,
+                "--output",
+                qualification,
+                "--session-id",
+                "full-package",
+                "--duration",
+                str(args.duration),
+                "--json",
+            ],
+            cwd=work,
+            expected_codes=(5,),
+        )
+
+        tampered_qualification = work / "qualification-tampered"
+        shutil.copytree(qualification, tampered_qualification)
+        report["tamper_tests"]["qualification_artifact"] = _append_tamper(
+            tampered_qualification / "runtime.json"
+        )
+        _run(
+            results,
+            "tampered-qualification-rejected",
+            [neuros_cli, "reproduce", tampered_qualification, "--json"],
+            cwd=work,
+            expected_codes=(5,),
+        )
+        _run(
+            results,
+            "tampered-qualification-pinned-rejected",
+            [
+                neuros_cli,
+                "reproduce",
+                tampered_qualification,
+                "--expected-sha256",
+                root_sha,
+                "--json",
+            ],
+            cwd=work,
+            expected_codes=(5,),
+        )
+
+        soak_elapsed: list[float] = []
+        soak_semantics: list[dict[str, Any]] = []
+        soak_duration = min(max(args.duration / 4.0, 0.03), 0.08)
+        for index in range(args.soak_iterations):
+            started = time.perf_counter()
+            payload = _run(
+                results,
+                f"lifecycle-soak-{index:03d}",
+                [neuros_cli, "run", config, "--duration", str(soak_duration), "--json"],
+                cwd=work,
+                expect_json=True,
+            )
+            soak_elapsed.append(time.perf_counter() - started)
+            _assert_clean_runtime(payload, label=f"lifecycle soak {index}")
+            soak_semantics.append(_runtime_semantics(payload))
+        report["checks"]["lifecycle_soak"] = {
+            "iterations": args.soak_iterations,
+            "duration_per_iteration_s": soak_duration,
+            "elapsed_median_s": statistics.median(soak_elapsed),
+            "elapsed_max_s": max(soak_elapsed),
+            "all_stopped": all(item["state"] == "stopped" for item in soak_semantics),
+            "zero_node_failures": all(
+                all(value == 0 for value in item["node_failed"].values()) for item in soak_semantics
+            ),
+            "zero_dropped_edges": all(
+                all(value == 0 for value in item["edge_dropped"].values()) for item in soak_semantics
+            ),
+        }
+
+        report["checks"]["qualification"] = {
+            "bundle_sha256": root_sha,
+            "reproduction_exact": True,
+            "externally_pinned_reproduction": pinned.get("origin_authenticity") == "externally_pinned",
+            "claim_boundary": boundary,
+        }
+        report["status"] = "pass"
+        return 0
+    except Exception as exc:
+        report["status"] = "fail"
+        report["failure"] = {"type": type(exc).__name__, "message": str(exc)}
+        return 1
+    finally:
+        report["commands"] = [item.to_dict() for item in results]
+        _write_json(output / "environment-qualification.json", report)
+
+
+def _policy_selected_packages(repo_root: Path) -> list[dict[str, Any]]:
+    scripts = repo_root / "scripts"
+    sys.path.insert(0, str(scripts))
+    try:
+        from list_release_packages import release_policy
+
+        entries = release_policy()
+    finally:
+        try:
+            sys.path.remove(str(scripts))
+        except ValueError:
+            pass
+    selected = [
+        item
+        for item in entries
+        if bool(item.get("default_release_candidate", item.get("publish_candidate", False)))
+    ]
+    names = sorted(_canonical_name(item["distribution"]) for item in selected)
+    expected = sorted(_canonical_name(name) for name in REQUIRED_DISTRIBUTIONS)
+    if names != expected:
+        raise RuntimeError(
+            "default release policy differs from full-package qualification contract: "
+            f"expected {expected}, observed {names}"
+        )
+    return selected
+
+
+def _build_wheels(repo_root: Path, wheel_dir: Path, results: list[CommandResult]) -> list[dict[str, Any]]:
+    wheel_dir.mkdir(parents=True, exist_ok=False)
+    selected = _policy_selected_packages(repo_root)
+    for item in selected:
+        _run(
+            results,
+            f"build-{item['distribution']}",
+            [
+                sys.executable,
+                "-m",
+                "build",
+                "--wheel",
+                "--outdir",
+                wheel_dir,
+                repo_root / item["path"],
+            ],
+            cwd=repo_root,
+        )
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) != len(REQUIRED_DISTRIBUTIONS):
+        raise RuntimeError(
+            f"expected {len(REQUIRED_DISTRIBUTIONS)} default wheels, built {len(wheels)}"
+        )
+    metadata_rows = [_wheel_metadata(path) for path in wheels]
+    observed = sorted(row["canonical_name"] for row in metadata_rows)
+    expected = sorted(_canonical_name(name) for name in REQUIRED_DISTRIBUTIONS)
+    if observed != expected:
+        raise RuntimeError(f"built wheel names differ from policy: {observed} != {expected}")
+    return metadata_rows
+
+
+def _outer(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    output = Path(args.output).resolve()
+    if output.exists():
+        if not args.overwrite:
+            raise SystemExit(f"output already exists: {output}; pass --overwrite to replace it")
+        shutil.rmtree(output)
+    output.mkdir(parents=True, exist_ok=False)
+
+    results: list[CommandResult] = []
+    report: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "running",
+        "source_revision": args.source_revision,
+        "orchestrator_environment": {
+            "python": sys.version,
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "commands": [],
+    }
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="neuros-full-package-") as temporary:
+            temp = Path(temporary)
+            wheel_dir = temp / "wheels"
+            wheel_rows = _build_wheels(repo_root, wheel_dir, results)
+            wheel_manifest_path = output / "wheel-manifest.json"
+            wheel_manifest = {
+                "schema": "neuros.full_package_wheel_manifest.v1",
+                "source_revision": args.source_revision,
+                "wheels": wheel_rows,
+            }
+            _write_json(wheel_manifest_path, wheel_manifest)
+
+            closure_path = output / "release-dependency-closure.json"
+            _run(
+                results,
+                "release-dependency-closure",
+                [
+                    sys.executable,
+                    repo_root / "scripts/check_release_dependency_closure.py",
+                    wheel_dir,
+                    "--output",
+                    closure_path,
+                ],
+                cwd=repo_root,
+            )
+            ownership_path = output / "wheel-ownership.json"
+            _run(
+                results,
+                "wheel-ownership",
+                [
+                    sys.executable,
+                    repo_root / "scripts/check_wheel_ownership.py",
+                    wheel_dir,
+                    "--output",
+                    ownership_path,
+                ],
+                cwd=repo_root,
+            )
+
+            env_root = temp / "venv"
+            venv.EnvBuilder(with_pip=True, clear=True).create(env_root)
+            env_python = _python_in_venv(env_root)
+            _run(results, "upgrade-clean-room-pip", [env_python, "-m", "pip", "install", "--upgrade", "pip"])
+            _run(
+                results,
+                "install-exact-default-wheels",
+                [env_python, "-m", "pip", "install", *sorted(wheel_dir.glob("*.whl"))],
+            )
+            _run(results, "pip-check", [env_python, "-m", "pip", "check"])
+
+            child_output = output / "clean-room"
+            child_env = dict(os.environ)
+            child_env.pop("PYTHONPATH", None)
+            child_env.pop("PYTHONHOME", None)
+            # The GitHub PR event SHA can be a synthetic merge commit.  Ordinary
+            # qualification should not silently mistake that for installed-wheel
+            # source identity during this clean-room test.
+            child_env.pop("GITHUB_SHA", None)
+            child_env.pop("GITHUB_REF", None)
+            child_env["PYTHONNOUSERSITE"] = "1"
+            outside_cwd = temp / "outside-repository"
+            outside_cwd.mkdir()
+            child = _run(
+                results,
+                "installed-wheel-clean-room",
+                [
+                    env_python,
+                    Path(__file__).resolve(),
+                    "--inside-env",
+                    "--repo-root",
+                    repo_root,
+                    "--output",
+                    child_output,
+                    "--wheel-manifest",
+                    wheel_manifest_path,
+                    "--source-revision",
+                    args.source_revision,
+                    "--duration",
+                    str(args.duration),
+                    "--soak-iterations",
+                    str(args.soak_iterations),
+                ],
+                cwd=outside_cwd,
+                env=child_env,
+            )
+            assert child is None
+            child_report = json.loads(
+                (child_output / "environment-qualification.json").read_text(encoding="utf-8")
+            )
+            _require(child_report.get("status") == "pass", "clean-room child report is not passing")
+
+            report["wheel_manifest"] = wheel_manifest
+            report["release_dependency_closure"] = json.loads(closure_path.read_text(encoding="utf-8"))
+            report["wheel_ownership"] = json.loads(ownership_path.read_text(encoding="utf-8"))
+            report["clean_room"] = child_report
+            report["claim_boundary"] = {
+                "installed_wheel_product_path_qualified": True,
+                "cross_platform_claim_requires_matrix_aggregation": True,
+                "real_dataset_qualified": False,
+                "hardware_qualified": False,
+                "closed_loop_qualified": False,
+                "clinical_qualified": False,
+                "statement": (
+                    "This report exercises packaging, runtime lifecycle, recording/replay, "
+                    "tamper rejection, and software qualification from exact installed wheels. "
+                    "It does not establish neural efficacy, physical-device validity, safety, "
+                    "or clinical benefit."
+                ),
+            }
+            report["status"] = "pass"
+            return 0
+    except Exception as exc:
+        report["status"] = "fail"
+        report["failure"] = {"type": type(exc).__name__, "message": str(exc)}
+        return 1
+    finally:
+        report["commands"] = [item.to_dict() for item in results]
+        _write_json(output / "full-package-qualification.json", report)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source-revision", type=str, default="unknown")
+    parser.add_argument("--duration", type=float, default=0.2)
+    parser.add_argument("--soak-iterations", type=int, default=8)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--inside-env", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--wheel-manifest", type=Path, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    if args.duration <= 0:
+        raise SystemExit("--duration must be positive")
+    if args.soak_iterations <= 0:
+        raise SystemExit("--soak-iterations must be positive")
+    if args.inside_env:
+        if args.wheel_manifest is None:
+            raise SystemExit("--wheel-manifest is required in --inside-env mode")
+        return _inside_environment(args)
+    return _outer(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_full_package_qualification.py
+++ b/scripts/run_full_package_qualification.py
@@ -523,7 +523,11 @@ def _inside_environment(args: argparse.Namespace) -> int:
             "tampered-recording-replay-rejected",
             [neuros_cli, "replay", tampered_session, "--config", config, "--json"],
             cwd=work,
-            expected_codes=(5,),
+            expected_codes=(4,),
+        )
+        _require(
+            "Data hash mismatch" in results[-1].stderr,
+            "tampered recording replay failed for an unrelated runtime reason",
         )
 
         qualification = work / "qualification"

--- a/tests/test_full_package_qualification_harness.py
+++ b/tests/test_full_package_qualification_harness.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from run_full_package_qualification import (  # noqa: E402
+    REQUIRED_DISTRIBUTIONS,
+    _append_tamper,
+    _assert_clean_runtime,
+    _canonical_name,
+    _flip_one_byte,
+    _policy_selected_packages,
+    _runtime_semantics,
+)
+
+
+def test_canonical_distribution_names_follow_packaging_equivalence():
+    assert _canonical_name("neuros_core") == "neuros-core"
+    assert _canonical_name("NeurOS.Core") == "neuros-core"
+
+
+def test_recording_tamper_changes_exactly_the_selected_payload(tmp_path: Path):
+    target = tmp_path / "frame.npy"
+    original = bytes(range(64))
+    target.write_bytes(original)
+
+    receipt = _flip_one_byte(target)
+
+    mutated = target.read_bytes()
+    assert len(mutated) == len(original)
+    assert sum(left != right for left, right in zip(original, mutated)) == 1
+    assert receipt["sha256_before"] != receipt["sha256_after"]
+    assert receipt["byte_offset"] == len(original) // 2
+
+
+def test_qualification_tamper_preserves_file_but_changes_identity(tmp_path: Path):
+    target = tmp_path / "runtime.json"
+    target.write_text(json.dumps({"state": "stopped"}) + "\n", encoding="utf-8")
+
+    receipt = _append_tamper(target)
+
+    assert target.is_file()
+    assert receipt["sha256_before"] != receipt["sha256_after"]
+
+
+def test_runtime_semantics_ignore_timing_but_preserve_failure_counts():
+    snapshot = {
+        "state": "stopped",
+        "runtime_seconds": 99.9,
+        "nodes": {
+            "source:eeg": {"processed": 7, "failed": 0, "p99_latency_ms": 123.4},
+            "decoder:primary": {"processed": 7, "failed": 0, "p99_latency_ms": 0.2},
+        },
+        "edges": {
+            "source:eeg->decoder:primary": {"accepted": 7, "dropped": 0},
+        },
+    }
+    semantics = _runtime_semantics(snapshot)
+    assert semantics == {
+        "state": "stopped",
+        "node_processed": {"decoder:primary": 7, "source:eeg": 7},
+        "node_failed": {"decoder:primary": 0, "source:eeg": 0},
+        "edge_accepted": {"source:eeg->decoder:primary": 7},
+        "edge_dropped": {"source:eeg->decoder:primary": 0},
+    }
+    _assert_clean_runtime(snapshot, label="fixture")
+
+
+def test_runtime_gate_rejects_failed_or_dropped_execution():
+    failed = {
+        "state": "stopped",
+        "nodes": {"decoder:primary": {"processed": 1, "failed": 1}},
+        "edges": {"edge": {"accepted": 1, "dropped": 0}},
+    }
+    with pytest.raises(RuntimeError, match="node failures"):
+        _assert_clean_runtime(failed, label="failed")
+
+    dropped = {
+        "state": "stopped",
+        "nodes": {"decoder:primary": {"processed": 1, "failed": 0}},
+        "edges": {"edge": {"accepted": 1, "dropped": 1}},
+    }
+    with pytest.raises(RuntimeError, match="dropped runtime items"):
+        _assert_clean_runtime(dropped, label="dropped")
+
+
+def test_full_package_contract_tracks_exact_default_release_policy():
+    selected = _policy_selected_packages(ROOT)
+    assert {_canonical_name(item["distribution"]) for item in selected} == {
+        _canonical_name(name) for name in REQUIRED_DISTRIBUTIONS
+    }

--- a/validation_tests/test_signal_contract_properties.py
+++ b/validation_tests/test_signal_contract_properties.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from neuros.contracts import (
+    ClockDomain,
+    SignalFrame,
+    StreamDescriptor,
+    validate_frame_against_descriptor,
+)
+from neuros.recording import SessionArchiveReader, SessionArchiveWriter
+
+
+@st.composite
+def finite_signal_arrays(draw):
+    channels = draw(st.integers(min_value=1, max_value=8))
+    samples = draw(st.integers(min_value=1, max_value=24))
+    values = draw(
+        st.lists(
+            st.floats(
+                min_value=-1_000.0,
+                max_value=1_000.0,
+                allow_nan=False,
+                allow_infinity=False,
+                width=32,
+            ),
+            min_size=channels * samples,
+            max_size=channels * samples,
+        )
+    )
+    return np.asarray(values, dtype=np.float32).reshape(channels, samples)
+
+
+@given(data=finite_signal_arrays())
+@settings(max_examples=24, deadline=None)
+def test_signal_contract_archive_roundtrip_and_payload_tamper_fail_closed(data: np.ndarray):
+    channels = int(data.shape[0])
+    names = tuple(f"ch{index}" for index in range(channels))
+    descriptor = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=250.0,
+        channel_names=names,
+        clock_domain=ClockDomain.HOST_MONOTONIC,
+        metadata={"fixture": "hypothesis"},
+    )
+    caller_owned = data.copy()
+    frame = SignalFrame(
+        stream_id="eeg",
+        sequence_id=0,
+        data=caller_owned,
+        sample_rate_hz=250.0,
+        host_receive_time_ns=123,
+        clock_domain=ClockDomain.HOST_MONOTONIC,
+        metadata={
+            "axis_order": ("channel", "time"),
+            "channel_names": names,
+            "modality": "eeg",
+        },
+    )
+    validate_frame_against_descriptor(descriptor, frame)
+
+    caller_owned[...] = 0
+    assert np.array_equal(frame.data, data)
+    assert frame.data.flags.writeable is False
+
+    async def write_archive(root: Path) -> None:
+        writer = SessionArchiveWriter(root, session_id="property")
+        writer.register_stream(descriptor)
+        await writer.write(frame)
+        await writer.close(runtime_metrics={"state": "stopped"})
+
+    with tempfile.TemporaryDirectory(prefix="neuros-property-") as raw_root:
+        root = Path(raw_root) / "archive"
+        asyncio.run(write_archive(root))
+
+        reader = SessionArchiveReader(root, verify_hashes=True)
+        restored = list(reader.iter_frames("eeg"))
+        assert len(restored) == 1
+        assert np.array_equal(restored[0].data, data)
+        assert restored[0].data.dtype == data.dtype
+        assert reader.descriptor("eeg").fingerprint() == descriptor.fingerprint()
+
+        payload = next((root / "streams" / "eeg" / "frames").glob("*.npy"))
+        mutated = bytearray(payload.read_bytes())
+        mutated[len(mutated) // 2] ^= 0x01
+        payload.write_bytes(mutated)
+
+        with pytest.raises(IOError, match="Data hash mismatch"):
+            list(SessionArchiveReader(root, verify_hashes=True).iter_frames("eeg"))
+
+
+@given(left=st.integers(), right=st.integers(), nested=st.integers())
+@settings(max_examples=50, deadline=None)
+def test_stream_descriptor_fingerprint_is_mapping_order_invariant(left: int, right: int, nested: int):
+    first = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=256.0,
+        metadata={"left": left, "right": right, "nested": {"value": nested, "kind": "x"}},
+    )
+    second = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=256.0,
+        metadata={"nested": {"kind": "x", "value": nested}, "right": right, "left": left},
+    )
+    assert first.fingerprint() == second.fingerprint()
+
+
+@given(
+    bad_rate=st.one_of(
+        st.just(0.0),
+        st.floats(max_value=-1e-12, allow_nan=False, allow_infinity=False),
+        st.just(float("inf")),
+        st.just(float("-inf")),
+        st.just(float("nan")),
+    )
+)
+@settings(max_examples=20, deadline=None)
+def test_signal_contract_rejects_nonphysical_declared_sample_rates(bad_rate: float):
+    with pytest.raises((TypeError, ValueError)):
+        StreamDescriptor(stream_id="eeg", modality="eeg", sample_rate_hz=bad_rate)
+
+    with pytest.raises((TypeError, ValueError)):
+        SignalFrame(
+            stream_id="eeg",
+            sequence_id=0,
+            data=np.ones(2, dtype=np.float32),
+            sample_rate_hz=bad_rate,
+            host_receive_time_ns=1,
+        )
+
+
+@given(channels=st.integers(min_value=1, max_value=8), delta=st.integers(min_value=1, max_value=4))
+@settings(max_examples=24, deadline=None)
+def test_descriptor_frame_channel_geometry_mismatch_is_never_silently_accepted(channels: int, delta: int):
+    descriptor = StreamDescriptor(
+        stream_id="eeg",
+        modality="eeg",
+        sample_rate_hz=250.0,
+        channel_names=tuple(f"ch{index}" for index in range(channels)),
+    )
+    frame = SignalFrame(
+        stream_id="eeg",
+        sequence_id=0,
+        data=np.ones(channels + delta, dtype=np.float32),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=1,
+    )
+    with pytest.raises(ValueError, match="channel geometry"):
+        validate_frame_against_descriptor(descriptor, frame)


### PR DESCRIPTION
## Purpose

Turn neurOS validation from a collection of strong specialized checks into an explicit **whole-package qualification program** that directly tests the installed product, corruption/failure semantics, property-level neural contracts, and the larger workspace without confusing software validation with neural or hardware validation.

This PR is intentionally **draft** and stacked on #119. It does not touch frozen `main` and must not merge while the Kumar2024 one-shard authorization remains tied to `56fd0c5132bec17575d68f62256cb80fd5661395`.

## Whole Package Qualification

The new umbrella workflow exposes one stable terminal check while fanning out into:

- 9 exact-wheel clean rooms: Ubuntu 24.04 x64, Windows 2025 x64, macOS 14 ARM64 × Python 3.10/3.11/3.12;
- generated property/corruption contracts;
- all-workspace wheel/build ownership audit;
- qualification-harness self-tests.

Every product matrix job checks out the exact PR head, builds only the four policy-selected default distributions (`neuros-core`, `neuros-drivers`, `neuros-models`, `neuros`), installs them in a fresh venv, verifies exact wheel SHA-256 via `direct_url.json`, excludes all non-default neurOS distributions, and executes the public CLI from outside the repository checkout.

## Adversarial public path

`scripts/run_full_package_qualification.py` exercises:

- doctor / compatibility / plugin inventory;
- init and overwrite refusal;
- valid and invalid config paths;
- runtime execution;
- record → verified inspect → replay;
- recording overwrite refusal;
- qualify → repeated reproduce → externally pinned reproduce;
- wrong external root rejection;
- qualification overwrite refusal;
- bounded repeated lifecycle runs.

It directly mutates authority-bearing bytes:

1. flips one byte in an actual recorded `.npy` SignalFrame payload;
2. requires `inspect --verify` to reject it as a recording error;
3. requires replay to preserve the source integrity failure through RuntimeExecutor and exit as a runtime error containing `Data hash mismatch`;
4. mutates checksum-bound `runtime.json` in a sealed qualification copy and requires normal/pinned reproduction to reject it.

## Property-based contracts

`validation_tests/test_signal_contract_properties.py` uses Hypothesis to generate signal arrays and metadata, testing immutable sample ownership, exact archive round-trip, descriptor-fingerprint invariance, nonphysical sampling-rate rejection, channel-geometry contradiction rejection, and direct payload corruption failure.

## Workspace vs product

A separate job builds every maintained workspace distribution and checks metadata/file ownership. This proves workspace integrity without making every research package a default release artifact.

## Validation policy

`docs/VALIDATION.md` defines the promotion ladder from local contracts through clean-room software, scientific qualification, public real-data external floor, hardware evidence, and independent reproduction. Software qualification explicitly does not establish neural efficacy, hardware validity, closed-loop safety, or clinical benefit.

## Failures already found by this PR

### Superseded head `2d788fe...`

The harness-test job failed before collection because it installed pytest without the repository-configured `pytest-asyncio` plugin. The validation lanes now install that plugin explicitly.

### Superseded head `314be3ef...`

All macOS jobs reached the adversarial harness and failed at the same check. Independent inspection of the uploaded macOS/Python 3.12 artifact showed neurOS **correctly** detected the flipped recording payload. `inspect --verify` exited 5 as a direct recording `IOError`; replay preserved the same `OSError: Data hash mismatch` as a RuntimeExecutor source-node failure and therefore exited 4 under the CLI's runtime-error contract. The harness had incorrectly required exit 5 from both surfaces.

The current harness now requires replay exit 4 **and** requires `Data hash mismatch` in stderr, so an unrelated runtime crash cannot satisfy the tamper test.

All evidence from both superseded heads is historical diagnostic evidence only.

## Important architecture gap exposed

Ordinary v1 qualification records installed package versions, not exact wheel/container artifact digests. The new clean-room evidence binds the exact built wheel SHA-256s independently. A future runtime qualification schema should carry equivalent artifact-level environment identity.

## Scientific boundary

No promoted Kumar2024 model execution, no Kumar2024 authority change, no promoted numerical interpretation, no ORION comparison authorization, no hardware/real-data claim, and no movement of `main`.

## Current exact head

`0e04c062ce4acb8037ed059c45d9801f73982fbf`

All prior #120 workflow evidence is superseded for qualification purposes.

## Merge gate

1. Keep draft while the frozen one-shard authorization remains active.
2. Require all 9 clean rooms, property contracts, workspace audit, harness tests, and stable Whole Package Qualification gate green on one exact head.
3. Independently inspect evidence from Linux x64, Windows x64, and macOS ARM64 rather than trusting the terminal green check alone.
4. Preserve software-only claim boundaries.
5. After the frozen scientific gate is consumed and #119 lands, retarget/requalify against resulting `main` before merge.

Related: #75, #85, #89, #117, #119.