### PR TITLE
Runtime process authority: persistent per-node workers

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -11,6 +11,7 @@ on:
       - "tests/test_runtime_fault_qualification.py"
       - "tests/test_runtime_fusion_cancellation.py"
       - "tests/test_runtime_execution_authority.py"
+      - "tests/test_runtime_process_authority.py"
   push:
     branches:
       - main
@@ -23,6 +24,7 @@ on:
       - "tests/test_runtime_fault_qualification.py"
       - "tests/test_runtime_fusion_cancellation.py"
       - "tests/test_runtime_execution_authority.py"
+      - "tests/test_runtime_process_authority.py"
   workflow_dispatch:
 
 permissions:
@@ -89,7 +91,8 @@ jobs:
             tests/test_runtime_queues.py \
             tests/test_runtime_fault_qualification.py \
             tests/test_runtime_fusion_cancellation.py \
-            tests/test_runtime_execution_authority.py
+            tests/test_runtime_execution_authority.py \
+            tests/test_runtime_process_authority.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/packages/neuros-core/src/neuros/runtime/__init__.py
+++ b/packages/neuros-core/src/neuros/runtime/__init__.py
@@ -6,10 +6,22 @@ from .executor import (
     RuntimeDrainTimeoutError,
     RuntimeExecutor,
     RuntimeFailure,
+    RuntimeProcessCleanupError,
     RuntimeUnexpectedCancellationError,
 )
 from .graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from .lifecycle import RuntimeEvent, RuntimeState
