### PR TITLE
Release trust: require byte-reproducible default wheels

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/release-candidate.yml"
+      - ".github/workflows/reproducible-release-build.yml"
       - "requirements/release-build-py311.txt"
       - "packages/*/pyproject.toml"
       - "packages/*/src/neuros/__init__.py"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - ".github/workflows/release-candidate.yml"
+      - "requirements/release-build-py311.txt"
       - "packages/*/pyproject.toml"
       - "packages/*/src/neuros/__init__.py"
       - "CITATION.cff"
       - "docs/RELEASE_POLICY.md"
       - "docs/SCIENTIFIC_CLAIMS.md"
       - "release/package-policy.json"
+      - "scripts/build_reproducible_release.py"
       - "scripts/check_public_contracts.py"
       - "scripts/check_release_dependency_closure.py"
       - "scripts/check_wheel_ownership.py"
@@ -35,54 +37,100 @@ concurrency:
 jobs:
   build-and-verify:
     name: Build, validate, checksum, and smoke-install release artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ env.RELEASE_SOURCE_SHA }}
           fetch-depth: 0
           persist-credentials: false
+
       - name: Require exact clean release source
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "${RELEASE_SOURCE_SHA}"
           git diff --quiet HEAD --
           git diff --cached --quiet HEAD --
+
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: "3.11"
+          python-version: "3.11.9"
           cache: pip
-      - name: Install release tooling
+          cache-dependency-path: requirements/release-build-py311.txt
+
+      - name: Install exact hash-pinned release build authority
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build twine packaging pyyaml mkdocs-material cffconvert
+          set -euo pipefail
+          python -m pip install \
+            --only-binary=:all: \
+            --require-hashes \
+            --requirement requirements/release-build-py311.txt
+          python -m pip check
+          python - <<'PY'
+          from importlib import metadata
+
+          expected = {
+              "pip": "26.2.1",
+              "build": "1.6.0",
+              "setuptools": "84.0.0",
+              "wheel": "0.48.0",
+              "packaging": "26.3",
+              "pyproject-hooks": "1.2.0",
+          }
+          observed = {name: metadata.version(name) for name in expected}
+          if observed != expected:
+              raise SystemExit(
+                  f"release build authority drift: expected={expected}, observed={observed}"
+              )
+          print(f"release build authority: {observed}")
+          PY
+
+      - name: Bind deterministic archive time to exact release source
+        run: |
+          set -euo pipefail
+          epoch="$(git show -s --format=%ct "${RELEASE_SOURCE_SHA}")"
+          test -n "${epoch}"
+          echo "SOURCE_DATE_EPOCH=${epoch}" >> "${GITHUB_ENV}"
+          echo "SOURCE_DATE_EPOCH=${epoch}"
+
+      - name: Build canonical default release wheels
+        run: |
+          set -euo pipefail
+          DIST="${RUNNER_TEMP}/neuros-release"
+          python scripts/build_reproducible_release.py \
+            --repo-root . \
+            --output "${DIST}" \
+            --source-revision "${RELEASE_SOURCE_SHA}" \
+            --source-date-epoch "${SOURCE_DATE_EPOCH}"
+          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq \
+            "$(python scripts/list_release_packages.py --count)"
+
+      - name: Install release verification tooling after artifact construction
+        run: |
+          python -m pip install twine pyyaml mkdocs-material cffconvert
+
       - name: Validate public contracts, release policy, and documentation
         run: |
           python scripts/check_public_contracts.py
           python scripts/list_release_packages.py --all --json > "${RUNNER_TEMP}/release-package-policy.json"
           cffconvert --validate
           mkdocs build --strict --site-dir "${RUNNER_TEMP}/neuros-docs"
-      - name: Build explicit default release wheels
+
+      - name: Validate canonical wheel metadata and ownership
         run: |
           set -euo pipefail
           DIST="${RUNNER_TEMP}/neuros-release"
