### PR TITLE
[STAGING] Phase C neural transport codec qualification

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -15,6 +15,7 @@ on:
       - "tests/test_runtime_process_authority.py"
       - "tests/test_runtime_neural_transport.py"
       - "tests/test_runtime_shared_transport_integration.py"
+      - "tests/test_runtime_transport_protocol_corruption.py"
   push:
     branches:
       - main
@@ -31,6 +32,7 @@ on:
       - "tests/test_runtime_process_authority.py"
       - "tests/test_runtime_neural_transport.py"
       - "tests/test_runtime_shared_transport_integration.py"
+      - "tests/test_runtime_transport_protocol_corruption.py"
   workflow_dispatch:
 
 permissions:
@@ -100,7 +102,8 @@ jobs:
             tests/test_runtime_execution_authority.py \
             tests/test_runtime_process_authority.py \
             tests/test_runtime_neural_transport.py \
-            tests/test_runtime_shared_transport_integration.py
+            tests/test_runtime_shared_transport_integration.py \
+            tests/test_runtime_transport_protocol_corruption.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_runtime_executor.py"
@@ -12,11 +13,13 @@ on:
       - "tests/test_runtime_fusion_cancellation.py"
       - "tests/test_runtime_execution_authority.py"
       - "tests/test_runtime_process_authority.py"
+      - "tests/test_runtime_neural_transport.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_runtime_executor.py"
@@ -25,6 +28,7 @@ on:
       - "tests/test_runtime_fusion_cancellation.py"
       - "tests/test_runtime_execution_authority.py"
       - "tests/test_runtime_process_authority.py"
+      - "tests/test_runtime_neural_transport.py"
   workflow_dispatch:
 
 permissions:
@@ -92,7 +96,8 @@ jobs:
             tests/test_runtime_fault_qualification.py \
             tests/test_runtime_fusion_cancellation.py \
             tests/test_runtime_execution_authority.py \
-            tests/test_runtime_process_authority.py
+            tests/test_runtime_process_authority.py \
+            tests/test_runtime_neural_transport.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -14,6 +14,7 @@ on:
       - "tests/test_runtime_execution_authority.py"
       - "tests/test_runtime_process_authority.py"
       - "tests/test_runtime_neural_transport.py"
+      - "tests/test_runtime_shared_transport_integration.py"
   push:
     branches:
       - main
@@ -29,6 +30,7 @@ on:
       - "tests/test_runtime_execution_authority.py"
       - "tests/test_runtime_process_authority.py"
       - "tests/test_runtime_neural_transport.py"
+      - "tests/test_runtime_shared_transport_integration.py"
   workflow_dispatch:
 
 permissions:
@@ -97,7 +99,8 @@ jobs:
             tests/test_runtime_fusion_cancellation.py \
             tests/test_runtime_execution_authority.py \
             tests/test_runtime_process_authority.py \
-            tests/test_runtime_neural_transport.py
+            tests/test_runtime_neural_transport.py \
+            tests/test_runtime_shared_transport_integration.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -16,6 +16,7 @@ on:
       - "tests/test_runtime_neural_transport.py"
       - "tests/test_runtime_shared_transport_integration.py"
       - "tests/test_runtime_transport_protocol_corruption.py"
+      - "tests/test_runtime_process_provenance.py"
   push:
     branches:
       - main
@@ -33,6 +34,7 @@ on:
       - "tests/test_runtime_neural_transport.py"
       - "tests/test_runtime_shared_transport_integration.py"
       - "tests/test_runtime_transport_protocol_corruption.py"
+      - "tests/test_runtime_process_provenance.py"
   workflow_dispatch:
 
 permissions:
@@ -103,7 +105,8 @@ jobs:
             tests/test_runtime_process_authority.py \
             tests/test_runtime_neural_transport.py \
             tests/test_runtime_shared_transport_integration.py \
-            tests/test_runtime_transport_protocol_corruption.py
+            tests/test_runtime_transport_protocol_corruption.py \
+            tests/test_runtime_process_provenance.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/packages/neuros-core/src/neuros/contracts/window.py
+++ b/packages/neuros-core/src/neuros/contracts/window.py
@@ -9,14 +9,15 @@ replayable.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
-from types import MappingProxyType
+from numbers import Integral, Real
 from typing import Any, Mapping
 
 import numpy as np
 from numpy.typing import NDArray
 
-from .signal import ClockDomain, QualityFlag
+from .signal import ClockDomain, QualityFlag, _freeze_metadata_mapping
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,6 +64,10 @@ class NeuralWindow:
     ``data`` is always two-dimensional and channel-major: ``(channels, time)``.
     The runtime adds the batch axis at decoder invocation, yielding
     ``(batch=1, channels, time)`` for raw-window neural decoders.
+
+    Window arrays and metadata are detached from caller-owned mutable state at
+    construction. ``data`` is stored read-only, matching :class:`SignalFrame`'s
+    immutable software-observation boundary.
     """
 
     stream_id: str
@@ -78,16 +83,39 @@ class NeuralWindow:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.stream_id:
+        if not isinstance(self.stream_id, str) or not self.stream_id.strip():
             raise ValueError("stream_id must be non-empty")
-        if self.window_id < 0:
+        if isinstance(self.window_id, (bool, np.bool_)) or not isinstance(
+            self.window_id, Integral
+        ):
+            raise TypeError("window_id must be an integer")
+        if int(self.window_id) < 0:
             raise ValueError("window_id must be >= 0")
-        if self.sample_rate_hz <= 0:
-            raise ValueError("sample_rate_hz must be positive")
-        if self.start_time_ns < 0 or self.end_time_ns <= self.start_time_ns:
-            raise ValueError("NeuralWindow requires a positive half-open time interval")
+        object.__setattr__(self, "window_id", int(self.window_id))
 
-        arr = np.asarray(self.data)
+        if isinstance(self.sample_rate_hz, (bool, np.bool_)) or not isinstance(
+            self.sample_rate_hz, Real
+        ):
+            raise TypeError("sample_rate_hz must be a real numeric scalar")
+        sample_rate_hz = float(self.sample_rate_hz)
+        if not math.isfinite(sample_rate_hz) or sample_rate_hz <= 0:
+            raise ValueError("sample_rate_hz must be finite and positive")
+        object.__setattr__(self, "sample_rate_hz", sample_rate_hz)
+
+        for field_name, value in (
+            ("start_time_ns", self.start_time_ns),
+            ("end_time_ns", self.end_time_ns),
+        ):
+            if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+                raise TypeError(f"{field_name} must be an integer")
+        start_time_ns = int(self.start_time_ns)
+        end_time_ns = int(self.end_time_ns)
+        if start_time_ns < 0 or end_time_ns <= start_time_ns:
+            raise ValueError("NeuralWindow requires a positive half-open time interval")
+        object.__setattr__(self, "start_time_ns", start_time_ns)
+        object.__setattr__(self, "end_time_ns", end_time_ns)
+
+        arr = np.array(self.data, copy=True, subok=False)
         if arr.ndim != 2:
             raise ValueError(
                 "NeuralWindow.data must have shape (channels, time); "
@@ -95,22 +123,55 @@ class NeuralWindow:
             )
         if arr.shape[0] <= 0 or arr.shape[1] <= 0:
             raise ValueError("NeuralWindow.data cannot contain empty axes")
-        if not np.isfinite(arr).all():
+        if arr.dtype.kind not in "biufc":
+            raise TypeError(
+                "NeuralWindow.data must use a boolean or numeric dtype; "
+                f"received {arr.dtype}"
+            )
+        if arr.dtype.kind in "fc" and not np.isfinite(arr).all():
             raise ValueError("NeuralWindow.data contains NaN or infinite values")
-        if self.channel_names and len(self.channel_names) != arr.shape[0]:
+
+        channel_names = tuple(self.channel_names)
+        if any(not isinstance(name, str) or not name.strip() for name in channel_names):
+            raise ValueError("channel_names must contain non-empty strings")
+        if channel_names and len(channel_names) != arr.shape[0]:
             raise ValueError("channel_names must match the channel axis")
-        if any(sequence_id < 0 for sequence_id in self.source_sequence_ids):
-            raise ValueError("source_sequence_ids must be non-negative")
+        object.__setattr__(self, "channel_names", channel_names)
+
+        source_sequence_ids: list[int] = []
+        for sequence_id in self.source_sequence_ids:
+            if isinstance(sequence_id, (bool, np.bool_)) or not isinstance(
+                sequence_id, Integral
+            ):
+                raise TypeError("source_sequence_ids must contain integers")
+            resolved = int(sequence_id)
+            if resolved < 0:
+                raise ValueError("source_sequence_ids must be non-negative")
+            source_sequence_ids.append(resolved)
+        source_sequence_tuple = tuple(source_sequence_ids)
         if any(
             current <= previous
             for previous, current in zip(
-                self.source_sequence_ids, self.source_sequence_ids[1:]
+                source_sequence_tuple, source_sequence_tuple[1:]
             )
         ):
             raise ValueError("source_sequence_ids must be strictly increasing")
+        object.__setattr__(self, "source_sequence_ids", source_sequence_tuple)
 
+        object.__setattr__(self, "clock_domain", ClockDomain(self.clock_domain))
+        quality_value = int(self.quality)
+        if quality_value < 0:
+            raise ValueError("quality must be non-negative")
+        known_mask = 0
+        for flag in QualityFlag:
+            known_mask |= int(flag)
+        if quality_value & ~known_mask:
+            raise ValueError("quality contains undefined QualityFlag bits")
+        object.__setattr__(self, "quality", QualityFlag(quality_value))
+
+        arr.setflags(write=False)
         object.__setattr__(self, "data", arr)
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+        object.__setattr__(self, "metadata", _freeze_metadata_mapping(self.metadata))
 
     @property
     def n_channels(self) -> int:

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -22,6 +22,7 @@ from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, Transform
 from neuros.errors import ProcessingError
 from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from neuros.runtime.process_worker import PersistentProcessWorker
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
 from neuros.runtime.lifecycle import RuntimeEvent, RuntimeState
 from neuros.runtime.queues import OverflowPolicy, QueueStats, put_with_policy
 
@@ -164,6 +165,9 @@ def _call(func: Callable[[Any], Any], item: Any) -> Any:
     return asyncio.run(await_result())
 
 
+_ProcessWorker = PersistentProcessWorker | SharedMemoryProcessWorker
+
+
 class RuntimeExecutor:
     """Execute a validated :class:`RuntimeGraph`.
 
@@ -200,7 +204,7 @@ class RuntimeExecutor:
         self._completion_task: asyncio.Task[None] | None = None
         self._output_queue: asyncio.Queue[Any] = asyncio.Queue()
         self._event_queue: asyncio.Queue[RuntimeEvent] = asyncio.Queue()
-        self._process_workers: dict[str, PersistentProcessWorker] = {}
+        self._process_workers: dict[str, _ProcessWorker] = {}
         self._process_receipts: dict[str, deque[dict[str, Any]]] = {
             node_id: deque(maxlen=4096)
             for node_id, node in graph.nodes.items()
@@ -618,11 +622,27 @@ class RuntimeExecutor:
                 )
             worker = self._process_workers.get(node.node_id)
             if worker is None:
-                worker = PersistentProcessWorker(
-                    node.node_id,
-                    node.operator,
-                    execution_timeout_s=timeout_s,
-                )
+                if node.process_transport == "shared_memory":
+                    request_capacity = node.process_request_capacity_bytes
+                    response_capacity = node.process_response_capacity_bytes
+                    if request_capacity is None or response_capacity is None:
+                        raise ValueError(
+                            f"Shared-memory process node {node.node_id} lacks "
+                            "explicit request/response mailbox capacities"
+                        )
+                    worker = SharedMemoryProcessWorker(
+                        node.node_id,
+                        node.operator,
+                        execution_timeout_s=timeout_s,
+                        request_capacity_bytes=request_capacity,
+                        response_capacity_bytes=response_capacity,
+                    )
+                else:
+                    worker = PersistentProcessWorker(
+                        node.node_id,
+                        node.operator,
+                        execution_timeout_s=timeout_s,
+                    )
                 self._process_workers[node.node_id] = worker
             receipts = self._process_receipts.setdefault(
                 node.node_id, deque(maxlen=4096)

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -399,8 +399,6 @@ class RuntimeExecutor:
                     error_type=error_type,
                     message=str(cause),
                 )
-                # The task currently executing this handler must be allowed to
-                # finish propagating its exception. All peers are cancelled.
                 for peer_id, task in self._tasks.items():
                     if peer_id != node.node_id and not task.done():
                         task.cancel()