+from .process_worker import (
+    PersistentProcessWorker,
+    ProcessExecutionReceipt,
+    ProcessWorkerCrashedError,
+    ProcessWorkerError,
+    ProcessWorkerProtocolError,
+    ProcessWorkerRemoteError,
+    ProcessWorkerSerializationError,
+    ProcessWorkerTerminationError,
+    ProcessWorkerTimeoutError,
+)
 from .queues import OverflowPolicy, QueueStats, put_with_policy
 
 __all__ = [
@@ -17,12 +29,22 @@ __all__ = [
     "NodeKind",
     "NodeStats",
     "OverflowPolicy",
+    "PersistentProcessWorker",
+    "ProcessExecutionReceipt",
+    "ProcessWorkerCrashedError",
+    "ProcessWorkerError",
+    "ProcessWorkerProtocolError",
+    "ProcessWorkerRemoteError",
+    "ProcessWorkerSerializationError",
+    "ProcessWorkerTerminationError",
+    "ProcessWorkerTimeoutError",
     "QueueStats",
     "RuntimeDrainTimeoutError",
     "RuntimeEdge",
     "RuntimeEvent",
     "RuntimeExecutor",
     "RuntimeFailure",
+    "RuntimeProcessCleanupError",
     "RuntimeGraph",
     "RuntimeNode",
     "RuntimeState",

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -12,7 +12,6 @@ import asyncio
 import inspect
 import time
 from collections import deque
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, AsyncIterator, Callable
@@ -22,6 +21,7 @@ import numpy as np
 from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
 from neuros.errors import ProcessingError
 from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
+from neuros.runtime.process_worker import PersistentProcessWorker
 from neuros.runtime.lifecycle import RuntimeEvent, RuntimeState
 from neuros.runtime.queues import OverflowPolicy, QueueStats, put_with_policy
 
@@ -31,7 +31,8 @@ class ExecutionClass(str, Enum):
 
     ``GPU`` is scheduled inline because the operator owns its framework/device
     context; the label exists so graph specifications and telemetry preserve the
-    scheduling intent. ``PROCESS`` is opt-in because operators must be picklable.
+    scheduling intent. ``PROCESS`` owns one persistent direct child per runtime
+    node and requires an explicit hard execution timeout.
     """
 
     INLINE = "inline"
@@ -113,6 +114,18 @@ class RuntimeDrainTimeoutError(RuntimeError):
         )
 
 
+class RuntimeProcessCleanupError(RuntimeError):
+    """Raised when executor-owned process cleanup cannot prove termination."""
+
+    def __init__(self, failures: tuple[tuple[str, str, str], ...]) -> None:
+        self.failures = tuple(sorted(failures))
+        detail = "; ".join(
+            f"{node_id}: {error_type}: {message}"
+            for node_id, error_type, message in self.failures
+        )
+        super().__init__(f"process cleanup failed: {detail}")
+
+
 class RuntimeUnexpectedCancellationError(RuntimeError):
     """Raised when a runtime node task is cancelled without runtime authority."""
 
@@ -187,8 +200,14 @@ class RuntimeExecutor:
         self._completion_task: asyncio.Task[None] | None = None
         self._output_queue: asyncio.Queue[Any] = asyncio.Queue()
         self._event_queue: asyncio.Queue[RuntimeEvent] = asyncio.Queue()
-        self._process_pool: ProcessPoolExecutor | None = None
+        self._process_workers: dict[str, PersistentProcessWorker] = {}
+        self._process_receipts: dict[str, deque[dict[str, Any]]] = {
+            node_id: deque(maxlen=4096)
+            for node_id, node in graph.nodes.items()
+            if node.executor == "process"
+        }
         self._stopping = False
+        self._process_cleanup_error: RuntimeProcessCleanupError | None = None
         self._build_channels()
 
     def _build_channels(self) -> None:
@@ -219,20 +238,54 @@ class RuntimeExecutor:
     def edge_channels(self) -> dict[tuple[str, str], EdgeChannel]:
         return self._channels
 
-    def _close_process_pool(self) -> None:
-        """Release executor-owned process-pool authority on every terminal path.
+    async def _close_process_workers(self) -> None:
+        """Prove every executor-owned child is closed before successful terminal state."""
 
-        ``cancel_futures=True`` prevents queued work from starting. Python cannot
-        forcibly terminate a function already executing inside a worker process,
-        so this helper deliberately claims ownership release rather than process
-        kill semantics.
-        """
-
-        if self._process_pool is None:
+        workers = tuple(sorted(self._process_workers.items()))
+        if not workers:
             return
-        pool = self._process_pool
-        self._process_pool = None
-        pool.shutdown(wait=False, cancel_futures=True)
+        results = await asyncio.gather(
+            *(asyncio.to_thread(worker.close) for _, worker in workers),
+            return_exceptions=True,
+        )
+        failures = tuple(
+            (
+                node_id,
+                type(result).__name__,
+                str(result),
+            )
+            for (node_id, _), result in zip(workers, results)
+            if isinstance(result, BaseException)
+        )
+        if not failures:
+            return
+        if self._process_cleanup_error is not None:
+            return
+        error = RuntimeProcessCleanupError(failures)
+        self._process_cleanup_error = error
+        metadata = {
+            "error_type": type(error).__name__,
+            "message": str(error),
+            "failures": error.failures,
+        }
+        if self.failure is None:
+            self.failure = RuntimeFailure(
+                "runtime", type(error).__name__, str(error)
+            )
+            self.stopped_ns = time.monotonic_ns()
+            await self._transition(
+                RuntimeState.FAILED,
+                "runtime_process_cleanup_failed",
+                **metadata,
+            )
+            return
+        await self._event_queue.put(
+            RuntimeEvent(
+                event="runtime_process_cleanup_failed",
+                state=RuntimeState.FAILED,
+                metadata=metadata,
+            )
+        )
 
     async def start(self) -> None:
         if self.state is not RuntimeState.CREATED:
@@ -283,15 +336,17 @@ class RuntimeExecutor:
                 return
             await self._finish_successfully()
         finally:
-            self._close_process_pool()
+            await self._close_process_workers()
 
     async def _finish_successfully(self) -> None:
         if self.state not in (RuntimeState.DRAINING, RuntimeState.STOPPED):
             await self._transition(RuntimeState.DRAINING, "runtime_draining")
+        await self._close_process_workers()
+        if self.failure is not None:
+            return
         self.stopped_ns = time.monotonic_ns()
         if self.state is not RuntimeState.STOPPED:
             await self._transition(RuntimeState.STOPPED, "runtime_stopped")
-        self._close_process_pool()
 
     async def _run_guarded(self, node: RuntimeNode) -> None:
         try:
@@ -328,15 +383,16 @@ class RuntimeExecutor:
                 culprit_id = exc.node_id
                 cause = exc.cause
             self._node_stats[culprit_id].failed += 1
+            error_type = str(
+                getattr(cause, "runtime_error_type", type(cause).__name__)
+            )
             if self.failure is None:
-                self.failure = RuntimeFailure(
-                    culprit_id, type(cause).__name__, str(cause)
-                )
+                self.failure = RuntimeFailure(culprit_id, error_type, str(cause))
                 await self._transition(
                     RuntimeState.FAILED,
                     "node_failed",
                     node_id=culprit_id,
-                    error_type=type(cause).__name__,
+                    error_type=error_type,
                     message=str(cause),
                 )
                 # The task currently executing this handler must be allowed to
@@ -546,12 +602,42 @@ class RuntimeExecutor:
         if execution is ExecutionClass.THREAD:
             return await asyncio.to_thread(_call, func, item)
         if execution is ExecutionClass.PROCESS:
-            if self._process_pool is None:
-                self._process_pool = ProcessPoolExecutor()
-            loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(
-                self._process_pool, _call, func, item
+            timeout_s = node.execution_timeout_s
+            if timeout_s is None:
+                raise ValueError(
+                    f"Process node {node.node_id} lacks execution_timeout_s"
+                )
+            method_name = getattr(func, "__name__", None)
+            if (
+                not isinstance(method_name, str)
+                or not method_name
+                or getattr(func, "__self__", None) is not node.operator
+            ):
+                raise TypeError(
+                    f"Process node {node.node_id} requires a bound operator method"
+                )
+            worker = self._process_workers.get(node.node_id)
+            if worker is None:
+                worker = PersistentProcessWorker(
+                    node.node_id,
+                    node.operator,
+                    execution_timeout_s=timeout_s,
+                )
+                self._process_workers[node.node_id] = worker
+            receipts = self._process_receipts.setdefault(
+                node.node_id, deque(maxlen=4096)
             )
+            try:
+                call = await worker.invoke(method_name, item)
+                return call.result
+            finally:
+                receipt = worker.last_receipt
+                if receipt is not None and (
+                    not receipts
+                    or receipts[-1].get("request_id") != receipt.request_id
+                    or receipts[-1].get("generation") != receipt.generation
+                ):
+                    receipts.append(receipt.as_dict())
         raise ValueError(f"Unsupported execution class: {execution.value}")
 
     async def _emit(self, node: RuntimeNode, item: Any) -> None:
@@ -656,12 +742,13 @@ class RuntimeExecutor:
                 await asyncio.gather(
                     self._completion_task, return_exceptions=True
                 )
-            self._close_process_pool()
+            await self._close_process_workers()
             return
         if self.state is RuntimeState.CREATED:
-            self.stopped_ns = time.monotonic_ns()
-            await self._transition(RuntimeState.STOPPED, "runtime_stopped")
-            self._close_process_pool()
+            await self._close_process_workers()
+            if self.failure is None:
+                self.stopped_ns = time.monotonic_ns()
+                await self._transition(RuntimeState.STOPPED, "runtime_stopped")
             return
 
         self._stopping = True
@@ -717,7 +804,7 @@ class RuntimeExecutor:
                 )
         finally:
             if self._completion_task is not None and self._completion_task.done():
-                self._close_process_pool()
+                await self._close_process_workers()
 
         if self.state is not RuntimeState.FAILED:
             await self._finish_successfully()
@@ -790,4 +877,8 @@ class RuntimeExecutor:
                 for node_id, stats in self._node_stats.items()
             },
             "edges": edge_metrics,
+            "process_receipts": {
+                node_id: list(receipts)
+                for node_id, receipts in self._process_receipts.items()
+            },
         }

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -26,6 +26,7 @@ class RuntimeNode:
     operator: Any
     executor: str = "inline"
     latency_budget_ms: float | None = None
+    execution_timeout_s: float | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -33,17 +34,23 @@ class RuntimeNode:
             raise ValueError("node_id must be non-empty")
         if self.latency_budget_ms is not None and self.latency_budget_ms <= 0:
             raise ValueError("latency_budget_ms must be positive")
+        if self.execution_timeout_s is not None and self.execution_timeout_s <= 0:
+            raise ValueError("execution_timeout_s must be positive")
         if self.executor not in {"inline", "thread", "process", "gpu"}:
             raise ValueError(f"Unsupported executor: {self.executor}")
-        if self.executor == "process":
-            raise ValueError(
-                "executor='process' is not authoritative until neurOS uses "
-                "a persistent per-node worker; see runtime execution authority"
-            )
         if self.kind is NodeKind.SOURCE and self.executor != "inline":
             raise ValueError(
                 "Source nodes currently require executor='inline'; source "
                 "lifecycle/stream isolation is not yet implemented"
+            )
+        if self.execution_timeout_s is not None and self.executor != "process":
+            raise ValueError(
+                "execution_timeout_s is only authoritative for executor='process'"
+            )
+        if self.executor == "process" and self.execution_timeout_s is None:
+            raise ValueError(
+                "executor='process' requires an explicit execution_timeout_s; "
+                "latency_budget_ms is an SLO and is not termination authority"
             )
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 

--- a/packages/neuros-core/src/neuros/runtime/process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/process_worker.py
@@ -1,0 +1,475 @@
+"""Persistent direct-child authority for process-executed runtime nodes.
+
+Trusted Python objects cross a multiprocessing boundary, so this is fault
+isolation, not a security sandbox. Termination authority covers only the direct
+child created here, never arbitrary descendants.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import multiprocessing as mp
+import pickle
+from dataclasses import dataclass
+from multiprocessing.connection import Connection
+from typing import Any
+
+_PROTOCOL = 1
+
+
+class ProcessWorkerError(RuntimeError):
+    def __init__(self, node_id: str, message: str) -> None:
+        self.node_id = node_id
+        super().__init__(message)
+
+
+class ProcessWorkerTimeoutError(ProcessWorkerError):
+    pass
+
+
+class ProcessWorkerCrashedError(ProcessWorkerError):
+    pass
+
+
+class ProcessWorkerProtocolError(ProcessWorkerError):
+    pass
+
+
+class ProcessWorkerSerializationError(ProcessWorkerError):
+    pass
+
+
+class ProcessWorkerTerminationError(ProcessWorkerError):
+    pass
+
+
+class ProcessWorkerRemoteError(ProcessWorkerError):
+    def __init__(self, node_id: str, error_type: str, message: str) -> None:
+        self.remote_error_type = error_type
+        self.runtime_error_type = error_type
+        super().__init__(node_id, message)
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessExecutionReceipt:
+    node_id: str
+    generation: int
+    request_id: int
+    outcome: str
+    remote_error_type: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "generation": self.generation,
+            "request_id": self.request_id,
+            "outcome": self.outcome,
+            "remote_error_type": self.remote_error_type,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessCallResult:
+    result: Any
+    receipt: ProcessExecutionReceipt
+
+
+def _run_callback(func: Any, item: Any) -> Any:
+    value = func(item)
+    if not inspect.isawaitable(value):
+        return value
+
+    async def _await() -> Any:
+        return await value
+
+    return asyncio.run(_await())
+
+
+def _send(conn: Connection, envelope: dict[str, Any]) -> None:
+    conn.send_bytes(pickle.dumps(envelope, protocol=pickle.HIGHEST_PROTOCOL))
+
+
+def _child(conn: Connection, operator: Any, node_id: str, generation: int) -> None:
+    base = {"protocol": _PROTOCOL, "node_id": node_id, "generation": generation}
+    try:
+        _send(conn, {**base, "kind": "ready"})
+        while True:
+            try:
+                payload = conn.recv_bytes()
+            except (EOFError, ConnectionResetError, BrokenPipeError, OSError):
+                return
+            try:
+                request = pickle.loads(payload)
+            except Exception as exc:
+                try:
+                    _send(
+                        conn,
+                        {**base, "kind": "protocol_error", "message": str(exc)},
+                    )
+                except (EOFError, ConnectionResetError, BrokenPipeError, OSError):
+                    pass
+                return
+            if not isinstance(request, dict) or any(
+                (
+                    request.get("protocol") != _PROTOCOL,
+                    request.get("node_id") != node_id,
+                    request.get("generation") != generation,
+                )
+            ):
+                _send(conn, {**base, "kind": "protocol_error", "message": "identity mismatch"})
+                return
+            command = request.get("command")
+            if command == "heartbeat":
+                _send(conn, {**base, "kind": "heartbeat"})
+                continue
+            if command == "shutdown":
+                _send(conn, {**base, "kind": "shutdown"})
+                return
+            request_id = request.get("request_id")
+            method = request.get("method")
+            item_bytes = request.get("item")
+            call_base = {**base, "request_id": request_id}
+            if (
+                command != "call"
+                or not isinstance(request_id, int)
+                or request_id <= 0
+                or not isinstance(method, str)
+                or not isinstance(item_bytes, bytes)
+            ):
+                _send(conn, {**call_base, "kind": "protocol_error", "message": "malformed call"})
+                return
+            try:
+                item = pickle.loads(item_bytes)
+            except Exception as exc:
+                _send(conn, {**call_base, "kind": "serialization_error", "message": f"input deserialization failed: {exc}"})
+                return
+            try:
+                result = _run_callback(getattr(operator, method), item)
+            except BaseException as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "error",
+                        "error_type": type(exc).__name__,
+                        "message": str(exc),
+                    },
+                )
+                continue
+            try:
+                result_bytes = pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL)
+            except Exception as exc:
+                _send(conn, {**call_base, "kind": "serialization_error", "message": f"result serialization failed: {exc}"})
+                return
+            _send(conn, {**call_base, "kind": "result", "result": result_bytes})
+    finally:
+        conn.close()
+
+
+class PersistentProcessWorker:
+    """One operator instance in one spawn-safe direct child, with no auto-retry."""
+
+    def __init__(
+        self,
+        node_id: str,
+        operator: Any,
+        *,
+        execution_timeout_s: float,
+        generation: int = 0,
+        startup_timeout_s: float = 5.0,
+        termination_grace_s: float = 0.25,
+    ) -> None:
+        if not node_id:
+            raise ValueError("node_id must be non-empty")
+        if min(execution_timeout_s, startup_timeout_s, termination_grace_s) <= 0:
+            raise ValueError("worker timeouts must be positive")
+        if generation < 0:
+            raise ValueError("generation must be non-negative")
+        self.node_id = node_id
+        self.operator = operator
+        self.execution_timeout_s = float(execution_timeout_s)
+        self.startup_timeout_s = float(startup_timeout_s)
+        self.termination_grace_s = float(termination_grace_s)
+        self.generation = int(generation)
+        self._ctx = mp.get_context("spawn")
+        self._conn: Connection | None = None
+        self._process: mp.Process | None = None
+        self._request_id = 0
+        self._last_receipt: ProcessExecutionReceipt | None = None
+        self._lock = asyncio.Lock()
+        self._terminal = False
+
+    @property
+    def last_receipt(self) -> ProcessExecutionReceipt | None:
+        return self._last_receipt
+
+    @property
+    def pid(self) -> int | None:
+        return None if self._process is None else self._process.pid
+
+    @property
+    def is_alive(self) -> bool:
+        return bool(self._process is not None and self._process.is_alive())
+
+    def _receipt(
+        self, request_id: int, outcome: str, error_type: str | None = None
+    ) -> None:
+        self._last_receipt = ProcessExecutionReceipt(
+            self.node_id, self.generation, request_id, outcome, error_type
+        )
+
+    def _identity(self, response: dict[str, Any], request_id: int | None) -> None:
+        if (
+            response.get("protocol") != _PROTOCOL
+            or response.get("node_id") != self.node_id
+            or response.get("generation") != self.generation
+            or (request_id is not None and response.get("request_id") != request_id)
+        ):
+            raise ProcessWorkerProtocolError(
+                self.node_id,
+                f"stale or mismatched process response for request {request_id}",
+            )
+
+    def _recv(self, timeout_s: float, request_id: int | None) -> dict[str, Any]:
+        if self._conn is None:
+            raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
+        if not self._conn.poll(timeout_s):
+            if not self.is_alive:
+                raise ProcessWorkerCrashedError(self.node_id, "worker exited before response")
+            raise ProcessWorkerTimeoutError(
+                self.node_id,
+                f"request {request_id} exceeded {timeout_s:.6f}s hard execution timeout",
+            )
+        try:
+            response = pickle.loads(self._conn.recv_bytes())
+        except EOFError as exc:
+            raise ProcessWorkerCrashedError(self.node_id, "worker EOF before response") from exc
+        except Exception as exc:
+            raise ProcessWorkerProtocolError(self.node_id, f"invalid worker response: {exc}") from exc
+        if not isinstance(response, dict):
+            raise ProcessWorkerProtocolError(self.node_id, "worker response is not a mapping")
+        self._identity(response, request_id)
+        return response
+
+    def _send_control(self, command: str) -> None:
+        if self._conn is None:
+            raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
+        try:
+            _send(
+                self._conn,
+                {
+                    "protocol": _PROTOCOL,
+                    "node_id": self.node_id,
+                    "generation": self.generation,
+                    "command": command,
+                },
+            )
+        except (EOFError, ConnectionResetError, BrokenPipeError, OSError) as exc:
+            raise ProcessWorkerCrashedError(
+                self.node_id, f"worker IPC failed while sending {command}"
+            ) from exc
+
+    def _start(self) -> None:
+        if self._terminal:
+            raise ProcessWorkerError(self.node_id, "worker is terminal; create a new generation")
+        if self._process is not None:
+            if self._process.is_alive():
+                return
+            raise ProcessWorkerCrashedError(self.node_id, "worker exited")
+        parent, child = self._ctx.Pipe(duplex=True)
+        process = self._ctx.Process(
+            target=_child,
+            args=(child, self.operator, self.node_id, self.generation),
+            name=f"neuros-process:{self.node_id}:g{self.generation}",
+        )
+        self._conn, self._process = parent, process
+        try:
+            process.start()
+        except Exception as exc:
+            parent.close()
+            self._conn = self._process = None
+            raise ProcessWorkerSerializationError(
+                self.node_id, f"operator/start serialization failed: {exc}"
+            ) from exc
+        finally:
+            child.close()
+        ready = self._recv(self.startup_timeout_s, None)
+        if ready.get("kind") != "ready":
+            raise ProcessWorkerProtocolError(self.node_id, "worker did not become ready")
+        self._send_control("heartbeat")
+        heartbeat = self._recv(self.startup_timeout_s, None)
+        if heartbeat.get("kind") != "heartbeat":
+            raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
+
+    async def invoke(self, method: str, item: Any) -> ProcessCallResult:
+        async with self._lock:
+            request_id = self._request_id + 1
+            try:
+                await asyncio.to_thread(self._start)
+                self._request_id = request_id
+                item_bytes = pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+                if self._conn is None:
+                    raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
+                try:
+                    await asyncio.to_thread(
+                        _send,
+                        self._conn,
+                        {
+                            "protocol": _PROTOCOL,
+                            "node_id": self.node_id,
+                            "generation": self.generation,
+                            "command": "call",
+                            "request_id": request_id,
+                            "method": method,
+                            "item": item_bytes,
+                        },
+                    )
+                except (EOFError, ConnectionResetError, BrokenPipeError, OSError) as exc:
+                    raise ProcessWorkerCrashedError(
+                        self.node_id,
+                        f"worker IPC failed while sending request {request_id}",
+                    ) from exc
+                response = await asyncio.to_thread(
+                    self._recv, self.execution_timeout_s, request_id
+                )
+                if not isinstance(response, dict):
+                    raise ProcessWorkerProtocolError(
+                        self.node_id, "worker response is not a mapping"
+                    )
+                self._identity(response, request_id)
+            except asyncio.CancelledError:
+                self._receipt(request_id, "cancelled")
+                await asyncio.shield(asyncio.to_thread(self.abort))
+                raise
+            except ProcessWorkerTimeoutError:
+                self._receipt(request_id, "timeout")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerCrashedError:
+                self._receipt(request_id, "crashed")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerProtocolError:
+                self._receipt(request_id, "protocol_error")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerSerializationError:
+                self._request_id = request_id
+                self._receipt(request_id, "serialization_error")
+                await asyncio.to_thread(self.abort)
+                raise
+            except Exception as exc:
+                self._request_id = request_id
+                self._receipt(request_id, "serialization_error")
+                await asyncio.to_thread(self.abort)
+                raise ProcessWorkerSerializationError(
+                    self.node_id, f"input/request serialization failed: {exc}"
+                ) from exc
+
+            kind = response.get("kind")
+            if kind == "result":
+                try:
+                    result = pickle.loads(response["result"])
+                except Exception as exc:
+                    self._receipt(request_id, "serialization_error")
+                    await asyncio.to_thread(self.abort)
+                    raise ProcessWorkerSerializationError(
+                        self.node_id, f"result deserialization failed: {exc}"
+                    ) from exc
+                receipt = ProcessExecutionReceipt(
+                    self.node_id, self.generation, request_id, "success"
+                )
+                self._last_receipt = receipt
+                return ProcessCallResult(result, receipt)
+            if kind == "error":
+                error_type = str(response.get("error_type") or "RemoteError")
+                self._receipt(request_id, "error", error_type)
+                raise ProcessWorkerRemoteError(
+                    self.node_id, error_type, str(response.get("message") or "")
+                )
+            if kind == "serialization_error":
+                self._receipt(request_id, "serialization_error")
+                await asyncio.to_thread(self.abort)
+                raise ProcessWorkerSerializationError(
+                    self.node_id, str(response.get("message") or "serialization failure")
+                )
+            self._receipt(request_id, "protocol_error")
+            await asyncio.to_thread(self.abort)
+            raise ProcessWorkerProtocolError(
+                self.node_id, f"unexpected worker response kind {kind!r}"
+            )
+
+    async def heartbeat(self) -> None:
+        async with self._lock:
+            try:
+                await asyncio.to_thread(self._start)
+                await asyncio.to_thread(self._send_control, "heartbeat")
+                response = await asyncio.to_thread(
+                    self._recv, self.startup_timeout_s, None
+                )
+                if response.get("kind") != "heartbeat":
+                    raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
+            except asyncio.CancelledError:
+                await asyncio.shield(asyncio.to_thread(self.abort))
+                raise
+            except Exception:
+                await asyncio.to_thread(self.abort)
+                raise
+
+    def _terminate_owned_process(self, process: mp.Process) -> None:
+        """Prove the direct child is dead or fail closed with its handle retained."""
+
+        if process.is_alive():
+            process.terminate()
+            process.join(self.termination_grace_s)
+        if process.is_alive() and hasattr(process, "kill"):
+            process.kill()
+            process.join(self.termination_grace_s)
+        if process.is_alive():
+            self._process = process
+            raise ProcessWorkerTerminationError(
+                self.node_id,
+                "direct child remained alive after terminate/join/kill escalation",
+            )
+        process.close()
+        self._process = None
+
+    def abort(self) -> None:
+        self._terminal = True
+        conn, process = self._conn, self._process
+        self._conn = None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        if process is None:
+            self._process = None
+            return
+        self._terminate_owned_process(process)
+
+    def close(self) -> None:
+        self._terminal = True
+        conn, process = self._conn, self._process
+        if process is None:
+            if conn is not None:
+                conn.close()
+            self._conn = None
+            return
+        if process.is_alive() and conn is not None:
+            try:
+                self._send_control("shutdown")
+                if conn.poll(self.termination_grace_s):
+                    response = pickle.loads(conn.recv_bytes())
+                    self._identity(response, None)
+            except Exception:
+                pass
+        process.join(self.termination_grace_s)
+        if conn is not None:
+            conn.close()
+        self._conn = None
+        if process.is_alive():
+            self._terminate_owned_process(process)
+            return
+        process.close()
+        self._process = None

