### PR TITLE
experiment: benchmark persistent runtime transports

### DIFF
--- a/.github/workflows/runtime-transport-benchmark.yml
+++ b/.github/workflows/runtime-transport-benchmark.yml
@@ -19,8 +19,15 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Non-gating pickle vs shared-memory benchmark
-    runs-on: ubuntu-24.04
+    name: Non-gating benchmark / ${{ matrix.os }} / Python 3.12
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-14
+          - windows-2025
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -53,12 +60,15 @@ jobs:
           python -m pip install -e "packages/neuros-core[test]"
           python -m pip check
 
-      - name: Measure persistent process transports
+      - name: Measure persistent process transports across crossover sizes
         shell: bash
         run: |
           set -euo pipefail
           python scripts/benchmark_runtime_transport.py \
-            --output "${RUNNER_TEMP}/transport-benchmark.json"
+            --payload-bytes \
+              4096 16384 32768 65536 131072 262144 524288 \
+              1048576 2097152 4194304 8388608 \
+            --output transport-benchmark.json
 
       - name: Validate evidence binding and publish readable summary
         shell: bash
@@ -67,9 +77,10 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import platform
           from pathlib import Path
 
-          path = Path(os.environ["RUNNER_TEMP"]) / "transport-benchmark.json"
+          path = Path("transport-benchmark.json")
           payload = json.loads(path.read_text(encoding="utf-8"))
           if payload.get("schema") != "neuros.runtime_transport_benchmark.v1":
               raise SystemExit("unexpected benchmark schema")
@@ -85,10 +96,11 @@ jobs:
           summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
           lines = [
               "## Runtime transport benchmark\n\n",
+              f"Runner: `{platform.platform()}`  \n",
               f"Semantic source: `{os.environ['BENCH_SEMANTIC_SHA']}`  \n",
               f"Benchmark source: `{os.environ['BENCH_SOURCE_SHA']}`  \n",
               "Timing is descriptive and non-gating.\n\n",
-              "| Payload | Pickle p50 ms | Shared p50 ms | Shared / Pickle | Pickle MiB/s | Shared MiB/s |\n",
+              "| Payload | Pickle p50 ms | Shared p50 ms | Shared/Pickle latency | Pickle MiB/s | Shared MiB/s |\n",
               "|---:|---:|---:|---:|---:|---:|\n",
           ]
           for size, rows in sorted(by_size.items()):
@@ -106,7 +118,7 @@ jobs:
       - name: Upload immutable benchmark evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: runtime-transport-benchmark-${{ env.BENCH_SOURCE_SHA }}
-          path: ${{ runner.temp }}/transport-benchmark.json
+          name: runtime-transport-benchmark-${{ matrix.os }}-${{ env.BENCH_SOURCE_SHA }}
+          path: transport-benchmark.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/runtime-transport-benchmark.yml
+++ b/.github/workflows/runtime-transport-benchmark.yml
@@ -1,0 +1,112 @@
+name: Runtime Transport Benchmark
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/runtime-transport-benchmark.yml"
+      - "scripts/benchmark_runtime_transport.py"
+
+permissions:
+  contents: read
+
+env:
+  BENCH_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+  BENCH_SEMANTIC_SHA: ec07e6a7dd89c65684dde5415c8d86b2e3dd9c41
+
+concurrency:
+  group: runtime-transport-bench-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Non-gating pickle vs shared-memory benchmark
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.BENCH_SOURCE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require exact clean benchmark source and frozen production semantics
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${BENCH_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+          git cat-file -e "${BENCH_SEMANTIC_SHA}^{commit}"
+          git diff --quiet "${BENCH_SEMANTIC_SHA}" HEAD -- packages/neuros-core/src
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: packages/neuros-core/pyproject.toml
+
+      - name: Install benchmark runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[test]"
+          python -m pip check
+
+      - name: Measure persistent process transports
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/benchmark_runtime_transport.py \
+            --output "${RUNNER_TEMP}/transport-benchmark.json"
+
+      - name: Validate evidence binding and publish readable summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["RUNNER_TEMP"]) / "transport-benchmark.json"
+          payload = json.loads(path.read_text(encoding="utf-8"))
+          if payload.get("schema") != "neuros.runtime_transport_benchmark.v1":
+              raise SystemExit("unexpected benchmark schema")
+          if payload.get("source_revision") != os.environ["BENCH_SOURCE_SHA"]:
+              raise SystemExit("benchmark source revision mismatch")
+          if payload.get("semantic_source_revision") != os.environ["BENCH_SEMANTIC_SHA"]:
+              raise SystemExit("benchmark semantic revision mismatch")
+
+          by_size = {}
+          for row in payload["summary"]:
+              by_size.setdefault(row["payload_bytes"], {})[row["transport"]] = row
+
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          lines = [
+              "## Runtime transport benchmark\n\n",
+              f"Semantic source: `{os.environ['BENCH_SEMANTIC_SHA']}`  \n",
+              f"Benchmark source: `{os.environ['BENCH_SOURCE_SHA']}`  \n",
+              "Timing is descriptive and non-gating.\n\n",
+              "| Payload | Pickle p50 ms | Shared p50 ms | Shared / Pickle | Pickle MiB/s | Shared MiB/s |\n",
+              "|---:|---:|---:|---:|---:|---:|\n",
+          ]
+          for size, rows in sorted(by_size.items()):
+              pickle = rows["pickle"]
+              shared = rows["shared_memory"]
+              ratio = shared["p50_ms"] / pickle["p50_ms"]
+              lines.append(
+                  f"| {size:,} B | {pickle['p50_ms']:.3f} | {shared['p50_ms']:.3f} | "
+                  f"{ratio:.3f}× | {pickle['effective_round_trip_mib_s']:.1f} | "
+                  f"{shared['effective_round_trip_mib_s']:.1f} |\n"
+              )
+          summary_path.write_text("".join(lines), encoding="utf-8")
+          PY
+
+      - name: Upload immutable benchmark evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: runtime-transport-benchmark-${{ env.BENCH_SOURCE_SHA }}
+          path: ${{ runner.temp }}/transport-benchmark.json
+          if-no-files-found: error
+          retention-days: 30