@@ -422,10 +420,6 @@ class RuntimeExecutor:
             raise
         finally:
             await source.stop()
-            # Only normal completion or an explicit graceful stop owns an
-            # in-band shutdown marker. During failure propagation the peer
-            # consumer may already be cancelled, so enqueueing _STOP into a
-            # saturated data queue can deadlock containment indefinitely.
             graceful_stop = (
                 cancelled and self._stopping and self.failure is None
             )
@@ -484,9 +478,6 @@ class RuntimeExecutor:
                     pending, return_when=asyncio.FIRST_COMPLETED
                 )
             except BaseException:
-                # Fusion owns these temporary queue-get tasks. If the fusion
-                # node is cancelled, every child must be cancelled and awaited
-                # before the node itself can become terminal.
                 for task in pending:
                     if not task.done():
                         task.cancel()
@@ -677,8 +668,6 @@ class RuntimeExecutor:
 
     async def _emit_stop(self, node_id: str) -> None:
         for channel in self._outgoing[node_id]:
-            # Shutdown markers are control-plane authority and must never be
-            # dropped by the data overflow policy.
             await channel.queue.put(_STOP)
 
     async def _notify_monitors(self, node: RuntimeNode, item: Any) -> None:
@@ -756,8 +745,6 @@ class RuntimeExecutor:
         if self.state is RuntimeState.STOPPED:
             return
         if self.state is RuntimeState.FAILED:
-            # FAILED is scientific terminal authority, but callers invoking
-            # stop() also receive a resource-cleanup barrier.
             if self._completion_task is not None and not self._completion_task.done():
                 await asyncio.gather(
                     self._completion_task, return_exceptions=True
@@ -897,6 +884,16 @@ class RuntimeExecutor:
                 for node_id, stats in self._node_stats.items()
             },
             "edges": edge_metrics,
+            "process_execution": {
+                node_id: {
+                    "transport": node.process_transport,
+                    "execution_timeout_s": node.execution_timeout_s,
+                    "request_capacity_bytes": node.process_request_capacity_bytes,
+                    "response_capacity_bytes": node.process_response_capacity_bytes,
+                }
+                for node_id, node in sorted(self.graph.nodes.items())
+                if node.executor == "process"
+            },
             "process_receipts": {
                 node_id: list(receipts)
                 for node_id, receipts in self._process_receipts.items()

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -19,6 +19,9 @@ class NodeKind(str, Enum):
     MONITOR = "monitor"
 
 
+_PROCESS_TRANSPORTS = frozenset({"pickle", "shared_memory"})
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeNode:
     node_id: str
@@ -27,6 +30,9 @@ class RuntimeNode:
     executor: str = "inline"
     latency_budget_ms: float | None = None
     execution_timeout_s: float | None = None
+    process_transport: str = "pickle"
+    process_request_capacity_bytes: int | None = None
+    process_response_capacity_bytes: int | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -52,6 +58,33 @@ class RuntimeNode:
                 "executor='process' requires an explicit execution_timeout_s; "
                 "latency_budget_ms is an SLO and is not termination authority"
             )
+
+        if self.process_transport not in _PROCESS_TRANSPORTS:
+            raise ValueError(
+                f"Unsupported process_transport: {self.process_transport}"
+            )
+        capacities = (
+            ("process_request_capacity_bytes", self.process_request_capacity_bytes),
+            ("process_response_capacity_bytes", self.process_response_capacity_bytes),
+        )
+        any_capacity = any(value is not None for _, value in capacities)
+        if self.executor != "process":
+            if self.process_transport != "pickle" or any_capacity:
+                raise ValueError(
+                    "process transport declarations are only valid for executor='process'"
+                )
+        elif self.process_transport == "shared_memory":
+            for field_name, value in capacities:
+                if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                    raise ValueError(
+                        f"shared_memory transport requires positive {field_name}"
+                    )
+        elif any_capacity:
+            raise ValueError(
+                "process mailbox capacities are only valid for "
+                "process_transport='shared_memory'"
+            )
+
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
 