--- a/tests/test_runtime_execution_authority.py
+++ b/tests/test_runtime_execution_authority.py
@@ -105,9 +105,17 @@ def test_source_non_inline_executor_is_rejected_instead_of_ignored():
         RuntimeNode("source", NodeKind.SOURCE, object(), executor="thread")
 
 
-def test_process_executor_is_rejected_until_per_node_worker_is_authoritative():
-    with pytest.raises(ValueError, match="not authoritative"):
+def test_process_executor_requires_explicit_hard_timeout():
+    with pytest.raises(ValueError, match="execution_timeout_s"):
         RuntimeNode("transform", NodeKind.TRANSFORM, object(), executor="process")
+    node = RuntimeNode(
+        "transform",
+        NodeKind.TRANSFORM,
+        object(),
+        executor="process",
+        execution_timeout_s=1.0,
+    )
+    assert node.execution_timeout_s == 1.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_fault_qualification.py
+++ b/tests/test_runtime_fault_qualification.py
@@ -121,14 +121,21 @@ class FailingMonitor:
         raise LookupError(f"monitor rejected {payload['node_id']}")
 
 
-class FakeProcessPool:
+class FakeProcessWorker:
     def __init__(self):
-        self.shutdown_calls = []
+        self.close_calls = 0
 
-    def shutdown(self, *, wait, cancel_futures):
-        self.shutdown_calls.append(
-            {"wait": wait, "cancel_futures": cancel_futures}
-        )
+    def close(self):
+        self.close_calls += 1
+
+
+class FailingProcessWorker:
+    def __init__(self):
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        raise RuntimeError("worker cleanup refused")
 
 
 def source_sink_graph(source, sink, *, capacity=2, overflow="block"):