-          mkdir -p "${DIST}"
-          mapfile -t PACKAGES < <(python scripts/list_release_packages.py)
-          test "${#PACKAGES[@]}" -gt 0
-          for package in "${PACKAGES[@]}"
-          do
-            python -m build --wheel --outdir "${DIST}" "${package}"
-          done
-          test "$(find "${DIST}" -maxdepth 1 -name '*.whl' | wc -l)" -eq "${#PACKAGES[@]}"
           python -m twine check "${DIST}"/*.whl
           python scripts/check_wheel_ownership.py "${DIST}" \
             --output "${DIST}/wheel-ownership.json"
+
       - name: Verify internal default dependency closure
         run: |
           set -euo pipefail
           python scripts/check_release_dependency_closure.py \
             "${RUNNER_TEMP}/neuros-release" \
             --output "${RUNNER_TEMP}/neuros-release/release-dependency-closure.json"
+
       - name: Prove component namespace without the SDK
         run: |
           set -euo pipefail
@@ -113,6 +161,7 @@ jobs:
           if not neuros.__spec__ or not neuros.__spec__.submodule_search_locations:
               raise SystemExit("component-only neuros namespace has no search locations")
           PY
+
       - name: Generate self-describing release manifest and checksums
         run: |
           set -euo pipefail
@@ -145,33 +194,91 @@ jobs:
           bundled_policy_path = dist / "package-policy.json"
           bundled_policy_path.write_bytes(policy_bytes)
 
+          build_authority_path = dist / "reproducible-build-manifest.json"
+          if not build_authority_path.is_file():
+              raise SystemExit("reproducible build authority manifest is missing")
+          build_authority = json.loads(
+              build_authority_path.read_text(encoding="utf-8")
+          )
+          if build_authority.get("schema") != "neuros.reproducible_release_build.v1":
+              raise SystemExit("unexpected reproducible build authority schema")
+          build_source = build_authority.get("source", {})
+          if build_source.get("revision") != os.environ["RELEASE_SOURCE_SHA"]:
+              raise SystemExit("reproducible build authority source revision drift")
+          if str(build_source.get("source_date_epoch")) != os.environ["SOURCE_DATE_EPOCH"]:
+              raise SystemExit("reproducible build authority timestamp drift")
+          build_authority_sha = hashlib.sha256(
+              build_authority_path.read_bytes()
+          ).hexdigest()
+
           artifacts = []
           for wheel in sorted(dist.glob("*.whl")):
               digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
               with ZipFile(wheel) as archive:
                   metadata_name = next(
-                      name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+                      name
+                      for name in archive.namelist()
+                      if name.endswith(".dist-info/METADATA")
                   )
-                  metadata = archive.read(metadata_name).decode("utf-8", errors="strict")
+                  metadata = archive.read(metadata_name).decode(
+                      "utf-8", errors="strict"
+                  )
               message = Parser().parsestr(metadata)
               name = message.get("Name")
               version = message.get("Version")
               if not name or not version:
                   raise SystemExit(f"missing package metadata in {wheel.name}")
-              artifacts.append({"file": wheel.name, "sha256": digest, "name": name, "version": version})
+              artifacts.append(
+                  {
+                      "file": wheel.name,
+                      "sha256": digest,
+                      "name": name,
+                      "version": version,
+                  }
+              )
 
           if len(artifacts) != expected_count:
-              raise SystemExit(f"expected {expected_count} wheels, found {len(artifacts)}")
-          observed_names = {canonicalize_name(item["name"]) for item in artifacts}
+              raise SystemExit(
+                  f"expected {expected_count} wheels, found {len(artifacts)}"
+              )
+          observed_names = {
+              canonicalize_name(item["name"]) for item in artifacts
+          }
           if len(observed_names) != expected_count:
               raise SystemExit("release contains duplicate distribution names")
-          expected_names = {canonicalize_name(item["distribution"]) for item in selected_policy["packages"]}
+          expected_names = {
+              canonicalize_name(item["distribution"])
+              for item in selected_policy["packages"]
+          }
           if expected_names != observed_names:
               raise SystemExit(
                   "release wheel distributions differ from explicit package policy: "
                   f"missing={sorted(expected_names - observed_names)}, "
                   f"foreign={sorted(observed_names - expected_names)}"
               )
+
+          build_rows = {
+              canonicalize_name(str(item.get("name", ""))): item
+              for item in build_authority.get("artifacts", [])
+          }
+          if set(build_rows) != observed_names:
+              raise SystemExit(
+                  "reproducible build authority distribution set differs from wheels"
+              )
+          for artifact in artifacts:
+              row = build_rows[canonicalize_name(artifact["name"])]
+              if row.get("file") != artifact["file"]:
+                  raise SystemExit(
+                      f"reproducible build filename drift for {artifact['name']}"
+                  )
+              if row.get("sha256") != artifact["sha256"]:
+                  raise SystemExit(
+                      f"reproducible build digest drift for {artifact['name']}"
+                  )
+              if str(row.get("version")) != artifact["version"]:
+                  raise SystemExit(
+                      f"reproducible build version drift for {artifact['name']}"
+                  )
 
           closure_path = dist / "release-dependency-closure.json"
           if not closure_path.is_file():
@@ -193,7 +300,9 @@ jobs:
           ownership_path = dist / "wheel-ownership.json"
           if not ownership_path.is_file():
               raise SystemExit("wheel ownership manifest is missing")
-          ownership_payload = json.loads(ownership_path.read_text(encoding="utf-8"))
+          ownership_payload = json.loads(
+              ownership_path.read_text(encoding="utf-8")
+          )
           if ownership_payload.get("schema") != "neuros.wheel_ownership.v1":
               raise SystemExit("unexpected wheel ownership schema")
           if ownership_payload.get("status") != "pass":
@@ -201,19 +310,38 @@ jobs:
           ownership_sha = hashlib.sha256(ownership_path.read_bytes()).hexdigest()
 
           manifest = {
-              "schema_version": 2,
+              "schema_version": 3,
               "source_revision": os.environ["RELEASE_SOURCE_SHA"],
               "source_ref": os.environ["RELEASE_SOURCE_REF"],
               "github_event_sha": os.environ["GITHUB_SHA"],
               "artifact_count": len(artifacts),
               "artifacts": artifacts,
+              "reproducible_build": {
+                  "file": build_authority_path.name,
+                  "sha256": build_authority_sha,
+                  "schema": build_authority["schema"],
+                  "source_date_epoch": build_source["source_date_epoch"],
+                  "python_version": build_authority.get("build_authority", {}).get(
+                      "python_version"
+                  ),
+                  "toolchain": build_authority.get("build_authority", {}).get(
+                      "toolchain", {}
+                  ),
+                  "wheel_canonicalization": build_authority.get(
+                      "build_authority", {}
+                  ).get("wheel_canonicalization"),
+              },
               "release_dependency_closure": {
                   "file": closure_path.name,
                   "sha256": closure_sha,
                   "schema": closure_payload["schema"],
                   "python_versions": closure_payload.get("python_versions", []),
-                  "target_environment_count": len(closure_payload.get("target_environments", [])),
-                  "dependency_count": len(closure_payload.get("dependencies", [])),
+                  "target_environment_count": len(
+                      closure_payload.get("target_environments", [])
+                  ),
+                  "dependency_count": len(
+                      closure_payload.get("dependencies", [])
+                  ),
               },
               "release_policy": {
                   "file": bundled_policy_path.name,
@@ -236,18 +364,23 @@ jobs:
 
           checksum_lines = [
               *(f"{a['sha256']}  {a['file']}\n" for a in artifacts),
+              f"{build_authority_sha}  {build_authority_path.name}\n",
               f"{closure_sha}  {closure_path.name}\n",
               f"{ownership_sha}  {ownership_path.name}\n",
               f"{policy_sha}  {bundled_policy_path.name}\n",
               f"{manifest_sha}  {manifest_path.name}\n",
           ]
-          (dist / "SHA256SUMS").write_text("".join(checksum_lines), encoding="utf-8")
+          (dist / "SHA256SUMS").write_text(
+              "".join(checksum_lines), encoding="utf-8"
+          )
           PY
+
       - name: Verify checksums before installation
         run: |
           set -euo pipefail
           cd "${RUNNER_TEMP}/neuros-release"
           sha256sum --check SHA256SUMS
+
       - name: Smoke-install the minimal public SDK from this exact wheel set
         run: |
           set -euo pipefail
@@ -275,7 +408,13 @@ jobs:
           "${PY}" - <<'PY'
           import neuros
 
-          required = {"SignalFrame", "Pipeline", "BaseDriver", "BaseModel", "load_plugin"}
+          required = {
+              "SignalFrame",
+              "Pipeline",
+              "BaseDriver",
+              "BaseModel",
+              "load_plugin",
+          }
           missing = sorted(name for name in required if not hasattr(neuros, name))
           if missing:
               raise SystemExit(f"public neuros SDK root is missing exports: {missing}")
@@ -284,6 +423,7 @@ jobs:
           PY
           "${NEUROS}" doctor --json
           "${NEUROS}" compatibility --json
+
       - name: Upload immutable release-candidate bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -294,13 +434,14 @@ jobs:
             ${{ runner.temp }}/neuros-release/package-policy.json
             ${{ runner.temp }}/neuros-release/release-dependency-closure.json
             ${{ runner.temp }}/neuros-release/release-manifest.json
+            ${{ runner.temp }}/neuros-release/reproducible-build-manifest.json
             ${{ runner.temp }}/neuros-release/wheel-ownership.json
           if-no-files-found: error
           retention-days: 30
 
   publishing-disabled:
     name: Publishing authority remains intentionally disabled
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Explain publication boundary
         run: |

--- a/.github/workflows/reproducible-release-build.yml
+++ b/.github/workflows/reproducible-release-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/reproducible-release-build.yml"
+      - ".github/workflows/release-candidate.yml"
       - "requirements/release-build-py311.txt"
       - "scripts/build_reproducible_release.py"
       - "scripts/check_reproducible_wheels.py"
@@ -20,6 +21,7 @@ on:
       - main
     paths:
       - ".github/workflows/reproducible-release-build.yml"
+      - ".github/workflows/release-candidate.yml"
       - "requirements/release-build-py311.txt"
       - "scripts/build_reproducible_release.py"
       - "scripts/check_reproducible_wheels.py"

--- a/.github/workflows/reproducible-release-build.yml
+++ b/.github/workflows/reproducible-release-build.yml
@@ -1,0 +1,202 @@
+name: Reproducible Release Build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/reproducible-release-build.yml"
+      - "requirements/release-build-py311.txt"
+      - "scripts/build_reproducible_release.py"
+      - "scripts/check_reproducible_wheels.py"
+      - "scripts/list_release_packages.py"
+      - "scripts/list_workspace_packages.py"
+      - "release/package-policy.json"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "packages/neuros-models/**"
+      - "packages/neuros/**"
+      - "tests/test_reproducible_release_build.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/reproducible-release-build.yml"
+      - "requirements/release-build-py311.txt"
+      - "scripts/build_reproducible_release.py"
+      - "scripts/check_reproducible_wheels.py"
+      - "scripts/list_release_packages.py"
+      - "scripts/list_workspace_packages.py"
+      - "release/package-policy.json"
+      - "packages/neuros-core/**"
+      - "packages/neuros-drivers/**"
+      - "packages/neuros-models/**"
+      - "packages/neuros/**"
+      - "tests/test_reproducible_release_build.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REPRO_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+concurrency:
+  group: reproducible-release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Deterministic wheels / ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+          - windows-2025
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.REPRO_SOURCE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require exact clean build source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${REPRO_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11.16"
+          cache: pip
+          cache-dependency-path: requirements/release-build-py311.txt
+
+      - name: Install exact hash-pinned build authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install \
+            --only-binary=:all: \
+            --require-hashes \
+            --requirement requirements/release-build-py311.txt
+          python -m pip check
+          python - <<'PY'
+          from importlib import metadata
+          expected = {
+              "pip": "26.2.1",
+              "build": "1.6.0",
+              "setuptools": "84.0.0",
+              "wheel": "0.48.0",
+              "packaging": "26.3",
+              "pyproject-hooks": "1.2.0",
+          }
+          observed = {name: metadata.version(name) for name in expected}
+          if observed != expected:
+              raise SystemExit(f"build authority drift: expected={expected}, observed={observed}")
+          print(f"build authority: {observed}")
+          PY
+
+      - name: Bind deterministic archive time to source commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          epoch="$(git show -s --format=%ct "${REPRO_SOURCE_SHA}")"
+          test -n "${epoch}"
+          echo "SOURCE_DATE_EPOCH=${epoch}" >> "${GITHUB_ENV}"
+          echo "SOURCE_DATE_EPOCH=${epoch}"
+
+      - name: Build the same release twice independently
+        shell: bash
+        env:
+          REPRO_ROOT: ${{ runner.temp }}/reproducible-release
+        run: |
+          set -euo pipefail
+          python scripts/build_reproducible_release.py \
+            --repo-root . \
+            --output "${REPRO_ROOT}/build-a" \
+            --source-revision "${REPRO_SOURCE_SHA}" \
+            --source-date-epoch "${SOURCE_DATE_EPOCH}"
+          python scripts/build_reproducible_release.py \
+            --repo-root . \
+            --output "${REPRO_ROOT}/build-b" \
+            --source-revision "${REPRO_SOURCE_SHA}" \
+            --source-date-epoch "${SOURCE_DATE_EPOCH}"
+          python scripts/check_reproducible_wheels.py \
+            "${REPRO_ROOT}/build-a" \
+            "${REPRO_ROOT}/build-b" \
+            --output "${REPRO_ROOT}/within-builder-comparison.json"
+
+      - name: Upload builder evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: neurOS-reproducible-release-${{ matrix.os }}
+          path: ${{ runner.temp }}/reproducible-release
+          if-no-files-found: warn
+          retention-days: 30
+
+  helper-contracts:
+    name: Reproducible build helper contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.REPRO_SOURCE_SHA }}
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11.16"
+      - name: Exercise comparison fail-closed behavior
+        run: python -m pytest -q tests/test_reproducible_release_build.py
+
+  reproducible-release:
+    name: Reproducible Release Build
+    if: always()
+    needs:
+      - build
+      - helper-contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require all independent builders and helper contracts
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          HELPER_RESULT: ${{ needs.helper-contracts.result }}
+        run: |
+          set -euo pipefail
+          test "${BUILD_RESULT}" = "success"
+          test "${HELPER_RESULT}" = "success"
+
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.REPRO_SOURCE_SHA }}
+          persist-credentials: false
+
+      - name: Download all independent builder artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
+        with:
+          pattern: neurOS-reproducible-release-*
+          path: ${{ runner.temp }}/reproducible-builders
+
+      - name: Require byte-identical wheels across operating systems
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="${RUNNER_TEMP}/reproducible-builders"
+          python scripts/check_reproducible_wheels.py \
+            "${ROOT}/neurOS-reproducible-release-ubuntu-24.04/build-a" \
+            "${ROOT}/neurOS-reproducible-release-macos-14/build-a" \
+            "${ROOT}/neurOS-reproducible-release-windows-2025/build-a" \
+            --output "${ROOT}/cross-builder-comparison.json"
+
+      - name: Upload cross-builder reproducibility evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: neurOS-reproducible-release-comparison-${{ env.REPRO_SOURCE_SHA }}
+          path: ${{ runner.temp }}/reproducible-builders/cross-builder-comparison.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/reproducible-release-build.yml
+++ b/.github/workflows/reproducible-release-build.yml
@@ -150,6 +150,8 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11.16"
+      - name: Install helper-test tooling
+        run: python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
       - name: Exercise comparison fail-closed behavior
         run: python -m pytest -q tests/test_reproducible_release_build.py
 

--- a/.github/workflows/reproducible-release-build.yml
+++ b/.github/workflows/reproducible-release-build.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: "3.11.16"
+          python-version: "3.11.9"
           cache: pip
           cache-dependency-path: requirements/release-build-py311.txt
 

--- a/requirements/release-build-py311.txt
+++ b/requirements/release-build-py311.txt
@@ -1,0 +1,23 @@
+# Exact, hash-pinned build authority for reproducible neurOS pure-Python wheels.
+#
+# This file intentionally contains only the packages that can influence the
+# wheel build frontend/backend under Python 3.11. Validation, documentation,
+# and publishing tooling are governed separately.
+#
+# Install with:
+#   python -m pip install --require-hashes -r requirements/release-build-py311.txt
+
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e
+build==1.6.0 \
+    --hash=sha256:f7aaf1ebbb79178a02ba248bb524f2176b256017e17e8e4bd4289c7b38cc2bad
+setuptools==84.0.0 \
+    --hash=sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670
+wheel==0.48.0 \
+    --hash=sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pyproject-hooks==1.2.0 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
+colorama==0.4.6 ; os_name == "nt" \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6

--- a/scripts/build_reproducible_release.py
+++ b/scripts/build_reproducible_release.py
@@ -1,34 +1,48 @@
 #!/usr/bin/env python3
-"""Build the default neurOS release wheels under an explicit build authority.
+"""Build byte-reproducible default neurOS wheels under explicit authority.
 
-This builder is intentionally narrower than the ordinary release workflow. It
-expects the caller to install the hash-pinned Python 3.11 build toolchain first,
-requires the source commit timestamp as SOURCE_DATE_EPOCH, disables PEP 517
-build isolation, and emits diagnostics sufficient to explain byte-level wheel
-drift across independent builders.
+The raw setuptools/wheel output is not assumed to be platform-neutral at the
+container byte level. In particular, Windows can emit CRLF core metadata and
+Windows-specific ZIP creator/permission fields even when the semantic wheel
+content is otherwise identical. This builder therefore performs a narrow Wheel
+spec-preserving canonicalization after the package backend has finished:
 
-A passing invocation proves only that one builder produced a self-consistent
-set of platform-independent wheels. Cross-builder reproducibility is established
-separately by ``check_reproducible_wheels.py``.
+* text metadata controlled by the build backend uses LF line endings;
+* ``RECORD`` is rebuilt from the canonical member bytes;
+* members are written in lexical order;
+* ZIP timestamps are bound to ``SOURCE_DATE_EPOCH``;
+* ZIP creator/mode metadata is normalized to one Unix representation; and
+* members use ``ZIP_STORED`` so zlib implementation/version cannot become an
+  undeclared cross-builder input.
+
+The canonicalizer is limited to the default platform-independent ``py3-none-any``
+release set. A passing invocation proves only that one builder produced a
+self-consistent release set. Cross-builder identity is established separately by
+``check_reproducible_wheels.py``.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
+import csv
 import hashlib
+import io
 import json
 import os
 import platform
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from email.parser import Parser
 from importlib import metadata
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
-from zipfile import ZipFile
+from zipfile import ZIP_STORED, ZipFile, ZipInfo
 
 SCHEMA = "neuros.reproducible_release_build.v1"
+CANONICALIZATION_SCHEMA = "neuros.wheel_canonicalization.v1"
 TOOLCHAIN_DISTRIBUTIONS = (
     "pip",
     "build",
@@ -37,11 +51,24 @@ TOOLCHAIN_DISTRIBUTIONS = (
     "packaging",
     "pyproject-hooks",
 )
+CANONICAL_TEXT_METADATA = {
+    "METADATA",
+    "WHEEL",
+    "entry_points.txt",
+    "top_level.txt",
+}
+CANONICAL_FILE_MODE = 0o100644
+CANONICAL_SCRIPT_MODE = 0o100755
+CANONICAL_DIRECTORY_MODE = 0o040755
 
 
 def _require(condition: bool, message: str) -> None:
     if not condition:
         raise RuntimeError(message)
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
 
 
 def _sha256_file(path: Path) -> str:
@@ -50,6 +77,12 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _record_hash(payload: bytes) -> str:
+    digest = hashlib.sha256(payload).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded}"
 
 
 def _canonical_name(value: str) -> str:
@@ -62,7 +95,9 @@ def _git(repo_root: Path, *args: str) -> str:
     ).strip()
 
 
-def _source_authority(repo_root: Path, revision: str, source_date_epoch: int) -> dict[str, Any]:
+def _source_authority(
+    repo_root: Path, revision: str, source_date_epoch: int
+) -> dict[str, Any]:
     head = _git(repo_root, "rev-parse", "HEAD")
     _require(head == revision, f"checkout drift: expected {revision}, observed {head}")
     _require(
@@ -70,14 +105,18 @@ def _source_authority(repo_root: Path, revision: str, source_date_epoch: int) ->
         "source revision must be a 40-character lowercase git SHA",
     )
     tracked_status = _git(repo_root, "status", "--porcelain", "--untracked-files=no")
-    _require(not tracked_status, f"tracked source tree is dirty before build: {tracked_status}")
+    _require(
+        not tracked_status,
+        f"tracked source tree is dirty before build: {tracked_status}",
+    )
     commit_epoch_text = _git(repo_root, "show", "-s", "--format=%ct", revision)
     _require(commit_epoch_text.isdigit(), "source commit timestamp is not an integer")
     commit_epoch = int(commit_epoch_text)
-    _require(source_date_epoch == commit_epoch, (
+    _require(
+        source_date_epoch == commit_epoch,
         "SOURCE_DATE_EPOCH must equal the exact source commit timestamp: "
-        f"expected {commit_epoch}, observed {source_date_epoch}"
-    ))
+        f"expected {commit_epoch}, observed {source_date_epoch}",
+    )
     return {
         "revision": revision,
         "commit_timestamp_epoch": commit_epoch,
@@ -93,10 +132,19 @@ def _selected_packages(repo_root: Path) -> list[dict[str, Any]]:
             text=True,
         )
     )
-    _require(payload.get("schema") == "neuros.release_package_inventory.v1", "unexpected release policy inventory schema")
+    _require(
+        payload.get("schema") == "neuros.release_package_inventory.v1",
+        "unexpected release policy inventory schema",
+    )
     packages = payload.get("packages")
-    _require(isinstance(packages, list) and packages, "release policy selected no packages")
-    _require(payload.get("count") == len(packages), "release policy count does not match selected package list")
+    _require(
+        isinstance(packages, list) and packages,
+        "release policy selected no packages",
+    )
+    _require(
+        payload.get("count") == len(packages),
+        "release policy count does not match selected package list",
+    )
     return packages
 
 
@@ -114,17 +162,207 @@ def _clean_build_state(package_root: Path) -> None:
                 path.unlink()
 
 
+def _canonical_zip_datetime(source_date_epoch: int) -> tuple[int, int, int, int, int, int]:
+    # The ZIP timestamp format starts in 1980 and has a two-second resolution.
+    timestamp = datetime.fromtimestamp(source_date_epoch, tz=timezone.utc)
+    if timestamp.year < 1980:
+        timestamp = datetime(1980, 1, 1, tzinfo=timezone.utc)
+    if timestamp.year > 2107:
+        timestamp = datetime(2107, 12, 31, 23, 59, 58, tzinfo=timezone.utc)
+    second = timestamp.second - (timestamp.second % 2)
+    return (
+        timestamp.year,
+        timestamp.month,
+        timestamp.day,
+        timestamp.hour,
+        timestamp.minute,
+        second,
+    )
+
+
+def _validate_member_name(name: str) -> None:
+    _require(bool(name), "wheel contains an empty member name")
+    path = PurePosixPath(name)
+    _require(not path.is_absolute(), f"wheel contains an absolute member path: {name}")
+    _require(".." not in path.parts, f"wheel member escapes archive root: {name}")
+    _require("\\" not in name, f"wheel member uses a non-POSIX separator: {name}")
+
+
+def _normalize_line_endings(payload: bytes, *, member: str) -> bytes:
+    try:
+        payload.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError(f"wheel metadata is not UTF-8: {member}") from exc
+    return payload.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def _canonical_record(
+    members: dict[str, bytes], *, record_name: str
+) -> bytes:
+    stream = io.StringIO(newline="")
+    writer = csv.writer(stream, lineterminator="\n")
+    for name in sorted(members):
+        if name == record_name:
+            continue
+        payload = members[name]
+        writer.writerow((name, _record_hash(payload), str(len(payload))))
+    writer.writerow((record_name, "", ""))
+    return stream.getvalue().encode("utf-8")
+
+
+def _canonical_mode(name: str, *, is_directory: bool) -> int:
+    if is_directory:
+        return CANONICAL_DIRECTORY_MODE
+    if ".data/scripts/" in name:
+        return CANONICAL_SCRIPT_MODE
+    return CANONICAL_FILE_MODE
+
+
+def _canonical_zip_info(
+    name: str,
+    *,
+    timestamp: tuple[int, int, int, int, int, int],
+    is_directory: bool,
+) -> ZipInfo:
+    info = ZipInfo(filename=name, date_time=timestamp)
+    info.create_system = 3
+    info.compress_type = ZIP_STORED
+    info.external_attr = _canonical_mode(name, is_directory=is_directory) << 16
+    if is_directory:
+        info.external_attr |= 0x10
+    return info
+
+
+def _verify_record(members: dict[str, bytes], *, record_name: str) -> None:
+    expected = _canonical_record(members, record_name=record_name)
+    _require(
+        members.get(record_name) == expected,
+        f"canonical RECORD verification failed: {record_name}",
+    )
+
+
+def _canonicalize_wheel(path: Path, *, source_date_epoch: int) -> dict[str, Any]:
+    _require(
+        path.name.endswith("-py3-none-any.whl"),
+        f"wheel canonicalizer accepts only platform-independent wheels: {path.name}",
+    )
+    before_sha256 = _sha256_file(path)
+    with ZipFile(path, "r") as archive:
+        infos = archive.infolist()
+        names = [item.filename for item in infos]
+        _require(len(names) == len(set(names)), f"wheel contains duplicate members: {path.name}")
+        for name in names:
+            _validate_member_name(name)
+        members = {item.filename: archive.read(item.filename) for item in infos}
+        directory_names = {item.filename for item in infos if item.is_dir()}
+
+    record_names = [name for name in names if name.endswith(".dist-info/RECORD")]
+    metadata_names = [name for name in names if name.endswith(".dist-info/METADATA")]
+    _require(len(record_names) == 1, f"{path.name}: expected exactly one RECORD member")
+    _require(len(metadata_names) == 1, f"{path.name}: expected exactly one METADATA member")
+    dist_info = record_names[0].rsplit("/", 1)[0] + "/"
+    _require(
+        metadata_names[0].startswith(dist_info),
+        f"{path.name}: METADATA and RECORD belong to different dist-info trees",
+    )
+    record_name = record_names[0]
+
+    normalized_text: list[str] = []
+    for name in sorted(members):
+        if not name.startswith(dist_info):
+            continue
+        basename = name.rsplit("/", 1)[-1]
+        if basename not in CANONICAL_TEXT_METADATA:
+            continue
+        normalized = _normalize_line_endings(members[name], member=name)
+        if normalized != members[name]:
+            normalized_text.append(name)
+        members[name] = normalized
+
+    members[record_name] = _canonical_record(members, record_name=record_name)
+    _verify_record(members, record_name=record_name)
+
+    timestamp = _canonical_zip_datetime(source_date_epoch)
+    temporary = path.with_suffix(path.suffix + ".canonical.tmp")
+    if temporary.exists():
+        temporary.unlink()
+    try:
+        with ZipFile(temporary, "w", compression=ZIP_STORED, strict_timestamps=True) as archive:
+            for name in sorted(members):
+                is_directory = name in directory_names or name.endswith("/")
+                payload = b"" if is_directory else members[name]
+                info = _canonical_zip_info(
+                    name,
+                    timestamp=timestamp,
+                    is_directory=is_directory,
+                )
+                archive.writestr(info, payload)
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+    after_sha256 = _sha256_file(path)
+    with ZipFile(path, "r") as archive:
+        rewritten = {item.filename: archive.read(item.filename) for item in archive.infolist()}
+        rewritten_infos = archive.infolist()
+    _verify_record(rewritten, record_name=record_name)
+    _require(
+        [item.filename for item in rewritten_infos] == sorted(rewritten),
+        f"canonical wheel member order is not lexical: {path.name}",
+    )
+    for item in rewritten_infos:
+        _require(item.date_time == timestamp, f"non-canonical ZIP timestamp: {item.filename}")
+        _require(item.create_system == 3, f"non-canonical ZIP creator: {item.filename}")
+        _require(item.compress_type == ZIP_STORED, f"non-canonical compression: {item.filename}")
+        expected_attr = _canonical_mode(
+            item.filename, is_directory=item.is_dir()
+        ) << 16
+        if item.is_dir():
+            expected_attr |= 0x10
+        _require(
+            item.external_attr == expected_attr,
+            f"non-canonical ZIP mode for {item.filename}: "
+            f"expected {expected_attr}, observed {item.external_attr}",
+        )
+
+    return {
+        "schema": CANONICALIZATION_SCHEMA,
+        "wheel": path.name,
+        "sha256_before": before_sha256,
+        "sha256_after": after_sha256,
+        "source_date_epoch": source_date_epoch,
+        "zip_datetime_utc": list(timestamp),
+        "compression": "stored",
+        "create_system": 3,
+        "default_file_mode": oct(CANONICAL_FILE_MODE),
+        "script_mode": oct(CANONICAL_SCRIPT_MODE),
+        "normalized_text_members": normalized_text,
+        "record": record_name,
+    }
+
+
 def _wheel_metadata(path: Path) -> dict[str, Any]:
     with ZipFile(path) as archive:
         members = archive.infolist()
-        metadata_names = [item.filename for item in members if item.filename.endswith(".dist-info/METADATA")]
-        _require(len(metadata_names) == 1, f"{path.name}: expected exactly one METADATA member")
+        metadata_names = [
+            item.filename
+            for item in members
+            if item.filename.endswith(".dist-info/METADATA")
+        ]
+        _require(
+            len(metadata_names) == 1,
+            f"{path.name}: expected exactly one METADATA member",
+        )
         message = Parser().parsestr(
             archive.read(metadata_names[0]).decode("utf-8", errors="strict")
         )
         name = message.get("Name")
         version = message.get("Version")
-        _require(bool(name) and bool(version), f"{path.name}: missing distribution name/version")
+        _require(
+            bool(name) and bool(version),
+            f"{path.name}: missing distribution name/version",
+        )
         zip_entries = [
             {
                 "name": item.filename,
@@ -138,7 +376,10 @@ def _wheel_metadata(path: Path) -> dict[str, Any]:
             }
             for item in members
         ]
-    _require(path.name.endswith("-py3-none-any.whl"), f"default release wheel is not platform-independent: {path.name}")
+    _require(
+        path.name.endswith("-py3-none-any.whl"),
+        f"default release wheel is not platform-independent: {path.name}",
+    )
     zip_metadata_sha = hashlib.sha256(
         json.dumps(zip_entries, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
@@ -184,10 +425,12 @@ def build_release(
     env["SOURCE_DATE_EPOCH"] = str(source_date_epoch)
     env["PYTHONHASHSEED"] = "0"
 
-    built_paths: list[Path] = []
     for item in selected:
         package_root = (repo_root / item["path"]).resolve()
-        _require(package_root.is_dir(), f"release package directory does not exist: {package_root}")
+        _require(
+            package_root.is_dir(),
+            f"release package directory does not exist: {package_root}",
+        )
         _clean_build_state(package_root)
         try:
             subprocess.run(
@@ -209,15 +452,22 @@ def build_release(
             _clean_build_state(package_root)
 
     built_paths = sorted(output.glob("*.whl"))
-    _require(len(built_paths) == len(selected), (
-        f"expected {len(selected)} release wheels, built {len(built_paths)}"
-    ))
+    _require(
+        len(built_paths) == len(selected),
+        f"expected {len(selected)} release wheels, built {len(built_paths)}",
+    )
+    canonicalization = [
+        _canonicalize_wheel(path, source_date_epoch=source_date_epoch)
+        for path in built_paths
+    ]
     artifacts = [_wheel_metadata(path) for path in built_paths]
     expected_names = sorted(_canonical_name(item["distribution"]) for item in selected)
     observed_names = sorted(item["canonical_name"] for item in artifacts)
-    _require(observed_names == expected_names, (
-        f"built release distribution set differs from policy: {observed_names} != {expected_names}"
-    ))
+    _require(
+        observed_names == expected_names,
+        f"built release distribution set differs from policy: "
+        f"{observed_names} != {expected_names}",
+    )
 
     manifest = {
         "schema": SCHEMA,
@@ -231,6 +481,7 @@ def build_release(
             "python_implementation": platform.python_implementation(),
             "toolchain": toolchain,
             "python_hash_seed": env["PYTHONHASHSEED"],
+            "wheel_canonicalization": CANONICALIZATION_SCHEMA,
         },
         "builder_environment": {
             "system": platform.system(),
@@ -238,11 +489,13 @@ def build_release(
             "platform": platform.platform(),
             "python_executable": sys.executable,
         },
+        "canonicalization": canonicalization,
         "artifacts": artifacts,
     }
     manifest_path = output / "reproducible-build-manifest.json"
     manifest_path.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
     return manifest
 
@@ -265,7 +518,10 @@ def main() -> int:
             source_date_epoch=args.source_date_epoch,
         )
     except Exception as exc:
-        print(f"reproducible release build failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        print(
+            f"reproducible release build failed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
         return 1
     return 0
 

--- a/scripts/build_reproducible_release.py
+++ b/scripts/build_reproducible_release.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Build the default neurOS release wheels under an explicit build authority.
+
+This builder is intentionally narrower than the ordinary release workflow. It
+expects the caller to install the hash-pinned Python 3.11 build toolchain first,
+requires the source commit timestamp as SOURCE_DATE_EPOCH, disables PEP 517
+build isolation, and emits diagnostics sufficient to explain byte-level wheel
+drift across independent builders.
+
+A passing invocation proves only that one builder produced a self-consistent
+set of platform-independent wheels. Cross-builder reproducibility is established
+separately by ``check_reproducible_wheels.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from email.parser import Parser
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+from zipfile import ZipFile
+
+SCHEMA = "neuros.reproducible_release_build.v1"
+TOOLCHAIN_DISTRIBUTIONS = (
+    "pip",
+    "build",
+    "setuptools",
+    "wheel",
+    "packaging",
+    "pyproject-hooks",
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_name(value: str) -> str:
+    return value.lower().replace("_", "-").replace(".", "-")
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args], cwd=repo_root, text=True, stderr=subprocess.STDOUT
+    ).strip()
+
+
+def _source_authority(repo_root: Path, revision: str, source_date_epoch: int) -> dict[str, Any]:
+    head = _git(repo_root, "rev-parse", "HEAD")
+    _require(head == revision, f"checkout drift: expected {revision}, observed {head}")
+    _require(
+        len(revision) == 40 and all(ch in "0123456789abcdef" for ch in revision),
+        "source revision must be a 40-character lowercase git SHA",
+    )
+    tracked_status = _git(repo_root, "status", "--porcelain", "--untracked-files=no")
+    _require(not tracked_status, f"tracked source tree is dirty before build: {tracked_status}")
+    commit_epoch_text = _git(repo_root, "show", "-s", "--format=%ct", revision)
+    _require(commit_epoch_text.isdigit(), "source commit timestamp is not an integer")
+    commit_epoch = int(commit_epoch_text)
+    _require(source_date_epoch == commit_epoch, (
+        "SOURCE_DATE_EPOCH must equal the exact source commit timestamp: "
+        f"expected {commit_epoch}, observed {source_date_epoch}"
+    ))
+    return {
+        "revision": revision,
+        "commit_timestamp_epoch": commit_epoch,
+        "source_date_epoch": source_date_epoch,
+    }
+
+
+def _selected_packages(repo_root: Path) -> list[dict[str, Any]]:
+    payload = json.loads(
+        subprocess.check_output(
+            [sys.executable, repo_root / "scripts/list_release_packages.py", "--json"],
+            cwd=repo_root,
+            text=True,
+        )
+    )
+    _require(payload.get("schema") == "neuros.release_package_inventory.v1", "unexpected release policy inventory schema")
+    packages = payload.get("packages")
+    _require(isinstance(packages, list) and packages, "release policy selected no packages")
+    _require(payload.get("count") == len(packages), "release policy count does not match selected package list")
+    return packages
+
+
+def _clean_build_state(package_root: Path) -> None:
+    for path in (package_root / "build", package_root / "dist"):
+        if path.exists():
+            shutil.rmtree(path)
+    for parent in (package_root, package_root / "src"):
+        if not parent.is_dir():
+            continue
+        for path in parent.glob("*.egg-info"):
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+
+
+def _wheel_metadata(path: Path) -> dict[str, Any]:
+    with ZipFile(path) as archive:
+        members = archive.infolist()
+        metadata_names = [item.filename for item in members if item.filename.endswith(".dist-info/METADATA")]
+        _require(len(metadata_names) == 1, f"{path.name}: expected exactly one METADATA member")
+        message = Parser().parsestr(
+            archive.read(metadata_names[0]).decode("utf-8", errors="strict")
+        )
+        name = message.get("Name")
+        version = message.get("Version")
+        _require(bool(name) and bool(version), f"{path.name}: missing distribution name/version")
+        zip_entries = [
+            {
+                "name": item.filename,
+                "date_time": list(item.date_time),
+                "compress_type": item.compress_type,
+                "crc": item.CRC,
+                "compressed_size": item.compress_size,
+                "file_size": item.file_size,
+                "external_attr": item.external_attr,
+                "create_system": item.create_system,
+            }
+            for item in members
+        ]
+    _require(path.name.endswith("-py3-none-any.whl"), f"default release wheel is not platform-independent: {path.name}")
+    zip_metadata_sha = hashlib.sha256(
+        json.dumps(zip_entries, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return {
+        "name": str(name),
+        "canonical_name": _canonical_name(str(name)),
+        "version": str(version),
+        "file": path.name,
+        "bytes": path.stat().st_size,
+        "sha256": _sha256_file(path),
+        "zip_metadata_sha256": zip_metadata_sha,
+        "zip_entries": zip_entries,
+    }
+
+
+def _toolchain_identity() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    for distribution in TOOLCHAIN_DISTRIBUTIONS:
+        versions[distribution] = metadata.version(distribution)
+    try:
+        versions["colorama"] = metadata.version("colorama")
+    except metadata.PackageNotFoundError:
+        versions["colorama"] = "absent"
+    return versions
+
+
+def build_release(
+    *,
+    repo_root: Path,
+    output: Path,
+    source_revision: str,
+    source_date_epoch: int,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    output = output.resolve()
+    _require(not output.exists(), f"output already exists: {output}")
+    output.mkdir(parents=True)
+
+    source = _source_authority(repo_root, source_revision, source_date_epoch)
+    selected = _selected_packages(repo_root)
+    toolchain = _toolchain_identity()
+    env = dict(os.environ)
+    env["SOURCE_DATE_EPOCH"] = str(source_date_epoch)
+    env["PYTHONHASHSEED"] = "0"
+
+    built_paths: list[Path] = []
+    for item in selected:
+        package_root = (repo_root / item["path"]).resolve()
+        _require(package_root.is_dir(), f"release package directory does not exist: {package_root}")
+        _clean_build_state(package_root)
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "build",
+                    "--no-isolation",
+                    "--wheel",
+                    "--outdir",
+                    str(output),
+                    str(package_root),
+                ],
+                cwd=repo_root,
+                env=env,
+                check=True,
+            )
+        finally:
+            _clean_build_state(package_root)
+
+    built_paths = sorted(output.glob("*.whl"))
+    _require(len(built_paths) == len(selected), (
+        f"expected {len(selected)} release wheels, built {len(built_paths)}"
+    ))
+    artifacts = [_wheel_metadata(path) for path in built_paths]
+    expected_names = sorted(_canonical_name(item["distribution"]) for item in selected)
+    observed_names = sorted(item["canonical_name"] for item in artifacts)
+    _require(observed_names == expected_names, (
+        f"built release distribution set differs from policy: {observed_names} != {expected_names}"
+    ))
+
+    manifest = {
+        "schema": SCHEMA,
+        "source": source,
+        "policy": {
+            "count": len(selected),
+            "distributions": expected_names,
+        },
+        "build_authority": {
+            "python_version": platform.python_version(),
+            "python_implementation": platform.python_implementation(),
+            "toolchain": toolchain,
+            "python_hash_seed": env["PYTHONHASHSEED"],
+        },
+        "builder_environment": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "platform": platform.platform(),
+            "python_executable": sys.executable,
+        },
+        "artifacts": artifacts,
+    }
+    manifest_path = output / "reproducible-build-manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--source-date-epoch", type=int, required=True)
+    args = parser.parse_args()
+
+    if args.source_date_epoch <= 0:
+        raise SystemExit("--source-date-epoch must be positive")
+    try:
+        build_release(
+            repo_root=args.repo_root,
+            output=args.output,
+            source_revision=args.source_revision,
+            source_date_epoch=args.source_date_epoch,
+        )
+    except Exception as exc:
+        print(f"reproducible release build failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_reproducible_wheels.py
+++ b/scripts/check_reproducible_wheels.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Compare independent neurOS release builds for byte-for-byte reproducibility."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+BUILD_SCHEMA = "neuros.reproducible_release_build.v1"
+REPORT_SCHEMA = "neuros.reproducible_release_comparison.v1"
+CORE_TOOLCHAIN = (
+    "pip",
+    "build",
+    "setuptools",
+    "wheel",
+    "packaging",
+    "pyproject-hooks",
+)
+
+
+def _load_build(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    manifest_path = root / "reproducible-build-manifest.json"
+    if not manifest_path.is_file():
+        raise RuntimeError(f"build manifest is missing: {manifest_path}")
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if payload.get("schema") != BUILD_SCHEMA:
+        raise RuntimeError(f"unexpected build manifest schema in {manifest_path}")
+    payload["_root"] = str(root)
+    return payload
+
+
+def _artifact_map(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows = payload.get("artifacts")
+    if not isinstance(rows, list) or not rows:
+        raise RuntimeError(f"build has no artifacts: {payload.get('_root')}")
+    result: dict[str, dict[str, Any]] = {}
+    for item in rows:
+        if not isinstance(item, dict):
+            raise RuntimeError("artifact entry is not an object")
+        name = str(item.get("canonical_name", ""))
+        if not name or name in result:
+            raise RuntimeError(f"invalid or duplicate canonical artifact name: {name!r}")
+        result[name] = item
+    return result
+
+
+def _zip_diff(reference: dict[str, Any], observed: dict[str, Any]) -> dict[str, Any]:
+    ref_entries = {item["name"]: item for item in reference.get("zip_entries", [])}
+    obs_entries = {item["name"]: item for item in observed.get("zip_entries", [])}
+    names = sorted(set(ref_entries) | set(obs_entries))
+    differences: dict[str, Any] = {}
+    for name in names:
+        left = ref_entries.get(name)
+        right = obs_entries.get(name)
+        if left is None or right is None:
+            differences[name] = {"reference": left, "observed": right}
+            continue
+        fields = (
+            "date_time",
+            "compress_type",
+            "crc",
+            "compressed_size",
+            "file_size",
+            "external_attr",
+            "create_system",
+        )
+        drift = {
+            field: {"reference": left.get(field), "observed": right.get(field)}
+            for field in fields
+            if left.get(field) != right.get(field)
+        }
+        if drift:
+            differences[name] = drift
+    return differences
+
+
+def compare_builds(builds: list[dict[str, Any]]) -> dict[str, Any]:
+    if len(builds) < 2:
+        raise RuntimeError("at least two independent builds are required")
+    reference = builds[0]
+    ref_artifacts = _artifact_map(reference)
+    mismatches: list[dict[str, Any]] = []
+
+    ref_source = reference.get("source")
+    ref_policy = reference.get("policy")
+    ref_authority = reference.get("build_authority", {})
+    ref_toolchain = ref_authority.get("toolchain", {})
+
+    for observed in builds[1:]:
+        root = observed.get("_root")
+        if observed.get("source") != ref_source:
+            mismatches.append({
+                "kind": "source_authority",
+                "build": root,
+                "reference": ref_source,
+                "observed": observed.get("source"),
+            })
+        if observed.get("policy") != ref_policy:
+            mismatches.append({
+                "kind": "release_policy",
+                "build": root,
+                "reference": ref_policy,
+                "observed": observed.get("policy"),
+            })
+
+        authority = observed.get("build_authority", {})
+        for field in ("python_version", "python_implementation", "python_hash_seed"):
+            if authority.get(field) != ref_authority.get(field):
+                mismatches.append({
+                    "kind": "build_authority",
+                    "field": field,
+                    "build": root,
+                    "reference": ref_authority.get(field),
+                    "observed": authority.get(field),
+                })
+        toolchain = authority.get("toolchain", {})
+        for distribution in CORE_TOOLCHAIN:
+            if toolchain.get(distribution) != ref_toolchain.get(distribution):
+                mismatches.append({
+                    "kind": "build_toolchain",
+                    "distribution": distribution,
+                    "build": root,
+                    "reference": ref_toolchain.get(distribution),
+                    "observed": toolchain.get(distribution),
+                })
+
+        artifacts = _artifact_map(observed)
+        if set(artifacts) != set(ref_artifacts):
+            mismatches.append({
+                "kind": "artifact_set",
+                "build": root,
+                "reference": sorted(ref_artifacts),
+                "observed": sorted(artifacts),
+            })
+            continue
+
+        for name in sorted(ref_artifacts):
+            left = ref_artifacts[name]
+            right = artifacts[name]
+            identity_fields = ("name", "version", "file", "bytes", "sha256")
+            drift = {
+                field: {"reference": left.get(field), "observed": right.get(field)}
+                for field in identity_fields
+                if left.get(field) != right.get(field)
+            }
+            if drift:
+                mismatch: dict[str, Any] = {
+                    "kind": "wheel_identity",
+                    "distribution": name,
+                    "build": root,
+                    "drift": drift,
+                }
+                if left.get("sha256") != right.get("sha256"):
+                    mismatch["zip_metadata_drift"] = _zip_diff(left, right)
+                mismatches.append(mismatch)
+
+    builders = [
+        {
+            "root": item.get("_root"),
+            "environment": item.get("builder_environment"),
+            "toolchain": item.get("build_authority", {}).get("toolchain"),
+        }
+        for item in builds
+    ]
+    artifact_identity = {
+        name: {
+            "file": row.get("file"),
+            "bytes": row.get("bytes"),
+            "sha256": row.get("sha256"),
+        }
+        for name, row in sorted(ref_artifacts.items())
+    }
+    return {
+        "schema": REPORT_SCHEMA,
+        "status": "pass" if not mismatches else "fail",
+        "build_count": len(builds),
+        "source": ref_source,
+        "policy": ref_policy,
+        "builders": builders,
+        "reference_artifacts": artifact_identity,
+        "mismatches": mismatches,
+        "claim_boundary": {
+            "byte_identical_wheels": not mismatches,
+            "runtime_dependency_environment_reproduced": False,
+            "scientific_result_reproduced": False,
+            "statement": (
+                "A passing comparison establishes byte-identical default pure-Python "
+                "wheel artifacts under the recorded build authority. It does not establish "
+                "reproducibility of downstream dependency resolution, runtime numerics, "
+                "hardware behavior, or scientific results."
+            ),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("builds", nargs="+", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        builds = [_load_build(path) for path in args.builds]
+        report = compare_builds(builds)
+    except Exception as exc:
+        print(f"reproducible wheel comparison failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    if report["status"] != "pass":
+        print("release wheels are not byte-reproducible; inspect comparison report", file=sys.stderr)
+        return 1
+    print(f"reproducible release wheels: PASS ({report['build_count']} independent builds)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_reproducible_release_build.py
+++ b/tests/test_reproducible_release_build.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import base64
+import csv
+import hashlib
 import importlib.util
+import io
 from copy import deepcopy
 from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile, ZipInfo
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -21,7 +26,9 @@ checker = _load_script("check_reproducible_wheels.py")
 builder = _load_script("build_reproducible_release.py")
 
 
-def _manifest(*, root: str, sha: str = "a" * 64, external_attr: int = 2175008768):
+def _manifest(
+    *, root: str, sha: str = "a" * 64, external_attr: int = 2175008768
+):
     return {
         "schema": checker.BUILD_SCHEMA,
         "_root": root,
@@ -35,7 +42,7 @@ def _manifest(*, root: str, sha: str = "a" * 64, external_attr: int = 2175008768
             "distributions": ["neuros"],
         },
         "build_authority": {
-            "python_version": "3.11.16",
+            "python_version": "3.11.9",
             "python_implementation": "CPython",
             "python_hash_seed": "0",
             "toolchain": {
@@ -77,6 +84,40 @@ def _manifest(*, root: str, sha: str = "a" * 64, external_attr: int = 2175008768
     }
 
 
+def _raw_test_wheel(path: Path, *, windows_style: bool) -> None:
+    members = {
+        "demo/__init__.py": b"VALUE = 1\n",
+        "demo-1.0.0.dist-info/METADATA": (
+            b"Metadata-Version: 2.1\r\nName: demo\r\nVersion: 1.0.0\r\n\r\n"
+            if windows_style
+            else b"Metadata-Version: 2.1\nName: demo\nVersion: 1.0.0\n\n"
+        ),
+        "demo-1.0.0.dist-info/WHEEL": (
+            b"Wheel-Version: 1.0\r\nGenerator: test\r\nRoot-Is-Purelib: true\r\n"
+            b"Tag: py3-none-any\r\n"
+            if windows_style
+            else b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+        ),
+        "demo-1.0.0.dist-info/RECORD": b"stale,sha256=not-authoritative,1\r\n",
+    }
+    with ZipFile(path, "w", compression=ZIP_DEFLATED) as archive:
+        for name, payload in reversed(list(members.items())):
+            info = ZipInfo(name, (2026, 8, 30, 12, 34, 56))
+            info.compress_type = ZIP_DEFLATED
+            info.create_system = 0 if windows_style else 3
+            info.external_attr = (
+                0o100666 << 16 if windows_style else 0o100644 << 16
+            )
+            archive.writestr(info, payload)
+
+
+def _urlsafe_sha256(payload: bytes) -> str:
+    digest = hashlib.sha256(payload).digest()
+    encoded = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"sha256={encoded}"
+
+
 def test_identical_builds_pass_even_with_platform_only_colorama_difference():
     left = _manifest(root="linux")
     right = deepcopy(left)
@@ -98,7 +139,9 @@ def test_wheel_hash_drift_fails_and_reports_zip_metadata_cause():
     report = checker.compare_builds([left, right])
 
     assert report["status"] == "fail"
-    mismatch = next(item for item in report["mismatches"] if item["kind"] == "wheel_identity")
+    mismatch = next(
+        item for item in report["mismatches"] if item["kind"] == "wheel_identity"
+    )
     assert mismatch["distribution"] == "neuros"
     assert "sha256" in mismatch["drift"]
     assert mismatch["zip_metadata_drift"]["neuros/__init__.py"]["external_attr"] == {
@@ -129,7 +172,8 @@ def test_core_build_toolchain_drift_fails_closed():
 
     assert report["status"] == "fail"
     assert any(
-        item["kind"] == "build_toolchain" and item["distribution"] == "setuptools"
+        item["kind"] == "build_toolchain"
+        and item["distribution"] == "setuptools"
         for item in report["mismatches"]
     )
 
@@ -137,3 +181,65 @@ def test_core_build_toolchain_drift_fails_closed():
 def test_builder_canonicalizes_distribution_names():
     assert builder._canonical_name("NeurOS_Core") == "neuros-core"
     assert builder._canonical_name("neuros.models") == "neuros-models"
+
+
+def test_canonical_wheel_normalizes_windows_and_unix_containers(tmp_path: Path):
+    windows = tmp_path / "windows" / "demo-1.0.0-py3-none-any.whl"
+    unix = tmp_path / "unix" / "demo-1.0.0-py3-none-any.whl"
+    windows.parent.mkdir()
+    unix.parent.mkdir()
+    _raw_test_wheel(windows, windows_style=True)
+    _raw_test_wheel(unix, windows_style=False)
+
+    epoch = 1_800_000_001
+    windows_receipt = builder._canonicalize_wheel(
+        windows, source_date_epoch=epoch
+    )
+    unix_receipt = builder._canonicalize_wheel(unix, source_date_epoch=epoch)
+
+    assert windows.read_bytes() == unix.read_bytes()
+    assert windows_receipt["sha256_after"] == unix_receipt["sha256_after"]
+    assert windows_receipt["sha256_before"] != windows_receipt["sha256_after"]
+    assert windows_receipt["zip_datetime_utc"][-1] % 2 == 0
+
+    with ZipFile(windows) as archive:
+        infos = archive.infolist()
+        names = [item.filename for item in infos]
+        assert names == sorted(names)
+        assert all(item.create_system == 3 for item in infos)
+        assert all(item.compress_type == ZIP_STORED for item in infos)
+        assert all(item.external_attr == 0o100644 << 16 for item in infos)
+        metadata_payload = archive.read("demo-1.0.0.dist-info/METADATA")
+        wheel_payload = archive.read("demo-1.0.0.dist-info/WHEEL")
+        assert b"\r" not in metadata_payload
+        assert b"\r" not in wheel_payload
+
+
+def test_canonical_wheel_rebuilds_record_from_canonical_bytes(tmp_path: Path):
+    wheel = tmp_path / "demo-1.0.0-py3-none-any.whl"
+    _raw_test_wheel(wheel, windows_style=True)
+    builder._canonicalize_wheel(wheel, source_date_epoch=1_800_000_000)
+
+    record_name = "demo-1.0.0.dist-info/RECORD"
+    with ZipFile(wheel) as archive:
+        members = {item.filename: archive.read(item.filename) for item in archive.infolist()}
+    rows = list(csv.reader(io.StringIO(members[record_name].decode("utf-8"))))
+    assert [row[0] for row in rows[:-1]] == sorted(
+        name for name in members if name != record_name
+    )
+    assert rows[-1] == [record_name, "", ""]
+    for name, digest, size in rows[:-1]:
+        assert digest == _urlsafe_sha256(members[name])
+        assert int(size) == len(members[name])
+    assert b"\r" not in members[record_name]
+
+
+def test_canonicalizer_rejects_non_platform_independent_wheel(tmp_path: Path):
+    wheel = tmp_path / "demo-1.0.0-cp311-cp311-win_amd64.whl"
+    _raw_test_wheel(wheel, windows_style=True)
+    try:
+        builder._canonicalize_wheel(wheel, source_date_epoch=1_800_000_000)
+    except RuntimeError as exc:
+        assert "platform-independent" in str(exc)
+    else:
+        raise AssertionError("platform-specific wheel unexpectedly canonicalized")

--- a/tests/test_reproducible_release_build.py
+++ b/tests/test_reproducible_release_build.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib.util
+from copy import deepcopy
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str):
+    path = ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_script("check_reproducible_wheels.py")
+builder = _load_script("build_reproducible_release.py")
+
+
+def _manifest(*, root: str, sha: str = "a" * 64, external_attr: int = 2175008768):
+    return {
+        "schema": checker.BUILD_SCHEMA,
+        "_root": root,
+        "source": {
+            "revision": "1" * 40,
+            "commit_timestamp_epoch": 1_800_000_000,
+            "source_date_epoch": 1_800_000_000,
+        },
+        "policy": {
+            "count": 1,
+            "distributions": ["neuros"],
+        },
+        "build_authority": {
+            "python_version": "3.11.16",
+            "python_implementation": "CPython",
+            "python_hash_seed": "0",
+            "toolchain": {
+                "pip": "26.2.1",
+                "build": "1.6.0",
+                "setuptools": "84.0.0",
+                "wheel": "0.48.0",
+                "packaging": "26.3",
+                "pyproject-hooks": "1.2.0",
+                "colorama": "absent",
+            },
+        },
+        "builder_environment": {
+            "system": "Linux",
+            "machine": "x86_64",
+        },
+        "artifacts": [
+            {
+                "name": "neuros",
+                "canonical_name": "neuros",
+                "version": "2.1.0",
+                "file": "neuros-2.1.0-py3-none-any.whl",
+                "bytes": 123,
+                "sha256": sha,
+                "zip_entries": [
+                    {
+                        "name": "neuros/__init__.py",
+                        "date_time": [2027, 1, 15, 8, 0, 0],
+                        "compress_type": 8,
+                        "crc": 1234,
+                        "compressed_size": 20,
+                        "file_size": 30,
+                        "external_attr": external_attr,
+                        "create_system": 3,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_identical_builds_pass_even_with_platform_only_colorama_difference():
+    left = _manifest(root="linux")
+    right = deepcopy(left)
+    right["_root"] = "windows"
+    right["builder_environment"] = {"system": "Windows", "machine": "AMD64"}
+    right["build_authority"]["toolchain"]["colorama"] = "0.4.6"
+
+    report = checker.compare_builds([left, right])
+
+    assert report["status"] == "pass"
+    assert report["claim_boundary"]["byte_identical_wheels"] is True
+    assert report["mismatches"] == []
+
+
+def test_wheel_hash_drift_fails_and_reports_zip_metadata_cause():
+    left = _manifest(root="linux")
+    right = _manifest(root="windows", sha="b" * 64, external_attr=123)
+
+    report = checker.compare_builds([left, right])
+
+    assert report["status"] == "fail"
+    mismatch = next(item for item in report["mismatches"] if item["kind"] == "wheel_identity")
+    assert mismatch["distribution"] == "neuros"
+    assert "sha256" in mismatch["drift"]
+    assert mismatch["zip_metadata_drift"]["neuros/__init__.py"]["external_attr"] == {
+        "reference": 2175008768,
+        "observed": 123,
+    }
+
+
+def test_source_authority_drift_is_not_masked_by_identical_wheels():
+    left = _manifest(root="one")
+    right = deepcopy(left)
+    right["_root"] = "two"
+    right["source"]["source_date_epoch"] += 1
+
+    report = checker.compare_builds([left, right])
+
+    assert report["status"] == "fail"
+    assert any(item["kind"] == "source_authority" for item in report["mismatches"])
+
+
+def test_core_build_toolchain_drift_fails_closed():
+    left = _manifest(root="one")
+    right = deepcopy(left)
+    right["_root"] = "two"
+    right["build_authority"]["toolchain"]["setuptools"] = "85.0.0"
+
+    report = checker.compare_builds([left, right])
+
+    assert report["status"] == "fail"
+    assert any(
+        item["kind"] == "build_toolchain" and item["distribution"] == "setuptools"
+        for item in report["mismatches"]
+    )
+
+
+def test_builder_canonicalizes_distribution_names():
+    assert builder._canonical_name("NeurOS_Core") == "neuros-core"
+    assert builder._canonical_name("neuros.models") == "neuros-models"


### PR DESCRIPTION
## Purpose

Turn the reproducibility defect uncovered by #120 into an executable release invariant and then promote the proven deterministic builder into the actual Release Candidate path.

#120 proved the installed product behaves consistently across Ubuntu x64, Windows x64, and macOS ARM64, but independent artifact inspection found that wheels built from the same exact source revision had different SHA-256 identities across ambient builders. This PR closes that supply-chain gap without moving frozen `main`.

## Exact qualified head

`6e0544f4d2bd45ec26b6c5701e6a8db9320ec812`

Every qualification statement below refers to this exact head.

## Deterministic build authority

The independent builders use common CPython 3.11.9 plus a hash-pinned build frontend/backend installed with `--only-binary=:all: --require-hashes`:

- pip 26.2.1
- build 1.6.0
- setuptools 84.0.0
- wheel 0.48.0
- packaging 26.3
- pyproject-hooks 1.2.0
- colorama 0.4.6 only on Windows

PEP 517 isolation is disabled so the build backend cannot silently resolve another setuptools/wheel environment.

`scripts/build_reproducible_release.py` additionally requires an exact clean source revision, binds `SOURCE_DATE_EPOCH` to that commit, fixes `PYTHONHASHSEED=0`, derives the default wheel set from release policy, cleans generated setuptools state, and canonicalizes the platform-independent wheel container.

## Wheel canonicalization

The cross-platform defect was isolated to container representation rather than semantic package content. Windows emitted CRLF build metadata and Windows ZIP creator/permission fields. The canonicalizer now:

- normalizes backend-controlled text metadata to LF;
- rebuilds `.dist-info/RECORD` from canonical member bytes;
- writes members in lexical order;
- binds ZIP timestamps to the exact source commit;
- normalizes ZIP creator and file modes to one Unix representation;
- uses `ZIP_STORED` so zlib version is not an undeclared build input;
- accepts only the default `py3-none-any` release wheels.

Synthetic tests construct divergent Windows-style and Unix-style wheels, canonicalize both, require the entire output byte stream to match, and independently verify every RECORD SHA-256 and size.

## Reproducible Release Build

Exact-head run `33353577693` is fully green:

- Ubuntu 24.04 x64 builds the release twice identically: PASS
- macOS 14 ARM64 builds the release twice identically: PASS
- Windows 2025 x64 builds the release twice identically: PASS
- helper/fail-closed contracts: PASS
- cross-OS byte identity: PASS
- stable terminal `Reproducible Release Build`: PASS

Cross-builder artifact ID: `9744411354`
GitHub ZIP digest: `sha256:e04690806a3f658d53155b706b6224fd4da2980ee7bff1eec8a56a0245150251`

Independent download/re-hash matched that GitHub digest exactly. The report binds source revision `6e0544f4d2bd45ec26b6c5701e6a8db9320ec812`, has `mismatches: []`, and proves all three builders produced the same four wheel identities.

## Actual Release Candidate promotion

The release-candidate workflow now uses the same deterministic builder rather than ambient `python -m build`. Verification tooling is installed only after the authoritative wheel bytes exist.

Exact-head Release Candidate run `33353577677` is fully green:

- exact source checkout: PASS
- hash-pinned build authority: PASS
- canonical wheel construction: PASS
- public contracts/docs/CFF: PASS
- Twine metadata: PASS
- wheel ownership: PASS
- internal dependency closure: PASS
- component namespace without SDK: PASS
- self-describing release manifest: PASS
- SHA256SUMS verification: PASS
- clean SDK smoke-install / doctor / compatibility: PASS
- publishing remains intentionally disabled: PASS

Release artifact ID: `9744416761`
GitHub ZIP digest: `sha256:0490c646361af27074bdbc715502b93cedd139067a686a70a1b4755ba08580c8`

Independent download/re-hash matched the GitHub digest exactly.

The release bundle's `release-manifest.json` is now schema v3 and SHA-binds `reproducible-build-manifest.json`. The four wheel SHA-256s in the release bundle match the three-builder cross-platform reference exactly:

- `neuros-2.1.0-py3-none-any.whl`: `d523a22032d41e50a0742b81d3630f5916b4135b8b33e7af38fe48d55414a1d5`
- `neuros_core-2.0.0-py3-none-any.whl`: `da78112473cc0a3167d3988bc92ab467d2ee537dd74ba20b2c997d9888fd55f4`
- `neuros_drivers-2.1.0-py3-none-any.whl`: `4b7f6ce7e0fc6c8601c34b59e14d8588be35a0c85d3e165f3504055f2d1c6c21`
- `neuros_models-2.1.0-py3-none-any.whl`: `1ee59c150d69c2e3b81c99eb8b43753ccbf5ffdb0e02f20c5025b37e5df14941`

The embedded reproducible-build manifest SHA is `83a9c3ab325beed1d987b87877930e739be3582afc08682a4df504731a2abc9f`.

## Other exact-head contracts

On the same exact head, all triggered inherited workflows are green:

- neurOS CI
- Public Trust Contracts
- Packaging Contracts
- Packaging Uninstall Contract
- Reproducible Release Build
- Release Candidate Artifacts

## Diagnostic history

Superseded `97a3c838...` proved Ubuntu within-builder repeatability but found that CPython 3.11.16 is unavailable on macOS 14 ARM64. Builders were therefore pinned to common 3.11.9.

Superseded `bdf31912...` proved all three builders individually deterministic and showed Linux/macOS byte-identical, while Windows differed only in CRLF metadata and ZIP creator/mode representation. That evidence directly motivated the wheel canonicalizer. We did not weaken the equality requirement.

## Claim boundary

This PR establishes byte-identical default pure-Python release artifacts under the recorded build authority and proves the actual Release Candidate path emits those same bytes.

It does **not** establish reproducibility of arbitrary downstream dependency resolution, numerical floating-point behavior on physical hardware, neural efficacy, clinical validity, or promoted Kumar2024 results.

## Governance / stacking

- base: exact-qualified #120 branch `test/full-package-qualification-v1`
- branch started from #120 head `0e04c062ce4acb8037ed059c45d9801f73982fbf`
- no change to frozen `main`
- no Kumar2024 worker/model execution or scientific authority mutation
- keep draft until the authorized one-shard systems qualification is consumed and the stacked release chain is ready to advance

Repository rulesets remain a separate governance gap and should not be conflated with artifact reproducibility.