--- a/packages/neuros-core/src/neuros/runtime/shared_process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/shared_process_worker.py
@@ -1,0 +1,720 @@
+"""Persistent direct-child worker using canonical shared-memory payload transport.
+
+This worker is deliberately separate from :mod:`neuros.runtime.process_worker`
+while Phase C transport semantics are being qualified. The already-qualified
+pickle worker remains untouched. Both workers expose the same execution receipt
+and fail-closed direct-child authority, while this implementation owns one
+request and one response shared-memory mailbox for each worker generation.
+
+The multiprocessing pipe remains a small control plane. Array bytes and
+canonical neural payloads live in shared memory and are materialized into local
+memory before arbitrary operator callbacks execute. This is not a zero-copy
+callback contract.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import multiprocessing as mp
+import pickle
+from multiprocessing.connection import Connection
+from typing import Any
+
+from .process_worker import (
+    ProcessCallResult,
+    ProcessExecutionReceipt,
+    ProcessWorkerCrashedError,
+    ProcessWorkerError,
+    ProcessWorkerProtocolError,
+    ProcessWorkerRemoteError,
+    ProcessWorkerSerializationError,
+    ProcessWorkerTerminationError,
+    ProcessWorkerTimeoutError,
+)
+from .transport import NeuralTransportError, SharedMemoryMailbox
+
+_PROTOCOL = 1
+
+
+class ProcessWorkerTransportError(ProcessWorkerError):
+    """Shared-memory creation, codec, identity, or cleanup authority failure."""
+
+
+def _run_callback(func: Any, item: Any) -> Any:
+    value = func(item)
+    if not inspect.isawaitable(value):
+        return value
+
+    async def _await() -> Any:
+        return await value
+
+    return asyncio.run(_await())
+
+
+def _send(conn: Connection, envelope: dict[str, Any]) -> None:
+    conn.send_bytes(pickle.dumps(envelope, protocol=pickle.HIGHEST_PROTOCOL))
+
+
+def _child(
+    conn: Connection,
+    operator: Any,
+    node_id: str,
+    generation: int,
+    request_mailbox_name: str,
+    request_capacity_bytes: int,
+    response_mailbox_name: str,
+    response_capacity_bytes: int,
+) -> None:
+    base = {"protocol": _PROTOCOL, "node_id": node_id, "generation": generation}
+    request_mailbox: SharedMemoryMailbox | None = None
+    response_mailbox: SharedMemoryMailbox | None = None
+    try:
+        try:
+            request_mailbox = SharedMemoryMailbox.attach(
+                request_mailbox_name, request_capacity_bytes
+            )
+            response_mailbox = SharedMemoryMailbox.attach(
+                response_mailbox_name, response_capacity_bytes
+            )
+        except Exception as exc:
+            try:
+                _send(
+                    conn,
+                    {
+                        **base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"child shared-memory attach failed: {exc}",
+                    },
+                )
+            finally:
+                return
+
+        _send(conn, {**base, "kind": "ready"})
+        while True:
+            try:
+                payload = conn.recv_bytes()
+            except (EOFError, ConnectionResetError, BrokenPipeError, OSError):
+                return
+            try:
+                request = pickle.loads(payload)
+            except Exception as exc:
+                try:
+                    _send(
+                        conn,
+                        {**base, "kind": "protocol_error", "message": str(exc)},
+                    )
+                except (EOFError, ConnectionResetError, BrokenPipeError, OSError):
+                    pass
+                return
+
+            if not isinstance(request, dict) or any(
+                (
+                    request.get("protocol") != _PROTOCOL,
+                    request.get("node_id") != node_id,
+                    request.get("generation") != generation,
+                )
+            ):
+                _send(
+                    conn,
+                    {**base, "kind": "protocol_error", "message": "identity mismatch"},
+                )
+                return
+
+            command = request.get("command")
+            if command == "heartbeat":
+                _send(conn, {**base, "kind": "heartbeat"})
+                continue
+            if command == "shutdown":
+                _send(conn, {**base, "kind": "shutdown"})
+                return
+
+            request_id = request.get("request_id")
+            method = request.get("method")
+            item_envelope = request.get("item")
+            call_base = {**base, "request_id": request_id}
+            if (
+                command != "call"
+                or not isinstance(request_id, int)
+                or isinstance(request_id, bool)
+                or request_id <= 0
+                or not isinstance(method, str)
+                or not method
+            ):
+                _send(
+                    conn,
+                    {**call_base, "kind": "protocol_error", "message": "malformed call"},
+                )
+                return
+
+            try:
+                assert request_mailbox is not None
+                item = request_mailbox.decode(
+                    item_envelope, expected_lease_id=request_id
+                )
+            except NeuralTransportError as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"input transport failed: {exc}",
+                    },
+                )
+                return
+            except Exception as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"input transport decoding failed: {exc}",
+                    },
+                )
+                return
+
+            try:
+                result = _run_callback(getattr(operator, method), item)
+            except BaseException as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "error",
+                        "error_type": type(exc).__name__,
+                        "message": str(exc),
+                    },
+                )
+                continue
+
+            try:
+                assert response_mailbox is not None
+                result_envelope = response_mailbox.encode(
+                    result, lease_id=request_id
+                )
+            except NeuralTransportError as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"result transport failed: {exc}",
+                    },
+                )
+                return
+            except Exception as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"result transport encoding failed: {exc}",
+                    },
+                )
+                return
+
+            _send(
+                conn,
+                {**call_base, "kind": "result", "result": result_envelope},
+            )
+    finally:
+        if request_mailbox is not None:
+            try:
+                request_mailbox.close()
+            except Exception:
+                pass
+        if response_mailbox is not None:
+            try:
+                response_mailbox.close()
+            except Exception:
+                pass
+        conn.close()
+
+
+class SharedMemoryProcessWorker:
+    """One persistent operator child with parent-owned shared-memory mailboxes."""
+
+    def __init__(
+        self,
+        node_id: str,
+        operator: Any,
+        *,
+        execution_timeout_s: float,
+        request_capacity_bytes: int,
+        response_capacity_bytes: int,
+        generation: int = 0,
+        startup_timeout_s: float = 5.0,
+        termination_grace_s: float = 0.25,
+    ) -> None:
+        if not node_id:
+            raise ValueError("node_id must be non-empty")
+        if min(execution_timeout_s, startup_timeout_s, termination_grace_s) <= 0:
+            raise ValueError("worker timeouts must be positive")
+        if generation < 0:
+            raise ValueError("generation must be non-negative")
+        for field_name, capacity in (
+            ("request_capacity_bytes", request_capacity_bytes),
+            ("response_capacity_bytes", response_capacity_bytes),
+        ):
+            if isinstance(capacity, bool) or not isinstance(capacity, int) or capacity <= 0:
+                raise ValueError(f"{field_name} must be a positive integer")
+
+        self.node_id = node_id
+        self.operator = operator
+        self.execution_timeout_s = float(execution_timeout_s)
+        self.startup_timeout_s = float(startup_timeout_s)
+        self.termination_grace_s = float(termination_grace_s)
+        self.request_capacity_bytes = request_capacity_bytes
+        self.response_capacity_bytes = response_capacity_bytes
+        self.generation = int(generation)
+        self._ctx = mp.get_context("spawn")
+        self._conn: Connection | None = None
+        self._process: mp.Process | None = None
+        self._request_mailbox: SharedMemoryMailbox | None = None
+        self._response_mailbox: SharedMemoryMailbox | None = None
+        self._request_id = 0
+        self._last_receipt: ProcessExecutionReceipt | None = None
+        self._lock = asyncio.Lock()
+        self._terminal = False
+
+    @property
+    def last_receipt(self) -> ProcessExecutionReceipt | None:
+        return self._last_receipt
+
+    @property
+    def pid(self) -> int | None:
+        return None if self._process is None else self._process.pid
+
+    @property
+    def is_alive(self) -> bool:
+        return bool(self._process is not None and self._process.is_alive())
+
+    @property
+    def shared_memory_names(self) -> dict[str, str] | None:
+        if self._request_mailbox is None or self._response_mailbox is None:
+            return None
+        return {
+            "request": self._request_mailbox.name,
+            "response": self._response_mailbox.name,
+        }
+
+    def _receipt(
+        self, request_id: int, outcome: str, error_type: str | None = None
+    ) -> None:
+        self._last_receipt = ProcessExecutionReceipt(
+            self.node_id,
+            self.generation,
+            request_id,
+            outcome,
+            error_type,
+        )
+
+    def _identity(self, response: dict[str, Any], request_id: int | None) -> None:
+        if (
+            response.get("protocol") != _PROTOCOL
+            or response.get("node_id") != self.node_id
+            or response.get("generation") != self.generation
+            or (request_id is not None and response.get("request_id") != request_id)
+        ):
+            raise ProcessWorkerProtocolError(
+                self.node_id,
+                f"stale or mismatched process response for request {request_id}",
+            )
+
+    def _recv(self, timeout_s: float, request_id: int | None) -> dict[str, Any]:
+        if self._conn is None:
+            raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
+        if not self._conn.poll(timeout_s):
+            if not self.is_alive:
+                raise ProcessWorkerCrashedError(
+                    self.node_id, "worker exited before response"
+                )
+            raise ProcessWorkerTimeoutError(
+                self.node_id,
+                f"request {request_id} exceeded {timeout_s:.6f}s hard execution timeout",
+            )
+        try:
+            response = pickle.loads(self._conn.recv_bytes())
+        except EOFError as exc:
+            raise ProcessWorkerCrashedError(
+                self.node_id, "worker EOF before response"
+            ) from exc
+        except Exception as exc:
+            raise ProcessWorkerProtocolError(
+                self.node_id, f"invalid worker response: {exc}"
+            ) from exc
+        if not isinstance(response, dict):
+            raise ProcessWorkerProtocolError(
+                self.node_id, "worker response is not a mapping"
+            )
+        self._identity(response, request_id)
+        return response
+
+    def _send_control(self, command: str) -> None:
+        if self._conn is None:
+            raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
+        try:
+            _send(
+                self._conn,
+                {
+                    "protocol": _PROTOCOL,
+                    "node_id": self.node_id,
+                    "generation": self.generation,
+                    "command": command,
+                },
+            )
+        except (EOFError, ConnectionResetError, BrokenPipeError, OSError) as exc:
+            raise ProcessWorkerCrashedError(
+                self.node_id, f"worker IPC failed while sending {command}"
+            ) from exc
+
+    def _create_transport(self) -> None:
+        if self._request_mailbox is not None or self._response_mailbox is not None:
+            if self._request_mailbox is None or self._response_mailbox is None:
+                raise ProcessWorkerTransportError(
+                    self.node_id, "shared-memory mailbox ownership is incomplete"
+                )
+            return
+
+        try:
+            request_mailbox = SharedMemoryMailbox(self.request_capacity_bytes)
+        except Exception as exc:
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                "request shared-memory mailbox creation failed: "
+                f"{type(exc).__name__}: {exc}",
+            ) from exc
+
+        try:
+            response_mailbox = SharedMemoryMailbox(self.response_capacity_bytes)
+        except Exception as exc:
+            cleanup_suffix = ""
+            try:
+                request_mailbox.close_and_unlink()
+            except Exception as cleanup_exc:
+                cleanup_suffix = (
+                    "; request mailbox cleanup also failed: "
+                    f"{type(cleanup_exc).__name__}: {cleanup_exc}"
+                )
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                "response shared-memory mailbox creation failed: "
+                f"{type(exc).__name__}: {exc}{cleanup_suffix}",
+            ) from exc
+
+        self._request_mailbox = request_mailbox
+        self._response_mailbox = response_mailbox
+
+    def _cleanup_transport(self) -> None:
+        errors: list[str] = []
+        for attr_name in ("_request_mailbox", "_response_mailbox"):
+            mailbox = getattr(self, attr_name)
+            if mailbox is None:
+                continue
+            try:
+                mailbox.close_and_unlink()
+            except Exception as exc:
+                errors.append(f"{attr_name}: {type(exc).__name__}: {exc}")
+                continue
+            setattr(self, attr_name, None)
+        if errors:
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                "shared-memory cleanup authority failed: " + "; ".join(errors),
+            )
+
+    def _start(self) -> None:
+        if self._terminal:
+            raise ProcessWorkerError(
+                self.node_id, "worker is terminal; create a new generation"
+            )
+        if self._process is not None:
+            if self._process.is_alive():
+                return
+            raise ProcessWorkerCrashedError(self.node_id, "worker exited")
+
+        self._create_transport()
+        assert self._request_mailbox is not None
+        assert self._response_mailbox is not None
+        parent, child = self._ctx.Pipe(duplex=True)
+        process = self._ctx.Process(
+            target=_child,
+            args=(
+                child,
+                self.operator,
+                self.node_id,
+                self.generation,
+                self._request_mailbox.name,
+                self.request_capacity_bytes,
+                self._response_mailbox.name,
+                self.response_capacity_bytes,
+            ),
+            name=f"neuros-shm-process:{self.node_id}:g{self.generation}",
+        )
+        self._conn, self._process = parent, process
+        try:
+            process.start()
+        except Exception as exc:
+            parent.close()
+            self._conn = self._process = None
+            cleanup_suffix = ""
+            try:
+                self._cleanup_transport()
+            except ProcessWorkerTransportError as cleanup_exc:
+                cleanup_suffix = f"; transport cleanup also failed: {cleanup_exc}"
+            raise ProcessWorkerSerializationError(
+                self.node_id,
+                f"operator/start serialization failed: {exc}{cleanup_suffix}",
+            ) from exc
+        finally:
+            child.close()
+
+        ready = self._recv(self.startup_timeout_s, None)
+        if ready.get("kind") == "transport_error":
+            raise ProcessWorkerTransportError(
+                self.node_id, str(ready.get("message") or "child transport startup failed")
+            )
+        if ready.get("kind") != "ready":
+            raise ProcessWorkerProtocolError(
+                self.node_id, "worker did not become ready"
+            )
+        self._send_control("heartbeat")
+        heartbeat = self._recv(self.startup_timeout_s, None)
+        if heartbeat.get("kind") != "heartbeat":
+            raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
+
+    async def invoke(self, method: str, item: Any) -> ProcessCallResult:
+        async with self._lock:
+            request_id = self._request_id + 1
+            try:
+                await asyncio.to_thread(self._start)
+                self._request_id = request_id
+                if self._request_mailbox is None:
+                    raise ProcessWorkerTransportError(
+                        self.node_id, "request mailbox is unavailable"
+                    )
+                try:
+                    item_envelope = self._request_mailbox.encode(
+                        item, lease_id=request_id
+                    )
+                except NeuralTransportError as exc:
+                    raise ProcessWorkerTransportError(
+                        self.node_id, f"input transport failed: {exc}"
+                    ) from exc
+                except Exception as exc:
+                    raise ProcessWorkerTransportError(
+                        self.node_id,
+                        f"input transport encoding failed: {type(exc).__name__}: {exc}",
+                    ) from exc
+
+                if self._conn is None:
+                    raise ProcessWorkerCrashedError(
+                        self.node_id, "worker IPC is closed"
+                    )
+                try:
+                    await asyncio.to_thread(
+                        _send,
+                        self._conn,
+                        {
+                            "protocol": _PROTOCOL,
+                            "node_id": self.node_id,
+                            "generation": self.generation,
+                            "command": "call",
+                            "request_id": request_id,
+                            "method": method,
+                            "item": item_envelope,
+                        },
+                    )
+                except (EOFError, ConnectionResetError, BrokenPipeError, OSError) as exc:
+                    raise ProcessWorkerCrashedError(
+                        self.node_id,
+                        f"worker IPC failed while sending request {request_id}",
+                    ) from exc
+
+                response = await asyncio.to_thread(
+                    self._recv, self.execution_timeout_s, request_id
+                )
+            except asyncio.CancelledError:
+                self._receipt(request_id, "cancelled")
+                await asyncio.shield(asyncio.to_thread(self.abort))
+                raise
+            except ProcessWorkerTimeoutError:
+                self._receipt(request_id, "timeout")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerCrashedError:
+                self._receipt(request_id, "crashed")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerProtocolError:
+                self._receipt(request_id, "protocol_error")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerTransportError:
+                self._request_id = request_id
+                self._receipt(request_id, "transport_error")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerSerializationError:
+                self._request_id = request_id
+                self._receipt(request_id, "serialization_error")
+                await asyncio.to_thread(self.abort)
+                raise
+            except Exception as exc:
+                self._request_id = request_id
+                self._receipt(request_id, "serialization_error")
+                await asyncio.to_thread(self.abort)
+                raise ProcessWorkerSerializationError(
+                    self.node_id, f"input/request serialization failed: {exc}"
+                ) from exc
+
+            kind = response.get("kind")
+            if kind == "result":
+                if self._response_mailbox is None:
+                    self._receipt(request_id, "transport_error")
+                    await asyncio.to_thread(self.abort)
+                    raise ProcessWorkerTransportError(
+                        self.node_id, "response mailbox is unavailable"
+                    )
+                try:
+                    result = self._response_mailbox.decode(
+                        response.get("result"), expected_lease_id=request_id
+                    )
+                except NeuralTransportError as exc:
+                    self._receipt(request_id, "transport_error")
+                    await asyncio.to_thread(self.abort)
+                    raise ProcessWorkerTransportError(
+                        self.node_id, f"result transport failed: {exc}"
+                    ) from exc
+                except Exception as exc:
+                    self._receipt(request_id, "transport_error")
+                    await asyncio.to_thread(self.abort)
+                    raise ProcessWorkerTransportError(
+                        self.node_id,
+                        f"result transport decoding failed: {type(exc).__name__}: {exc}",
+                    ) from exc
+
+                receipt = ProcessExecutionReceipt(
+                    self.node_id, self.generation, request_id, "success"
+                )
+                self._last_receipt = receipt
+                return ProcessCallResult(result, receipt)
+
+            if kind == "error":
+                error_type = str(response.get("error_type") or "RemoteError")
+                self._receipt(request_id, "error", error_type)
+                raise ProcessWorkerRemoteError(
+                    self.node_id,
+                    error_type,
+                    str(response.get("message") or ""),
+                )
+            if kind == "transport_error":
+                self._receipt(request_id, "transport_error")
+                await asyncio.to_thread(self.abort)
+                raise ProcessWorkerTransportError(
+                    self.node_id, str(response.get("message") or "transport failure")
+                )
+            if kind == "serialization_error":
+                self._receipt(request_id, "serialization_error")
+                await asyncio.to_thread(self.abort)
+                raise ProcessWorkerSerializationError(
+                    self.node_id,
+                    str(response.get("message") or "serialization failure"),
+                )
+
+            self._receipt(request_id, "protocol_error")
+            await asyncio.to_thread(self.abort)
+            raise ProcessWorkerProtocolError(
+                self.node_id, f"unexpected worker response kind {kind!r}"
+            )
+
+    async def heartbeat(self) -> None:
+        async with self._lock:
+            try:
+                await asyncio.to_thread(self._start)
+                await asyncio.to_thread(self._send_control, "heartbeat")
+                response = await asyncio.to_thread(
+                    self._recv, self.startup_timeout_s, None
+                )
+                if response.get("kind") != "heartbeat":
+                    raise ProcessWorkerProtocolError(
+                        self.node_id, "worker heartbeat failed"
+                    )
+            except asyncio.CancelledError:
+                await asyncio.shield(asyncio.to_thread(self.abort))
+                raise
+            except Exception:
+                await asyncio.to_thread(self.abort)
+                raise
+
+    def _terminate_owned_process(self, process: mp.Process) -> None:
+        """Prove the direct child is dead or retain its live handle and fail."""
+
+        if process.is_alive():
+            process.terminate()
+            process.join(self.termination_grace_s)
+        if process.is_alive() and hasattr(process, "kill"):
+            process.kill()
+            process.join(self.termination_grace_s)
+        if process.is_alive():
+            self._process = process
+            raise ProcessWorkerTerminationError(
+                self.node_id,
+                "direct child remained alive after terminate/join/kill escalation",
+            )
+        process.close()
+        self._process = None
+
+    def abort(self) -> None:
+        self._terminal = True
+        conn, process = self._conn, self._process
+        self._conn = None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        if process is None:
+            self._process = None
+            self._cleanup_transport()
+            return
+        self._terminate_owned_process(process)
+        # Shared-memory names are unlinked only after direct-child death has
+        # been proven. If termination raises, these handles intentionally stay.
+        self._cleanup_transport()
+
+    def close(self) -> None:
+        self._terminal = True
+        conn, process = self._conn, self._process
+        if process is None:
+            if conn is not None:
+                conn.close()
+            self._conn = None
+            self._cleanup_transport()
+            return
+
+        if process.is_alive() and conn is not None:
+            try:
+                self._send_control("shutdown")
+                if conn.poll(self.termination_grace_s):
+                    response = pickle.loads(conn.recv_bytes())
+                    self._identity(response, None)
+            except Exception:
+                pass
+
+        process.join(self.termination_grace_s)
+        if conn is not None:
+            conn.close()
+        self._conn = None
+        if process.is_alive():
+            self._terminate_owned_process(process)
+            self._cleanup_transport()
+            return
+
+        process.close()
+        self._process = None
+        self._cleanup_transport()

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -5,6 +5,12 @@ and moves numeric array bytes through a fixed-capacity shared-memory mailbox.
 Decoded arrays are materialized into independent local memory before arbitrary
 operator code is invoked. This is therefore a shared-memory transport, not a
 zero-copy callback contract.
+
+Transport is representation authority, not scientific-value authority. Generic
+numeric payloads preserve their existing values, including non-finite floating
+values when the surrounding contract permits them. Canonical contracts such as
+``SignalFrame`` and ``NeuralWindow`` continue to enforce their own stricter
+scientific invariants during construction.
 """
 from __future__ import annotations
 