@@ -311,7 +318,7 @@ async def test_fail_overflow_is_runtime_failure_at_emitting_source():
 
 
 @pytest.mark.asyncio
-async def test_executor_owned_process_pool_is_closed_on_failure_path():
+async def test_executor_owned_process_workers_are_closed_on_failure_path():
     executor = RuntimeExecutor(
         source_transform_sink_graph(
             FiniteSource([1]),
@@ -319,16 +326,13 @@ async def test_executor_owned_process_pool_is_closed_on_failure_path():
             CollectingSink(),
         )
     )
-    fake_pool = FakeProcessPool()
-    executor._process_pool = fake_pool  # ownership-path test, no subprocess spawned
+    fake_worker = FakeProcessWorker()
+    executor._process_workers["owned-test-worker"] = fake_worker
 
     with pytest.raises(RuntimeError, match="qualified transform failure"):
         await executor.run()
 
-    assert fake_pool.shutdown_calls == [
-        {"wait": False, "cancel_futures": True}
-    ]
-    assert executor._process_pool is None
+    assert fake_worker.close_calls == 1
     assert_executor_tasks_terminal(executor)
 
 
@@ -419,3 +423,48 @@ async def test_failure_peer_cancellation_cannot_deadlock_on_saturated_stop_queue
         and task.get_name().startswith("neuros:")
     ]
     assert leaked == []