--- a/scripts/benchmark_runtime_transport.py
+++ b/scripts/benchmark_runtime_transport.py
@@ -35,7 +35,7 @@ class IdentityOperator:
 
 
 def _source_revision() -> str:
-    explicit = os.environ.get("GITHUB_SHA")
+    explicit = os.environ.get("BENCH_SOURCE_SHA")
     if explicit:
         return explicit
     try:
@@ -176,6 +176,7 @@ async def run_benchmark(
     return {
         "schema": "neuros.runtime_transport_benchmark.v1",
         "source_revision": _source_revision(),
+        "semantic_source_revision": os.environ.get("BENCH_SEMANTIC_SHA", "unknown"),
         "python": sys.version,
         "platform": platform.platform(),
         "processor": platform.processor(),

--- a/scripts/benchmark_runtime_transport.py
+++ b/scripts/benchmark_runtime_transport.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Non-gating benchmark for neurOS persistent process transports.
+
+The benchmark compares the already-qualified pickle worker with the experimental
+shared-memory worker using identical NumPy round trips. It deliberately excludes
+process startup from measured samples via warmups, alternates transport order
+between repeats, verifies every returned payload, and records distributions.
+
+It is evidence about one machine/runtime combination, not a release threshold.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from neuros.runtime.process_worker import PersistentProcessWorker
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
+
+
+class IdentityOperator:
+    def transform(self, item: Any) -> Any:
+        return item
+
+
+def _source_revision() -> str:
+    explicit = os.environ.get("GITHUB_SHA")
+    if explicit:
+        return explicit
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return math.nan
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * q
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return ordered[lower]
+    fraction = rank - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def _iterations_for(payload_bytes: int) -> int:
+    if payload_bytes <= 64 * 1024:
+        return 50
+    if payload_bytes <= 1024 * 1024:
+        return 20
+    return 8
+
+
+def _make_worker(transport: str, payload_bytes: int):
+    if transport == "pickle":
+        return PersistentProcessWorker(
+            f"bench-{transport}",
+            IdentityOperator(),
+            execution_timeout_s=15.0,
+        )
+    capacity = payload_bytes + 4096
+    return SharedMemoryProcessWorker(
+        f"bench-{transport}",
+        IdentityOperator(),
+        execution_timeout_s=15.0,
+        request_capacity_bytes=capacity,
+        response_capacity_bytes=capacity,
+    )
+
+
+async def _measure_once(
+    transport: str,
+    payload: np.ndarray,
+    *,
+    warmups: int,
+    iterations: int,
+) -> list[float]:
+    worker = _make_worker(transport, int(payload.nbytes))
+    try:
+        for _ in range(warmups):
+            call = await worker.invoke("transform", payload)
+            if not np.array_equal(call.result, payload):
+                raise RuntimeError(f"{transport} warmup changed the payload")
+
+        samples_ms: list[float] = []
+        for _ in range(iterations):
+            started = time.perf_counter_ns()
+            call = await worker.invoke("transform", payload)
+            elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000.0
+            if not np.array_equal(call.result, payload):
+                raise RuntimeError(f"{transport} changed the payload")
+            samples_ms.append(elapsed_ms)
+        return samples_ms
+    finally:
+        worker.close()
+
+
+async def run_benchmark(
+    payload_sizes: list[int],
+    *,
+    repeats: int,
+    warmups: int,
+    fixed_iterations: int | None,
+) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    aggregates: dict[tuple[int, str], list[float]] = {}
+
+    for payload_bytes in payload_sizes:
+        if payload_bytes <= 0 or payload_bytes % np.dtype(np.float32).itemsize:
+            raise ValueError("payload sizes must be positive multiples of four bytes")
+        elements = payload_bytes // np.dtype(np.float32).itemsize
+        payload = np.arange(elements, dtype=np.float32)
+        iterations = fixed_iterations or _iterations_for(payload_bytes)
+
+        for repeat in range(repeats):
+            order = ("pickle", "shared_memory") if repeat % 2 == 0 else (
+                "shared_memory",
+                "pickle",
+            )
+            for transport in order:
+                samples_ms = await _measure_once(
+                    transport,
+                    payload,
+                    warmups=warmups,
+                    iterations=iterations,
+                )
+                aggregates.setdefault((payload_bytes, transport), []).extend(samples_ms)
+                records.append(
+                    {
+                        "payload_bytes": payload_bytes,
+                        "transport": transport,
+                        "repeat": repeat,
+                        "warmups": warmups,
+                        "iterations": iterations,
+                        "latency_ms": samples_ms,
+                    }
+                )
+
+    summary: list[dict[str, Any]] = []
+    for (payload_bytes, transport), values in sorted(aggregates.items()):
+        mean_ms = statistics.fmean(values)
+        p50_ms = _percentile(values, 0.50)
+        p95_ms = _percentile(values, 0.95)
+        p99_ms = _percentile(values, 0.99)
+        round_trip_mib = (2.0 * payload_bytes) / (1024.0 * 1024.0)
+        effective_mib_s = round_trip_mib / (mean_ms / 1000.0)
+        summary.append(
+            {
+                "payload_bytes": payload_bytes,
+                "transport": transport,
+                "samples": len(values),
+                "mean_ms": mean_ms,
+                "p50_ms": p50_ms,
+                "p95_ms": p95_ms,
+                "p99_ms": p99_ms,
+                "effective_round_trip_mib_s": effective_mib_s,
+            }
+        )
+
+    return {
+        "schema": "neuros.runtime_transport_benchmark.v1",
+        "source_revision": _source_revision(),
+        "python": sys.version,
+        "platform": platform.platform(),
+        "processor": platform.processor(),
+        "numpy": np.__version__,
+        "repeats": repeats,
+        "warmups": warmups,
+        "payload_sizes": payload_sizes,
+        "summary": summary,
+        "records": records,
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--payload-bytes",
+        type=int,
+        nargs="+",
+        default=[4 * 1024, 64 * 1024, 1024 * 1024, 8 * 1024 * 1024],
+    )
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--warmups", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=None)
+    parser.add_argument("--output", type=Path, default=Path("transport-benchmark.json"))
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.repeats <= 0 or args.warmups < 0:
+        raise ValueError("repeats must be positive and warmups non-negative")
+    if args.iterations is not None and args.iterations <= 0:
+        raise ValueError("iterations must be positive")
+    result = asyncio.run(
+        run_benchmark(
+            list(args.payload_bytes),
+            repeats=args.repeats,
+            warmups=args.warmups,
+            fixed_iterations=args.iterations,
+        )
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result["summary"], indent=2))
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Disposable, non-gating performance experiment for Phase C transport selection.

This branch is pinned to semantic source `ec07e6a7dd89c65684dde5415c8d86b2e3dd9c41`. The benchmark workflow fails if any `packages/neuros-core/src` production source differs from that SHA.

It compares persistent pickle and shared-memory workers on identical float32 NumPy round trips at 4 KiB, 64 KiB, 1 MiB, and 8 MiB. Startup is excluded through warmups, transport order alternates across repeats, every result is byte-equivalent checked, and the artifact records raw latency samples plus p50/p95/p99 and effective round-trip throughput.

There is intentionally no performance threshold and no claim that shared memory is universally faster. The purpose is to locate the empirical crossover region on one controlled GitHub runner and decide whether the additional transport complexity is justified.