@@ -81,11 +87,6 @@ class _MailboxWriter:
                 "shared-memory arrays must use boolean or numeric dtype; "
                 f"received {array.dtype}"
             )
-        if array.dtype.kind in "fc" and not np.isfinite(array).all():
-            raise NeuralTransportTypeError(
-                "shared-memory arrays must be finite; preserve signal quality "
-                "with explicit samples and provenance"
-            )
         array = np.ascontiguousarray(array)
         offset = self._aligned(self.offset)
         end = offset + int(array.nbytes)
@@ -149,12 +150,14 @@ class _MailboxReader:
 
 
 def _encode(value: Any, writer: _MailboxWriter) -> Any:
-    if value is None or isinstance(value, (str, bool, int)):
+    if value is None or isinstance(value, (str, bool, int, float)):
         return {"type": "scalar", "value": value}
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise NeuralTransportTypeError("transport scalar floats must be finite")
-        return {"type": "scalar", "value": value}
+    if isinstance(value, complex):
+        return {
+            "type": "complex_scalar",
+            "real": float(value.real),
+            "imag": float(value.imag),
+        }
     if isinstance(value, np.generic):
         return _encode(value.item(), writer)
     if isinstance(value, np.ndarray):
@@ -209,12 +212,13 @@ def _encode(value: Any, writer: _MailboxWriter) -> Any:
     if isinstance(value, list):
         return {"type": "list", "items": [_encode(item, writer) for item in value]}
     if isinstance(value, Mapping):
-        items: list[list[Any]] = []
-        for key in sorted(value):
-            if not isinstance(key, str):
-                raise NeuralTransportTypeError("transport mapping keys must be strings")
-            items.append([key, _encode(value[key], writer)])
-        return {"type": "mapping", "items": items}
+        keys = tuple(value.keys())
+        if any(not isinstance(key, str) for key in keys):
+            raise NeuralTransportTypeError("transport mapping keys must be strings")
+        return {
+            "type": "mapping",
+            "items": [[key, _encode(value[key], writer)] for key in sorted(keys)],
+        }
     raise NeuralTransportTypeError(
         "unsupported shared-memory payload type "
         f"{type(value).__module__}.{type(value).__qualname__}"
@@ -229,9 +233,12 @@ def _decode(node: Any, reader: _MailboxReader) -> Any:
         value = node.get("value")
         if value is not None and not isinstance(value, (str, bool, int, float)):
             raise NeuralTransportProtocolError("invalid transport scalar")
-        if isinstance(value, float) and not math.isfinite(value):
-            raise NeuralTransportProtocolError("non-finite transport scalar")
         return value
+    if node_type == "complex_scalar":
+        try:
+            return complex(float(node["real"]), float(node["imag"]))
+        except Exception as exc:
+            raise NeuralTransportProtocolError("invalid complex transport scalar") from exc
     if node_type == "ndarray":
         return reader.get_array(node)
     if node_type == "tuple":

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -77,6 +77,28 @@ def _manifest_int(value: Any, field_name: str) -> int:
     return value
 
 
+def _manifest_optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _manifest_int(value, field_name)
+
+
+def _manifest_str(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise NeuralTransportProtocolError(
+            f"transport field {field_name} must be a string"
+        )
+    return value
+
+
+def _manifest_real(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise NeuralTransportProtocolError(
+            f"transport field {field_name} must be a real numeric scalar"
+        )
+    return float(value)
+
+
 class _MailboxWriter:
     def __init__(self, buffer: memoryview, capacity_bytes: int) -> None:
         self.buffer = buffer
@@ -252,6 +274,15 @@ def _encode(value: Any, writer: _MailboxWriter) -> Any:
     )
 
 
+def _decode_items(node: Mapping[str, Any], node_type: str) -> list[Any]:
+    items = node.get("items")
+    if not isinstance(items, list):
+        raise NeuralTransportProtocolError(
+            f"{node_type} transport manifest items must be a list"
+        )
+    return items
+
+
 def _decode(node: Any, reader: _MailboxReader) -> Any:
     if not isinstance(node, Mapping):
         raise NeuralTransportProtocolError("transport manifest node is not a mapping")
@@ -263,20 +294,23 @@ def _decode(node: Any, reader: _MailboxReader) -> Any:
         return value
     if node_type == "complex_scalar":
         try:
-            return complex(float(node["real"]), float(node["imag"]))
+            return complex(
+                _manifest_real(node["real"], "complex.real"),
+                _manifest_real(node["imag"], "complex.imag"),
+            )
+        except NeuralTransportProtocolError:
+            raise
         except Exception as exc:
             raise NeuralTransportProtocolError("invalid complex transport scalar") from exc
     if node_type == "ndarray":
         return reader.get_array(node)
     if node_type == "tuple":
-        return tuple(_decode(item, reader) for item in node.get("items", ()))
+        return tuple(_decode(item, reader) for item in _decode_items(node, "tuple"))
     if node_type == "list":
-        return [_decode(item, reader) for item in node.get("items", ())]
+        return [_decode(item, reader) for item in _decode_items(node, "list")]
     if node_type == "mapping":
         result: dict[str, Any] = {}
-        items = node.get("items")
-        if not isinstance(items, list):
-            raise NeuralTransportProtocolError("mapping manifest items must be a list")
+        items = _decode_items(node, "mapping")
         for pair in items:
             if not isinstance(pair, list) or len(pair) != 2 or not isinstance(pair[0], str):
                 raise NeuralTransportProtocolError("malformed mapping manifest item")
@@ -286,50 +320,109 @@ def _decode(node: Any, reader: _MailboxReader) -> Any:
             result[key] = _decode(pair[1], reader)
         return result
     if node_type == "signal_frame":
-        return SignalFrame(
-            stream_id=str(node["stream_id"]),
-            sequence_id=int(node["sequence_id"]),
-            data=_decode(node["data"], reader),
-            sample_rate_hz=float(node["sample_rate_hz"]),
-            host_receive_time_ns=int(node["host_receive_time_ns"]),
-            device_time_ns=node.get("device_time_ns"),
-            synchronized_time_ns=node.get("synchronized_time_ns"),
-            clock_domain=ClockDomain(str(node["clock_domain"])),
-            quality=QualityFlag(int(node["quality"])),
-            metadata=_decode(node["metadata"], reader),
-        )
+        try:
+            return SignalFrame(
+                stream_id=_manifest_str(node["stream_id"], "signal_frame.stream_id"),
+                sequence_id=_manifest_int(node["sequence_id"], "signal_frame.sequence_id"),
+                data=_decode(node["data"], reader),
+                sample_rate_hz=_manifest_real(
+                    node["sample_rate_hz"], "signal_frame.sample_rate_hz"
+                ),
+                host_receive_time_ns=_manifest_int(
+                    node["host_receive_time_ns"], "signal_frame.host_receive_time_ns"
+                ),
+                device_time_ns=_manifest_optional_int(
+                    node.get("device_time_ns"), "signal_frame.device_time_ns"
+                ),
+                synchronized_time_ns=_manifest_optional_int(
+                    node.get("synchronized_time_ns"),
+                    "signal_frame.synchronized_time_ns",
+                ),
+                clock_domain=ClockDomain(
+                    _manifest_str(node["clock_domain"], "signal_frame.clock_domain")
+                ),
+                quality=QualityFlag(
+                    _manifest_int(node["quality"], "signal_frame.quality")
+                ),
+                metadata=_decode(node["metadata"], reader),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid SignalFrame transport payload: {exc}"
+            ) from exc
     if node_type == "neural_window":
-        return NeuralWindow(
-            stream_id=str(node["stream_id"]),
-            window_id=int(node["window_id"]),
-            data=_decode(node["data"], reader),
-            sample_rate_hz=float(node["sample_rate_hz"]),
-            start_time_ns=int(node["start_time_ns"]),
-            end_time_ns=int(node["end_time_ns"]),
-            channel_names=tuple(_decode(node["channel_names"], reader)),
-            source_sequence_ids=tuple(_decode(node["source_sequence_ids"], reader)),
-            clock_domain=ClockDomain(str(node["clock_domain"])),
-            quality=QualityFlag(int(node["quality"])),
-            metadata=_decode(node["metadata"], reader),
-        )
+        try:
+            channel_names = _decode(node["channel_names"], reader)
+            source_sequence_ids = _decode(node["source_sequence_ids"], reader)
+            if not isinstance(channel_names, tuple):
+                raise NeuralTransportProtocolError(
+                    "NeuralWindow channel_names must decode to tuple"
+                )
+            if not isinstance(source_sequence_ids, tuple):
+                raise NeuralTransportProtocolError(
+                    "NeuralWindow source_sequence_ids must decode to tuple"
+                )
+            return NeuralWindow(
+                stream_id=_manifest_str(node["stream_id"], "neural_window.stream_id"),
+                window_id=_manifest_int(node["window_id"], "neural_window.window_id"),
+                data=_decode(node["data"], reader),
+                sample_rate_hz=_manifest_real(
+                    node["sample_rate_hz"], "neural_window.sample_rate_hz"
+                ),
+                start_time_ns=_manifest_int(
+                    node["start_time_ns"], "neural_window.start_time_ns"
+                ),
+                end_time_ns=_manifest_int(
+                    node["end_time_ns"], "neural_window.end_time_ns"
+                ),
+                channel_names=channel_names,
+                source_sequence_ids=source_sequence_ids,
+                clock_domain=ClockDomain(
+                    _manifest_str(node["clock_domain"], "neural_window.clock_domain")
+                ),
+                quality=QualityFlag(
+                    _manifest_int(node["quality"], "neural_window.quality")
+                ),
+                metadata=_decode(node["metadata"], reader),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid NeuralWindow transport payload: {exc}"
+            ) from exc
     if node_type == "decoder_output":
-        return DecoderOutput(
-            prediction=_decode(node["prediction"], reader),
-            confidence=_decode(node["confidence"], reader),
-            uncertainty=_decode(node["uncertainty"], reader),
-            probabilities=_decode(node["probabilities"], reader),
-            logits=_decode(node["logits"], reader),
-            embedding=_decode(node["embedding"], reader),
-            model_id=_decode(node["model_id"], reader),
-            model_version=_decode(node["model_version"], reader),
-            inference_time_ns=_decode(node["inference_time_ns"], reader),
-            metadata=_decode(node["metadata"], reader),
-        )
+        try:
+            return DecoderOutput(
+                prediction=_decode(node["prediction"], reader),
+                confidence=_decode(node["confidence"], reader),
+                uncertainty=_decode(node["uncertainty"], reader),
+                probabilities=_decode(node["probabilities"], reader),
+                logits=_decode(node["logits"], reader),
+                embedding=_decode(node["embedding"], reader),
+                model_id=_decode(node["model_id"], reader),
+                model_version=_decode(node["model_version"], reader),
+                inference_time_ns=_decode(node["inference_time_ns"], reader),
+                metadata=_decode(node["metadata"], reader),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid DecoderOutput transport payload: {exc}"
+            ) from exc
     if node_type == "transform_emission":
         items = _decode(node["items"], reader)
         if not isinstance(items, tuple):
             raise NeuralTransportProtocolError("TransformEmission items must decode to tuple")
-        return TransformEmission(items)
+        try:
+            return TransformEmission(items)
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid TransformEmission transport payload: {exc}"
+            ) from exc
     raise NeuralTransportProtocolError(f"unknown transport manifest node type {node_type!r}")
 
 

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -69,6 +69,14 @@ class SharedPayloadEnvelope:
         }
 
 
