### PR TITLE
Runtime execution authority: fail closed on unsupported declarations

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -10,6 +10,7 @@ on:
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
       - "tests/test_runtime_fusion_cancellation.py"
+      - "tests/test_runtime_execution_authority.py"
   push:
     branches:
       - main
@@ -21,6 +22,7 @@ on:
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
       - "tests/test_runtime_fusion_cancellation.py"
+      - "tests/test_runtime_execution_authority.py"
   workflow_dispatch:
 
 permissions:
@@ -86,7 +88,8 @@ jobs:
             tests/test_runtime_executor.py \
             tests/test_runtime_queues.py \
             tests/test_runtime_fault_qualification.py \
-            tests/test_runtime_fusion_cancellation.py
+            tests/test_runtime_fusion_cancellation.py \
+            tests/test_runtime_execution_authority.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -140,7 +140,15 @@ _STOP = _Stop()
 
 
 def _call(func: Callable[[Any], Any], item: Any) -> Any:
-    return func(item)
+    """Execute a sync or async callback inside the current execution domain."""
+    result = func(item)
+    if not inspect.isawaitable(result):
+        return result
+
+    async def await_result() -> Any:
+        return await result
+
+    return asyncio.run(await_result())
 
 
 class RuntimeExecutor:
@@ -520,9 +528,7 @@ class RuntimeExecutor:
         if node.kind is NodeKind.SINK:
             if not hasattr(operator, "write"):
                 raise TypeError(f"Sink node {node.node_id} lacks write()")