+
+
+@pytest.mark.asyncio
+async def test_process_cleanup_failure_prevents_false_stopped_state():
+    executor = RuntimeExecutor(
+        source_sink_graph(FiniteSource([1]), CollectingSink())
+    )
+    failing_worker = FailingProcessWorker()
+    executor._process_workers["stuck"] = failing_worker
+
+    with pytest.raises(RuntimeError, match="RuntimeProcessCleanupError"):
+        await executor.run()
+
+    snapshot = executor.snapshot()
+    assert snapshot["state"] == "failed"
+    assert snapshot["failure"]["node_id"] == "runtime"
+    assert snapshot["failure"]["error_type"] == "RuntimeProcessCleanupError"
+    assert "worker cleanup refused" in snapshot["failure"]["message"]
+    events = await collect_events(executor)
+    assert sum(event.event == "runtime_process_cleanup_failed" for event in events) == 1
+    assert not any(event.event == "runtime_stopped" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_does_not_overwrite_primary_node_culprit():
+    executor = RuntimeExecutor(
+        source_transform_sink_graph(
+            FiniteSource([1]),
+            FailTransform(),
+            CollectingSink(),
+        )
+    )
+    failing_worker = FailingProcessWorker()
+    executor._process_workers["stuck"] = failing_worker
+
+    with pytest.raises(RuntimeError, match="qualified transform failure"):
+        await executor.run()
+
+    assert executor.snapshot()["failure"] == {
+        "node_id": "transform",
+        "error_type": "ValueError",
+        "message": "qualified transform failure",
+    }
+    events = await collect_events(executor)
+    assert sum(event.event == "runtime_process_cleanup_failed" for event in events) == 1

--- a/tests/test_runtime_process_authority.py
+++ b/tests/test_runtime_process_authority.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import os
+import pickle
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+from neuros.runtime.process_worker import (
+    PersistentProcessWorker,
+    ProcessWorkerProtocolError,
+    ProcessWorkerTerminationError,
+)
+
+
+class FiniteSource:
+    def __init__(self, values):
+        self.values = tuple(values)
+
+    async def start(self):
+        return None
+
+    async def stop(self):
+        return None
+
+    async def frames(self):
+        for value in self.values:
+            await asyncio.sleep(0)
+            yield value
+
+
+class CollectingSink:
+    def __init__(self):
+        self.items = []
+
+    async def write(self, item):
+        self.items.append(item)
+
+
+class CounterTransform:
+    def __init__(self):
+        self.calls = 0
+
+    def transform(self, item):
+        self.calls += 1
+        return self.calls, item, os.getpid()
+
+
+class AsyncPidTransform:
+    async def transform(self, item):
+        await asyncio.sleep(0)
+        return os.getpid(), item
+
+
+class FailingTransform:
+    def transform(self, item):
+        raise LookupError(f"process rejected {item}")
+
+
+class SleepTransform:
+    def __init__(self, pid_path: Path, delay_s: float = 10.0):
+        self.pid_path = pid_path
+        self.delay_s = delay_s
+
+    def transform(self, item):
+        self.pid_path.write_text(str(os.getpid()), encoding="utf-8")
+        time.sleep(self.delay_s)
+        return item
+
+
+class DelayedFailTransform:
+    def __init__(self, pid_path: Path, delay_s: float = 0.2):
+        self.pid_path = pid_path
+        self.delay_s = delay_s
+
+    def transform(self, item):
+        self.pid_path.write_text(str(os.getpid()), encoding="utf-8")
+        time.sleep(self.delay_s)
+        raise RuntimeError("peer process failed")
+
+
+class CrashDecoder:
+    def __init__(self, pid_path: Path):
+        self.pid_path = pid_path
+
+    def infer(self, item):
+        self.pid_path.write_text(str(os.getpid()), encoding="utf-8")
+        os._exit(17)
+
+
+class SleepDecoder:
+    def __init__(self, pid_path: Path):
+        self.pid_path = pid_path
+
+    def infer(self, item):
+        self.pid_path.write_text(str(os.getpid()), encoding="utf-8")
+        time.sleep(10.0)
+        return 1
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class UnpicklableOperator:
+    def __init__(self):
+        self.lock = threading.Lock()
+
+    def transform(self, item):
+        return item
+
+
+class UnpicklableResultTransform:
+    def transform(self, item):
+        return lambda value: (item, value)
+
+
+class FileSink:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def write(self, item):
+        self.path.write_text(f"{os.getpid()}:{item}", encoding="utf-8")
+
+
+class FileMonitor:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def update(self, payload):
+        self.path.write_text(
+            f"{os.getpid()}:{payload['node_id']}", encoding="utf-8"
+        )
+
+
+def _source_transform_sink(transform, *, timeout_s=2.0, values=(1,)):
+    sink = CollectingSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource(values)))
+    graph.add_node(
+        RuntimeNode(
+            "transform",
+            NodeKind.TRANSFORM,
+            transform,
+            executor="process",
+            execution_timeout_s=timeout_s,
+        )
+    )
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+    graph.connect(RuntimeEdge("transform", "sink", overflow="block"))
+    return graph, sink
+
+
+def _source_decoder(decoder, *, timeout_s):
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource((1,))))
+    graph.add_node(
+        RuntimeNode(
+            "decoder",
+            NodeKind.DECODER,
+            decoder,
+            executor="process",
+            execution_timeout_s=timeout_s,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "decoder", overflow="block"))
+    return graph
+
+
+def _active_child_pids():
+    return {process.pid for process in mp.active_children() if process.pid is not None}
+
+
+async def _wait_for_path(path: Path, timeout_s: float = 3.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while not path.exists():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"timed out waiting for {path}")
+        await asyncio.sleep(0.01)
+
+
+def test_process_timeout_is_explicit_and_separate_from_latency_slo():
+    with pytest.raises(ValueError, match="execution_timeout_s"):
+        RuntimeNode(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            latency_budget_ms=0.001,
+        )
+
+    node = RuntimeNode(
+        "transform",
+        NodeKind.TRANSFORM,
+        IdentityTransform(),
+        executor="process",
+        latency_budget_ms=0.001,
+        execution_timeout_s=0.5,
+    )
+    assert node.latency_budget_ms == pytest.approx(0.001)
+    assert node.execution_timeout_s == pytest.approx(0.5)
+
+    with pytest.raises(ValueError, match="only authoritative"):
+        RuntimeNode(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="thread",
+            execution_timeout_s=0.5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_process_worker_preserves_operator_state_and_semantic_receipts():
+    graph, sink = _source_transform_sink(CounterTransform(), values=(10, 20, 30))
+    snapshot = await RuntimeExecutor(graph).run()
+
+    assert [(calls, item) for calls, item, _ in sink.items] == [
+        (1, 10),
+        (2, 20),
+        (3, 30),
+    ]
+    worker_pids = {pid for _, _, pid in sink.items}
+    assert len(worker_pids) == 1
+    assert os.getpid() not in worker_pids
+    assert worker_pids.isdisjoint(_active_child_pids())
+    assert snapshot["process_receipts"]["transform"] == [
+        {
+            "node_id": "transform",
+            "generation": 0,
+            "request_id": request_id,
+            "outcome": "success",
+            "remote_error_type": None,
+        }
+        for request_id in (1, 2, 3)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_transform_runs_coroutine_inside_persistent_process():
+    graph, sink = _source_transform_sink(AsyncPidTransform())
+    await RuntimeExecutor(graph).run()
+    pid, item = sink.items[0]
+    assert item == 1
+    assert pid != os.getpid()
+
+
+@pytest.mark.asyncio
+async def test_process_sink_and_monitor_honor_declared_domain(tmp_path):
+    sink_path = tmp_path / "sink.txt"
+    monitor_path = tmp_path / "monitor.txt"
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource((7,))))
+    graph.add_node(
+        RuntimeNode(
+            "sink",
+            NodeKind.SINK,
+            FileSink(sink_path),
+            executor="process",
+            execution_timeout_s=2.0,
+        )
+    )
+    graph.add_node(
+        RuntimeNode(
+            "monitor",
+            NodeKind.MONITOR,
+            FileMonitor(monitor_path),
+            executor="process",
+            execution_timeout_s=2.0,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "sink", overflow="block"))
+
+    snapshot = await RuntimeExecutor(graph).run()
+    sink_pid, sink_item = sink_path.read_text(encoding="utf-8").split(":", 1)
+    monitor_pid, monitor_node = monitor_path.read_text(encoding="utf-8").split(":", 1)
+    assert int(sink_pid) != os.getpid()
+    assert int(monitor_pid) != os.getpid()
+    assert sink_item == "7"
+    assert monitor_node == "source"
+    assert snapshot["process_receipts"]["sink"][0]["outcome"] == "success"
+    assert snapshot["process_receipts"]["monitor"][0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_remote_exception_preserves_exact_node_and_remote_error_type():
+    graph, _ = _source_transform_sink(FailingTransform())
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="LookupError: process rejected 1"):
+        await executor.run()
+
+    assert executor.snapshot()["failure"] == {
+        "node_id": "transform",
+        "error_type": "LookupError",
+        "message": "process rejected 1",
+    }
+    receipt = executor.snapshot()["process_receipts"]["transform"][-1]
+    assert receipt["outcome"] == "error"
+    assert receipt["remote_error_type"] == "LookupError"
+
+
+@pytest.mark.asyncio
+async def test_hard_timeout_terminates_direct_child_and_admits_no_output(tmp_path):
+    pid_path = tmp_path / "timeout.pid"
+    executor = RuntimeExecutor(_source_decoder(SleepDecoder(pid_path), timeout_s=0.1))
+    await executor.start()
+    with pytest.raises(RuntimeError, match="ProcessWorkerTimeoutError"):
+        await executor.wait()
+    await _wait_for_path(pid_path)
+    child_pid = int(pid_path.read_text(encoding="utf-8"))
+    assert child_pid not in _active_child_pids()
+    assert [item async for item in executor.outputs()] == []
+    assert executor.snapshot()["process_receipts"]["decoder"][-1]["outcome"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_asyncio_cancellation_terminates_direct_child(tmp_path):
+    pid_path = tmp_path / "cancel.pid"
+    graph, _ = _source_transform_sink(SleepTransform(pid_path), timeout_s=5.0)
+    executor = RuntimeExecutor(graph)
+    await executor.start()
+    await _wait_for_path(pid_path)
+    child_pid = int(pid_path.read_text(encoding="utf-8"))
+    executor._tasks["transform"].cancel()
+
+    with pytest.raises(RuntimeError, match="RuntimeUnexpectedCancellationError"):
+        await executor.wait()
+    assert child_pid not in _active_child_pids()
+    assert executor.snapshot()["process_receipts"]["transform"][-1]["outcome"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_child_crash_becomes_explicit_failure_and_admits_no_output(tmp_path):
+    pid_path = tmp_path / "crash.pid"
+    executor = RuntimeExecutor(_source_decoder(CrashDecoder(pid_path), timeout_s=2.0))
+    with pytest.raises(RuntimeError, match="ProcessWorkerCrashedError"):
+        await executor.run()
+
+    child_pid = int(pid_path.read_text(encoding="utf-8"))
+    assert child_pid not in _active_child_pids()
+    assert [item async for item in executor.outputs()] == []
+    assert executor.snapshot()["process_receipts"]["decoder"][-1]["outcome"] == "crashed"
+
+
+@pytest.mark.asyncio
+async def test_stale_response_identity_is_rejected_and_worker_terminated():
+    worker = PersistentProcessWorker(
+        "transform", CounterTransform(), execution_timeout_s=1.0
+    )
+    await worker.heartbeat()
+
+    def stale_response(timeout_s, request_id):
+        return {
+            "protocol": 1,
+            "kind": "result",
+            "node_id": "transform",
+            "generation": 0,
+            "request_id": request_id - 1,
+            "result": pickle.dumps("stale"),
+        }
+
+    worker._recv = stale_response
+    with pytest.raises(ProcessWorkerProtocolError, match="stale or mismatched"):
+        await worker.invoke("transform", 1)
+    assert not worker.is_alive
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "protocol_error"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operator", "values", "expected"),
+    [
+        (UnpicklableOperator(), (1,), "operator/start serialization failed"),
+        (IdentityTransform(), (lambda value: value,), "input/request serialization failed"),
+        (UnpicklableResultTransform(), (1,), "result serialization failed"),
+    ],
+)
+async def test_process_serialization_failures_fail_closed(operator, values, expected):
+    graph, _ = _source_transform_sink(operator, values=values)
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="ProcessWorkerSerializationError"):
+        await executor.run()
+    failure = executor.snapshot()["failure"]
+    assert failure["node_id"] == "transform"
+    assert expected in failure["message"]
+    assert executor.snapshot()["process_receipts"]["transform"][-1]["outcome"] == "serialization_error"
+
+
+@pytest.mark.asyncio
+async def test_runtime_failure_terminates_every_executor_owned_worker(tmp_path):
+    slow_pid_path = tmp_path / "slow.pid"
+    fail_pid_path = tmp_path / "fail.pid"
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource((1,))))
+    graph.add_node(
+        RuntimeNode(
+            "slow",
+            NodeKind.TRANSFORM,
+            SleepTransform(slow_pid_path),
+            executor="process",
+            execution_timeout_s=5.0,
+        )
+    )
+    graph.add_node(
+        RuntimeNode(
+            "fail",
+            NodeKind.TRANSFORM,
+            DelayedFailTransform(fail_pid_path),
+            executor="process",
+            execution_timeout_s=5.0,
+        )
+    )
+    graph.add_node(RuntimeNode("slow_sink", NodeKind.SINK, CollectingSink()))
+    graph.add_node(RuntimeNode("fail_sink", NodeKind.SINK, CollectingSink()))
+    graph.connect(RuntimeEdge("source", "slow", overflow="block"))
+    graph.connect(RuntimeEdge("source", "fail", overflow="block"))
+    graph.connect(RuntimeEdge("slow", "slow_sink", overflow="block"))
+    graph.connect(RuntimeEdge("fail", "fail_sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="peer process failed"):
+        await executor.run()
+
+    await _wait_for_path(slow_pid_path)
+    await _wait_for_path(fail_pid_path)
+    child_pids = {
+        int(slow_pid_path.read_text(encoding="utf-8")),
+        int(fail_pid_path.read_text(encoding="utf-8")),
+    }
+    assert child_pids.isdisjoint(_active_child_pids())
+    assert executor.snapshot()["failure"]["node_id"] == "fail"
+
+
+class ImmortalProcess:
+    def __init__(self):
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.join_calls = 0
+
+    def is_alive(self):
+        return True
+
+    def terminate(self):
+        self.terminate_calls += 1
+
+    def kill(self):
+        self.kill_calls += 1
+
+    def join(self, timeout=None):
+        self.join_calls += 1
+
+    def close(self):
+        raise AssertionError("live process handle must not be closed")
+
+
+def test_direct_child_surviving_escalation_fails_closed():
+    worker = PersistentProcessWorker(
+        "transform", CounterTransform(), execution_timeout_s=1.0
+    )
+    process = ImmortalProcess()
+    worker._process = process
+
+    with pytest.raises(ProcessWorkerTerminationError, match="remained alive"):
+        worker.abort()
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.join_calls == 2
+    assert worker._process is process


### PR DESCRIPTION
## Purpose

Implement **Phase B of #123** as a clean stacked tranche directly on exact-qualified Phase A.

This replaces the rejected pooled `process` semantics with one persistent, spawn-safe, executor-owned direct child per process-declared runtime node.

## Exact stack

- base branch: `feat/runtime-execution-authority-v1`
- exact base SHA: `1105e02790531877c7bd2d510e7d79c2adfcb658`
- head branch: `feat/runtime-process-authority-v1`
- **QUALIFIED exact head SHA: `e4d924223870959db88ef903b02f04244c42f9ff`**
- topology: exactly one commit ahead of qualified Phase A
- diff: exactly eight intended production/test/qualification paths

Frozen scientific `main` remains untouched.

## Authority model

1. `executor="process"` requires an explicit positive `execution_timeout_s`; `latency_budget_ms` remains an SLO and is never reused as termination authority.
2. Each process node owns one persistent spawn-context child and one persistent operator instance for that worker generation.
3. Calls use monotonically increasing request IDs and explicit node/generation/protocol identity.
4. Startup includes a ready handshake plus heartbeat before execution is admitted.
5. Sync and async operator callbacks execute inside the child process.
6. Timeout or asyncio cancellation terminates the direct child and makes that worker generation terminal.
7. Crash, EOF, broken IPC, protocol mismatch, stale response identity, and input/result/operator serialization failures all fail closed.
8. Parent cleanup uses graceful shutdown where possible, then bounded terminate -> join -> kill escalation where supported.
9. If the direct child remains alive after escalation, termination authority fails closed with `ProcessWorkerTerminationError`; the live process handle is retained rather than falsely marked closed.
10. A successful runtime cannot enter `STOPPED` until every executor-owned worker has proven cleanup. Cleanup authority loss becomes `RuntimeProcessCleanupError` and runtime `FAILED`.
11. If process cleanup also fails after an earlier node/scientific failure, the earlier exact culprit remains primary and cleanup loss is emitted as auxiliary runtime evidence rather than overwriting provenance.
12. Successful and failed calls emit deterministic semantic receipts containing node, generation, request identity, outcome, and remote error type without PID/hostname/wall-clock provenance noise.
13. Remote operator exceptions preserve the declared node as culprit and the remote exception type as runtime error type.
14. No automatic scientific retry occurs after a returned/completed operator result or containment failure.
15. Process sinks and monitors use the same execution authority as transforms/decoders/fusion.

## Adversarial qualification surface

Adds `tests/test_runtime_process_authority.py` and extends maintained fault qualification to cover:

- hard timeout distinct from latency SLO;
- stateful process persistence across multiple calls;
- sync + async execution inside the child;
- process sink and monitor authority;
- exact remote exception culprit/type preservation;
- timeout termination and no post-timeout output;
- asyncio cancellation termination;
- child crash/EOF containment and no output admission;
- stale/mismatched response rejection;
- unpicklable operator/input/result fail-closed behavior;
- runtime failure tearing down every executor-owned process worker;
- a synthetic direct child that survives terminate+kill escalation;
- cleanup failure preventing a false successful `STOPPED` state;
- cleanup failure preserving an earlier node culprit.

The existing Runtime Fault Qualification workflow owns this suite in the 3-OS x 3-Python exact-source matrix rather than creating CI sprawl.

## Exact-head qualification

**QUALIFIED exact head: `e4d924223870959db88ef903b02f04244c42f9ff`**

All **12/12 workflow suites triggered by this eight-file PR completed successfully on that exact SHA**:

- Public Trust Contracts `33419591600`
- neurOS CI `33419591586` with **14/14 jobs green**
- Developer Preview Journey `33419591593`
- Ecosystem Compatibility `33419591621`
- Neural Window Contracts `33419591631`
- Release Candidate Artifacts `33419591666`
- Reproducible Release Build `33419591590`
- External Plugin Contract `33419591588`
- neurOS driver contracts `33419591607`
- Braindecode Compatibility `33419591655`
- Runtime Fault Qualification `33419591639`
- Whole Package Qualification `33419591585`

Runtime Fault Qualification passed all **9/9 OS/Python lanes plus its fail-closed umbrella** across Ubuntu 24.04, macOS 14, and Windows 2025 on Python 3.10, 3.11, and 3.12. Every lane checked out and verified the exact clean source SHA, ran with `PYTHONASYNCIODEBUG=1`, and executed **39 maintained runtime/queue/fault/execution/process-authority tests**, for **351 cross-platform test executions** total.

As a concrete exact-source proof, Ubuntu/Python 3.12 job `99578425328` checked out `e4d924223870959db88ef903b02f04244c42f9ff`, passed the clean-source gate, and completed **39/39 tests**.

Whole Package Qualification also passed its exact-source installed-wheel clean-room surface across the maintained OS/Python matrix, alongside workspace build ownership, property/corruption, and qualification-harness contracts.

This evidence qualifies this exact source revision. It does not turn dynamically resolved test dependencies into a frozen environment claim.

## Staging and superseded evidence

A disposable staging branch was used only to discover and harden semantics. Its first real adversarial run produced **34 passing / 2 failing** tests. One failure identified an obsolete pooled-process ownership assertion. The second exposed a genuine stale-response identity bypass. Both were repaired, along with IPC teardown classification and heartbeat-cancellation containment.

The corrected first staging candidate then completed **36/36 targeted runtime tests** on Python 3.11 and persisted validated blobs as `b1967bb75dfc06265d407f91868acbedf405be35`.

The first clean production candidate `f5c7528f6ff3e3f99bac4e24f311829495532eab` subsequently passed all nine Runtime Fault Qualification OS/Python lanes at 36 tests per lane. **That CI record is explicitly superseded and is not final qualification.** A hostile post-matrix audit found that process cleanup exceptions were swallowed and `STOPPED` could be reached without proving every executor-owned child had actually terminated.

That cleanup-authority defect was repaired on a fresh disposable branch. The hardened staging candidate completed **39/39 targeted runtime tests** on Python 3.11, including adversaries for an immortal direct-child handle, false-STOPPED prevention, and preservation of an earlier scientific culprit during cleanup failure.

The current PR head was then reconstructed atomically from the original clean production tree, replacing only the five validated cleanup-hardened blobs. Exact Phase A SHA `1105e027...` is the sole parent. No `.staging` helper, trigger, or staging workflow is present in this PR.

No staging or superseded CI result is borrowed as final qualification; the qualification above belongs only to `e4d924223870959db88ef903b02f04244c42f9ff`.

## Claim boundary

This is **direct-child fault isolation**, not a security sandbox. Trusted Python objects may cross multiprocessing/pickle boundaries. Termination authority covers the direct child owned by neurOS and does not claim arbitrary descendant process-tree termination.

This remains runtime correctness work only. No Kumar2024 model/fleet execution is authorized by this PR, and ORION remains outside comparison authority.

Refs #123.