+def _manifest_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NeuralTransportProtocolError(
+            f"transport field {field_name} must be an exact integer"
+        )
+    return value
+
+
 class _MailboxWriter:
     def __init__(self, buffer: memoryview, capacity_bytes: int) -> None:
         self.buffer = buffer
@@ -115,10 +123,25 @@ class _MailboxReader:
 
     def get_array(self, node: Mapping[str, Any]) -> np.ndarray:
         try:
-            offset = int(node["offset"])
-            nbytes = int(node["nbytes"])
-            dtype = np.dtype(str(node["dtype"]))
-            shape = tuple(int(dim) for dim in node["shape"])
+            offset = _manifest_int(node["offset"], "ndarray.offset")
+            nbytes = _manifest_int(node["nbytes"], "ndarray.nbytes")
+            dtype_value = node["dtype"]
+            if not isinstance(dtype_value, str):
+                raise NeuralTransportProtocolError(
+                    "transport field ndarray.dtype must be a string"
+                )
+            dtype = np.dtype(dtype_value)
+            raw_shape = node["shape"]
+            if not isinstance(raw_shape, list):
+                raise NeuralTransportProtocolError(
+                    "transport field ndarray.shape must be a list"
+                )
+            shape = tuple(
+                _manifest_int(dim, f"ndarray.shape[{index}]")
+                for index, dim in enumerate(raw_shape)
+            )
+        except NeuralTransportProtocolError:
+            raise
         except Exception as exc:
             raise NeuralTransportProtocolError(
                 f"malformed ndarray transport descriptor: {exc}"
@@ -365,8 +388,10 @@ class SharedMemoryMailbox:
         if envelope.get("schema") != _SCHEMA:
             raise NeuralTransportProtocolError("shared-memory payload schema mismatch")
         try:
-            lease_id = int(envelope["lease_id"])
-            bytes_used = int(envelope["bytes_used"])
+            lease_id = _manifest_int(envelope["lease_id"], "lease_id")
+            bytes_used = _manifest_int(envelope["bytes_used"], "bytes_used")
+        except NeuralTransportProtocolError:
+            raise
         except Exception as exc:
             raise NeuralTransportProtocolError("malformed transport envelope identity") from exc
         if lease_id != expected_lease_id:

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -1,0 +1,393 @@
+"""Shared-memory transport for canonical neurOS runtime payloads.
+
+The transport deliberately keeps control metadata on the multiprocessing pipe
+and moves numeric array bytes through a fixed-capacity shared-memory mailbox.
+Decoded arrays are materialized into independent local memory before arbitrary
+operator code is invoked. This is therefore a shared-memory transport, not a
+zero-copy callback contract.
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from multiprocessing import shared_memory
+from typing import Any
+
+import numpy as np
+
+from neuros.contracts import (
+    ClockDomain,
+    DecoderOutput,
+    NeuralWindow,
+    QualityFlag,
+    SignalFrame,
+    TransformEmission,
+)
+
+_SCHEMA = "neuros.shared_memory_payload.v1"
+_ALIGNMENT = 64
+_SUPPORTED_ARRAY_KINDS = frozenset("biufc")
+
+
+class NeuralTransportError(RuntimeError):
+    """Base class for fail-closed neural transport errors."""
+
+
+class NeuralTransportCapacityError(NeuralTransportError):
+    """Raised when a logical payload cannot fit in the declared mailbox."""
+
+
+class NeuralTransportProtocolError(NeuralTransportError):
+    """Raised when a transport manifest is stale, malformed, or inconsistent."""
+
+
+class NeuralTransportTypeError(NeuralTransportError, TypeError):
+    """Raised when an unsupported Python payload crosses shared transport."""
+
+
+@dataclass(frozen=True, slots=True)
+class SharedPayloadEnvelope:
+    """Small control-plane description of bytes stored in one mailbox lease."""
+
+    lease_id: int
+    bytes_used: int
+    manifest: Any
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": _SCHEMA,
+            "lease_id": self.lease_id,
+            "bytes_used": self.bytes_used,
+            "manifest": self.manifest,
+        }
+
+
+class _MailboxWriter:
+    def __init__(self, buffer: memoryview, capacity_bytes: int) -> None:
+        self.buffer = buffer
+        self.capacity_bytes = capacity_bytes
+        self.offset = 0
+
+    @staticmethod
+    def _aligned(offset: int) -> int:
+        remainder = offset % _ALIGNMENT
+        return offset if remainder == 0 else offset + (_ALIGNMENT - remainder)
+
+    def put_array(self, value: np.ndarray) -> dict[str, Any]:
+        array = np.asarray(value)
+        if array.dtype.kind not in _SUPPORTED_ARRAY_KINDS:
+            raise NeuralTransportTypeError(
+                "shared-memory arrays must use boolean or numeric dtype; "
+                f"received {array.dtype}"
+            )
+        if array.dtype.kind in "fc" and not np.isfinite(array).all():
+            raise NeuralTransportTypeError(
+                "shared-memory arrays must be finite; preserve signal quality "
+                "with explicit samples and provenance"
+            )
+        array = np.ascontiguousarray(array)
+        offset = self._aligned(self.offset)
+        end = offset + int(array.nbytes)
+        if end > self.capacity_bytes:
+            raise NeuralTransportCapacityError(
+                f"payload requires {end} bytes but mailbox capacity is "
+                f"{self.capacity_bytes} bytes"
+            )
+        if array.nbytes:
+            self.buffer[offset:end] = memoryview(array).cast("B")
+        self.offset = end
+        return {
+            "type": "ndarray",
+            "offset": offset,
+            "nbytes": int(array.nbytes),
+            "dtype": array.dtype.str,
+            "shape": list(array.shape),
+        }
+
+
+class _MailboxReader:
+    def __init__(self, buffer: memoryview, bytes_used: int) -> None:
+        self.buffer = buffer
+        self.bytes_used = bytes_used
+        self._ranges: list[tuple[int, int]] = []
+
+    def get_array(self, node: Mapping[str, Any]) -> np.ndarray:
+        try:
+            offset = int(node["offset"])
+            nbytes = int(node["nbytes"])
+            dtype = np.dtype(str(node["dtype"]))
+            shape = tuple(int(dim) for dim in node["shape"])
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"malformed ndarray transport descriptor: {exc}"
+            ) from exc
+        if offset < 0 or nbytes < 0 or any(dim < 0 for dim in shape):
+            raise NeuralTransportProtocolError("negative shared-memory array geometry")
+        if dtype.kind not in _SUPPORTED_ARRAY_KINDS:
+            raise NeuralTransportProtocolError(
+                f"unsupported shared-memory dtype {dtype}"
+            )
+        expected = int(math.prod(shape)) * int(dtype.itemsize)
+        if expected != nbytes:
+            raise NeuralTransportProtocolError(
+                "shared-memory ndarray byte length does not match dtype/shape"
+            )
+        end = offset + nbytes
+        if end > self.bytes_used:
+            raise NeuralTransportProtocolError(
+                "shared-memory ndarray exceeds declared payload boundary"
+            )
+        for start, stop in self._ranges:
+            if offset < stop and start < end:
+                raise NeuralTransportProtocolError(
+                    "shared-memory ndarray regions overlap"
+                )
+        self._ranges.append((offset, end))
+        view = np.ndarray(shape=shape, dtype=dtype, buffer=self.buffer, offset=offset)
+        return np.array(view, copy=True, subok=False)
+
+
+def _encode(value: Any, writer: _MailboxWriter) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return {"type": "scalar", "value": value}
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise NeuralTransportTypeError("transport scalar floats must be finite")
+        return {"type": "scalar", "value": value}
+    if isinstance(value, np.generic):
+        return _encode(value.item(), writer)
+    if isinstance(value, np.ndarray):
+        return writer.put_array(value)
+    if isinstance(value, SignalFrame):
+        return {
+            "type": "signal_frame",
+            "stream_id": value.stream_id,
+            "sequence_id": value.sequence_id,
+            "data": _encode(value.data, writer),
+            "sample_rate_hz": value.sample_rate_hz,
+            "host_receive_time_ns": value.host_receive_time_ns,
+            "device_time_ns": value.device_time_ns,
+            "synchronized_time_ns": value.synchronized_time_ns,
+            "clock_domain": value.clock_domain.value,
+            "quality": int(value.quality),
+            "metadata": _encode(dict(value.metadata), writer),
+        }
+    if isinstance(value, NeuralWindow):
+        return {
+            "type": "neural_window",
+            "stream_id": value.stream_id,
+            "window_id": value.window_id,
+            "data": _encode(value.data, writer),
+            "sample_rate_hz": value.sample_rate_hz,
+            "start_time_ns": value.start_time_ns,
+            "end_time_ns": value.end_time_ns,
+            "channel_names": _encode(value.channel_names, writer),
+            "source_sequence_ids": _encode(value.source_sequence_ids, writer),
+            "clock_domain": value.clock_domain.value,
+            "quality": int(value.quality),
+            "metadata": _encode(dict(value.metadata), writer),
+        }
+    if isinstance(value, DecoderOutput):
+        return {
+            "type": "decoder_output",
+            "prediction": _encode(value.prediction, writer),
+            "confidence": _encode(value.confidence, writer),
+            "uncertainty": _encode(value.uncertainty, writer),
+            "probabilities": _encode(value.probabilities, writer),
+            "logits": _encode(value.logits, writer),
+            "embedding": _encode(value.embedding, writer),
+            "model_id": _encode(value.model_id, writer),
+            "model_version": _encode(value.model_version, writer),
+            "inference_time_ns": _encode(value.inference_time_ns, writer),
+            "metadata": _encode(dict(value.metadata), writer),
+        }
+    if isinstance(value, TransformEmission):
+        return {"type": "transform_emission", "items": _encode(value.items, writer)}
+    if isinstance(value, tuple):
+        return {"type": "tuple", "items": [_encode(item, writer) for item in value]}
+    if isinstance(value, list):
+        return {"type": "list", "items": [_encode(item, writer) for item in value]}
+    if isinstance(value, Mapping):
+        items: list[list[Any]] = []
+        for key in sorted(value):
+            if not isinstance(key, str):
+                raise NeuralTransportTypeError("transport mapping keys must be strings")
+            items.append([key, _encode(value[key], writer)])
+        return {"type": "mapping", "items": items}
+    raise NeuralTransportTypeError(
+        "unsupported shared-memory payload type "
+        f"{type(value).__module__}.{type(value).__qualname__}"
+    )
+
+
+def _decode(node: Any, reader: _MailboxReader) -> Any:
+    if not isinstance(node, Mapping):
+        raise NeuralTransportProtocolError("transport manifest node is not a mapping")
+    node_type = node.get("type")
+    if node_type == "scalar":
+        value = node.get("value")
+        if value is not None and not isinstance(value, (str, bool, int, float)):
+            raise NeuralTransportProtocolError("invalid transport scalar")
+        if isinstance(value, float) and not math.isfinite(value):
+            raise NeuralTransportProtocolError("non-finite transport scalar")
+        return value
+    if node_type == "ndarray":
+        return reader.get_array(node)
+    if node_type == "tuple":
+        return tuple(_decode(item, reader) for item in node.get("items", ()))
+    if node_type == "list":
+        return [_decode(item, reader) for item in node.get("items", ())]
+    if node_type == "mapping":
+        result: dict[str, Any] = {}
+        items = node.get("items")
+        if not isinstance(items, list):
+            raise NeuralTransportProtocolError("mapping manifest items must be a list")
+        for pair in items:
+            if not isinstance(pair, list) or len(pair) != 2 or not isinstance(pair[0], str):
+                raise NeuralTransportProtocolError("malformed mapping manifest item")
+            key = pair[0]
+            if key in result:
+                raise NeuralTransportProtocolError("duplicate transport mapping key")
+            result[key] = _decode(pair[1], reader)
+        return result
+    if node_type == "signal_frame":
+        return SignalFrame(
+            stream_id=str(node["stream_id"]),
+            sequence_id=int(node["sequence_id"]),
+            data=_decode(node["data"], reader),
+            sample_rate_hz=float(node["sample_rate_hz"]),
+            host_receive_time_ns=int(node["host_receive_time_ns"]),
+            device_time_ns=node.get("device_time_ns"),
+            synchronized_time_ns=node.get("synchronized_time_ns"),
+            clock_domain=ClockDomain(str(node["clock_domain"])),
+            quality=QualityFlag(int(node["quality"])),
+            metadata=_decode(node["metadata"], reader),
+        )
+    if node_type == "neural_window":
+        return NeuralWindow(
+            stream_id=str(node["stream_id"]),
+            window_id=int(node["window_id"]),
+            data=_decode(node["data"], reader),
+            sample_rate_hz=float(node["sample_rate_hz"]),
+            start_time_ns=int(node["start_time_ns"]),
+            end_time_ns=int(node["end_time_ns"]),
+            channel_names=tuple(_decode(node["channel_names"], reader)),
+            source_sequence_ids=tuple(_decode(node["source_sequence_ids"], reader)),
+            clock_domain=ClockDomain(str(node["clock_domain"])),
+            quality=QualityFlag(int(node["quality"])),
+            metadata=_decode(node["metadata"], reader),
+        )
+    if node_type == "decoder_output":
+        return DecoderOutput(
+            prediction=_decode(node["prediction"], reader),
+            confidence=_decode(node["confidence"], reader),
+            uncertainty=_decode(node["uncertainty"], reader),
+            probabilities=_decode(node["probabilities"], reader),
+            logits=_decode(node["logits"], reader),
+            embedding=_decode(node["embedding"], reader),
+            model_id=_decode(node["model_id"], reader),
+            model_version=_decode(node["model_version"], reader),
+            inference_time_ns=_decode(node["inference_time_ns"], reader),
+            metadata=_decode(node["metadata"], reader),
+        )
+    if node_type == "transform_emission":
+        items = _decode(node["items"], reader)
+        if not isinstance(items, tuple):
+            raise NeuralTransportProtocolError("TransformEmission items must decode to tuple")
+        return TransformEmission(items)
+    raise NeuralTransportProtocolError(f"unknown transport manifest node type {node_type!r}")
+
+
+class SharedMemoryMailbox:
+    """One fixed-capacity shared-memory mailbox with explicit lease identity."""
+
+    def __init__(
+        self,
+        capacity_bytes: int,
+        *,
+        name: str | None = None,
+        create: bool = True,
+        owner: bool | None = None,
+    ) -> None:
+        if isinstance(capacity_bytes, bool) or not isinstance(capacity_bytes, int):
+            raise TypeError("capacity_bytes must be an integer")
+        if capacity_bytes <= 0:
+            raise ValueError("capacity_bytes must be positive")
+        self.capacity_bytes = capacity_bytes
+        self._owner = create if owner is None else bool(owner)
+        self._shm = shared_memory.SharedMemory(
+            name=name,
+            create=create,
+            size=capacity_bytes if create else 0,
+        )
+        if self._shm.size < capacity_bytes:
+            self._shm.close()
+            raise NeuralTransportProtocolError(
+                "attached shared-memory region is smaller than declared capacity"
+            )
+        self._closed = False
+        self._unlinked = False
+
+    @classmethod
+    def attach(cls, name: str, capacity_bytes: int) -> "SharedMemoryMailbox":
+        return cls(capacity_bytes, name=name, create=False, owner=False)
+
+    @property
+    def name(self) -> str:
+        return self._shm.name
+
+    def encode(self, value: Any, *, lease_id: int) -> dict[str, Any]:
+        if self._closed:
+            raise NeuralTransportError("shared-memory mailbox is closed")
+        if isinstance(lease_id, bool) or not isinstance(lease_id, int) or lease_id <= 0:
+            raise ValueError("lease_id must be a positive integer")
+        writer = _MailboxWriter(self._shm.buf, self.capacity_bytes)
+        manifest = _encode(value, writer)
+        return SharedPayloadEnvelope(lease_id, writer.offset, manifest).as_dict()
+
+    def decode(self, envelope: Any, *, expected_lease_id: int) -> Any:
+        if self._closed:
+            raise NeuralTransportError("shared-memory mailbox is closed")
+        if not isinstance(envelope, Mapping):
+            raise NeuralTransportProtocolError("transport envelope is not a mapping")
+        if envelope.get("schema") != _SCHEMA:
+            raise NeuralTransportProtocolError("shared-memory payload schema mismatch")
+        try:
+            lease_id = int(envelope["lease_id"])
+            bytes_used = int(envelope["bytes_used"])
+        except Exception as exc:
+            raise NeuralTransportProtocolError("malformed transport envelope identity") from exc
+        if lease_id != expected_lease_id:
+            raise NeuralTransportProtocolError(
+                f"stale shared-memory lease {lease_id}; expected {expected_lease_id}"
+            )
+        if bytes_used < 0 or bytes_used > self.capacity_bytes:
+            raise NeuralTransportProtocolError(
+                "shared-memory payload bytes_used exceeds mailbox capacity"
+            )
+        reader = _MailboxReader(self._shm.buf, bytes_used)
+        return _decode(envelope.get("manifest"), reader)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._shm.close()
+            self._closed = True
+
+    def unlink(self) -> None:
+        if not self._owner:
+            raise NeuralTransportError("only the mailbox owner may unlink shared memory")
+        if self._unlinked:
+            return
+        try:
+            self._shm.unlink()
+        except FileNotFoundError:
+            pass
+        self._unlinked = True
+
+    def close_and_unlink(self) -> None:
+        if not self._owner:
+            self.close()
+            return
+        self.unlink()
+        self.close()

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -125,6 +125,10 @@ class _MailboxReader:
             ) from exc
         if offset < 0 or nbytes < 0 or any(dim < 0 for dim in shape):
             raise NeuralTransportProtocolError("negative shared-memory array geometry")
+        if offset % _ALIGNMENT != 0:
+            raise NeuralTransportProtocolError(
+                f"shared-memory ndarray offset must be {_ALIGNMENT}-byte aligned"
+            )
         if dtype.kind not in _SUPPORTED_ARRAY_KINDS:
             raise NeuralTransportProtocolError(
                 f"unsupported shared-memory dtype {dtype}"

--- a/tests/test_runtime_neural_transport.py
+++ b/tests/test_runtime_neural_transport.py
@@ -230,8 +230,32 @@ def test_capacity_and_unsupported_dtype_fail_closed_without_partial_decode():
             small.encode(np.arange(100, dtype=np.float64), lease_id=1)
         with pytest.raises(NeuralTransportTypeError, match="boolean or numeric"):
             small.encode(np.array([object()], dtype=object), lease_id=2)
+        with pytest.raises(NeuralTransportTypeError, match="keys must be strings"):
+            small.encode({"valid": 1, 2: "invalid"}, lease_id=3)
     finally:
         small.close_and_unlink()
+
+
+def test_transport_preserves_generic_numeric_values_without_inventing_policy():
+    payload = {
+        "array": np.array([np.nan, np.inf, -np.inf], dtype=np.float64),
+        "float": float("nan"),
+        "complex": complex(1.5, -2.25),
+        "complex_array": np.array([1 + 2j, np.nan + 1j], dtype=np.complex128),
+    }
+    box = SharedMemoryMailbox(4096)
+    try:
+        decoded = box.decode(box.encode(payload, lease_id=8), expected_lease_id=8)
+    finally:
+        box.close_and_unlink()
+
+    assert np.isnan(decoded["array"][0])
+    assert np.isposinf(decoded["array"][1])
+    assert np.isneginf(decoded["array"][2])
+    assert np.isnan(decoded["float"])
+    assert decoded["complex"] == complex(1.5, -2.25)
+    assert decoded["complex_array"][0] == 1 + 2j
+    assert np.isnan(decoded["complex_array"][1].real)
 
 
 def test_stale_lease_and_overlapping_array_descriptors_are_rejected():
@@ -484,8 +508,6 @@ def test_shared_worker_does_not_unlink_if_direct_child_survives_escalation():
         assert process.kill_calls == 1
         assert process.join_calls == 2
         assert worker._process is process
-        # The child is not proven dead, therefore parent must retain unlink
-        # authority rather than falsely claiming transport cleanup.
         _assert_names_exist(names)
     finally:
         worker._process = None

--- a/tests/test_runtime_neural_transport.py
+++ b/tests/test_runtime_neural_transport.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import copy
+import pickle
+from multiprocessing import shared_memory
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
+from neuros.runtime.transport import (
+    NeuralTransportCapacityError,
+    NeuralTransportError,
+    NeuralTransportProtocolError,
+    NeuralTransportTypeError,
+    SharedMemoryMailbox,
+)
+
+
+def _frame(data: np.ndarray | None = None) -> SignalFrame:
+    return SignalFrame(
+        stream_id="eeg",
+        sequence_id=7,
+        data=np.arange(12, dtype=np.float32).reshape(6, 2) if data is None else data,
+        sample_rate_hz=250.0,
+        host_receive_time_ns=123_000,
+        device_time_ns=120_000,
+        metadata={
+            "axis_order": ("sample", "channel"),
+            "channel_names": ("C3", "C4"),
+            "nested": {"session": "transport", "trial": 3},
+        },
+    )
+
+
+def _window(data: np.ndarray | None = None) -> NeuralWindow:
+    return NeuralWindow(
+        stream_id="eeg",
+        window_id=11,
+        data=np.arange(16, dtype=np.float32).reshape(2, 8) if data is None else data,
+        sample_rate_hz=250.0,
+        start_time_ns=1_000,
+        end_time_ns=33_000_000,
+        channel_names=("C3", "C4"),
+        source_sequence_ids=(6, 7),
+        metadata={"nested": {"source": "window"}},
+    )
+
+
+def test_neural_window_detaches_array_and_nested_metadata_from_caller_state():
+    source = np.arange(8, dtype=np.float32).reshape(2, 4)
+    nested = {"labels": ["left", "right"]}
+    window = NeuralWindow(
+        stream_id="eeg",
+        window_id=1,
+        data=source,
+        sample_rate_hz=100.0,
+        start_time_ns=1,
+        end_time_ns=40_000_001,
+        channel_names=["C3", "C4"],
+        source_sequence_ids=[1, 2],
+        metadata=nested,
+    )
+
+    source[:] = -1
+    nested["labels"].append("mutated")
+
+    assert window.data.tolist() == [[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]]
+    assert not window.data.flags.writeable
+    assert window.channel_names == ("C3", "C4")
+    assert window.source_sequence_ids == (1, 2)
+    assert window.metadata["labels"] == ("left", "right")
+    with pytest.raises(ValueError):
+        window.data[0, 0] = 99
+
+
+def test_generic_pickle_rejects_canonical_frame_but_shared_mailbox_round_trips_it():
+    frame = _frame()
+    with pytest.raises((TypeError, pickle.PicklingError)):
+        pickle.dumps(frame, protocol=pickle.HIGHEST_PROTOCOL)
+
+    box = SharedMemoryMailbox(16 * 1024)
+    try:
+        envelope = box.encode(frame, lease_id=1)
+        decoded = box.decode(envelope, expected_lease_id=1)
+    finally:
+        box.close_and_unlink()
+
+    assert isinstance(decoded, SignalFrame)
+    assert decoded.stream_id == frame.stream_id
+    assert decoded.sequence_id == frame.sequence_id
+    assert decoded.sample_rate_hz == frame.sample_rate_hz
+    assert decoded.metadata["nested"]["session"] == "transport"
+    assert np.array_equal(decoded.data, frame.data)
+    assert not decoded.data.flags.writeable
+
+
+def test_codec_recursively_packs_multiple_arrays_and_canonical_payloads():
+    window = _window()
+    output = DecoderOutput(
+        prediction=np.array([2], dtype=np.int64),
+        confidence=0.8,
+        probabilities=np.array([0.1, 0.2, 0.7], dtype=np.float32),
+        logits=np.array([-2.0, -1.0, 1.5], dtype=np.float32),
+        embedding=np.arange(6, dtype=np.float32).reshape(2, 3),
+        model_id="transport-model",
+        metadata={"window": 11},
+    )
+    payload = TransformEmission((window, output, {"aux": np.arange(5, dtype=np.int16)}))
+
+    box = SharedMemoryMailbox(32 * 1024)
+    try:
+        envelope = box.encode(payload, lease_id=9)
+        decoded = box.decode(envelope, expected_lease_id=9)
+    finally:
+        box.close_and_unlink()
+
+    assert isinstance(decoded, TransformEmission)
+    decoded_window, decoded_output, decoded_aux = decoded.items
+    assert isinstance(decoded_window, NeuralWindow)
+    assert np.array_equal(decoded_window.data, window.data)
+    assert isinstance(decoded_output, DecoderOutput)
+    assert np.array_equal(decoded_output.probabilities, output.probabilities)
+    assert np.array_equal(decoded_output.logits, output.logits)
+    assert np.array_equal(decoded_output.embedding, output.embedding)
+    assert np.array_equal(decoded_aux["aux"], np.arange(5, dtype=np.int16))
+    assert envelope["bytes_used"] >= (
+        window.data.nbytes
+        + output.prediction.nbytes
+        + output.probabilities.nbytes
+        + output.logits.nbytes
+        + output.embedding.nbytes
+    )
+
+
+def test_capacity_and_unsupported_dtype_fail_closed_without_partial_decode():
+    small = SharedMemoryMailbox(64)
+    try:
+        with pytest.raises(NeuralTransportCapacityError, match="capacity"):
+            small.encode(np.arange(100, dtype=np.float64), lease_id=1)
+        with pytest.raises(NeuralTransportTypeError, match="boolean or numeric"):
+            small.encode(np.array([object()], dtype=object), lease_id=2)
+    finally:
+        small.close_and_unlink()
+
+
+def test_stale_lease_and_overlapping_array_descriptors_are_rejected():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(
+            (np.arange(4, dtype=np.float32), np.arange(4, dtype=np.float32) + 10),
+            lease_id=4,
+        )
+        with pytest.raises(NeuralTransportProtocolError, match="stale"):
+            box.decode(envelope, expected_lease_id=5)
+
+        corrupted = copy.deepcopy(envelope)
+        first, second = corrupted["manifest"]["items"]
+        second["offset"] = first["offset"]
+        with pytest.raises(NeuralTransportProtocolError, match="overlap"):
+            box.decode(corrupted, expected_lease_id=4)
+    finally:
+        box.close_and_unlink()
+
+
+def test_decoded_array_is_independent_of_subsequent_mailbox_reuse():
+    box = SharedMemoryMailbox(4096)
+    try:
+        first = box.decode(
+            box.encode(np.arange(8, dtype=np.float32), lease_id=1),
+            expected_lease_id=1,
+        )
+        box.encode(np.full(8, 99, dtype=np.float32), lease_id=2)
+        assert np.array_equal(first, np.arange(8, dtype=np.float32))
+    finally:
+        box.close_and_unlink()
+
+
+def test_owner_cleanup_unlinks_named_region_and_attached_peer_cannot_claim_authority():
+    owner = SharedMemoryMailbox(1024)
+    name = owner.name
+    peer = SharedMemoryMailbox.attach(name, 1024)
+    try:
+        with pytest.raises(NeuralTransportError, match="owner"):
+            peer.unlink()
+        peer.close()
+        owner.close_and_unlink()
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name=name, create=False)
+    finally:
+        peer.close()
+        owner.close_and_unlink()

--- a/tests/test_runtime_neural_transport.py
+++ b/tests/test_runtime_neural_transport.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
+import asyncio
 import copy
+import os
 import pickle
+import time
 from multiprocessing import shared_memory
 
 import numpy as np
 import pytest
 
 from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
+from neuros.runtime.process_worker import (
+    ProcessWorkerTerminationError,
+    ProcessWorkerTimeoutError,
+)
+from neuros.runtime.shared_process_worker import (
+    ProcessWorkerTransportError,
+    SharedMemoryProcessWorker,
+)
 from neuros.runtime.transport import (
     NeuralTransportCapacityError,
     NeuralTransportError,
@@ -45,6 +56,85 @@ def _window(data: np.ndarray | None = None) -> NeuralWindow:
         source_sequence_ids=(6, 7),
         metadata={"nested": {"source": "window"}},
     )
+
+
+def _assert_names_exist(names: dict[str, str]) -> None:
+    for name in names.values():
+        probe = shared_memory.SharedMemory(name=name, create=False)
+        probe.close()
+
+
+def _assert_names_absent(names: dict[str, str]) -> None:
+    for name in names.values():
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name=name, create=False)
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class RetainingTransform:
+    def __init__(self):
+        self.first = None
+
+    def transform(self, item):
+        if self.first is None:
+            self.first = item
+            return item
+        return self.first
+
+
+class DecoderOutputTransform:
+    def transform(self, item):
+        value = float(np.asarray(item).reshape(-1)[0])
+        return DecoderOutput(
+            prediction=np.array([int(value)], dtype=np.int64),
+            probabilities=np.array([0.25, 0.75], dtype=np.float32),
+            logits=np.array([-0.5, 0.5], dtype=np.float32),
+            embedding=np.arange(6, dtype=np.float32).reshape(2, 3),
+            model_id="shared-worker",
+            metadata={"value": value},
+        )
+
+
+class LargeResultTransform:
+    def transform(self, item):
+        return np.arange(1024, dtype=np.float64)
+
+
+class SleepTransform:
+    def transform(self, item):
+        time.sleep(2.0)
+        return item
+
+
+class CrashTransform:
+    def transform(self, item):
+        os._exit(23)
+
+
+class ImmortalProcess:
+    def __init__(self):
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.join_calls = 0
+
+    def is_alive(self):
+        return True
+
+    def terminate(self):
+        self.terminate_calls += 1
+
+    def kill(self):
+        self.kill_calls += 1
+
+    def join(self, timeout=None):
+        self.join_calls += 1
+
+    def close(self):
+        raise AssertionError("live process handle must not be closed")
 
 
 def test_neural_window_detaches_array_and_nested_metadata_from_caller_state():
@@ -190,3 +280,215 @@ def test_owner_cleanup_unlinks_named_region_and_attached_peer_cannot_claim_autho
     finally:
         peer.close()
         owner.close_and_unlink()
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_round_trips_canonical_frame_and_unlinks_after_close():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        IdentityTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=16 * 1024,
+        response_capacity_bytes=16 * 1024,
+    )
+    call = await worker.invoke("transform", _frame())
+    names = worker.shared_memory_names
+    assert names is not None
+    _assert_names_exist(names)
+
+    assert isinstance(call.result, SignalFrame)
+    assert call.result.metadata["nested"]["trial"] == 3
+    assert np.array_equal(call.result.data, _frame().data)
+    assert call.receipt.outcome == "success"
+
+    worker.close()
+    assert not worker.is_alive
+    assert worker.shared_memory_names is None
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_retained_input_survives_mailbox_reuse():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        RetainingTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    try:
+        first_value = np.arange(8, dtype=np.float32)
+        first = await worker.invoke("transform", first_value)
+        second = await worker.invoke(
+            "transform", np.full(8, 99, dtype=np.float32)
+        )
+        assert np.array_equal(first.result, first_value)
+        assert np.array_equal(second.result, first_value)
+    finally:
+        worker.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_returns_decoder_output_with_multiple_arrays():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        DecoderOutputTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=16 * 1024,
+    )
+    try:
+        call = await worker.invoke("transform", np.array([4], dtype=np.float32))
+        output = call.result
+        assert isinstance(output, DecoderOutput)
+        assert np.array_equal(output.prediction, np.array([4], dtype=np.int64))
+        assert np.array_equal(output.probabilities, np.array([0.25, 0.75], dtype=np.float32))
+        assert np.array_equal(output.embedding, np.arange(6, dtype=np.float32).reshape(2, 3))
+        assert output.metadata["value"] == 4.0
+    finally:
+        worker.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_request_capacity_failure_is_terminal_and_leak_free():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        IdentityTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=64,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+    _assert_names_exist(names)
+
+    with pytest.raises(ProcessWorkerTransportError, match="capacity"):
+        await worker.invoke("transform", np.arange(100, dtype=np.float64))
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "transport_error"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_result_capacity_failure_is_terminal_and_leak_free():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        LargeResultTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=64,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    with pytest.raises(ProcessWorkerTransportError, match="result transport failed"):
+        await worker.invoke("transform", 1)
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "transport_error"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_timeout_terminates_child_and_unlinks_transport():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        SleepTransform(),
+        execution_timeout_s=0.05,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    with pytest.raises(ProcessWorkerTimeoutError):
+        await worker.invoke("transform", 1)
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "timeout"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_crash_admits_no_result_and_unlinks_transport():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        CrashTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    with pytest.raises(Exception, match="worker"):
+        await worker.invoke("transform", 1)
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "crashed"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_asyncio_cancellation_terminates_and_unlinks():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        SleepTransform(),
+        execution_timeout_s=5.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    task = asyncio.create_task(worker.invoke("transform", 1))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "cancelled"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+def test_shared_worker_does_not_unlink_if_direct_child_survives_escalation():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        IdentityTransform(),
+        execution_timeout_s=1.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    worker._create_transport()
+    names = worker.shared_memory_names
+    assert names is not None
+    process = ImmortalProcess()
+    worker._process = process
+
+    try:
+        with pytest.raises(ProcessWorkerTerminationError, match="remained alive"):
+            worker.abort()
+        assert process.terminate_calls == 1
+        assert process.kill_calls == 1
+        assert process.join_calls == 2
+        assert worker._process is process
+        # The child is not proven dead, therefore parent must retain unlink
+        # authority rather than falsely claiming transport cleanup.
+        _assert_names_exist(names)
+    finally:
+        worker._process = None
+        worker._cleanup_transport()
+
+    _assert_names_absent(names)

--- a/tests/test_runtime_process_provenance.py
+++ b/tests/test_runtime_process_provenance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from neuros.runtime import NodeKind, RuntimeExecutor, RuntimeGraph, RuntimeNode
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
 
 
 class IdentityTransform:
@@ -10,6 +10,7 @@ class IdentityTransform:
 
 def test_snapshot_records_pickle_and_shared_memory_process_authority_before_start():
     graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, object()))
     graph.add_node(
         RuntimeNode(
             "pickle-node",
@@ -31,6 +32,8 @@ def test_snapshot_records_pickle_and_shared_memory_process_authority_before_star
             process_response_capacity_bytes=16384,
         )
     )
+    graph.connect(RuntimeEdge("source", "pickle-node"))
+    graph.connect(RuntimeEdge("source", "shared-node"))
 
     snapshot = RuntimeExecutor(graph).snapshot()
 

--- a/tests/test_runtime_process_provenance.py
+++ b/tests/test_runtime_process_provenance.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from neuros.runtime import NodeKind, RuntimeExecutor, RuntimeGraph, RuntimeNode
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+def test_snapshot_records_pickle_and_shared_memory_process_authority_before_start():
+    graph = RuntimeGraph()
+    graph.add_node(
+        RuntimeNode(
+            "pickle-node",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=2.5,
+        )
+    )
+    graph.add_node(
+        RuntimeNode(
+            "shared-node",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.25,
+            process_transport="shared_memory",
+            process_request_capacity_bytes=8192,
+            process_response_capacity_bytes=16384,
+        )
+    )
+
+    snapshot = RuntimeExecutor(graph).snapshot()
+
+    assert snapshot["process_execution"] == {
+        "pickle-node": {
+            "transport": "pickle",
+            "execution_timeout_s": 2.5,
+            "request_capacity_bytes": None,
+            "response_capacity_bytes": None,
+        },
+        "shared-node": {
+            "transport": "shared_memory",
+            "execution_timeout_s": 1.25,
+            "request_capacity_bytes": 8192,
+            "response_capacity_bytes": 16384,
+        },
+    }
+    assert snapshot["process_receipts"] == {
+        "pickle-node": [],
+        "shared-node": [],
+    }

--- a/tests/test_runtime_shared_transport_integration.py
+++ b/tests/test_runtime_shared_transport_integration.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
+
+
+class ItemsSource:
+    def __init__(self, items):
+        self.items = list(items)
+        self.started = False
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.started = False
+
+    async def frames(self):
+        for item in self.items:
+            await asyncio.sleep(0)
+            yield item
+
+
+class CollectSink:
+    def __init__(self):
+        self.items = []
+
+    async def write(self, item):
+        self.items.append(item)
+
+
+class FrameScaleTransform:
+    def __init__(self, factor: float):
+        self.factor = float(factor)
+
+    def transform(self, frame: SignalFrame):
+        return replace(frame, data=np.asarray(frame.data) * self.factor)
+
+
+class BatchShapeDecoder:
+    def infer(self, X):
+        array = np.asarray(X)
+        return DecoderOutput(
+            prediction=int(float(array.mean()) >= 0.0),
+            confidence=0.9,
+            metadata={
+                "observed_shape": tuple(int(value) for value in array.shape),
+                "observed_sum": float(array.sum()),
+            },
+        )
+
+
+class PairEmitter:
+    def transform(self, frame: SignalFrame):
+        return TransformEmission(
+            (
+                replace(frame, data=np.asarray(frame.data) + 1.0),
+                replace(frame, data=np.asarray(frame.data) + 2.0),
+            )
+        )
+
+
+class FileSink:
+    def __init__(self, path: str):
+        self.path = path
+
+    def write(self, item):
+        if isinstance(item, SignalFrame):
+            value = float(np.asarray(item.data).reshape(-1)[0])
+            line = f"{item.stream_id}:{item.sequence_id}:{value}\n"
+        else:
+            line = f"{type(item).__name__}\n"
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+
+
+class FileMonitor:
+    def __init__(self, path: str):
+        self.path = path
+
+    def update(self, payload):
+        line = (
+            f"{payload['node_id']}:{payload['kind']}:"
+            f"{type(payload['item']).__name__}\n"
+        )
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class DelayedFailTransform:
+    def transform(self, item):
+        time.sleep(0.5)
+        raise ValueError("shared runtime synthetic failure")
+
+
+class SlowTransform:
+    def transform(self, item):
+        time.sleep(5.0)
+        return item
+
+
+def _frame(sequence_id: int = 0, value: float = 1.0) -> SignalFrame:
+    return SignalFrame(
+        stream_id="eeg",
+        sequence_id=sequence_id,
+        data=np.array([value, value + 0.5], dtype=np.float32),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=1_000 + sequence_id,
+        metadata={"channel_names": ("C3", "C4")},
+    )
+
+
+def _window() -> NeuralWindow:
+    return NeuralWindow(
+        stream_id="eeg",
+        window_id=17,
+        data=np.arange(8, dtype=np.float32).reshape(2, 4),
+        sample_rate_hz=250.0,
+        start_time_ns=1_000,
+        end_time_ns=16_001_000,
+        channel_names=("C3", "C4"),
+        source_sequence_ids=(10, 11),
+        metadata={"trial": "shared-runtime"},
+    )
+
+
+def _shared_node(
+    node_id: str,
+    kind: NodeKind,
+    operator,
+    *,
+    request_capacity: int = 64 * 1024,
+    response_capacity: int = 64 * 1024,
+    timeout_s: float = 3.0,
+) -> RuntimeNode:
+    return RuntimeNode(
+        node_id,
+        kind,
+        operator,
+        executor="process",
+        execution_timeout_s=timeout_s,
+        process_transport="shared_memory",
+        process_request_capacity_bytes=request_capacity,
+        process_response_capacity_bytes=response_capacity,
+    )
+
+
+def test_shared_memory_runtime_configuration_is_explicit_and_fail_closed():
+    with pytest.raises(ValueError, match="positive process_request_capacity_bytes"):
+        RuntimeNode(
+            "missing-capacity",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.0,
+            process_transport="shared_memory",
+            process_response_capacity_bytes=4096,
+        )
+
+    with pytest.raises(ValueError, match="only valid for executor='process'"):
+        RuntimeNode(
+            "inline-shared",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            process_transport="shared_memory",
+            process_request_capacity_bytes=4096,
+            process_response_capacity_bytes=4096,
+        )
+
+    with pytest.raises(ValueError, match="only valid for process_transport='shared_memory'"):
+        RuntimeNode(
+            "pickle-capacity",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.0,
+            process_request_capacity_bytes=4096,
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_transform_round_trips_signal_frames_and_closes_worker():
+    sink = CollectSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame(0, 1.0), _frame(1, 2.0)])))
+    graph.add_node(_shared_node("transform", NodeKind.TRANSFORM, FrameScaleTransform(3.0)))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+    graph.connect(RuntimeEdge("transform", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    snapshot = await executor.run()
+
+    assert [item.sequence_id for item in sink.items] == [0, 1]
+    assert np.allclose(sink.items[0].data, np.array([3.0, 4.5], dtype=np.float32))
+    assert np.allclose(sink.items[1].data, np.array([6.0, 7.5], dtype=np.float32))
+    assert snapshot["state"] == "stopped"
+    assert [receipt["outcome"] for receipt in snapshot["process_receipts"]["transform"]] == [
+        "success",
+        "success",
+    ]
+    worker = executor._process_workers["transform"]
+    assert isinstance(worker, SharedMemoryProcessWorker)
+    assert not worker.is_alive
+    assert worker.shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_decoder_preserves_neural_window_batching_and_provenance():
+    window = _window()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([window])))
+    graph.add_node(_shared_node("decoder", NodeKind.DECODER, BatchShapeDecoder()))
+    graph.connect(RuntimeEdge("source", "decoder", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    await executor.start()
+    outputs = [output async for output in executor.outputs()]
+    await executor.wait()
+
+    assert len(outputs) == 1
+    output = outputs[0]
+    assert output.metadata["observed_shape"] == (1, 2, 4)
+    assert output.metadata["observed_sum"] == pytest.approx(float(window.data.sum()))
+    assert output.metadata["neuros_stream_id"] == "eeg"
+    assert output.metadata["neuros_window_id"] == 17
+    assert output.metadata["window_channel_names"] == ("C3", "C4")
+    assert output.metadata["source_sequence_ids"] == (10, 11)
+    assert executor.snapshot()["process_receipts"]["decoder"][0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_transform_emission_preserves_fanout_semantics():
+    sink = CollectSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame()])))
+    graph.add_node(_shared_node("emit", NodeKind.TRANSFORM, PairEmitter()))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.connect(RuntimeEdge("source", "emit", overflow="block"))
+    graph.connect(RuntimeEdge("emit", "sink", overflow="block"))
+
+    snapshot = await RuntimeExecutor(graph).run()
+
+    assert snapshot["state"] == "stopped"
+    assert len(sink.items) == 2
+    assert np.allclose(sink.items[0].data, np.array([2.0, 2.5], dtype=np.float32))
+    assert np.allclose(sink.items[1].data, np.array([3.0, 3.5], dtype=np.float32))
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_process_sink_executes_side_effect_and_closes(tmp_path):
+    destination = tmp_path / "sink.txt"
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame(3, 4.0)])))
+    graph.add_node(_shared_node("sink", NodeKind.SINK, FileSink(str(destination))))
+    graph.connect(RuntimeEdge("source", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    snapshot = await executor.run()
+
+    assert destination.read_text(encoding="utf-8") == "eeg:3:4.0\n"
+    assert snapshot["process_receipts"]["sink"][0]["outcome"] == "success"
+    assert not executor._process_workers["sink"].is_alive
+    assert executor._process_workers["sink"].shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_process_monitor_observes_canonical_payload(tmp_path):
+    destination = tmp_path / "monitor.txt"
+    sink = CollectSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame()])))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.add_node(_shared_node("monitor", NodeKind.MONITOR, FileMonitor(str(destination))))
+    graph.connect(RuntimeEdge("source", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    snapshot = await executor.run()
+
+    assert destination.read_text(encoding="utf-8") == "source:source:SignalFrame\n"
+    assert snapshot["process_receipts"]["monitor"][0]["outcome"] == "success"
+    assert not executor._process_workers["monitor"].is_alive
+    assert executor._process_workers["monitor"].shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_attributes_shared_request_capacity_failure_to_owning_node():
+    graph = RuntimeGraph()
+    graph.add_node(
+        RuntimeNode(
+            "source",
+            NodeKind.SOURCE,
+            ItemsSource([np.arange(100, dtype=np.float64)]),
+        )
+    )
+    graph.add_node(
+        _shared_node(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            request_capacity=64,
+            response_capacity=4096,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="ProcessWorkerTransportError"):
+        await executor.run()
+
+    snapshot = executor.snapshot()
+    assert snapshot["state"] == "failed"
+    assert snapshot["failure"]["node_id"] == "transform"
+    assert snapshot["failure"]["error_type"] == "ProcessWorkerTransportError"
+    assert snapshot["process_receipts"]["transform"][-1]["outcome"] == "transport_error"
+    worker = executor._process_workers["transform"]
+    assert not worker.is_alive
+    assert worker.shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_failure_cancels_peer_worker_without_overwriting_culprit():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([np.array([1.0], dtype=np.float32)])))
+    graph.add_node(
+        _shared_node(
+            "fail",
+            NodeKind.TRANSFORM,
+            DelayedFailTransform(),
+            timeout_s=3.0,
+        )
+    )
+    graph.add_node(
+        _shared_node(
+            "slow",
+            NodeKind.TRANSFORM,
+            SlowTransform(),
+            timeout_s=10.0,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "fail", overflow="block"))
+    graph.connect(RuntimeEdge("source", "slow", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="shared runtime synthetic failure"):
+        await executor.run()
+
+    snapshot = executor.snapshot()
+    assert snapshot["failure"]["node_id"] == "fail"
+    assert snapshot["failure"]["error_type"] == "ValueError"
+    assert snapshot["process_receipts"]["fail"][-1]["outcome"] == "error"
+    assert snapshot["process_receipts"]["fail"][-1]["remote_error_type"] == "ValueError"
+    assert snapshot["process_receipts"]["slow"][-1]["outcome"] == "cancelled"
+    for worker in executor._process_workers.values():
+        assert not worker.is_alive
+        assert worker.shared_memory_names is None

--- a/tests/test_runtime_transport_protocol_corruption.py
+++ b/tests/test_runtime_transport_protocol_corruption.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from neuros.runtime.transport import NeuralTransportProtocolError, SharedMemoryMailbox
+
+
+def test_transport_manifest_rejects_coerced_and_misaligned_array_geometry():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(np.arange(8, dtype=np.float32), lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["offset"] = 1
+        with pytest.raises(NeuralTransportProtocolError, match="aligned"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["offset"] = "0"
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["nbytes"] = float(envelope["manifest"]["nbytes"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["shape"] = tuple(envelope["manifest"]["shape"])
+        with pytest.raises(NeuralTransportProtocolError, match="shape must be a list"):
+            box.decode(corrupted, expected_lease_id=7)
+    finally:
+        box.close_and_unlink()
+
+
+def test_transport_envelope_rejects_integer_coercion_for_identity_and_boundary():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(np.arange(4, dtype=np.float32), lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["lease_id"] = "3"
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["bytes_used"] = float(envelope["bytes_used"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["bytes_used"] = True
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=3)
+    finally:
+        box.close_and_unlink()

--- a/tests/test_runtime_transport_protocol_corruption.py
+++ b/tests/test_runtime_transport_protocol_corruption.py
@@ -5,6 +5,7 @@ import copy
 import numpy as np
 import pytest
 
+from neuros.contracts import DecoderOutput, SignalFrame
 from neuros.runtime.transport import NeuralTransportProtocolError, SharedMemoryMailbox
 
 
@@ -55,5 +56,60 @@ def test_transport_envelope_rejects_integer_coercion_for_identity_and_boundary()
         corrupted["bytes_used"] = True
         with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
             box.decode(corrupted, expected_lease_id=3)
+    finally:
+        box.close_and_unlink()
+
+
+def test_canonical_frame_manifest_rejects_lossy_field_coercion():
+    frame = SignalFrame(
+        stream_id="eeg",
+        sequence_id=8,
+        data=np.arange(4, dtype=np.float32),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=1000,
+    )
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(frame, lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["stream_id"] = 123
+        with pytest.raises(NeuralTransportProtocolError, match="stream_id must be a string"):
+            box.decode(corrupted, expected_lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["sequence_id"] = 8.9
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["host_receive_time_ns"] = "1000"
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=4)
+    finally:
+        box.close_and_unlink()
+
+
+def test_canonical_constructor_rejection_is_reported_as_protocol_failure():
+    output = DecoderOutput(prediction=1, confidence=0.5)
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(output, lease_id=5)
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["confidence"]["value"] = 2.0
+        with pytest.raises(NeuralTransportProtocolError, match="DecoderOutput"):
+            box.decode(corrupted, expected_lease_id=5)
+    finally:
+        box.close_and_unlink()
+
+
+def test_sequence_manifest_requires_writer_container_shape():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode((1, 2, 3), lease_id=6)
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["items"] = tuple(corrupted["manifest"]["items"])
+        with pytest.raises(NeuralTransportProtocolError, match="items must be a list"):
+            box.decode(corrupted, expected_lease_id=6)
     finally:
         box.close_and_unlink()


### PR DESCRIPTION
Disposable Phase C experiment stacked on exact-qualified Phase B `e4d924223870959db88ef903b02f04244c42f9ff`.

Scope intentionally excludes `PersistentProcessWorker` integration. This first gate tests only:
- canonical `NeuralWindow` deep immutability;
- shared-memory mailbox codec for arrays, `SignalFrame`, `NeuralWindow`, `DecoderOutput`, `TransformEmission`, nested mappings/sequences;
- exact lease identity and corruption rejection;
- capacity/type fail-closed behavior;
- receiver materialization independence;
- owner-only unlink authority;
- maintained 3-OS x 3-Python runtime qualification matrix.

This PR is experimental evidence only and will not be promoted directly. Refs #126.