-            result = operator.write(item)
-            if inspect.isawaitable(result):
-                await result
+            await self._invoke_callable(node, operator.write, item)
             return None
         raise ProcessingError(
             f"Unsupported unary node kind: {node.kind.value}"
@@ -538,7 +544,7 @@ class RuntimeExecutor:
                 return await result
             return result
         if execution is ExecutionClass.THREAD:
-            return await asyncio.to_thread(func, item)
+            return await asyncio.to_thread(_call, func, item)
         if execution is ExecutionClass.PROCESS:
             if self._process_pool is None:
                 self._process_pool = ProcessPoolExecutor()
@@ -576,17 +582,20 @@ class RuntimeExecutor:
             monitor = monitor_node.operator
             if not hasattr(monitor, "update"):
                 continue
+            payload = {
+                "node_id": node.node_id,
+                "kind": node.kind.value,
+                "item": item,
+                "monotonic_time_ns": time.monotonic_ns(),
+            }
+            started = time.perf_counter_ns()
             try:
-                result = monitor.update(
-                    {
-                        "node_id": node.node_id,
-                        "kind": node.kind.value,
-                        "item": item,
-                        "monotonic_time_ns": time.monotonic_ns(),
-                    }
+                await self._invoke_callable(
+                    monitor_node, monitor.update, payload
                 )
-                if inspect.isawaitable(result):
-                    await result
+                self._node_stats[monitor_node.node_id].observe(
+                    time.perf_counter_ns() - started
+                )
             except Exception as exc:
                 raise _AttributedNodeError(monitor_node.node_id, exc) from exc
 

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -35,6 +35,16 @@ class RuntimeNode:
             raise ValueError("latency_budget_ms must be positive")
         if self.executor not in {"inline", "thread", "process", "gpu"}:
             raise ValueError(f"Unsupported executor: {self.executor}")
+        if self.executor == "process":
+            raise ValueError(
+                "executor='process' is not authoritative until neurOS uses "
+                "a persistent per-node worker; see runtime execution authority"
+            )
+        if self.kind is NodeKind.SOURCE and self.executor != "inline":
+            raise ValueError(
+                "Source nodes currently require executor='inline'; source "
+                "lifecycle/stream isolation is not yet implemented"
+            )
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
 

--- a/tests/test_runtime_execution_authority.py
+++ b/tests/test_runtime_execution_authority.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from neuros.runtime import (
+    NodeKind,
+    RuntimeEdge,
+    RuntimeExecutor,
+    RuntimeGraph,
+    RuntimeNode,
+)
+
+
+class FiniteSource:
+    def __init__(self, values):
+        self.values = tuple(values)
+
+    async def start(self):
+        return None
+
+    async def stop(self):
+        return None
+
+    async def frames(self):
+        for value in self.values:
+            await asyncio.sleep(0)
+            yield value
+
+
+class CollectingSink:
+    def __init__(self):
+        self.items = []
+
+    async def write(self, item):
+        self.items.append(item)
+
+
+class SyncThreadTransform:
+    def transform(self, item):
+        return threading.get_ident(), item
+
+
+class AsyncThreadTransform:
+    async def transform(self, item):
+        await asyncio.sleep(0)
+        return threading.get_ident(), item
+
+
+class AsyncThreadSink:
+    def __init__(self):
+        self.thread_ids = []
+        self.items = []
+
+    async def write(self, item):
+        await asyncio.sleep(0)
+        self.thread_ids.append(threading.get_ident())
+        self.items.append(item)
+
+
+class AsyncThreadMonitor:
+    def __init__(self):
+        self.thread_ids = []
+        self.nodes = []
+
+    async def update(self, payload):
+        await asyncio.sleep(0)
+        self.thread_ids.append(threading.get_ident())
+        self.nodes.append(payload["node_id"])
+
+
+class FailingAsyncThreadMonitor:
+    async def update(self, payload):
+        await asyncio.sleep(0)
+        raise LookupError("thread monitor rejected " + payload["node_id"])
+
+
+def source_sink_graph(source, sink, *, sink_executor="inline"):
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, source))
+    graph.add_node(
+        RuntimeNode("sink", NodeKind.SINK, sink, executor=sink_executor)
+    )
+    graph.connect(RuntimeEdge("source", "sink", overflow="block"))
+    return graph
+
+
+def source_transform_sink_graph(transform, *, executor):
+    sink = CollectingSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource([7])))
+    graph.add_node(
+        RuntimeNode("transform", NodeKind.TRANSFORM, transform, executor=executor)
+    )
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+    graph.connect(RuntimeEdge("transform", "sink", overflow="block"))
+    return graph, sink
+
+
+def test_source_non_inline_executor_is_rejected_instead_of_ignored():
+    with pytest.raises(ValueError, match="Source nodes currently require"):
+        RuntimeNode("source", NodeKind.SOURCE, object(), executor="thread")
+
+
+def test_process_executor_is_rejected_until_per_node_worker_is_authoritative():
+    with pytest.raises(ValueError, match="not authoritative"):
+        RuntimeNode("transform", NodeKind.TRANSFORM, object(), executor="process")
+
+
+@pytest.mark.asyncio
+async def test_sync_transform_thread_executor_runs_off_event_loop_thread():
+    main_thread = threading.get_ident()
+    graph, sink = source_transform_sink_graph(SyncThreadTransform(), executor="thread")
+    await RuntimeExecutor(graph).run()
+    thread_id, value = sink.items[0]
+    assert value == 7
+    assert thread_id != main_thread
+
+
+@pytest.mark.asyncio
+async def test_async_transform_thread_executor_runs_coroutine_in_worker_thread():
+    main_thread = threading.get_ident()
+    graph, sink = source_transform_sink_graph(AsyncThreadTransform(), executor="thread")
+    await RuntimeExecutor(graph).run()
+    thread_id, value = sink.items[0]
+    assert value == 7
+    assert thread_id != main_thread
+
+
+@pytest.mark.asyncio
+async def test_async_sink_honors_thread_executor():
+    main_thread = threading.get_ident()
+    sink = AsyncThreadSink()
+    executor = RuntimeExecutor(
+        source_sink_graph(FiniteSource([3]), sink, sink_executor="thread")
+    )
+    await executor.run()
+    assert sink.items == [3]
+    assert len(sink.thread_ids) == 1
+    assert sink.thread_ids[0] != main_thread
+
+
+@pytest.mark.asyncio
+async def test_async_monitor_honors_thread_executor_and_records_success():
+    main_thread = threading.get_ident()
+    monitor = AsyncThreadMonitor()
+    graph = source_sink_graph(FiniteSource([5]), CollectingSink())
+    graph.add_node(
+        RuntimeNode("monitor", NodeKind.MONITOR, monitor, executor="thread")
+    )
+    executor = RuntimeExecutor(graph)
+    await executor.run()
+    assert monitor.nodes == ["source"]
+    assert len(monitor.thread_ids) == 1
+    assert monitor.thread_ids[0] != main_thread
+    assert executor.snapshot()["nodes"]["monitor"]["processed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_thread_monitor_failure_preserves_monitor_culprit():
+    graph = source_sink_graph(FiniteSource([11]), CollectingSink())
+    graph.add_node(
+        RuntimeNode(
+            "monitor",
+            NodeKind.MONITOR,
+            FailingAsyncThreadMonitor(),
+            executor="thread",
+        )
+    )
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="thread monitor rejected source"):
+        await executor.run()
+    assert executor.snapshot()["failure"] == {
+        "node_id": "monitor",
+        "error_type": "LookupError",
+        "message": "thread monitor rejected source",
+    }


### PR DESCRIPTION
## Purpose

Implement **Phase A of #123** directly on the exact-qualified #122 head.

This tranche makes `RuntimeNode.executor` truthful where neurOS can currently provide authority, and fails closed where it cannot.

## Exact stack

- base branch: `test/runtime-fault-qualification-v1`
- exact base SHA: `b139542bae482130968bcc93c26c33c1dd0a7ae5`
- head branch: `feat/runtime-execution-authority-v1`
- **QUALIFIED exact head SHA:** `1105e02790531877c7bd2d510e7d79c2adfcb658`
- topology: exactly one commit ahead of the qualified #122 head
- diff: exactly four intended paths

Frozen scientific `main` is untouched.

## Runtime authority semantics

1. **Sources fail closed on unsupported isolation.** `SOURCE` nodes currently require `executor="inline"`; non-inline declarations are rejected instead of silently ignored.
2. **Pooled process execution is rejected.** `executor="process"` is rejected until neurOS has a persistent per-node worker with explicit termination authority. The dormant shared `ProcessPoolExecutor` path is therefore no longer a valid runtime declaration.
3. **Sinks honor execution authority.** Sink `write()` callbacks route through the same dispatcher used by transform/decoder/fusion callbacks.
4. **Monitors honor execution authority.** Monitor `update()` callbacks route through the dispatcher, including threaded execution.
5. **Async callbacks execute inside threaded authority.** Threaded async callbacks are awaited from an event loop created inside the worker thread rather than returning a coroutine object to the runtime loop.
6. **Monitor success is observable.** Successful monitor callbacks now contribute to monitor processed/latency accounting.
7. **Monitor failure attribution remains exact.** Threaded async monitor failures preserve the monitor node as the culprit, not the producer whose emission triggered observation.

## Adversarial tests

Adds `tests/test_runtime_execution_authority.py` covering:

- source non-inline rejection;
- process declaration rejection;
- sync transform thread identity;
- async transform thread identity;
- async sink thread identity;
- async monitor thread identity plus successful execution accounting;
- threaded async monitor failure culprit preservation.

The existing Runtime Fault Qualification matrix owns this test file and executes it alongside the maintained runtime fault/cancellation suites.

## Exact-head qualification

**QUALIFIED exact head:** `1105e02790531877c7bd2d510e7d79c2adfcb658`

All **12/12 workflow suites triggered by this four-file PR completed successfully on that exact SHA**:

- Developer Preview Journey `33415856537`
- Release Candidate Artifacts `33415856580`
- Public Trust Contracts `33415856605`
- neurOS driver contracts `33415856545`
- Reproducible Release Build `33415856630`
- External Plugin Contract `33415856615`
- Runtime Fault Qualification `33415856562`
- Neural Window Contracts `33415856627`
- neurOS CI `33415856637` with **14/14 jobs green**
- Whole Package Qualification `33415856616`
- Braindecode Compatibility `33415856660`
- Ecosystem Compatibility `33415856500`

Runtime Fault Qualification passed all **9/9 OS/Python lanes plus its fail-closed umbrella**. Every lane checked out and verified the exact clean source SHA, ran with `PYTHONASYNCIODEBUG=1`, and executed **23 maintained runtime/queue/fault/authority tests**, for **207 cross-platform test executions** total.

This evidence qualifies this exact source revision. It does not turn dynamically resolved test dependencies into a frozen environment claim.

## Reconstruction provenance

A disposable staging branch previously validated the intended patch on Python 3.11: compilation succeeded and the targeted runtime suites completed **21/21 passing** before GitHub rejected the staging push solely because its Actions token lacked workflow-write permission. That staging result is retained only as diagnostic provenance and was **not borrowed** as qualification for this PR.

The final branch was reconstructed as one clean Git commit directly atop `b139542...` from the intended blobs. The final diff is exactly runtime graph validation, runtime executor dispatch, the new adversarial test file, and the existing runtime-fault qualification workflow.

## Claim boundary

This PR does **not** provide killable process isolation. It deliberately rejects `executor="process"` until Phase B supplies a dedicated persistent per-node worker with request identity, liveness/heartbeat evidence, an explicit hard execution timeout distinct from latency SLOs, terminate/join/kill authority, crash/EOF/protocol detection, deterministic semantic receipts, and no automatic scientific retries.

This remains runtime correctness work only. No Kumar2024 model/fleet execution is authorized here, and ORION remains outside comparison authority.

Refs #123.