### PR TITLE
Runtime neural transport: canonical shared-memory payloads

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -18,6 +18,7 @@ on:
       - "tests/test_runtime_transport_protocol_corruption.py"
       - "tests/test_runtime_process_provenance.py"
       - "tests/test_runtime_process_transport_parity.py"
+      - "tests/test_runtime_duration_authority.py"
   push:
     branches:
       - main
@@ -37,6 +38,7 @@ on:
       - "tests/test_runtime_transport_protocol_corruption.py"
       - "tests/test_runtime_process_provenance.py"
       - "tests/test_runtime_process_transport_parity.py"
+      - "tests/test_runtime_duration_authority.py"
   workflow_dispatch:
 
 permissions:
@@ -109,7 +111,8 @@ jobs:
             tests/test_runtime_shared_transport_integration.py \
             tests/test_runtime_transport_protocol_corruption.py \
             tests/test_runtime_process_provenance.py \
-            tests/test_runtime_process_transport_parity.py
+            tests/test_runtime_process_transport_parity.py \
+            tests/test_runtime_duration_authority.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "docs/RUNTIME_PROCESS_TRANSPORT.md"
       - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
@@ -24,6 +25,7 @@ on:
       - main
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "docs/RUNTIME_PROCESS_TRANSPORT.md"
       - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_runtime_executor.py"
@@ -12,11 +13,16 @@ on:
       - "tests/test_runtime_fusion_cancellation.py"
       - "tests/test_runtime_execution_authority.py"
       - "tests/test_runtime_process_authority.py"
+      - "tests/test_runtime_neural_transport.py"
+      - "tests/test_runtime_shared_transport_integration.py"
+      - "tests/test_runtime_transport_protocol_corruption.py"
+      - "tests/test_runtime_process_provenance.py"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_runtime_executor.py"
@@ -25,6 +31,10 @@ on:
       - "tests/test_runtime_fusion_cancellation.py"
       - "tests/test_runtime_execution_authority.py"
       - "tests/test_runtime_process_authority.py"
+      - "tests/test_runtime_neural_transport.py"
+      - "tests/test_runtime_shared_transport_integration.py"
+      - "tests/test_runtime_transport_protocol_corruption.py"
+      - "tests/test_runtime_process_provenance.py"
   workflow_dispatch:
 
 permissions:
@@ -92,7 +102,11 @@ jobs:
             tests/test_runtime_fault_qualification.py \
             tests/test_runtime_fusion_cancellation.py \
             tests/test_runtime_execution_authority.py \
-            tests/test_runtime_process_authority.py
+            tests/test_runtime_process_authority.py \
+            tests/test_runtime_neural_transport.py \
+            tests/test_runtime_shared_transport_integration.py \
+            tests/test_runtime_transport_protocol_corruption.py \
+            tests/test_runtime_process_provenance.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -17,6 +17,7 @@ on:
       - "tests/test_runtime_shared_transport_integration.py"
       - "tests/test_runtime_transport_protocol_corruption.py"
       - "tests/test_runtime_process_provenance.py"
+      - "tests/test_runtime_process_transport_parity.py"
   push:
     branches:
       - main
@@ -35,6 +36,7 @@ on:
       - "tests/test_runtime_shared_transport_integration.py"
       - "tests/test_runtime_transport_protocol_corruption.py"
       - "tests/test_runtime_process_provenance.py"
+      - "tests/test_runtime_process_transport_parity.py"
   workflow_dispatch:
 
 permissions:
@@ -106,7 +108,8 @@ jobs:
             tests/test_runtime_neural_transport.py \
             tests/test_runtime_shared_transport_integration.py \
             tests/test_runtime_transport_protocol_corruption.py \
-            tests/test_runtime_process_provenance.py
+            tests/test_runtime_process_provenance.py \
+            tests/test_runtime_process_transport_parity.py
 
   runtime-fault-qualification:
     name: Runtime Fault Qualification

--- a/docs/RUNTIME_PROCESS_TRANSPORT.md
+++ b/docs/RUNTIME_PROCESS_TRANSPORT.md
@@ -1,0 +1,237 @@
+# Runtime Process Transport Authority
+
+This document defines the promoted contract boundary for process-executed neurOS runtime nodes.
+
+The short version is deliberately conservative:
+
+- process execution is **fault isolation**, not a security sandbox;
+- `pickle` remains the compatibility default for payloads it can represent;
+- `shared_memory` is explicit opt-in for canonical/numeric payloads that need it;
+- shared-memory mailbox capacities are explicit authority, not hints;
+- unsupported payloads and capacity overflow fail closed;
+- there is no silent fallback from shared memory to pickle;
+- callback inputs are materialized into child-local memory before arbitrary operator code runs, so this is **not an end-to-end zero-copy contract**.
+
+## Programmatic runtime surface
+
+Process execution is currently configured through `RuntimeNode` / `RuntimeGraph`:
+
+```python
+RuntimeNode(
+    node_id="transform:eeg:0",
+    kind=NodeKind.TRANSFORM,
+    operator=transform,
+    executor="process",
+    execution_timeout_s=2.0,
+    process_transport="shared_memory",
+    process_request_capacity_bytes=2 * 1024 * 1024,
+    process_response_capacity_bytes=2 * 1024 * 1024,
+)
+```
+
+`executor="process"` requires an explicit finite positive `execution_timeout_s`.
+Booleans, strings, zero/negative values, NaN, and infinities are rejected as duration authority.
+
+`process_transport` is one of:
+
+- `pickle`
+- `shared_memory`
+
+`pickle` requires no mailbox-capacity declaration.
+
+`shared_memory` requires explicit positive integer request and response capacities. Booleans are not integers for this authority boundary.
+
+Process-only declarations on non-process nodes are rejected. Source nodes remain inline because source lifecycle/stream isolation is a separate capability and has not been promoted by this tranche.
+
+## Configuration compiler boundary
+
+The versioned `PipelineConfig -> resolve_config -> RuntimeGraph` compiler does **not** yet expose these process-execution and payload-transport fields.
+
+Do not imply that YAML configuration can select shared-memory process transport today. That configuration-authority work is tracked separately so schema/versioning compatibility can be answered explicitly rather than being smuggled into the runtime primitive.
+
+Programmatic `RuntimeNode` construction is the authoritative configuration surface for this tranche.
+
+## What each transport can represent
+
+Transport support is a representation question, not merely a performance question.
+
+At the current contract revision:
+
+| Payload | `pickle` process transport | `shared_memory` process transport |
+|---|---|---|
+| NumPy numeric/bool ndarray | supported | supported |
+| deterministic scalar/list/tuple/string-keyed mapping payloads | supported when pickleable | supported by canonical codec |
+| `SignalFrame` | canonical instance is not generically pickleable | supported |
+| `NeuralWindow` | canonical instance is not generically pickleable | supported |
+| current `DecoderOutput` | canonical instance is not generically pickleable | supported |
+| `TransformEmission` containing supported canonical items | depends on contained pickleability | supported |
+| unsupported Python object / object-dtype ndarray | pickle semantics apply | rejected fail-closed |
+
+The canonical contracts use immutable provenance structures such as `MappingProxyType`. Generic pickle therefore cannot currently represent several canonical neurOS objects without changing their representation.
+
+That is not converted into an automatic fallback. For example, a process transform, sink, or monitor that must receive a canonical `SignalFrame` should explicitly select `shared_memory` and capacities large enough for its declared payload envelope.
+
+A process decoder is a distinct case: the standard executor converts `SignalFrame` / `NeuralWindow` decoder input to the numeric model batch before crossing the process boundary. Therefore a decoder can still use pickle when the actual process payload is the resulting NumPy array.
+
+## Shared-memory payload language
+
+The shared-memory transport keeps process control metadata on the multiprocessing pipe and moves numeric array bytes through fixed-capacity parent-owned shared-memory mailboxes.
+
+The v1 payload language supports:
+
+- `None`, strings, booleans, integers, floats and complex scalars;
+- NumPy numeric and boolean arrays;
+- tuples and lists;
+- deterministic mappings with string keys;
+- `SignalFrame`;
+- `NeuralWindow`;
+- `DecoderOutput`;
+- `TransformEmission`.
+
+Object-dtype arrays and unsupported Python object graphs are rejected.
+
+The reader accepts the concrete built-in manifest/container shapes emitted by the writer. Protocol identity, lease identity, array geometry, alignment, non-overlap and declared byte boundaries are validated exactly. Reader permissiveness is intentionally not broader than the writer's protocol language.
+
+Once the v1 protocol is promoted, incompatible reader/writer changes should be treated as an explicit protocol-version decision rather than silently tightening or widening the accepted wire language.
+
+## Mailbox authority and ownership
+
+Shared-memory mailboxes are fixed-capacity by design.
+
+- request and response capacities are independent;
+- an encode that would exceed capacity raises a transport-capacity error;
+- the transport does not resize behind the caller's back;
+- the transport does not fall back to pickle;
+- the creator owns unlink authority;
+- an attached peer never owns unlink authority;
+- parent unlink happens only after direct-child death is proven.
+
+The explicit-capacity contract keeps resource ownership, deployment memory budgeting, and failure provenance inspectable. A future ergonomic sizing layer may derive recommendations, but it must not weaken the underlying authority contract.
+
+## Materialization and the zero-copy boundary
+
+Shared memory avoids serializing/copying bulk numeric bytes through the multiprocessing pipe, but arbitrary operator callbacks do not receive views into the live mailbox.
+
+The child decoder materializes arrays into independent local NumPy memory before invoking operator code. Parent-side results are likewise detached from subsequent mailbox reuse.
+
+This prevents a callback from retaining a view that is silently mutated on the next mailbox lease and keeps canonical objects independent of shared-memory lifetime.
+
+Accordingly, the promoted claim is:
+
+> shared-memory payload transport for numeric/canonical process messages
+
+It is **not**:
+
+> end-to-end zero-copy neural execution
+
+A future zero-copy callback contract would need separate lifetime/lease ownership semantics and its own adversarial qualification.
+
+## Process lifecycle and failure precedence
+
+Pickle and shared memory use one common `PersistentProcessWorker` lifecycle authority. They do not own separate process engines.
+
+The common state machine owns:
+
+- spawn-safe direct-child creation;
+- generation and request identity;
+- ready/heartbeat control;
+- persistent operator state;
+- hard execution timeout;
+- asyncio cancellation containment;
+- crash detection;
+- receipts;
+- graceful shutdown;
+- terminate/join/kill escalation.
+
+Primary execution evidence is not overwritten by secondary cleanup noise.
+
+For example, if a call exceeds its hard timeout and shared-memory cleanup then fails after direct-child death has already been proven, the timeout remains the primary operation failure. Cleanup degradation remains secondary evidence and cleanup may be retried by executor-owned close authority.
+
+Failure to prove direct-child death is different: loss of containment authority is allowed to supersede the original operation failure because the runtime can no longer truthfully claim that the owned child was terminated.
+
+## Snapshot provenance
+
+Runtime snapshots record process execution declarations and per-call receipts.
+
+For each process node, `process_execution` records:
+
+- transport;
+- hard execution timeout;
+- request capacity when applicable;
+- response capacity when applicable.
+
+`process_receipts` records generation/request identity and outcome history.
+
+A separate follow-up may expose historical cleanup degradation that was later successfully retried. Such telemetry must remain secondary provenance and must not rewrite the primary operation failure.
+
+## Performance evidence
+
+Performance evidence is descriptive and non-gating.
+
+### Raw-array crossover experiment
+
+The original transport crossover experiment measures identical contiguous `float32` NumPy round trips. It excludes process startup through warmups, alternates transport order, verifies every returned array and records latency distributions across Ubuntu, macOS and Windows.
+
+Those results show that tiny payloads are near parity while shared memory becomes materially faster for large arrays. The crossover and tail behavior differ by operating system, so the evidence does **not** justify one universal automatic transport threshold.
+
+These numbers are **array transport evidence**. They must not be presented as a blanket speedup for arbitrary canonical neural objects.
+
+### Canonical workload experiment
+
+A second semantic-source-pinned experiment measures:
+
+- raw ndarray;
+- `SignalFrame`;
+- `NeuralWindow`;
+- multi-array `DecoderOutput`.
+
+Across Ubuntu 24.04, macOS 14 and Windows 2025, shared memory successfully round-tripped all four workloads. Generic pickle supported the ndarray workload but canonical `SignalFrame`, `NeuralWindow` and current `DecoderOutput` failed pickle preflight because of immutable provenance representation.
+
+At roughly 1 MiB of numeric array payload, observed shared-memory p50 latency was approximately:
+
+| OS | `SignalFrame` | `NeuralWindow` | `DecoderOutput` |
+|---|---:|---:|---:|
+| Ubuntu 24.04 | 1.43 ms | 1.30 ms | 1.00 ms |
+| Windows 2025 | 2.22 ms | 2.26 ms | 1.46 ms |
+| macOS 14 | 0.90 ms | 0.79 ms | 0.69 ms |
+
+The corresponding control manifests remained below roughly 1 KiB in this experiment.
+
+Canonical reconstruction still has real cost. At 8 MiB on Ubuntu, for example, `SignalFrame` was about 8.7 ms p50 while a naked ndarray was about 2.9 ms p50 over shared memory. On Windows those values were about 10.2 ms and 4.9 ms respectively.
+
+Therefore the evidence supports two separate conclusions:
+
+1. shared memory materially improves large numeric process transport and enables canonical payload classes that generic pickle cannot currently represent;
+2. canonical object reconstruction is not free, and shared-memory canonical payloads must not be described as equivalent to raw ndarray transport.
+
+Benchmark results are environment-specific measurements, not real-time guarantees or scientific-performance claims.
+
+## Security and trust boundary
+
+Neither process transport is a hostile-code sandbox.
+
+Operators are trusted Python objects. The multiprocessing control plane uses Python serialization internally, and child code executes with the privileges of the neurOS process environment.
+
+The promoted guarantees are about:
+
+- fault isolation;
+- deterministic control/request identity;
+- timeout/cancellation/crash containment;
+- transport representation integrity;
+- direct-child termination authority;
+- resource ownership and provenance.
+
+They are not guarantees against malicious operator code.
+
+## Promotion checklist for a process node
+
+Before selecting shared-memory process transport for a maintained path, require:
+
+1. the payload type is in the canonical supported language;
+2. request/response worst-case sizing is known and capacities are declared with margin;
+3. hard execution timeout is finite, positive and operationally justified;
+4. capacity overflow is expected to fail closed rather than resize/fallback;
+5. downstream code does not assume zero-copy callback lifetime;
+6. runtime snapshots/receipts are archived when the run is evidence-bearing;
+7. cross-platform qualification covers the exact runtime semantics being promoted;
+8. performance claims are scoped to the measured payload/workload and host class.

--- a/packages/neuros-core/src/neuros/contracts/window.py
+++ b/packages/neuros-core/src/neuros/contracts/window.py
@@ -9,14 +9,15 @@ replayable.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
-from types import MappingProxyType
+from numbers import Integral, Real
 from typing import Any, Mapping
 
 import numpy as np
 from numpy.typing import NDArray
 
-from .signal import ClockDomain, QualityFlag
+from .signal import ClockDomain, QualityFlag, _freeze_metadata_mapping
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,6 +64,10 @@ class NeuralWindow:
     ``data`` is always two-dimensional and channel-major: ``(channels, time)``.
     The runtime adds the batch axis at decoder invocation, yielding
     ``(batch=1, channels, time)`` for raw-window neural decoders.
+
+    Window arrays and metadata are detached from caller-owned mutable state at
+    construction. ``data`` is stored read-only, matching :class:`SignalFrame`'s
+    immutable software-observation boundary.
     """
 
     stream_id: str
@@ -78,16 +83,39 @@ class NeuralWindow:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.stream_id:
+        if not isinstance(self.stream_id, str) or not self.stream_id.strip():
             raise ValueError("stream_id must be non-empty")
-        if self.window_id < 0:
+        if isinstance(self.window_id, (bool, np.bool_)) or not isinstance(
+            self.window_id, Integral
+        ):
+            raise TypeError("window_id must be an integer")
+        if int(self.window_id) < 0:
             raise ValueError("window_id must be >= 0")
-        if self.sample_rate_hz <= 0:
-            raise ValueError("sample_rate_hz must be positive")
-        if self.start_time_ns < 0 or self.end_time_ns <= self.start_time_ns:
-            raise ValueError("NeuralWindow requires a positive half-open time interval")
+        object.__setattr__(self, "window_id", int(self.window_id))
 
-        arr = np.asarray(self.data)
+        if isinstance(self.sample_rate_hz, (bool, np.bool_)) or not isinstance(
+            self.sample_rate_hz, Real
+        ):
+            raise TypeError("sample_rate_hz must be a real numeric scalar")
+        sample_rate_hz = float(self.sample_rate_hz)
+        if not math.isfinite(sample_rate_hz) or sample_rate_hz <= 0:
+            raise ValueError("sample_rate_hz must be finite and positive")
+        object.__setattr__(self, "sample_rate_hz", sample_rate_hz)
+
+        for field_name, value in (
+            ("start_time_ns", self.start_time_ns),
+            ("end_time_ns", self.end_time_ns),
+        ):
+            if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+                raise TypeError(f"{field_name} must be an integer")
+        start_time_ns = int(self.start_time_ns)
+        end_time_ns = int(self.end_time_ns)
+        if start_time_ns < 0 or end_time_ns <= start_time_ns:
+            raise ValueError("NeuralWindow requires a positive half-open time interval")
+        object.__setattr__(self, "start_time_ns", start_time_ns)
+        object.__setattr__(self, "end_time_ns", end_time_ns)
+
+        arr = np.array(self.data, copy=True, subok=False)
         if arr.ndim != 2:
             raise ValueError(
                 "NeuralWindow.data must have shape (channels, time); "
@@ -95,22 +123,55 @@ class NeuralWindow:
             )
         if arr.shape[0] <= 0 or arr.shape[1] <= 0:
             raise ValueError("NeuralWindow.data cannot contain empty axes")
-        if not np.isfinite(arr).all():
+        if arr.dtype.kind not in "biufc":
+            raise TypeError(
+                "NeuralWindow.data must use a boolean or numeric dtype; "
+                f"received {arr.dtype}"
+            )
+        if arr.dtype.kind in "fc" and not np.isfinite(arr).all():
             raise ValueError("NeuralWindow.data contains NaN or infinite values")
-        if self.channel_names and len(self.channel_names) != arr.shape[0]:
+
+        channel_names = tuple(self.channel_names)
+        if any(not isinstance(name, str) or not name.strip() for name in channel_names):
+            raise ValueError("channel_names must contain non-empty strings")
+        if channel_names and len(channel_names) != arr.shape[0]:
             raise ValueError("channel_names must match the channel axis")
-        if any(sequence_id < 0 for sequence_id in self.source_sequence_ids):
-            raise ValueError("source_sequence_ids must be non-negative")
+        object.__setattr__(self, "channel_names", channel_names)
+
+        source_sequence_ids: list[int] = []
+        for sequence_id in self.source_sequence_ids:
+            if isinstance(sequence_id, (bool, np.bool_)) or not isinstance(
+                sequence_id, Integral
+            ):
+                raise TypeError("source_sequence_ids must contain integers")
+            resolved = int(sequence_id)
+            if resolved < 0:
+                raise ValueError("source_sequence_ids must be non-negative")
+            source_sequence_ids.append(resolved)
+        source_sequence_tuple = tuple(source_sequence_ids)
         if any(
             current <= previous
             for previous, current in zip(
-                self.source_sequence_ids, self.source_sequence_ids[1:]
+                source_sequence_tuple, source_sequence_tuple[1:]
             )
         ):
             raise ValueError("source_sequence_ids must be strictly increasing")
+        object.__setattr__(self, "source_sequence_ids", source_sequence_tuple)
 
+        object.__setattr__(self, "clock_domain", ClockDomain(self.clock_domain))
+        quality_value = int(self.quality)
+        if quality_value < 0:
+            raise ValueError("quality must be non-negative")
+        known_mask = 0
+        for flag in QualityFlag:
+            known_mask |= int(flag)
+        if quality_value & ~known_mask:
+            raise ValueError("quality contains undefined QualityFlag bits")
+        object.__setattr__(self, "quality", QualityFlag(quality_value))
+
+        arr.setflags(write=False)
         object.__setattr__(self, "data", arr)
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+        object.__setattr__(self, "metadata", _freeze_metadata_mapping(self.metadata))
 
     @property
     def n_channels(self) -> int:

--- a/packages/neuros-core/src/neuros/runtime/_validation.py
+++ b/packages/neuros-core/src/neuros/runtime/_validation.py
@@ -1,0 +1,22 @@
+"""Internal validation helpers for runtime authority-bearing numeric fields."""
+from __future__ import annotations
+
+import math
+from numbers import Real
+from typing import Any
+
+
+def positive_finite_real(value: Any, *, field_name: str) -> float:
+    """Return a canonical finite positive float without accepting coercions.
+
+    Authority-bearing durations must not silently accept strings, booleans,
+    NaN, or infinities. ``numbers.Real`` intentionally accepts ordinary Python
+    numeric scalars and NumPy real scalars while excluding text-like values.
+    """
+
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"{field_name} must be a real numeric scalar")
+    resolved = float(value)
+    if not math.isfinite(resolved) or resolved <= 0:
+        raise ValueError(f"{field_name} must be finite and positive")
+    return resolved

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
 from neuros.errors import ProcessingError
+from neuros.runtime._validation import positive_finite_real
 from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from neuros.runtime.process_worker import PersistentProcessWorker
 from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
@@ -183,8 +184,9 @@ class RuntimeExecutor:
         *,
         drain_timeout_s: float = 2.0,
     ) -> None:
-        if drain_timeout_s <= 0:
-            raise ValueError("drain_timeout_s must be positive")
+        drain_timeout_s = positive_finite_real(
+            drain_timeout_s, field_name="drain_timeout_s"
+        )
         graph.validate()
         self.graph = graph
         self.drain_timeout_s = drain_timeout_s
@@ -830,8 +832,7 @@ class RuntimeExecutor:
         the same failure semantics as :meth:`run` and :meth:`wait`.
         """
 
-        if duration_s <= 0:
-            raise ValueError("duration_s must be positive")
+        duration_s = positive_finite_real(duration_s, field_name="duration_s")
         await self.start()
         if self._completion_task is None:
             raise RuntimeError("Runtime completion authority was not created")

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -22,6 +22,7 @@ from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, Transform
 from neuros.errors import ProcessingError
 from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from neuros.runtime.process_worker import PersistentProcessWorker
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
 from neuros.runtime.lifecycle import RuntimeEvent, RuntimeState
 from neuros.runtime.queues import OverflowPolicy, QueueStats, put_with_policy
 
@@ -164,6 +165,9 @@ def _call(func: Callable[[Any], Any], item: Any) -> Any:
     return asyncio.run(await_result())
 
 
+_ProcessWorker = PersistentProcessWorker | SharedMemoryProcessWorker
+
+
 class RuntimeExecutor:
     """Execute a validated :class:`RuntimeGraph`.
 
@@ -200,7 +204,7 @@ class RuntimeExecutor:
         self._completion_task: asyncio.Task[None] | None = None
         self._output_queue: asyncio.Queue[Any] = asyncio.Queue()
         self._event_queue: asyncio.Queue[RuntimeEvent] = asyncio.Queue()
-        self._process_workers: dict[str, PersistentProcessWorker] = {}
+        self._process_workers: dict[str, _ProcessWorker] = {}
         self._process_receipts: dict[str, deque[dict[str, Any]]] = {
             node_id: deque(maxlen=4096)
             for node_id, node in graph.nodes.items()
@@ -395,8 +399,6 @@ class RuntimeExecutor:
                     error_type=error_type,
                     message=str(cause),
                 )
-                # The task currently executing this handler must be allowed to
-                # finish propagating its exception. All peers are cancelled.
                 for peer_id, task in self._tasks.items():
                     if peer_id != node.node_id and not task.done():
                         task.cancel()
@@ -418,10 +420,6 @@ class RuntimeExecutor:
             raise
         finally:
             await source.stop()
-            # Only normal completion or an explicit graceful stop owns an
-            # in-band shutdown marker. During failure propagation the peer
-            # consumer may already be cancelled, so enqueueing _STOP into a
-            # saturated data queue can deadlock containment indefinitely.
             graceful_stop = (
                 cancelled and self._stopping and self.failure is None
             )
@@ -480,9 +478,6 @@ class RuntimeExecutor:
                     pending, return_when=asyncio.FIRST_COMPLETED
                 )
             except BaseException:
-                # Fusion owns these temporary queue-get tasks. If the fusion
-                # node is cancelled, every child must be cancelled and awaited
-                # before the node itself can become terminal.
                 for task in pending:
                     if not task.done():
                         task.cancel()
@@ -618,11 +613,27 @@ class RuntimeExecutor:
                 )
             worker = self._process_workers.get(node.node_id)
             if worker is None:
-                worker = PersistentProcessWorker(
-                    node.node_id,
-                    node.operator,
-                    execution_timeout_s=timeout_s,
-                )
+                if node.process_transport == "shared_memory":
+                    request_capacity = node.process_request_capacity_bytes
+                    response_capacity = node.process_response_capacity_bytes
+                    if request_capacity is None or response_capacity is None:
+                        raise ValueError(
+                            f"Shared-memory process node {node.node_id} lacks "
+                            "explicit request/response mailbox capacities"
+                        )
+                    worker = SharedMemoryProcessWorker(
+                        node.node_id,
+                        node.operator,
+                        execution_timeout_s=timeout_s,
+                        request_capacity_bytes=request_capacity,
+                        response_capacity_bytes=response_capacity,
+                    )
+                else:
+                    worker = PersistentProcessWorker(
+                        node.node_id,
+                        node.operator,
+                        execution_timeout_s=timeout_s,
+                    )
                 self._process_workers[node.node_id] = worker
             receipts = self._process_receipts.setdefault(
                 node.node_id, deque(maxlen=4096)
@@ -657,8 +668,6 @@ class RuntimeExecutor:
 
     async def _emit_stop(self, node_id: str) -> None:
         for channel in self._outgoing[node_id]:
-            # Shutdown markers are control-plane authority and must never be
-            # dropped by the data overflow policy.
             await channel.queue.put(_STOP)
 
     async def _notify_monitors(self, node: RuntimeNode, item: Any) -> None:
@@ -736,8 +745,6 @@ class RuntimeExecutor:
         if self.state is RuntimeState.STOPPED:
             return
         if self.state is RuntimeState.FAILED:
-            # FAILED is scientific terminal authority, but callers invoking
-            # stop() also receive a resource-cleanup barrier.
             if self._completion_task is not None and not self._completion_task.done():
                 await asyncio.gather(
                     self._completion_task, return_exceptions=True
@@ -877,6 +884,16 @@ class RuntimeExecutor:
                 for node_id, stats in self._node_stats.items()
             },
             "edges": edge_metrics,
+            "process_execution": {
+                node_id: {
+                    "transport": node.process_transport,
+                    "execution_timeout_s": node.execution_timeout_s,
+                    "request_capacity_bytes": node.process_request_capacity_bytes,
+                    "response_capacity_bytes": node.process_response_capacity_bytes,
+                }
+                for node_id, node in sorted(self.graph.nodes.items())
+                if node.executor == "process"
+            },
             "process_receipts": {
                 node_id: list(receipts)
                 for node_id, receipts in self._process_receipts.items()

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -19,6 +19,9 @@ class NodeKind(str, Enum):
     MONITOR = "monitor"
 
 
+_PROCESS_TRANSPORTS = frozenset({"pickle", "shared_memory"})
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeNode:
     node_id: str
@@ -27,6 +30,9 @@ class RuntimeNode:
     executor: str = "inline"
     latency_budget_ms: float | None = None
     execution_timeout_s: float | None = None
+    process_transport: str = "pickle"
+    process_request_capacity_bytes: int | None = None
+    process_response_capacity_bytes: int | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -52,6 +58,33 @@ class RuntimeNode:
                 "executor='process' requires an explicit execution_timeout_s; "
                 "latency_budget_ms is an SLO and is not termination authority"
             )
+
+        if self.process_transport not in _PROCESS_TRANSPORTS:
+            raise ValueError(
+                f"Unsupported process_transport: {self.process_transport}"
+            )
+        capacities = (
+            ("process_request_capacity_bytes", self.process_request_capacity_bytes),
+            ("process_response_capacity_bytes", self.process_response_capacity_bytes),
+        )
+        any_capacity = any(value is not None for _, value in capacities)
+        if self.executor != "process":
+            if self.process_transport != "pickle" or any_capacity:
+                raise ValueError(
+                    "process transport declarations are only valid for executor='process'"
+                )
+        elif self.process_transport == "shared_memory":
+            for field_name, value in capacities:
+                if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                    raise ValueError(
+                        f"shared_memory transport requires positive {field_name}"
+                    )
+        elif any_capacity:
+            raise ValueError(
+                "process mailbox capacities are only valid for "
+                "process_transport='shared_memory'"
+            )
+
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
 

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -7,6 +7,7 @@ from enum import Enum
 from types import MappingProxyType
 from typing import Any, Mapping
 
+from ._validation import positive_finite_real
 from .queues import OverflowPolicy
 
 
@@ -38,10 +39,22 @@ class RuntimeNode:
     def __post_init__(self) -> None:
         if not self.node_id:
             raise ValueError("node_id must be non-empty")
-        if self.latency_budget_ms is not None and self.latency_budget_ms <= 0:
-            raise ValueError("latency_budget_ms must be positive")
-        if self.execution_timeout_s is not None and self.execution_timeout_s <= 0:
-            raise ValueError("execution_timeout_s must be positive")
+        if self.latency_budget_ms is not None:
+            object.__setattr__(
+                self,
+                "latency_budget_ms",
+                positive_finite_real(
+                    self.latency_budget_ms, field_name="latency_budget_ms"
+                ),
+            )
+        if self.execution_timeout_s is not None:
+            object.__setattr__(
+                self,
+                "execution_timeout_s",
+                positive_finite_real(
+                    self.execution_timeout_s, field_name="execution_timeout_s"
+                ),
+            )
         if self.executor not in {"inline", "thread", "process", "gpu"}:
             raise ValueError(f"Unsupported executor: {self.executor}")
         if self.kind is NodeKind.SOURCE and self.executor != "inline":

--- a/packages/neuros-core/src/neuros/runtime/process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/process_worker.py
@@ -45,7 +45,7 @@ class ProcessWorkerSerializationError(ProcessWorkerError):
 
 
 class ProcessWorkerTransportError(ProcessWorkerError):
-    """Payload transport creation, codec, identity, or cleanup failure."""
+    """Payload/control transport creation, codec, identity, or cleanup failure."""
 
 
 class ProcessWorkerTerminationError(ProcessWorkerError):
@@ -97,6 +97,22 @@ class _PayloadProtocolFailure(Exception):
     pass
 
 
+def _is_exact_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _control_int(mapping: dict[str, Any], key: str) -> int:
+    if key not in mapping or not _is_exact_int(mapping[key]):
+        raise _PayloadProtocolFailure(f"control field {key} must be an exact integer")
+    return mapping[key]
+
+
+def _control_str(mapping: dict[str, Any], key: str) -> str:
+    if key not in mapping or not isinstance(mapping[key], str):
+        raise _PayloadProtocolFailure(f"control field {key} must be a string")
+    return mapping[key]
+
+
 class _PickleParentTransport:
     """Parent-side payload adapter preserving the Phase B pickle semantics."""
 
@@ -140,7 +156,7 @@ class _PickleChildTransport:
     def decode_request(self, payload: Any, lease_id: int) -> Any:
         del lease_id
         if not isinstance(payload, bytes):
-            raise _PayloadProtocolFailure("malformed call")
+            raise _PayloadProtocolFailure("malformed call payload")
         try:
             return pickle.loads(payload)
         except Exception as exc:
@@ -245,12 +261,24 @@ def _child(
                     pass
                 return
 
-            if not isinstance(request, dict) or any(
-                (
-                    request.get("protocol") != _PROTOCOL,
-                    request.get("node_id") != node_id,
-                    request.get("generation") != generation,
+            if type(request) is not dict:
+                _send(
+                    conn,
+                    {**base, "kind": "protocol_error", "message": "request is not an exact mapping"},
                 )
+                return
+            try:
+                protocol = _control_int(request, "protocol")
+                request_node_id = _control_str(request, "node_id")
+                request_generation = _control_int(request, "generation")
+                command = _control_str(request, "command")
+            except _PayloadProtocolFailure as exc:
+                _send(conn, {**base, "kind": "protocol_error", "message": str(exc)})
+                return
+            if (
+                protocol != _PROTOCOL
+                or request_node_id != node_id
+                or request_generation != generation
             ):
                 _send(
                     conn,
@@ -258,32 +286,46 @@ def _child(
                 )
                 return
 
-            command = request.get("command")
             if command == "heartbeat":
+                if "request_id" in request:
+                    _send(
+                        conn,
+                        {**base, "kind": "protocol_error", "message": "heartbeat cannot carry request identity"},
+                    )
+                    return
                 _send(conn, {**base, "kind": "heartbeat"})
                 continue
             if command == "shutdown":
+                if "request_id" in request:
+                    _send(
+                        conn,
+                        {**base, "kind": "protocol_error", "message": "shutdown cannot carry request identity"},
+                    )
+                    return
                 _send(conn, {**base, "kind": "shutdown"})
                 return
-
-            request_id = request.get("request_id")
-            method = request.get("method")
-            item_payload = request.get("item")
-            call_base = {**base, "request_id": request_id}
-            if (
-                command != "call"
-                or isinstance(request_id, bool)
-                or not isinstance(request_id, int)
-                or request_id <= 0
-                or not isinstance(method, str)
-                or not method
-            ):
+            if command != "call":
                 _send(
                     conn,
-                    {**call_base, "kind": "protocol_error", "message": "malformed call"},
+                    {**base, "kind": "protocol_error", "message": "unknown command"},
                 )
                 return
 
+            try:
+                request_id = _control_int(request, "request_id")
+                method = _control_str(request, "method")
+            except _PayloadProtocolFailure as exc:
+                _send(conn, {**base, "kind": "protocol_error", "message": str(exc)})
+                return
+            if request_id <= 0 or not method:
+                _send(
+                    conn,
+                    {**base, "kind": "protocol_error", "message": "malformed call"},
+                )
+                return
+
+            item_payload = request.get("item")
+            call_base = {**base, "request_id": request_id}
             try:
                 item = transport.decode_request(item_payload, request_id)
             except _PayloadProtocolFailure as exc:
@@ -396,8 +438,8 @@ class PersistentProcessWorker:
             raise ValueError("node_id must be non-empty")
         if min(execution_timeout_s, startup_timeout_s, termination_grace_s) <= 0:
             raise ValueError("worker timeouts must be positive")
-        if generation < 0:
-            raise ValueError("generation must be non-negative")
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+            raise ValueError("generation must be a non-negative integer")
         if not _process_name_prefix:
             raise ValueError("_process_name_prefix must be non-empty")
         self.node_id = node_id
@@ -405,21 +447,29 @@ class PersistentProcessWorker:
         self.execution_timeout_s = float(execution_timeout_s)
         self.startup_timeout_s = float(startup_timeout_s)
         self.termination_grace_s = float(termination_grace_s)
-        self.generation = int(generation)
+        self.generation = generation
         self._ctx = mp.get_context("spawn")
         self._conn: Connection | None = None
         self._process: mp.Process | None = None
         self._request_id = 0
         self._last_receipt: ProcessExecutionReceipt | None = None
+        self._last_cleanup_error: ProcessWorkerTransportError | None = None
         self._lock = asyncio.Lock()
         self._terminal = False
-        self._payload_transport = _payload_transport or _PickleParentTransport()
+        self._payload_transport = (
+            _payload_transport if _payload_transport is not None else _PickleParentTransport()
+        )
         self._child_transport_factory = _child_transport_factory
         self._process_name_prefix = _process_name_prefix
 
     @property
     def last_receipt(self) -> ProcessExecutionReceipt | None:
         return self._last_receipt
+
+    @property
+    def last_cleanup_error(self) -> ProcessWorkerTransportError | None:
+        """Most recent payload-resource cleanup degradation, if one occurred."""
+        return self._last_cleanup_error
 
     @property
     def pid(self) -> int | None:
@@ -441,12 +491,33 @@ class PersistentProcessWorker:
         )
 
     def _identity(self, response: dict[str, Any], request_id: int | None) -> None:
+        try:
+            protocol = _control_int(response, "protocol")
+            response_node_id = _control_str(response, "node_id")
+            response_generation = _control_int(response, "generation")
+        except _PayloadProtocolFailure as exc:
+            raise ProcessWorkerProtocolError(self.node_id, str(exc)) from exc
         if (
-            response.get("protocol") != _PROTOCOL
-            or response.get("node_id") != self.node_id
-            or response.get("generation") != self.generation
-            or (request_id is not None and response.get("request_id") != request_id)
+            protocol != _PROTOCOL
+            or response_node_id != self.node_id
+            or response_generation != self.generation
         ):
+            raise ProcessWorkerProtocolError(
+                self.node_id,
+                f"stale or mismatched process response for request {request_id}",
+            )
+        if request_id is None:
+            if "request_id" in response:
+                raise ProcessWorkerProtocolError(
+                    self.node_id,
+                    "control response unexpectedly carries request identity",
+                )
+            return
+        try:
+            response_request_id = _control_int(response, "request_id")
+        except _PayloadProtocolFailure as exc:
+            raise ProcessWorkerProtocolError(self.node_id, str(exc)) from exc
+        if response_request_id != request_id:
             raise ProcessWorkerProtocolError(
                 self.node_id,
                 f"stale or mismatched process response for request {request_id}",
@@ -457,26 +528,24 @@ class PersistentProcessWorker:
             raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
         if not self._conn.poll(timeout_s):
             if not self.is_alive:
-                raise ProcessWorkerCrashedError(
-                    self.node_id, "worker exited before response"
-                )
+                raise ProcessWorkerCrashedError(self.node_id, "worker exited before response")
             raise ProcessWorkerTimeoutError(
                 self.node_id,
                 f"request {request_id} exceeded {timeout_s:.6f}s hard execution timeout",
             )
         try:
             response = pickle.loads(self._conn.recv_bytes())
-        except EOFError as exc:
+        except (EOFError, ConnectionResetError, BrokenPipeError, OSError) as exc:
             raise ProcessWorkerCrashedError(
-                self.node_id, "worker EOF before response"
+                self.node_id, "worker IPC closed before response"
             ) from exc
         except Exception as exc:
             raise ProcessWorkerProtocolError(
                 self.node_id, f"invalid worker response: {exc}"
             ) from exc
-        if not isinstance(response, dict):
+        if type(response) is not dict:
             raise ProcessWorkerProtocolError(
-                self.node_id, "worker response is not a mapping"
+                self.node_id, "worker response is not an exact mapping"
             )
         self._identity(response, request_id)
         return response
@@ -525,6 +594,29 @@ class PersistentProcessWorker:
                 f"payload transport preparation failed: {type(exc).__name__}: {exc}",
             ) from exc
 
+    def _cleanup_suffix(self) -> str:
+        try:
+            self._cleanup_payload_transport()
+        except ProcessWorkerTransportError as exc:
+            self._last_cleanup_error = exc
+            return f"; payload cleanup also failed: {exc}"
+        return ""
+
+    def _abort_after_primary_failure(self) -> None:
+        """Contain a failed call without allowing cleanup noise to rewrite its cause.
+
+        Failure to prove direct-child death remains authority-critical and is
+        therefore allowed to supersede the original operation failure. Payload
+        cleanup degradation after child death is retained as secondary evidence
+        and retried by later executor-owned close authority.
+        """
+        try:
+            self.abort()
+        except ProcessWorkerTerminationError:
+            raise
+        except ProcessWorkerTransportError as exc:
+            self._last_cleanup_error = exc
+
     def _start(self) -> None:
         if self._terminal:
             raise ProcessWorkerError(
@@ -536,48 +628,88 @@ class PersistentProcessWorker:
             raise ProcessWorkerCrashedError(self.node_id, "worker exited")
 
         self._prepare_payload_transport()
-        parent, child = self._ctx.Pipe(duplex=True)
-        process = self._ctx.Process(
-            target=_child,
-            args=(
-                child,
-                self.operator,
+        try:
+            child_transport_spec = self._payload_transport.child_spec()
+        except _PayloadTransportFailure as exc:
+            suffix = self._cleanup_suffix()
+            raise ProcessWorkerTransportError(
+                self.node_id, f"child payload transport specification failed: {exc}{suffix}"
+            ) from exc
+        except Exception as exc:
+            suffix = self._cleanup_suffix()
+            raise ProcessWorkerTransportError(
                 self.node_id,
-                self.generation,
-                self._child_transport_factory,
-                self._payload_transport.child_spec(),
-            ),
-            name=f"{self._process_name_prefix}:{self.node_id}:g{self.generation}",
-        )
+                "child payload transport specification failed: "
+                f"{type(exc).__name__}: {exc}{suffix}",
+            ) from exc
+
+        try:
+            parent, child = self._ctx.Pipe(duplex=True)
+        except Exception as exc:
+            suffix = self._cleanup_suffix()
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                f"worker IPC creation failed: {type(exc).__name__}: {exc}{suffix}",
+            ) from exc
+
+        try:
+            process = self._ctx.Process(
+                target=_child,
+                args=(
+                    child,
+                    self.operator,
+                    self.node_id,
+                    self.generation,
+                    self._child_transport_factory,
+                    child_transport_spec,
+                ),
+                name=f"{self._process_name_prefix}:{self.node_id}:g{self.generation}",
+            )
+        except Exception as exc:
+            parent.close()
+            child.close()
+            suffix = self._cleanup_suffix()
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                f"worker process construction failed: {type(exc).__name__}: {exc}{suffix}",
+            ) from exc
+
         self._conn, self._process = parent, process
         try:
             process.start()
         except Exception as exc:
             parent.close()
             self._conn = self._process = None
-            cleanup_suffix = ""
-            try:
-                self._cleanup_payload_transport()
-            except ProcessWorkerTransportError as cleanup_exc:
-                cleanup_suffix = f"; transport cleanup also failed: {cleanup_exc}"
+            suffix = self._cleanup_suffix()
             raise ProcessWorkerSerializationError(
                 self.node_id,
-                f"operator/start serialization failed: {exc}{cleanup_suffix}",
+                f"operator/start serialization failed: {exc}{suffix}",
             ) from exc
         finally:
             child.close()
 
         ready = self._recv(self.startup_timeout_s, None)
-        if ready.get("kind") == "transport_error":
-            raise ProcessWorkerTransportError(
-                self.node_id,
-                str(ready.get("message") or "child payload transport startup failed"),
-            )
-        if ready.get("kind") != "ready":
+        try:
+            ready_kind = _control_str(ready, "kind")
+        except _PayloadProtocolFailure as exc:
+            raise ProcessWorkerProtocolError(self.node_id, str(exc)) from exc
+        if ready_kind == "transport_error":
+            message = ready.get("message")
+            error_type = ready.get("error_type")
+            if not isinstance(message, str) or not isinstance(error_type, str):
+                raise ProcessWorkerProtocolError(
+                    self.node_id, "malformed child transport startup error"
+                )
+            raise ProcessWorkerTransportError(self.node_id, message)
+        if ready_kind != "ready":
             raise ProcessWorkerProtocolError(self.node_id, "worker did not become ready")
         self._send_control("heartbeat")
         heartbeat = self._recv(self.startup_timeout_s, None)
-        if heartbeat.get("kind") != "heartbeat":
+        try:
+            heartbeat_kind = _control_str(heartbeat, "kind")
+        except _PayloadProtocolFailure as exc:
+            raise ProcessWorkerProtocolError(self.node_id, str(exc)) from exc
+        if heartbeat_kind != "heartbeat":
             raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
 
     def _encode_request(self, item: Any, request_id: int) -> Any:
@@ -605,6 +737,9 @@ class PersistentProcessWorker:
                 self.node_id,
                 f"result payload decoding failed: {type(exc).__name__}: {exc}",
             ) from exc
+
+    async def _contain_primary_failure(self) -> None:
+        await asyncio.to_thread(self._abort_after_primary_failure)
 
     async def invoke(self, method: str, item: Any) -> ProcessCallResult:
         async with self._lock:
@@ -641,79 +776,112 @@ class PersistentProcessWorker:
                 )
             except asyncio.CancelledError:
                 self._receipt(request_id, "cancelled")
-                await asyncio.shield(asyncio.to_thread(self.abort))
+                await asyncio.shield(self._contain_primary_failure())
                 raise
             except ProcessWorkerTimeoutError:
                 self._receipt(request_id, "timeout")
-                await asyncio.to_thread(self.abort)
+                await self._contain_primary_failure()
                 raise
             except ProcessWorkerCrashedError:
                 self._receipt(request_id, "crashed")
-                await asyncio.to_thread(self.abort)
+                await self._contain_primary_failure()
                 raise
             except ProcessWorkerProtocolError:
                 self._receipt(request_id, "protocol_error")
-                await asyncio.to_thread(self.abort)
+                await self._contain_primary_failure()
                 raise
             except ProcessWorkerTransportError:
                 self._request_id = request_id
                 self._receipt(request_id, "transport_error")
-                await asyncio.to_thread(self.abort)
+                await self._contain_primary_failure()
                 raise
             except ProcessWorkerSerializationError:
                 self._request_id = request_id
                 self._receipt(request_id, "serialization_error")
-                await asyncio.to_thread(self.abort)
+                await self._contain_primary_failure()
                 raise
             except Exception as exc:
                 self._request_id = request_id
                 self._receipt(request_id, "serialization_error")
-                await asyncio.to_thread(self.abort)
-                raise ProcessWorkerSerializationError(
+                wrapped = ProcessWorkerSerializationError(
                     self.node_id, f"input/request serialization failed: {exc}"
-                ) from exc
+                )
+                await self._contain_primary_failure()
+                raise wrapped from exc
 
-            kind = response.get("kind")
+            try:
+                kind = _control_str(response, "kind")
+            except _PayloadProtocolFailure as exc:
+                error = ProcessWorkerProtocolError(self.node_id, str(exc))
+                self._receipt(request_id, "protocol_error")
+                await self._contain_primary_failure()
+                raise error from exc
+
             if kind == "result":
                 try:
                     result = self._decode_result(response.get("result"), request_id)
                 except ProcessWorkerSerializationError:
                     self._receipt(request_id, "serialization_error")
-                    await asyncio.to_thread(self.abort)
+                    await self._contain_primary_failure()
                     raise
                 except ProcessWorkerTransportError:
                     self._receipt(request_id, "transport_error")
-                    await asyncio.to_thread(self.abort)
+                    await self._contain_primary_failure()
                     raise
                 receipt = ProcessExecutionReceipt(
                     self.node_id, self.generation, request_id, "success"
                 )
                 self._last_receipt = receipt
                 return ProcessCallResult(result, receipt)
+
             if kind == "error":
-                error_type = str(response.get("error_type") or "RemoteError")
+                error_type = response.get("error_type")
+                message = response.get("message")
+                if not isinstance(error_type, str) or not error_type or not isinstance(message, str):
+                    error = ProcessWorkerProtocolError(
+                        self.node_id, "malformed remote error response"
+                    )
+                    self._receipt(request_id, "protocol_error")
+                    await self._contain_primary_failure()
+                    raise error
                 self._receipt(request_id, "error", error_type)
-                raise ProcessWorkerRemoteError(
-                    self.node_id, error_type, str(response.get("message") or "")
-                )
+                raise ProcessWorkerRemoteError(self.node_id, error_type, message)
+
             if kind == "serialization_error":
+                message = response.get("message")
+                if not isinstance(message, str):
+                    error = ProcessWorkerProtocolError(
+                        self.node_id, "malformed serialization error response"
+                    )
+                    self._receipt(request_id, "protocol_error")
+                    await self._contain_primary_failure()
+                    raise error
                 self._receipt(request_id, "serialization_error")
-                await asyncio.to_thread(self.abort)
-                raise ProcessWorkerSerializationError(
-                    self.node_id,
-                    str(response.get("message") or "serialization failure"),
-                )
+                error = ProcessWorkerSerializationError(self.node_id, message)
+                await self._contain_primary_failure()
+                raise error
+
             if kind == "transport_error":
+                message = response.get("message")
+                error_type = response.get("error_type")
+                if not isinstance(message, str) or not isinstance(error_type, str):
+                    error = ProcessWorkerProtocolError(
+                        self.node_id, "malformed transport error response"
+                    )
+                    self._receipt(request_id, "protocol_error")
+                    await self._contain_primary_failure()
+                    raise error
                 self._receipt(request_id, "transport_error")
-                await asyncio.to_thread(self.abort)
-                raise ProcessWorkerTransportError(
-                    self.node_id, str(response.get("message") or "transport failure")
-                )
+                error = ProcessWorkerTransportError(self.node_id, message)
+                await self._contain_primary_failure()
+                raise error
+
             self._receipt(request_id, "protocol_error")
-            await asyncio.to_thread(self.abort)
-            raise ProcessWorkerProtocolError(
+            error = ProcessWorkerProtocolError(
                 self.node_id, f"unexpected worker response kind {kind!r}"
             )
+            await self._contain_primary_failure()
+            raise error
 
     async def heartbeat(self) -> None:
         async with self._lock:
@@ -723,15 +891,17 @@ class PersistentProcessWorker:
                 response = await asyncio.to_thread(
                     self._recv, self.startup_timeout_s, None
                 )
-                if response.get("kind") != "heartbeat":
-                    raise ProcessWorkerProtocolError(
-                        self.node_id, "worker heartbeat failed"
-                    )
+                try:
+                    kind = _control_str(response, "kind")
+                except _PayloadProtocolFailure as exc:
+                    raise ProcessWorkerProtocolError(self.node_id, str(exc)) from exc
+                if kind != "heartbeat":
+                    raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
             except asyncio.CancelledError:
-                await asyncio.shield(asyncio.to_thread(self.abort))
+                await asyncio.shield(self._contain_primary_failure())
                 raise
             except Exception:
-                await asyncio.to_thread(self.abort)
+                await self._contain_primary_failure()
                 raise
 
     def _terminate_owned_process(self, process: mp.Process) -> None:
@@ -783,7 +953,15 @@ class PersistentProcessWorker:
                 self._send_control("shutdown")
                 if conn.poll(self.termination_grace_s):
                     response = pickle.loads(conn.recv_bytes())
+                    if type(response) is not dict:
+                        raise ProcessWorkerProtocolError(
+                            self.node_id, "shutdown response is not an exact mapping"
+                        )
                     self._identity(response, None)
+                    if _control_str(response, "kind") != "shutdown":
+                        raise ProcessWorkerProtocolError(
+                            self.node_id, "worker shutdown acknowledgement failed"
+                        )
             except Exception:
                 pass
         process.join(self.termination_grace_s)

--- a/packages/neuros-core/src/neuros/runtime/process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/process_worker.py
@@ -3,6 +3,11 @@
 Trusted Python objects cross a multiprocessing boundary, so this is fault
 isolation, not a security sandbox. Termination authority covers only the direct
 child created here, never arbitrary descendants.
+
+The process lifecycle is intentionally transport-agnostic. Pickle remains the
+qualified default payload transport. Alternate transports plug into the same
+startup, identity, receipt, timeout, cancellation, crash, and termination state
+machine instead of duplicating process authority.
 """
 from __future__ import annotations
 
@@ -12,7 +17,7 @@ import multiprocessing as mp
 import pickle
 from dataclasses import dataclass
 from multiprocessing.connection import Connection
-from typing import Any
+from typing import Any, Callable
 
 _PROTOCOL = 1
 
@@ -37,6 +42,10 @@ class ProcessWorkerProtocolError(ProcessWorkerError):
 
 class ProcessWorkerSerializationError(ProcessWorkerError):
     pass
+
+
+class ProcessWorkerTransportError(ProcessWorkerError):
+    """Payload transport creation, codec, identity, or cleanup failure."""
 
 
 class ProcessWorkerTerminationError(ProcessWorkerError):
@@ -74,6 +83,90 @@ class ProcessCallResult:
     receipt: ProcessExecutionReceipt
 
 
+class _PayloadSerializationFailure(Exception):
+    pass
+
+
+class _PayloadTransportFailure(Exception):
+    def __init__(self, message: str, *, error_type: str | None = None) -> None:
+        self.error_type = error_type
+        super().__init__(message)
+
+
+class _PayloadProtocolFailure(Exception):
+    pass
+
+
+class _PickleParentTransport:
+    """Parent-side payload adapter preserving the Phase B pickle semantics."""
+
+    @property
+    def shared_memory_names(self) -> None:
+        return None
+
+    def prepare(self) -> None:
+        return None
+
+    def child_spec(self) -> None:
+        return None
+
+    def encode_request(self, value: Any, lease_id: int) -> bytes:
+        del lease_id
+        try:
+            return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        except Exception as exc:
+            raise _PayloadSerializationFailure(
+                f"input/request serialization failed: {exc}"
+            ) from exc
+
+    def decode_result(self, payload: Any, lease_id: int) -> Any:
+        del lease_id
+        if not isinstance(payload, bytes):
+            raise _PayloadSerializationFailure(
+                "result deserialization failed: result payload is not bytes"
+            )
+        try:
+            return pickle.loads(payload)
+        except Exception as exc:
+            raise _PayloadSerializationFailure(
+                f"result deserialization failed: {exc}"
+            ) from exc
+
+    def cleanup(self) -> None:
+        return None
+
+
+class _PickleChildTransport:
+    def decode_request(self, payload: Any, lease_id: int) -> Any:
+        del lease_id
+        if not isinstance(payload, bytes):
+            raise _PayloadProtocolFailure("malformed call")
+        try:
+            return pickle.loads(payload)
+        except Exception as exc:
+            raise _PayloadSerializationFailure(
+                f"input deserialization failed: {exc}"
+            ) from exc
+
+    def encode_result(self, value: Any, lease_id: int) -> bytes:
+        del lease_id
+        try:
+            return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        except Exception as exc:
+            raise _PayloadSerializationFailure(
+                f"result serialization failed: {exc}"
+            ) from exc
+
+    def close(self) -> None:
+        return None
+
+
+def _make_pickle_child_transport(spec: Any) -> _PickleChildTransport:
+    if spec is not None:
+        raise _PayloadProtocolFailure("pickle child transport spec must be null")
+    return _PickleChildTransport()
+
+
 def _run_callback(func: Any, item: Any) -> Any:
     value = func(item)
     if not inspect.isawaitable(value):
@@ -89,9 +182,51 @@ def _send(conn: Connection, envelope: dict[str, Any]) -> None:
     conn.send_bytes(pickle.dumps(envelope, protocol=pickle.HIGHEST_PROTOCOL))
 
 
-def _child(conn: Connection, operator: Any, node_id: str, generation: int) -> None:
+def _child(
+    conn: Connection,
+    operator: Any,
+    node_id: str,
+    generation: int,
+    child_transport_factory: Callable[[Any], Any],
+    child_transport_spec: Any,
+) -> None:
     base = {"protocol": _PROTOCOL, "node_id": node_id, "generation": generation}
+    transport: Any | None = None
     try:
+        try:
+            transport = child_transport_factory(child_transport_spec)
+        except _PayloadTransportFailure as exc:
+            try:
+                _send(
+                    conn,
+                    {
+                        **base,
+                        "kind": "transport_error",
+                        "error_type": exc.error_type or type(exc).__name__,
+                        "message": str(exc),
+                    },
+                )
+            finally:
+                return
+        except _PayloadProtocolFailure as exc:
+            try:
+                _send(conn, {**base, "kind": "protocol_error", "message": str(exc)})
+            finally:
+                return
+        except Exception as exc:
+            try:
+                _send(
+                    conn,
+                    {
+                        **base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"child payload transport startup failed: {exc}",
+                    },
+                )
+            finally:
+                return
+
         _send(conn, {**base, "kind": "ready"})
         while True:
             try:
@@ -109,6 +244,7 @@ def _child(conn: Connection, operator: Any, node_id: str, generation: int) -> No
                 except (EOFError, ConnectionResetError, BrokenPipeError, OSError):
                     pass
                 return
+
             if not isinstance(request, dict) or any(
                 (
                     request.get("protocol") != _PROTOCOL,
@@ -116,8 +252,12 @@ def _child(conn: Connection, operator: Any, node_id: str, generation: int) -> No
                     request.get("generation") != generation,
                 )
             ):
-                _send(conn, {**base, "kind": "protocol_error", "message": "identity mismatch"})
+                _send(
+                    conn,
+                    {**base, "kind": "protocol_error", "message": "identity mismatch"},
+                )
                 return
+
             command = request.get("command")
             if command == "heartbeat":
                 _send(conn, {**base, "kind": "heartbeat"})
@@ -125,24 +265,62 @@ def _child(conn: Connection, operator: Any, node_id: str, generation: int) -> No
             if command == "shutdown":
                 _send(conn, {**base, "kind": "shutdown"})
                 return
+
             request_id = request.get("request_id")
             method = request.get("method")
-            item_bytes = request.get("item")
+            item_payload = request.get("item")
             call_base = {**base, "request_id": request_id}
             if (
                 command != "call"
+                or isinstance(request_id, bool)
                 or not isinstance(request_id, int)
                 or request_id <= 0
                 or not isinstance(method, str)
-                or not isinstance(item_bytes, bytes)
+                or not method
             ):
-                _send(conn, {**call_base, "kind": "protocol_error", "message": "malformed call"})
+                _send(
+                    conn,
+                    {**call_base, "kind": "protocol_error", "message": "malformed call"},
+                )
                 return
+
             try:
-                item = pickle.loads(item_bytes)
-            except Exception as exc:
-                _send(conn, {**call_base, "kind": "serialization_error", "message": f"input deserialization failed: {exc}"})
+                item = transport.decode_request(item_payload, request_id)
+            except _PayloadProtocolFailure as exc:
+                _send(
+                    conn,
+                    {**call_base, "kind": "protocol_error", "message": str(exc)},
+                )
                 return
+            except _PayloadSerializationFailure as exc:
+                _send(
+                    conn,
+                    {**call_base, "kind": "serialization_error", "message": str(exc)},
+                )
+                return
+            except _PayloadTransportFailure as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": exc.error_type or type(exc).__name__,
+                        "message": str(exc),
+                    },
+                )
+                return
+            except Exception as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"input payload decoding failed: {exc}",
+                    },
+                )
+                return
+
             try:
                 result = _run_callback(getattr(operator, method), item)
             except BaseException as exc:
@@ -156,13 +334,45 @@ def _child(conn: Connection, operator: Any, node_id: str, generation: int) -> No
                     },
                 )
                 continue
+
             try:
-                result_bytes = pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL)
-            except Exception as exc:
-                _send(conn, {**call_base, "kind": "serialization_error", "message": f"result serialization failed: {exc}"})
+                result_payload = transport.encode_result(result, request_id)
+            except _PayloadSerializationFailure as exc:
+                _send(
+                    conn,
+                    {**call_base, "kind": "serialization_error", "message": str(exc)},
+                )
                 return
-            _send(conn, {**call_base, "kind": "result", "result": result_bytes})
+            except _PayloadTransportFailure as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": exc.error_type or type(exc).__name__,
+                        "message": str(exc),
+                    },
+                )
+                return
+            except Exception as exc:
+                _send(
+                    conn,
+                    {
+                        **call_base,
+                        "kind": "transport_error",
+                        "error_type": type(exc).__name__,
+                        "message": f"result payload encoding failed: {exc}",
+                    },
+                )
+                return
+
+            _send(conn, {**call_base, "kind": "result", "result": result_payload})
     finally:
+        if transport is not None:
+            try:
+                transport.close()
+            except Exception:
+                pass
         conn.close()
 
 
@@ -178,6 +388,9 @@ class PersistentProcessWorker:
         generation: int = 0,
         startup_timeout_s: float = 5.0,
         termination_grace_s: float = 0.25,
+        _payload_transport: Any | None = None,
+        _child_transport_factory: Callable[[Any], Any] = _make_pickle_child_transport,
+        _process_name_prefix: str = "neuros-process",
     ) -> None:
         if not node_id:
             raise ValueError("node_id must be non-empty")
@@ -185,6 +398,8 @@ class PersistentProcessWorker:
             raise ValueError("worker timeouts must be positive")
         if generation < 0:
             raise ValueError("generation must be non-negative")
+        if not _process_name_prefix:
+            raise ValueError("_process_name_prefix must be non-empty")
         self.node_id = node_id
         self.operator = operator
         self.execution_timeout_s = float(execution_timeout_s)
@@ -198,6 +413,9 @@ class PersistentProcessWorker:
         self._last_receipt: ProcessExecutionReceipt | None = None
         self._lock = asyncio.Lock()
         self._terminal = False
+        self._payload_transport = _payload_transport or _PickleParentTransport()
+        self._child_transport_factory = _child_transport_factory
+        self._process_name_prefix = _process_name_prefix
 
     @property
     def last_receipt(self) -> ProcessExecutionReceipt | None:
@@ -210,6 +428,10 @@ class PersistentProcessWorker:
     @property
     def is_alive(self) -> bool:
         return bool(self._process is not None and self._process.is_alive())
+
+    @property
+    def shared_memory_names(self) -> dict[str, str] | None:
+        return self._payload_transport.shared_memory_names
 
     def _receipt(
         self, request_id: int, outcome: str, error_type: str | None = None
@@ -235,7 +457,9 @@ class PersistentProcessWorker:
             raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
         if not self._conn.poll(timeout_s):
             if not self.is_alive:
-                raise ProcessWorkerCrashedError(self.node_id, "worker exited before response")
+                raise ProcessWorkerCrashedError(
+                    self.node_id, "worker exited before response"
+                )
             raise ProcessWorkerTimeoutError(
                 self.node_id,
                 f"request {request_id} exceeded {timeout_s:.6f}s hard execution timeout",
@@ -243,11 +467,17 @@ class PersistentProcessWorker:
         try:
             response = pickle.loads(self._conn.recv_bytes())
         except EOFError as exc:
-            raise ProcessWorkerCrashedError(self.node_id, "worker EOF before response") from exc
+            raise ProcessWorkerCrashedError(
+                self.node_id, "worker EOF before response"
+            ) from exc
         except Exception as exc:
-            raise ProcessWorkerProtocolError(self.node_id, f"invalid worker response: {exc}") from exc
+            raise ProcessWorkerProtocolError(
+                self.node_id, f"invalid worker response: {exc}"
+            ) from exc
         if not isinstance(response, dict):
-            raise ProcessWorkerProtocolError(self.node_id, "worker response is not a mapping")
+            raise ProcessWorkerProtocolError(
+                self.node_id, "worker response is not a mapping"
+            )
         self._identity(response, request_id)
         return response
 
@@ -269,18 +499,55 @@ class PersistentProcessWorker:
                 self.node_id, f"worker IPC failed while sending {command}"
             ) from exc
 
+    def _cleanup_payload_transport(self) -> None:
+        try:
+            self._payload_transport.cleanup()
+        except _PayloadTransportFailure as exc:
+            raise ProcessWorkerTransportError(self.node_id, str(exc)) from exc
+        except ProcessWorkerTransportError:
+            raise
+        except Exception as exc:
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                f"payload transport cleanup authority failed: {type(exc).__name__}: {exc}",
+            ) from exc
+
+    def _prepare_payload_transport(self) -> None:
+        try:
+            self._payload_transport.prepare()
+        except _PayloadTransportFailure as exc:
+            raise ProcessWorkerTransportError(self.node_id, str(exc)) from exc
+        except ProcessWorkerTransportError:
+            raise
+        except Exception as exc:
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                f"payload transport preparation failed: {type(exc).__name__}: {exc}",
+            ) from exc
+
     def _start(self) -> None:
         if self._terminal:
-            raise ProcessWorkerError(self.node_id, "worker is terminal; create a new generation")
+            raise ProcessWorkerError(
+                self.node_id, "worker is terminal; create a new generation"
+            )
         if self._process is not None:
             if self._process.is_alive():
                 return
             raise ProcessWorkerCrashedError(self.node_id, "worker exited")
+
+        self._prepare_payload_transport()
         parent, child = self._ctx.Pipe(duplex=True)
         process = self._ctx.Process(
             target=_child,
-            args=(child, self.operator, self.node_id, self.generation),
-            name=f"neuros-process:{self.node_id}:g{self.generation}",
+            args=(
+                child,
+                self.operator,
+                self.node_id,
+                self.generation,
+                self._child_transport_factory,
+                self._payload_transport.child_spec(),
+            ),
+            name=f"{self._process_name_prefix}:{self.node_id}:g{self.generation}",
         )
         self._conn, self._process = parent, process
         try:
@@ -288,12 +555,24 @@ class PersistentProcessWorker:
         except Exception as exc:
             parent.close()
             self._conn = self._process = None
+            cleanup_suffix = ""
+            try:
+                self._cleanup_payload_transport()
+            except ProcessWorkerTransportError as cleanup_exc:
+                cleanup_suffix = f"; transport cleanup also failed: {cleanup_exc}"
             raise ProcessWorkerSerializationError(
-                self.node_id, f"operator/start serialization failed: {exc}"
+                self.node_id,
+                f"operator/start serialization failed: {exc}{cleanup_suffix}",
             ) from exc
         finally:
             child.close()
+
         ready = self._recv(self.startup_timeout_s, None)
+        if ready.get("kind") == "transport_error":
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                str(ready.get("message") or "child payload transport startup failed"),
+            )
         if ready.get("kind") != "ready":
             raise ProcessWorkerProtocolError(self.node_id, "worker did not become ready")
         self._send_control("heartbeat")
@@ -301,15 +580,43 @@ class PersistentProcessWorker:
         if heartbeat.get("kind") != "heartbeat":
             raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
 
+    def _encode_request(self, item: Any, request_id: int) -> Any:
+        try:
+            return self._payload_transport.encode_request(item, request_id)
+        except _PayloadSerializationFailure as exc:
+            raise ProcessWorkerSerializationError(self.node_id, str(exc)) from exc
+        except _PayloadTransportFailure as exc:
+            raise ProcessWorkerTransportError(self.node_id, str(exc)) from exc
+        except Exception as exc:
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                f"input payload encoding failed: {type(exc).__name__}: {exc}",
+            ) from exc
+
+    def _decode_result(self, payload: Any, request_id: int) -> Any:
+        try:
+            return self._payload_transport.decode_result(payload, request_id)
+        except _PayloadSerializationFailure as exc:
+            raise ProcessWorkerSerializationError(self.node_id, str(exc)) from exc
+        except _PayloadTransportFailure as exc:
+            raise ProcessWorkerTransportError(self.node_id, str(exc)) from exc
+        except Exception as exc:
+            raise ProcessWorkerTransportError(
+                self.node_id,
+                f"result payload decoding failed: {type(exc).__name__}: {exc}",
+            ) from exc
+
     async def invoke(self, method: str, item: Any) -> ProcessCallResult:
         async with self._lock:
             request_id = self._request_id + 1
             try:
                 await asyncio.to_thread(self._start)
                 self._request_id = request_id
-                item_bytes = pickle.dumps(item, protocol=pickle.HIGHEST_PROTOCOL)
+                item_payload = self._encode_request(item, request_id)
                 if self._conn is None:
-                    raise ProcessWorkerCrashedError(self.node_id, "worker IPC is closed")
+                    raise ProcessWorkerCrashedError(
+                        self.node_id, "worker IPC is closed"
+                    )
                 try:
                     await asyncio.to_thread(
                         _send,
@@ -321,7 +628,7 @@ class PersistentProcessWorker:
                             "command": "call",
                             "request_id": request_id,
                             "method": method,
-                            "item": item_bytes,
+                            "item": item_payload,
                         },
                     )
                 except (EOFError, ConnectionResetError, BrokenPipeError, OSError) as exc:
@@ -332,11 +639,6 @@ class PersistentProcessWorker:
                 response = await asyncio.to_thread(
                     self._recv, self.execution_timeout_s, request_id
                 )
-                if not isinstance(response, dict):
-                    raise ProcessWorkerProtocolError(
-                        self.node_id, "worker response is not a mapping"
-                    )
-                self._identity(response, request_id)
             except asyncio.CancelledError:
                 self._receipt(request_id, "cancelled")
                 await asyncio.shield(asyncio.to_thread(self.abort))
@@ -351,6 +653,11 @@ class PersistentProcessWorker:
                 raise
             except ProcessWorkerProtocolError:
                 self._receipt(request_id, "protocol_error")
+                await asyncio.to_thread(self.abort)
+                raise
+            except ProcessWorkerTransportError:
+                self._request_id = request_id
+                self._receipt(request_id, "transport_error")
                 await asyncio.to_thread(self.abort)
                 raise
             except ProcessWorkerSerializationError:
@@ -369,13 +676,15 @@ class PersistentProcessWorker:
             kind = response.get("kind")
             if kind == "result":
                 try:
-                    result = pickle.loads(response["result"])
-                except Exception as exc:
+                    result = self._decode_result(response.get("result"), request_id)
+                except ProcessWorkerSerializationError:
                     self._receipt(request_id, "serialization_error")
                     await asyncio.to_thread(self.abort)
-                    raise ProcessWorkerSerializationError(
-                        self.node_id, f"result deserialization failed: {exc}"
-                    ) from exc
+                    raise
+                except ProcessWorkerTransportError:
+                    self._receipt(request_id, "transport_error")
+                    await asyncio.to_thread(self.abort)
+                    raise
                 receipt = ProcessExecutionReceipt(
                     self.node_id, self.generation, request_id, "success"
                 )
@@ -391,7 +700,14 @@ class PersistentProcessWorker:
                 self._receipt(request_id, "serialization_error")
                 await asyncio.to_thread(self.abort)
                 raise ProcessWorkerSerializationError(
-                    self.node_id, str(response.get("message") or "serialization failure")
+                    self.node_id,
+                    str(response.get("message") or "serialization failure"),
+                )
+            if kind == "transport_error":
+                self._receipt(request_id, "transport_error")
+                await asyncio.to_thread(self.abort)
+                raise ProcessWorkerTransportError(
+                    self.node_id, str(response.get("message") or "transport failure")
                 )
             self._receipt(request_id, "protocol_error")
             await asyncio.to_thread(self.abort)
@@ -408,7 +724,9 @@ class PersistentProcessWorker:
                     self._recv, self.startup_timeout_s, None
                 )
                 if response.get("kind") != "heartbeat":
-                    raise ProcessWorkerProtocolError(self.node_id, "worker heartbeat failed")
+                    raise ProcessWorkerProtocolError(
+                        self.node_id, "worker heartbeat failed"
+                    )
             except asyncio.CancelledError:
                 await asyncio.shield(asyncio.to_thread(self.abort))
                 raise
@@ -445,8 +763,11 @@ class PersistentProcessWorker:
                 pass
         if process is None:
             self._process = None
+            self._cleanup_payload_transport()
             return
         self._terminate_owned_process(process)
+        # Resource cleanup happens only after direct-child death is proven.
+        self._cleanup_payload_transport()
 
     def close(self) -> None:
         self._terminal = True
@@ -455,6 +776,7 @@ class PersistentProcessWorker:
             if conn is not None:
                 conn.close()
             self._conn = None
+            self._cleanup_payload_transport()
             return
         if process.is_alive() and conn is not None:
             try:
@@ -470,6 +792,8 @@ class PersistentProcessWorker:
         self._conn = None
         if process.is_alive():
             self._terminate_owned_process(process)
+            self._cleanup_payload_transport()
             return
         process.close()
         self._process = None
+        self._cleanup_payload_transport()

--- a/packages/neuros-core/src/neuros/runtime/process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/process_worker.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 from multiprocessing.connection import Connection
 from typing import Any, Callable
 
+from ._validation import positive_finite_real
+
 _PROTOCOL = 1
 
 
@@ -436,17 +438,24 @@ class PersistentProcessWorker:
     ) -> None:
         if not node_id:
             raise ValueError("node_id must be non-empty")
-        if min(execution_timeout_s, startup_timeout_s, termination_grace_s) <= 0:
-            raise ValueError("worker timeouts must be positive")
+        execution_timeout_s = positive_finite_real(
+            execution_timeout_s, field_name="execution_timeout_s"
+        )
+        startup_timeout_s = positive_finite_real(
+            startup_timeout_s, field_name="startup_timeout_s"
+        )
+        termination_grace_s = positive_finite_real(
+            termination_grace_s, field_name="termination_grace_s"
+        )
         if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
             raise ValueError("generation must be a non-negative integer")
         if not _process_name_prefix:
             raise ValueError("_process_name_prefix must be non-empty")
         self.node_id = node_id
         self.operator = operator
-        self.execution_timeout_s = float(execution_timeout_s)
-        self.startup_timeout_s = float(startup_timeout_s)
-        self.termination_grace_s = float(termination_grace_s)
+        self.execution_timeout_s = execution_timeout_s
+        self.startup_timeout_s = startup_timeout_s
+        self.termination_grace_s = termination_grace_s
         self.generation = generation
         self._ctx = mp.get_context("spawn")
         self._conn: Connection | None = None

--- a/packages/neuros-core/src/neuros/runtime/process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/process_worker.py
@@ -774,6 +774,14 @@ class PersistentProcessWorker:
                 response = await asyncio.to_thread(
                     self._recv, self.execution_timeout_s, request_id
                 )
+                # Defense in depth: do not make correctness depend on _recv being
+                # the only response source. Tests and future transports may wrap
+                # or replace it; every admitted call result is re-verified here.
+                if type(response) is not dict:
+                    raise ProcessWorkerProtocolError(
+                        self.node_id, "worker response is not an exact mapping"
+                    )
+                self._identity(response, request_id)
             except asyncio.CancelledError:
                 self._receipt(request_id, "cancelled")
                 await asyncio.shield(self._contain_primary_failure())

--- a/packages/neuros-core/src/neuros/runtime/shared_process_worker.py
+++ b/packages/neuros-core/src/neuros/runtime/shared_process_worker.py
@@ -1,0 +1,262 @@
+"""Shared-memory payload adapter for the common persistent process authority.
+
+The process lifecycle lives in :mod:`neuros.runtime.process_worker`. This module
+owns only shared-memory payload representation and resource ownership. Array
+bytes cross fixed-capacity parent-owned mailboxes while the multiprocessing pipe
+remains the control plane. Decoded callback inputs are materialized into local
+memory, so this is not a zero-copy callback contract.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .process_worker import (
+    PersistentProcessWorker,
+    _PayloadProtocolFailure,
+    _PayloadTransportFailure,
+)
+from .transport import NeuralTransportError, SharedMemoryMailbox
+
+
+@dataclass(frozen=True, slots=True)
+class _SharedMemoryChildSpec:
+    request_name: str
+    request_capacity_bytes: int
+    response_name: str
+    response_capacity_bytes: int
+
+
+class _SharedMemoryParentTransport:
+    def __init__(self, request_capacity_bytes: int, response_capacity_bytes: int) -> None:
+        self.request_capacity_bytes = request_capacity_bytes
+        self.response_capacity_bytes = response_capacity_bytes
+        self._request_mailbox: SharedMemoryMailbox | None = None
+        self._response_mailbox: SharedMemoryMailbox | None = None
+
+    @property
+    def shared_memory_names(self) -> dict[str, str] | None:
+        if self._request_mailbox is None or self._response_mailbox is None:
+            return None
+        return {
+            "request": self._request_mailbox.name,
+            "response": self._response_mailbox.name,
+        }
+
+    def prepare(self) -> None:
+        if self._request_mailbox is not None or self._response_mailbox is not None:
+            if self._request_mailbox is None or self._response_mailbox is None:
+                raise _PayloadTransportFailure(
+                    "shared-memory mailbox ownership is incomplete"
+                )
+            return
+
+        try:
+            request_mailbox = SharedMemoryMailbox(self.request_capacity_bytes)
+        except Exception as exc:
+            raise _PayloadTransportFailure(
+                "request shared-memory mailbox creation failed: "
+                f"{type(exc).__name__}: {exc}",
+                error_type=type(exc).__name__,
+            ) from exc
+
+        try:
+            response_mailbox = SharedMemoryMailbox(self.response_capacity_bytes)
+        except Exception as exc:
+            cleanup_suffix = ""
+            try:
+                request_mailbox.close_and_unlink()
+            except Exception as cleanup_exc:
+                cleanup_suffix = (
+                    "; request mailbox cleanup also failed: "
+                    f"{type(cleanup_exc).__name__}: {cleanup_exc}"
+                )
+            raise _PayloadTransportFailure(
+                "response shared-memory mailbox creation failed: "
+                f"{type(exc).__name__}: {exc}{cleanup_suffix}",
+                error_type=type(exc).__name__,
+            ) from exc
+
+        self._request_mailbox = request_mailbox
+        self._response_mailbox = response_mailbox
+
+    def child_spec(self) -> _SharedMemoryChildSpec:
+        if self._request_mailbox is None or self._response_mailbox is None:
+            raise _PayloadTransportFailure(
+                "shared-memory transport must be prepared before child startup"
+            )
+        return _SharedMemoryChildSpec(
+            request_name=self._request_mailbox.name,
+            request_capacity_bytes=self.request_capacity_bytes,
+            response_name=self._response_mailbox.name,
+            response_capacity_bytes=self.response_capacity_bytes,
+        )
+
+    def encode_request(self, value: Any, lease_id: int) -> dict[str, Any]:
+        if self._request_mailbox is None:
+            raise _PayloadTransportFailure("request mailbox is unavailable")
+        try:
+            return self._request_mailbox.encode(value, lease_id=lease_id)
+        except NeuralTransportError as exc:
+            raise _PayloadTransportFailure(
+                f"input transport failed: {exc}", error_type=type(exc).__name__
+            ) from exc
+        except Exception as exc:
+            raise _PayloadTransportFailure(
+                f"input transport encoding failed: {type(exc).__name__}: {exc}",
+                error_type=type(exc).__name__,
+            ) from exc
+
+    def decode_result(self, payload: Any, lease_id: int) -> Any:
+        if self._response_mailbox is None:
+            raise _PayloadTransportFailure("response mailbox is unavailable")
+        try:
+            return self._response_mailbox.decode(
+                payload, expected_lease_id=lease_id
+            )
+        except NeuralTransportError as exc:
+            raise _PayloadTransportFailure(
+                f"result transport failed: {exc}", error_type=type(exc).__name__
+            ) from exc
+        except Exception as exc:
+            raise _PayloadTransportFailure(
+                f"result transport decoding failed: {type(exc).__name__}: {exc}",
+                error_type=type(exc).__name__,
+            ) from exc
+
+    def cleanup(self) -> None:
+        errors: list[str] = []
+        for attr_name in ("_request_mailbox", "_response_mailbox"):
+            mailbox = getattr(self, attr_name)
+            if mailbox is None:
+                continue
+            try:
+                mailbox.close_and_unlink()
+            except Exception as exc:
+                errors.append(f"{attr_name}: {type(exc).__name__}: {exc}")
+                continue
+            setattr(self, attr_name, None)
+        if errors:
+            raise _PayloadTransportFailure(
+                "shared-memory cleanup authority failed: " + "; ".join(errors)
+            )
+
+
+class _SharedMemoryChildTransport:
+    def __init__(
+        self,
+        request_mailbox: SharedMemoryMailbox,
+        response_mailbox: SharedMemoryMailbox,
+    ) -> None:
+        self._request_mailbox = request_mailbox
+        self._response_mailbox = response_mailbox
+
+    def decode_request(self, payload: Any, lease_id: int) -> Any:
+        try:
+            return self._request_mailbox.decode(
+                payload, expected_lease_id=lease_id
+            )
+        except NeuralTransportError as exc:
+            raise _PayloadTransportFailure(
+                f"input transport failed: {exc}", error_type=type(exc).__name__
+            ) from exc
+        except Exception as exc:
+            raise _PayloadTransportFailure(
+                f"input transport decoding failed: {type(exc).__name__}: {exc}",
+                error_type=type(exc).__name__,
+            ) from exc
+
+    def encode_result(self, value: Any, lease_id: int) -> dict[str, Any]:
+        try:
+            return self._response_mailbox.encode(value, lease_id=lease_id)
+        except NeuralTransportError as exc:
+            raise _PayloadTransportFailure(
+                f"result transport failed: {exc}", error_type=type(exc).__name__
+            ) from exc
+        except Exception as exc:
+            raise _PayloadTransportFailure(
+                f"result transport encoding failed: {type(exc).__name__}: {exc}",
+                error_type=type(exc).__name__,
+            ) from exc
+
+    def close(self) -> None:
+        errors: list[str] = []
+        for label, mailbox in (
+            ("request", self._request_mailbox),
+            ("response", self._response_mailbox),
+        ):
+            try:
+                mailbox.close()
+            except Exception as exc:
+                errors.append(f"{label}: {type(exc).__name__}: {exc}")
+        if errors:
+            raise _PayloadTransportFailure(
+                "child shared-memory close failed: " + "; ".join(errors)
+            )
+
+
+def _make_shared_memory_child_transport(
+    spec: Any,
+) -> _SharedMemoryChildTransport:
+    if not isinstance(spec, _SharedMemoryChildSpec):
+        raise _PayloadProtocolFailure("invalid shared-memory child transport spec")
+
+    request_mailbox: SharedMemoryMailbox | None = None
+    try:
+        request_mailbox = SharedMemoryMailbox.attach(
+            spec.request_name, spec.request_capacity_bytes
+        )
+        response_mailbox = SharedMemoryMailbox.attach(
+            spec.response_name, spec.response_capacity_bytes
+        )
+    except Exception as exc:
+        if request_mailbox is not None:
+            try:
+                request_mailbox.close()
+            except Exception:
+                pass
+        raise _PayloadTransportFailure(
+            f"child shared-memory attach failed: {type(exc).__name__}: {exc}",
+            error_type=type(exc).__name__,
+        ) from exc
+
+    return _SharedMemoryChildTransport(request_mailbox, response_mailbox)
+
+
+class SharedMemoryProcessWorker(PersistentProcessWorker):
+    """Persistent process worker using parent-owned shared-memory mailboxes."""
+
+    def __init__(
+        self,
+        node_id: str,
+        operator: Any,
+        *,
+        execution_timeout_s: float,
+        request_capacity_bytes: int,
+        response_capacity_bytes: int,
+        generation: int = 0,
+        startup_timeout_s: float = 5.0,
+        termination_grace_s: float = 0.25,
+    ) -> None:
+        for field_name, capacity in (
+            ("request_capacity_bytes", request_capacity_bytes),
+            ("response_capacity_bytes", response_capacity_bytes),
+        ):
+            if isinstance(capacity, bool) or not isinstance(capacity, int) or capacity <= 0:
+                raise ValueError(f"{field_name} must be a positive integer")
+
+        self.request_capacity_bytes = request_capacity_bytes
+        self.response_capacity_bytes = response_capacity_bytes
+        super().__init__(
+            node_id,
+            operator,
+            execution_timeout_s=execution_timeout_s,
+            generation=generation,
+            startup_timeout_s=startup_timeout_s,
+            termination_grace_s=termination_grace_s,
+            _payload_transport=_SharedMemoryParentTransport(
+                request_capacity_bytes, response_capacity_bytes
+            ),
+            _child_transport_factory=_make_shared_memory_child_transport,
+            _process_name_prefix="neuros-shm-process",
+        )

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -1,0 +1,522 @@
+"""Shared-memory transport for canonical neurOS runtime payloads.
+
+The transport deliberately keeps control metadata on the multiprocessing pipe
+and moves numeric array bytes through a fixed-capacity shared-memory mailbox.
+Decoded arrays are materialized into independent local memory before arbitrary
+operator code is invoked. This is therefore a shared-memory transport, not a
+zero-copy callback contract.
+
+Transport is representation authority, not scientific-value authority. Generic
+numeric payloads preserve their existing values, including non-finite floating
+values when the surrounding contract permits them. Canonical contracts such as
+``SignalFrame`` and ``NeuralWindow`` continue to enforce their own stricter
+scientific invariants during construction.
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from multiprocessing import shared_memory
+from typing import Any
+
+import numpy as np
+
+from neuros.contracts import (
+    ClockDomain,
+    DecoderOutput,
+    NeuralWindow,
+    QualityFlag,
+    SignalFrame,
+    TransformEmission,
+)
+
+_SCHEMA = "neuros.shared_memory_payload.v1"
+_ALIGNMENT = 64
+_SUPPORTED_ARRAY_KINDS = frozenset("biufc")
+
+
+class NeuralTransportError(RuntimeError):
+    """Base class for fail-closed neural transport errors."""
+
+
+class NeuralTransportCapacityError(NeuralTransportError):
+    """Raised when a logical payload cannot fit in the declared mailbox."""
+
+
+class NeuralTransportProtocolError(NeuralTransportError):
+    """Raised when a transport manifest is stale, malformed, or inconsistent."""
+
+
+class NeuralTransportTypeError(NeuralTransportError, TypeError):
+    """Raised when an unsupported Python payload crosses shared transport."""
+
+
+@dataclass(frozen=True, slots=True)
+class SharedPayloadEnvelope:
+    """Small control-plane description of bytes stored in one mailbox lease."""
+
+    lease_id: int
+    bytes_used: int
+    manifest: Any
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": _SCHEMA,
+            "lease_id": self.lease_id,
+            "bytes_used": self.bytes_used,
+            "manifest": self.manifest,
+        }
+
+
+def _manifest_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NeuralTransportProtocolError(
+            f"transport field {field_name} must be an exact integer"
+        )
+    return value
+
+
+def _manifest_optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _manifest_int(value, field_name)
+
+
+def _manifest_str(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise NeuralTransportProtocolError(
+            f"transport field {field_name} must be a string"
+        )
+    return value
+
+
+def _manifest_real(value: Any, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise NeuralTransportProtocolError(
+            f"transport field {field_name} must be a real numeric scalar"
+        )
+    return float(value)
+
+
+class _MailboxWriter:
+    def __init__(self, buffer: memoryview, capacity_bytes: int) -> None:
+        self.buffer = buffer
+        self.capacity_bytes = capacity_bytes
+        self.offset = 0
+
+    @staticmethod
+    def _aligned(offset: int) -> int:
+        remainder = offset % _ALIGNMENT
+        return offset if remainder == 0 else offset + (_ALIGNMENT - remainder)
+
+    def put_array(self, value: np.ndarray) -> dict[str, Any]:
+        array = np.asarray(value)
+        if array.dtype.kind not in _SUPPORTED_ARRAY_KINDS:
+            raise NeuralTransportTypeError(
+                "shared-memory arrays must use boolean or numeric dtype; "
+                f"received {array.dtype}"
+            )
+        array = np.ascontiguousarray(array)
+        offset = self._aligned(self.offset)
+        end = offset + int(array.nbytes)
+        if end > self.capacity_bytes:
+            raise NeuralTransportCapacityError(
+                f"payload requires {end} bytes but mailbox capacity is "
+                f"{self.capacity_bytes} bytes"
+            )
+        if array.nbytes:
+            self.buffer[offset:end] = memoryview(array).cast("B")
+        self.offset = end
+        return {
+            "type": "ndarray",
+            "offset": offset,
+            "nbytes": int(array.nbytes),
+            "dtype": array.dtype.str,
+            "shape": list(array.shape),
+        }
+
+
+class _MailboxReader:
+    def __init__(self, buffer: memoryview, bytes_used: int) -> None:
+        self.buffer = buffer
+        self.bytes_used = bytes_used
+        self._ranges: list[tuple[int, int]] = []
+
+    def get_array(self, node: Mapping[str, Any]) -> np.ndarray:
+        try:
+            offset = _manifest_int(node["offset"], "ndarray.offset")
+            nbytes = _manifest_int(node["nbytes"], "ndarray.nbytes")
+            dtype_value = node["dtype"]
+            if not isinstance(dtype_value, str):
+                raise NeuralTransportProtocolError(
+                    "transport field ndarray.dtype must be a string"
+                )
+            dtype = np.dtype(dtype_value)
+            raw_shape = node["shape"]
+            if not isinstance(raw_shape, list):
+                raise NeuralTransportProtocolError(
+                    "transport field ndarray.shape must be a list"
+                )
+            shape = tuple(
+                _manifest_int(dim, f"ndarray.shape[{index}]")
+                for index, dim in enumerate(raw_shape)
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"malformed ndarray transport descriptor: {exc}"
+            ) from exc
+        if offset < 0 or nbytes < 0 or any(dim < 0 for dim in shape):
+            raise NeuralTransportProtocolError("negative shared-memory array geometry")
+        if offset % _ALIGNMENT != 0:
+            raise NeuralTransportProtocolError(
+                f"shared-memory ndarray offset must be {_ALIGNMENT}-byte aligned"
+            )
+        if dtype.kind not in _SUPPORTED_ARRAY_KINDS:
+            raise NeuralTransportProtocolError(
+                f"unsupported shared-memory dtype {dtype}"
+            )
+        expected = int(math.prod(shape)) * int(dtype.itemsize)
+        if expected != nbytes:
+            raise NeuralTransportProtocolError(
+                "shared-memory ndarray byte length does not match dtype/shape"
+            )
+        end = offset + nbytes
+        if end > self.bytes_used:
+            raise NeuralTransportProtocolError(
+                "shared-memory ndarray exceeds declared payload boundary"
+            )
+        for start, stop in self._ranges:
+            if offset < stop and start < end:
+                raise NeuralTransportProtocolError(
+                    "shared-memory ndarray regions overlap"
+                )
+        self._ranges.append((offset, end))
+        view = np.ndarray(shape=shape, dtype=dtype, buffer=self.buffer, offset=offset)
+        return np.array(view, copy=True, subok=False)
+
+
+def _encode(value: Any, writer: _MailboxWriter) -> Any:
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return {"type": "scalar", "value": value}
+    if isinstance(value, complex):
+        return {
+            "type": "complex_scalar",
+            "real": float(value.real),
+            "imag": float(value.imag),
+        }
+    if isinstance(value, np.generic):
+        return _encode(value.item(), writer)
+    if isinstance(value, np.ndarray):
+        return writer.put_array(value)
+    if isinstance(value, SignalFrame):
+        return {
+            "type": "signal_frame",
+            "stream_id": value.stream_id,
+            "sequence_id": value.sequence_id,
+            "data": _encode(value.data, writer),
+            "sample_rate_hz": value.sample_rate_hz,
+            "host_receive_time_ns": value.host_receive_time_ns,
+            "device_time_ns": value.device_time_ns,
+            "synchronized_time_ns": value.synchronized_time_ns,
+            "clock_domain": value.clock_domain.value,
+            "quality": int(value.quality),
+            "metadata": _encode(dict(value.metadata), writer),
+        }
+    if isinstance(value, NeuralWindow):
+        return {
+            "type": "neural_window",
+            "stream_id": value.stream_id,
+            "window_id": value.window_id,
+            "data": _encode(value.data, writer),
+            "sample_rate_hz": value.sample_rate_hz,
+            "start_time_ns": value.start_time_ns,
+            "end_time_ns": value.end_time_ns,
+            "channel_names": _encode(value.channel_names, writer),
+            "source_sequence_ids": _encode(value.source_sequence_ids, writer),
+            "clock_domain": value.clock_domain.value,
+            "quality": int(value.quality),
+            "metadata": _encode(dict(value.metadata), writer),
+        }
+    if isinstance(value, DecoderOutput):
+        return {
+            "type": "decoder_output",
+            "prediction": _encode(value.prediction, writer),
+            "confidence": _encode(value.confidence, writer),
+            "uncertainty": _encode(value.uncertainty, writer),
+            "probabilities": _encode(value.probabilities, writer),
+            "logits": _encode(value.logits, writer),
+            "embedding": _encode(value.embedding, writer),
+            "model_id": _encode(value.model_id, writer),
+            "model_version": _encode(value.model_version, writer),
+            "inference_time_ns": _encode(value.inference_time_ns, writer),
+            "metadata": _encode(dict(value.metadata), writer),
+        }
+    if isinstance(value, TransformEmission):
+        return {"type": "transform_emission", "items": _encode(value.items, writer)}
+    if isinstance(value, tuple):
+        return {"type": "tuple", "items": [_encode(item, writer) for item in value]}
+    if isinstance(value, list):
+        return {"type": "list", "items": [_encode(item, writer) for item in value]}
+    if isinstance(value, Mapping):
+        keys = tuple(value.keys())
+        if any(not isinstance(key, str) for key in keys):
+            raise NeuralTransportTypeError("transport mapping keys must be strings")
+        return {
+            "type": "mapping",
+            "items": [[key, _encode(value[key], writer)] for key in sorted(keys)],
+        }
+    raise NeuralTransportTypeError(
+        "unsupported shared-memory payload type "
+        f"{type(value).__module__}.{type(value).__qualname__}"
+    )
+
+
+def _decode_items(node: Mapping[str, Any], node_type: str) -> list[Any]:
+    items = node.get("items")
+    if not isinstance(items, list):
+        raise NeuralTransportProtocolError(
+            f"{node_type} transport manifest items must be a list"
+        )
+    return items
+
+
+def _decode(node: Any, reader: _MailboxReader) -> Any:
+    if not isinstance(node, Mapping):
+        raise NeuralTransportProtocolError("transport manifest node is not a mapping")
+    node_type = node.get("type")
+    if node_type == "scalar":
+        value = node.get("value")
+        if value is not None and not isinstance(value, (str, bool, int, float)):
+            raise NeuralTransportProtocolError("invalid transport scalar")
+        return value
+    if node_type == "complex_scalar":
+        try:
+            return complex(
+                _manifest_real(node["real"], "complex.real"),
+                _manifest_real(node["imag"], "complex.imag"),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError("invalid complex transport scalar") from exc
+    if node_type == "ndarray":
+        return reader.get_array(node)
+    if node_type == "tuple":
+        return tuple(_decode(item, reader) for item in _decode_items(node, "tuple"))
+    if node_type == "list":
+        return [_decode(item, reader) for item in _decode_items(node, "list")]
+    if node_type == "mapping":
+        result: dict[str, Any] = {}
+        items = _decode_items(node, "mapping")
+        for pair in items:
+            if not isinstance(pair, list) or len(pair) != 2 or not isinstance(pair[0], str):
+                raise NeuralTransportProtocolError("malformed mapping manifest item")
+            key = pair[0]
+            if key in result:
+                raise NeuralTransportProtocolError("duplicate transport mapping key")
+            result[key] = _decode(pair[1], reader)
+        return result
+    if node_type == "signal_frame":
+        try:
+            return SignalFrame(
+                stream_id=_manifest_str(node["stream_id"], "signal_frame.stream_id"),
+                sequence_id=_manifest_int(node["sequence_id"], "signal_frame.sequence_id"),
+                data=_decode(node["data"], reader),
+                sample_rate_hz=_manifest_real(
+                    node["sample_rate_hz"], "signal_frame.sample_rate_hz"
+                ),
+                host_receive_time_ns=_manifest_int(
+                    node["host_receive_time_ns"], "signal_frame.host_receive_time_ns"
+                ),
+                device_time_ns=_manifest_optional_int(
+                    node.get("device_time_ns"), "signal_frame.device_time_ns"
+                ),
+                synchronized_time_ns=_manifest_optional_int(
+                    node.get("synchronized_time_ns"),
+                    "signal_frame.synchronized_time_ns",
+                ),
+                clock_domain=ClockDomain(
+                    _manifest_str(node["clock_domain"], "signal_frame.clock_domain")
+                ),
+                quality=QualityFlag(
+                    _manifest_int(node["quality"], "signal_frame.quality")
+                ),
+                metadata=_decode(node["metadata"], reader),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid SignalFrame transport payload: {exc}"
+            ) from exc
+    if node_type == "neural_window":
+        try:
+            channel_names = _decode(node["channel_names"], reader)
+            source_sequence_ids = _decode(node["source_sequence_ids"], reader)
+            if not isinstance(channel_names, tuple):
+                raise NeuralTransportProtocolError(
+                    "NeuralWindow channel_names must decode to tuple"
+                )
+            if not isinstance(source_sequence_ids, tuple):
+                raise NeuralTransportProtocolError(
+                    "NeuralWindow source_sequence_ids must decode to tuple"
+                )
+            return NeuralWindow(
+                stream_id=_manifest_str(node["stream_id"], "neural_window.stream_id"),
+                window_id=_manifest_int(node["window_id"], "neural_window.window_id"),
+                data=_decode(node["data"], reader),
+                sample_rate_hz=_manifest_real(
+                    node["sample_rate_hz"], "neural_window.sample_rate_hz"
+                ),
+                start_time_ns=_manifest_int(
+                    node["start_time_ns"], "neural_window.start_time_ns"
+                ),
+                end_time_ns=_manifest_int(
+                    node["end_time_ns"], "neural_window.end_time_ns"
+                ),
+                channel_names=channel_names,
+                source_sequence_ids=source_sequence_ids,
+                clock_domain=ClockDomain(
+                    _manifest_str(node["clock_domain"], "neural_window.clock_domain")
+                ),
+                quality=QualityFlag(
+                    _manifest_int(node["quality"], "neural_window.quality")
+                ),
+                metadata=_decode(node["metadata"], reader),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid NeuralWindow transport payload: {exc}"
+            ) from exc
+    if node_type == "decoder_output":
+        try:
+            return DecoderOutput(
+                prediction=_decode(node["prediction"], reader),
+                confidence=_decode(node["confidence"], reader),
+                uncertainty=_decode(node["uncertainty"], reader),
+                probabilities=_decode(node["probabilities"], reader),
+                logits=_decode(node["logits"], reader),
+                embedding=_decode(node["embedding"], reader),
+                model_id=_decode(node["model_id"], reader),
+                model_version=_decode(node["model_version"], reader),
+                inference_time_ns=_decode(node["inference_time_ns"], reader),
+                metadata=_decode(node["metadata"], reader),
+            )
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid DecoderOutput transport payload: {exc}"
+            ) from exc
+    if node_type == "transform_emission":
+        items = _decode(node["items"], reader)
+        if not isinstance(items, tuple):
+            raise NeuralTransportProtocolError("TransformEmission items must decode to tuple")
+        try:
+            return TransformEmission(items)
+        except Exception as exc:
+            raise NeuralTransportProtocolError(
+                f"invalid TransformEmission transport payload: {exc}"
+            ) from exc
+    raise NeuralTransportProtocolError(f"unknown transport manifest node type {node_type!r}")
+
+
+class SharedMemoryMailbox:
+    """One fixed-capacity shared-memory mailbox with explicit lease identity."""
+
+    def __init__(
+        self,
+        capacity_bytes: int,
+        *,
+        name: str | None = None,
+        create: bool = True,
+        owner: bool | None = None,
+    ) -> None:
+        if isinstance(capacity_bytes, bool) or not isinstance(capacity_bytes, int):
+            raise TypeError("capacity_bytes must be an integer")
+        if capacity_bytes <= 0:
+            raise ValueError("capacity_bytes must be positive")
+        self.capacity_bytes = capacity_bytes
+        self._owner = create if owner is None else bool(owner)
+        self._shm = shared_memory.SharedMemory(
+            name=name,
+            create=create,
+            size=capacity_bytes if create else 0,
+        )
+        if self._shm.size < capacity_bytes:
+            self._shm.close()
+            raise NeuralTransportProtocolError(
+                "attached shared-memory region is smaller than declared capacity"
+            )
+        self._closed = False
+        self._unlinked = False
+
+    @classmethod
+    def attach(cls, name: str, capacity_bytes: int) -> "SharedMemoryMailbox":
+        return cls(capacity_bytes, name=name, create=False, owner=False)
+
+    @property
+    def name(self) -> str:
+        return self._shm.name
+
+    def encode(self, value: Any, *, lease_id: int) -> dict[str, Any]:
+        if self._closed:
+            raise NeuralTransportError("shared-memory mailbox is closed")
+        if isinstance(lease_id, bool) or not isinstance(lease_id, int) or lease_id <= 0:
+            raise ValueError("lease_id must be a positive integer")
+        writer = _MailboxWriter(self._shm.buf, self.capacity_bytes)
+        manifest = _encode(value, writer)
+        return SharedPayloadEnvelope(lease_id, writer.offset, manifest).as_dict()
+
+    def decode(self, envelope: Any, *, expected_lease_id: int) -> Any:
+        if self._closed:
+            raise NeuralTransportError("shared-memory mailbox is closed")
+        if not isinstance(envelope, Mapping):
+            raise NeuralTransportProtocolError("transport envelope is not a mapping")
+        if envelope.get("schema") != _SCHEMA:
+            raise NeuralTransportProtocolError("shared-memory payload schema mismatch")
+        try:
+            lease_id = _manifest_int(envelope["lease_id"], "lease_id")
+            bytes_used = _manifest_int(envelope["bytes_used"], "bytes_used")
+        except NeuralTransportProtocolError:
+            raise
+        except Exception as exc:
+            raise NeuralTransportProtocolError("malformed transport envelope identity") from exc
+        if lease_id != expected_lease_id:
+            raise NeuralTransportProtocolError(
+                f"stale shared-memory lease {lease_id}; expected {expected_lease_id}"
+            )
+        if bytes_used < 0 or bytes_used > self.capacity_bytes:
+            raise NeuralTransportProtocolError(
+                "shared-memory payload bytes_used exceeds mailbox capacity"
+            )
+        reader = _MailboxReader(self._shm.buf, bytes_used)
+        return _decode(envelope.get("manifest"), reader)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._shm.close()
+            self._closed = True
+
+    def unlink(self) -> None:
+        if not self._owner:
+            raise NeuralTransportError("only the mailbox owner may unlink shared memory")
+        if self._unlinked:
+            return
+        try:
+            self._shm.unlink()
+        except FileNotFoundError:
+            pass
+        self._unlinked = True
+
+    def close_and_unlink(self) -> None:
+        if not self._owner:
+            self.close()
+            return
+        self.unlink()
+        self.close()

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -143,6 +143,10 @@ class _MailboxReader:
         self.bytes_used = bytes_used
         self._ranges: list[tuple[int, int]] = []
 
+    @property
+    def referenced_end(self) -> int:
+        return max((stop for _, stop in self._ranges), default=0)
+
     def get_array(self, node: Mapping[str, Any]) -> np.ndarray:
         try:
             offset = _manifest_int(node["offset"], "ndarray.offset")
@@ -427,7 +431,12 @@ def _decode(node: Any, reader: _MailboxReader) -> Any:
 
 
 class SharedMemoryMailbox:
-    """One fixed-capacity shared-memory mailbox with explicit lease identity."""
+    """One fixed-capacity shared-memory mailbox with structural ownership.
+
+    A mailbox created by this object owns unlink authority. An attached mailbox
+    never does. Ownership is derived from creation and cannot be overridden by a
+    caller-provided flag.
+    """
 
     def __init__(
         self,
@@ -435,14 +444,13 @@ class SharedMemoryMailbox:
         *,
         name: str | None = None,
         create: bool = True,
-        owner: bool | None = None,
     ) -> None:
         if isinstance(capacity_bytes, bool) or not isinstance(capacity_bytes, int):
             raise TypeError("capacity_bytes must be an integer")
         if capacity_bytes <= 0:
             raise ValueError("capacity_bytes must be positive")
         self.capacity_bytes = capacity_bytes
-        self._owner = create if owner is None else bool(owner)
+        self._owner = bool(create)
         self._shm = shared_memory.SharedMemory(
             name=name,
             create=create,
@@ -458,7 +466,7 @@ class SharedMemoryMailbox:
 
     @classmethod
     def attach(cls, name: str, capacity_bytes: int) -> "SharedMemoryMailbox":
-        return cls(capacity_bytes, name=name, create=False, owner=False)
+        return cls(capacity_bytes, name=name, create=False)
 
     @property
     def name(self) -> str:
@@ -496,7 +504,12 @@ class SharedMemoryMailbox:
                 "shared-memory payload bytes_used exceeds mailbox capacity"
             )
         reader = _MailboxReader(self._shm.buf, bytes_used)
-        return _decode(envelope.get("manifest"), reader)
+        value = _decode(envelope.get("manifest"), reader)
+        if reader.referenced_end != bytes_used:
+            raise NeuralTransportProtocolError(
+                "shared-memory bytes_used does not match referenced payload boundary"
+            )
+        return value
 
     def close(self) -> None:
         if not self._closed:

--- a/packages/neuros-core/src/neuros/runtime/transport.py
+++ b/packages/neuros-core/src/neuros/runtime/transport.py
@@ -158,9 +158,9 @@ class _MailboxReader:
                 )
             dtype = np.dtype(dtype_value)
             raw_shape = node["shape"]
-            if not isinstance(raw_shape, list):
+            if type(raw_shape) is not list:
                 raise NeuralTransportProtocolError(
-                    "transport field ndarray.shape must be a list"
+                    "transport field ndarray.shape must be an exact list"
                 )
             shape = tuple(
                 _manifest_int(dim, f"ndarray.shape[{index}]")
@@ -280,16 +280,16 @@ def _encode(value: Any, writer: _MailboxWriter) -> Any:
 
 def _decode_items(node: Mapping[str, Any], node_type: str) -> list[Any]:
     items = node.get("items")
-    if not isinstance(items, list):
+    if type(items) is not list:
         raise NeuralTransportProtocolError(
-            f"{node_type} transport manifest items must be a list"
+            f"{node_type} transport manifest items must be an exact list"
         )
     return items
 
 
 def _decode(node: Any, reader: _MailboxReader) -> Any:
-    if not isinstance(node, Mapping):
-        raise NeuralTransportProtocolError("transport manifest node is not a mapping")
+    if type(node) is not dict:
+        raise NeuralTransportProtocolError("transport manifest node is not an exact mapping")
     node_type = node.get("type")
     if node_type == "scalar":
         value = node.get("value")
@@ -316,7 +316,7 @@ def _decode(node: Any, reader: _MailboxReader) -> Any:
         result: dict[str, Any] = {}
         items = _decode_items(node, "mapping")
         for pair in items:
-            if not isinstance(pair, list) or len(pair) != 2 or not isinstance(pair[0], str):
+            if type(pair) is not list or len(pair) != 2 or not isinstance(pair[0], str):
                 raise NeuralTransportProtocolError("malformed mapping manifest item")
             key = pair[0]
             if key in result:
@@ -484,8 +484,14 @@ class SharedMemoryMailbox:
     def decode(self, envelope: Any, *, expected_lease_id: int) -> Any:
         if self._closed:
             raise NeuralTransportError("shared-memory mailbox is closed")
-        if not isinstance(envelope, Mapping):
-            raise NeuralTransportProtocolError("transport envelope is not a mapping")
+        if (
+            isinstance(expected_lease_id, bool)
+            or not isinstance(expected_lease_id, int)
+            or expected_lease_id <= 0
+        ):
+            raise ValueError("expected_lease_id must be a positive integer")
+        if type(envelope) is not dict:
+            raise NeuralTransportProtocolError("transport envelope is not an exact mapping")
         if envelope.get("schema") != _SCHEMA:
             raise NeuralTransportProtocolError("shared-memory payload schema mismatch")
         try:

--- a/tests/test_runtime_duration_authority.py
+++ b/tests/test_runtime_duration_authority.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.runtime import NodeKind, RuntimeExecutor, RuntimeGraph, RuntimeNode
+from neuros.runtime.process_worker import PersistentProcessWorker
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+INVALID_DURATION_VALUES = (
+    True,
+    np.bool_(True),
+    "1.0",
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    0,
+    0.0,
+    -1,
+    -0.5,
+)
+
+
+@pytest.mark.parametrize("value", INVALID_DURATION_VALUES)
+def test_runtime_node_rejects_invalid_execution_timeout_authority(value):
+    with pytest.raises((TypeError, ValueError)):
+        RuntimeNode(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=value,
+        )
+
+
+@pytest.mark.parametrize("value", INVALID_DURATION_VALUES)
+def test_runtime_node_rejects_invalid_latency_budget(value):
+    with pytest.raises((TypeError, ValueError)):
+        RuntimeNode(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            latency_budget_ms=value,
+        )
+
+
+@pytest.mark.parametrize("value", INVALID_DURATION_VALUES)
+def test_executor_rejects_invalid_drain_timeout_authority(value):
+    with pytest.raises((TypeError, ValueError)):
+        RuntimeExecutor(RuntimeGraph(), drain_timeout_s=value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", INVALID_DURATION_VALUES)
+async def test_run_for_rejects_invalid_duration_before_starting_runtime(value):
+    executor = RuntimeExecutor(RuntimeGraph())
+    with pytest.raises((TypeError, ValueError)):
+        await executor.run_for(value)
+    assert executor.state.value == "created"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("execution_timeout_s", value)
+        for value in INVALID_DURATION_VALUES
+    ]
+    + [
+        ("startup_timeout_s", value)
+        for value in INVALID_DURATION_VALUES
+    ]
+    + [
+        ("termination_grace_s", value)
+        for value in INVALID_DURATION_VALUES
+    ],
+)
+def test_pickle_worker_rejects_invalid_lifecycle_duration_authority(field_name, value):
+    kwargs = {
+        "execution_timeout_s": 1.0,
+        "startup_timeout_s": 1.0,
+        "termination_grace_s": 0.25,
+    }
+    kwargs[field_name] = value
+    with pytest.raises((TypeError, ValueError)):
+        PersistentProcessWorker("transform", IdentityTransform(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("execution_timeout_s", value)
+        for value in INVALID_DURATION_VALUES
+    ]
+    + [
+        ("startup_timeout_s", value)
+        for value in INVALID_DURATION_VALUES
+    ]
+    + [
+        ("termination_grace_s", value)
+        for value in INVALID_DURATION_VALUES
+    ],
+)
+def test_shared_worker_rejects_invalid_lifecycle_duration_authority(field_name, value):
+    kwargs = {
+        "execution_timeout_s": 1.0,
+        "startup_timeout_s": 1.0,
+        "termination_grace_s": 0.25,
+        "request_capacity_bytes": 4096,
+        "response_capacity_bytes": 4096,
+    }
+    kwargs[field_name] = value
+    with pytest.raises((TypeError, ValueError)):
+        SharedMemoryProcessWorker("transform", IdentityTransform(), **kwargs)
+
+
+def test_valid_real_duration_inputs_are_canonicalized_without_transport_drift():
+    node = RuntimeNode(
+        "transform",
+        NodeKind.TRANSFORM,
+        IdentityTransform(),
+        executor="process",
+        latency_budget_ms=np.float32(12.5),
+        execution_timeout_s=np.float64(1.25),
+    )
+    executor = RuntimeExecutor(RuntimeGraph(), drain_timeout_s=np.float32(2.5))
+    pickle_worker = PersistentProcessWorker(
+        "pickle",
+        IdentityTransform(),
+        execution_timeout_s=np.float32(1.5),
+        startup_timeout_s=np.float64(2.0),
+        termination_grace_s=np.int64(1),
+    )
+    shared_worker = SharedMemoryProcessWorker(
+        "shared",
+        IdentityTransform(),
+        execution_timeout_s=np.float64(1.75),
+        startup_timeout_s=np.float32(2.25),
+        termination_grace_s=np.int64(1),
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+
+    assert node.latency_budget_ms == 12.5
+    assert type(node.latency_budget_ms) is float
+    assert node.execution_timeout_s == 1.25
+    assert type(node.execution_timeout_s) is float
+    assert executor.drain_timeout_s == 2.5
+    assert type(executor.drain_timeout_s) is float
+    assert pickle_worker.execution_timeout_s == 1.5
+    assert pickle_worker.startup_timeout_s == 2.0
+    assert pickle_worker.termination_grace_s == 1.0
+    assert shared_worker.execution_timeout_s == 1.75
+    assert shared_worker.startup_timeout_s == 2.25
+    assert shared_worker.termination_grace_s == 1.0

--- a/tests/test_runtime_neural_transport.py
+++ b/tests/test_runtime_neural_transport.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import pickle
+import time
+from multiprocessing import shared_memory
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
+from neuros.runtime.process_worker import (
+    ProcessWorkerTerminationError,
+    ProcessWorkerTimeoutError,
+    ProcessWorkerTransportError,
+)
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
+from neuros.runtime.transport import (
+    NeuralTransportCapacityError,
+    NeuralTransportError,
+    NeuralTransportProtocolError,
+    NeuralTransportTypeError,
+    SharedMemoryMailbox,
+)
+
+
+def _frame(data: np.ndarray | None = None) -> SignalFrame:
+    return SignalFrame(
+        stream_id="eeg",
+        sequence_id=7,
+        data=np.arange(12, dtype=np.float32).reshape(6, 2) if data is None else data,
+        sample_rate_hz=250.0,
+        host_receive_time_ns=123_000,
+        device_time_ns=120_000,
+        metadata={
+            "axis_order": ("sample", "channel"),
+            "channel_names": ("C3", "C4"),
+            "nested": {"session": "transport", "trial": 3},
+        },
+    )
+
+
+def _window(data: np.ndarray | None = None) -> NeuralWindow:
+    return NeuralWindow(
+        stream_id="eeg",
+        window_id=11,
+        data=np.arange(16, dtype=np.float32).reshape(2, 8) if data is None else data,
+        sample_rate_hz=250.0,
+        start_time_ns=1_000,
+        end_time_ns=33_000_000,
+        channel_names=("C3", "C4"),
+        source_sequence_ids=(6, 7),
+        metadata={"nested": {"source": "window"}},
+    )
+
+
+def _assert_names_exist(names: dict[str, str]) -> None:
+    for name in names.values():
+        probe = shared_memory.SharedMemory(name=name, create=False)
+        probe.close()
+
+
+def _assert_names_absent(names: dict[str, str]) -> None:
+    for name in names.values():
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name=name, create=False)
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class RetainingTransform:
+    def __init__(self):
+        self.first = None
+
+    def transform(self, item):
+        if self.first is None:
+            self.first = item
+            return item
+        return self.first
+
+
+class DecoderOutputTransform:
+    def transform(self, item):
+        value = float(np.asarray(item).reshape(-1)[0])
+        return DecoderOutput(
+            prediction=np.array([int(value)], dtype=np.int64),
+            probabilities=np.array([0.25, 0.75], dtype=np.float32),
+            logits=np.array([-0.5, 0.5], dtype=np.float32),
+            embedding=np.arange(6, dtype=np.float32).reshape(2, 3),
+            model_id="shared-worker",
+            metadata={"value": value},
+        )
+
+
+class LargeResultTransform:
+    def transform(self, item):
+        return np.arange(1024, dtype=np.float64)
+
+
+class SleepTransform:
+    def transform(self, item):
+        time.sleep(2.0)
+        return item
+
+
+class CrashTransform:
+    def transform(self, item):
+        os._exit(23)
+
+
+class ImmortalProcess:
+    def __init__(self):
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.join_calls = 0
+
+    def is_alive(self):
+        return True
+
+    def terminate(self):
+        self.terminate_calls += 1
+
+    def kill(self):
+        self.kill_calls += 1
+
+    def join(self, timeout=None):
+        self.join_calls += 1
+
+    def close(self):
+        raise AssertionError("live process handle must not be closed")
+
+
+def test_neural_window_detaches_array_and_nested_metadata_from_caller_state():
+    source = np.arange(8, dtype=np.float32).reshape(2, 4)
+    nested = {"labels": ["left", "right"]}
+    window = NeuralWindow(
+        stream_id="eeg",
+        window_id=1,
+        data=source,
+        sample_rate_hz=100.0,
+        start_time_ns=1,
+        end_time_ns=40_000_001,
+        channel_names=["C3", "C4"],
+        source_sequence_ids=[1, 2],
+        metadata=nested,
+    )
+
+    source[:] = -1
+    nested["labels"].append("mutated")
+
+    assert window.data.tolist() == [[0.0, 1.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]]
+    assert not window.data.flags.writeable
+    assert window.channel_names == ("C3", "C4")
+    assert window.source_sequence_ids == (1, 2)
+    assert window.metadata["labels"] == ("left", "right")
+    with pytest.raises(ValueError):
+        window.data[0, 0] = 99
+
+
+def test_generic_pickle_rejects_canonical_frame_but_shared_mailbox_round_trips_it():
+    frame = _frame()
+    with pytest.raises((TypeError, pickle.PicklingError)):
+        pickle.dumps(frame, protocol=pickle.HIGHEST_PROTOCOL)
+
+    box = SharedMemoryMailbox(16 * 1024)
+    try:
+        envelope = box.encode(frame, lease_id=1)
+        decoded = box.decode(envelope, expected_lease_id=1)
+    finally:
+        box.close_and_unlink()
+
+    assert isinstance(decoded, SignalFrame)
+    assert decoded.stream_id == frame.stream_id
+    assert decoded.sequence_id == frame.sequence_id
+    assert decoded.sample_rate_hz == frame.sample_rate_hz
+    assert decoded.metadata["nested"]["session"] == "transport"
+    assert np.array_equal(decoded.data, frame.data)
+    assert not decoded.data.flags.writeable
+
+
+def test_codec_recursively_packs_multiple_arrays_and_canonical_payloads():
+    window = _window()
+    output = DecoderOutput(
+        prediction=np.array([2], dtype=np.int64),
+        confidence=0.8,
+        probabilities=np.array([0.1, 0.2, 0.7], dtype=np.float32),
+        logits=np.array([-2.0, -1.0, 1.5], dtype=np.float32),
+        embedding=np.arange(6, dtype=np.float32).reshape(2, 3),
+        model_id="transport-model",
+        metadata={"window": 11},
+    )
+    payload = TransformEmission((window, output, {"aux": np.arange(5, dtype=np.int16)}))
+
+    box = SharedMemoryMailbox(32 * 1024)
+    try:
+        envelope = box.encode(payload, lease_id=9)
+        decoded = box.decode(envelope, expected_lease_id=9)
+    finally:
+        box.close_and_unlink()
+
+    assert isinstance(decoded, TransformEmission)
+    decoded_window, decoded_output, decoded_aux = decoded.items
+    assert isinstance(decoded_window, NeuralWindow)
+    assert np.array_equal(decoded_window.data, window.data)
+    assert isinstance(decoded_output, DecoderOutput)
+    assert np.array_equal(decoded_output.probabilities, output.probabilities)
+    assert np.array_equal(decoded_output.logits, output.logits)
+    assert np.array_equal(decoded_output.embedding, output.embedding)
+    assert np.array_equal(decoded_aux["aux"], np.arange(5, dtype=np.int16))
+    assert envelope["bytes_used"] >= (
+        window.data.nbytes
+        + output.prediction.nbytes
+        + output.probabilities.nbytes
+        + output.logits.nbytes
+        + output.embedding.nbytes
+    )
+
+
+def test_capacity_and_unsupported_dtype_fail_closed_without_partial_decode():
+    small = SharedMemoryMailbox(64)
+    try:
+        with pytest.raises(NeuralTransportCapacityError, match="capacity"):
+            small.encode(np.arange(100, dtype=np.float64), lease_id=1)
+        with pytest.raises(NeuralTransportTypeError, match="boolean or numeric"):
+            small.encode(np.array([object()], dtype=object), lease_id=2)
+        with pytest.raises(NeuralTransportTypeError, match="keys must be strings"):
+            small.encode({"valid": 1, 2: "invalid"}, lease_id=3)
+    finally:
+        small.close_and_unlink()
+
+
+def test_transport_preserves_generic_numeric_values_without_inventing_policy():
+    payload = {
+        "array": np.array([np.nan, np.inf, -np.inf], dtype=np.float64),
+        "float": float("nan"),
+        "complex": complex(1.5, -2.25),
+        "complex_array": np.array([1 + 2j, np.nan + 1j], dtype=np.complex128),
+    }
+    box = SharedMemoryMailbox(4096)
+    try:
+        decoded = box.decode(box.encode(payload, lease_id=8), expected_lease_id=8)
+    finally:
+        box.close_and_unlink()
+
+    assert np.isnan(decoded["array"][0])
+    assert np.isposinf(decoded["array"][1])
+    assert np.isneginf(decoded["array"][2])
+    assert np.isnan(decoded["float"])
+    assert decoded["complex"] == complex(1.5, -2.25)
+    assert decoded["complex_array"][0] == 1 + 2j
+    assert np.isnan(decoded["complex_array"][1].real)
+
+
+def test_stale_lease_and_overlapping_array_descriptors_are_rejected():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(
+            (np.arange(4, dtype=np.float32), np.arange(4, dtype=np.float32) + 10),
+            lease_id=4,
+        )
+        with pytest.raises(NeuralTransportProtocolError, match="stale"):
+            box.decode(envelope, expected_lease_id=5)
+
+        corrupted = copy.deepcopy(envelope)
+        first, second = corrupted["manifest"]["items"]
+        second["offset"] = first["offset"]
+        with pytest.raises(NeuralTransportProtocolError, match="overlap"):
+            box.decode(corrupted, expected_lease_id=4)
+    finally:
+        box.close_and_unlink()
+
+
+def test_decoded_array_is_independent_of_subsequent_mailbox_reuse():
+    box = SharedMemoryMailbox(4096)
+    try:
+        first = box.decode(
+            box.encode(np.arange(8, dtype=np.float32), lease_id=1),
+            expected_lease_id=1,
+        )
+        box.encode(np.full(8, 99, dtype=np.float32), lease_id=2)
+        assert np.array_equal(first, np.arange(8, dtype=np.float32))
+    finally:
+        box.close_and_unlink()
+
+
+def test_owner_cleanup_unlinks_named_region_and_attached_peer_cannot_claim_authority():
+    owner = SharedMemoryMailbox(1024)
+    name = owner.name
+    peer = SharedMemoryMailbox.attach(name, 1024)
+    try:
+        with pytest.raises(NeuralTransportError, match="owner"):
+            peer.unlink()
+        peer.close()
+        owner.close_and_unlink()
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name=name, create=False)
+    finally:
+        peer.close()
+        owner.close_and_unlink()
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_round_trips_canonical_frame_and_unlinks_after_close():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        IdentityTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=16 * 1024,
+        response_capacity_bytes=16 * 1024,
+    )
+    call = await worker.invoke("transform", _frame())
+    names = worker.shared_memory_names
+    assert names is not None
+    _assert_names_exist(names)
+
+    assert isinstance(call.result, SignalFrame)
+    assert call.result.metadata["nested"]["trial"] == 3
+    assert np.array_equal(call.result.data, _frame().data)
+    assert call.receipt.outcome == "success"
+
+    worker.close()
+    assert not worker.is_alive
+    assert worker.shared_memory_names is None
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_retained_input_survives_mailbox_reuse():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        RetainingTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    try:
+        first_value = np.arange(8, dtype=np.float32)
+        first = await worker.invoke("transform", first_value)
+        second = await worker.invoke(
+            "transform", np.full(8, 99, dtype=np.float32)
+        )
+        assert np.array_equal(first.result, first_value)
+        assert np.array_equal(second.result, first_value)
+    finally:
+        worker.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_returns_decoder_output_with_multiple_arrays():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        DecoderOutputTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=16 * 1024,
+    )
+    try:
+        call = await worker.invoke("transform", np.array([4], dtype=np.float32))
+        output = call.result
+        assert isinstance(output, DecoderOutput)
+        assert np.array_equal(output.prediction, np.array([4], dtype=np.int64))
+        assert np.array_equal(output.probabilities, np.array([0.25, 0.75], dtype=np.float32))
+        assert np.array_equal(output.embedding, np.arange(6, dtype=np.float32).reshape(2, 3))
+        assert output.metadata["value"] == 4.0
+    finally:
+        worker.close()
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_request_capacity_failure_is_terminal_and_leak_free():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        IdentityTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=64,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+    _assert_names_exist(names)
+
+    with pytest.raises(ProcessWorkerTransportError, match="capacity"):
+        await worker.invoke("transform", np.arange(100, dtype=np.float64))
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "transport_error"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_result_capacity_failure_is_terminal_and_leak_free():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        LargeResultTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=64,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    with pytest.raises(ProcessWorkerTransportError, match="result transport failed"):
+        await worker.invoke("transform", 1)
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "transport_error"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_timeout_terminates_child_and_unlinks_transport():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        SleepTransform(),
+        execution_timeout_s=0.05,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    with pytest.raises(ProcessWorkerTimeoutError):
+        await worker.invoke("transform", 1)
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "timeout"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_crash_admits_no_result_and_unlinks_transport():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        CrashTransform(),
+        execution_timeout_s=2.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    with pytest.raises(Exception, match="worker"):
+        await worker.invoke("transform", 1)
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "crashed"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_asyncio_cancellation_terminates_and_unlinks():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        SleepTransform(),
+        execution_timeout_s=5.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    await worker.heartbeat()
+    names = worker.shared_memory_names
+    assert names is not None
+
+    task = asyncio.create_task(worker.invoke("transform", 1))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "cancelled"
+    assert not worker.is_alive
+    _assert_names_absent(names)
+
+
+def test_shared_worker_does_not_unlink_if_direct_child_survives_escalation():
+    worker = SharedMemoryProcessWorker(
+        "transform",
+        IdentityTransform(),
+        execution_timeout_s=1.0,
+        request_capacity_bytes=4096,
+        response_capacity_bytes=4096,
+    )
+    worker._prepare_payload_transport()
+    names = worker.shared_memory_names
+    assert names is not None
+    process = ImmortalProcess()
+    worker._process = process
+
+    try:
+        with pytest.raises(ProcessWorkerTerminationError, match="remained alive"):
+            worker.abort()
+        assert process.terminate_calls == 1
+        assert process.kill_calls == 1
+        assert process.join_calls == 2
+        assert worker._process is process
+        _assert_names_exist(names)
+    finally:
+        worker._process = None
+        worker._cleanup_payload_transport()
+
+    _assert_names_absent(names)

--- a/tests/test_runtime_process_provenance.py
+++ b/tests/test_runtime_process_provenance.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+def test_snapshot_records_pickle_and_shared_memory_process_authority_before_start():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, object()))
+    graph.add_node(
+        RuntimeNode(
+            "pickle-node",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=2.5,
+        )
+    )
+    graph.add_node(
+        RuntimeNode(
+            "shared-node",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.25,
+            process_transport="shared_memory",
+            process_request_capacity_bytes=8192,
+            process_response_capacity_bytes=16384,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "pickle-node"))
+    graph.connect(RuntimeEdge("source", "shared-node"))
+
+    snapshot = RuntimeExecutor(graph).snapshot()
+
+    assert snapshot["process_execution"] == {
+        "pickle-node": {
+            "transport": "pickle",
+            "execution_timeout_s": 2.5,
+            "request_capacity_bytes": None,
+            "response_capacity_bytes": None,
+        },
+        "shared-node": {
+            "transport": "shared_memory",
+            "execution_timeout_s": 1.25,
+            "request_capacity_bytes": 8192,
+            "response_capacity_bytes": 16384,
+        },
+    }
+    assert snapshot["process_receipts"] == {
+        "pickle-node": [],
+        "shared-node": [],
+    }

--- a/tests/test_runtime_process_transport_parity.py
+++ b/tests/test_runtime_process_transport_parity.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import numpy as np
+import pytest
+
+from neuros.runtime.process_worker import (
+    PersistentProcessWorker,
+    ProcessWorkerProtocolError,
+    ProcessWorkerRemoteError,
+    ProcessWorkerTimeoutError,
+    ProcessWorkerTransportError,
+    _PayloadTransportFailure,
+    _PickleParentTransport,
+)
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
+
+
+class CounterTransform:
+    def __init__(self):
+        self.calls = 0
+
+    def transform(self, item):
+        self.calls += 1
+        return self.calls, np.asarray(item) + self.calls
+
+
+class FailingTransform:
+    def transform(self, item):
+        raise LookupError(f"rejected {int(np.asarray(item).reshape(-1)[0])}")
+
+
+class SleepTransform:
+    def transform(self, item):
+        time.sleep(2.0)
+        return item
+
+
+class CrashTransform:
+    def transform(self, item):
+        os._exit(31)
+
+
+def _worker(transport: str, operator, *, timeout_s: float = 2.0):
+    if transport == "pickle":
+        return PersistentProcessWorker(
+            "transform", operator, execution_timeout_s=timeout_s
+        )
+    return SharedMemoryProcessWorker(
+        "transform",
+        operator,
+        execution_timeout_s=timeout_s,
+        request_capacity_bytes=64 * 1024,
+        response_capacity_bytes=64 * 1024,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["pickle", "shared_memory"])
+async def test_process_transports_share_stateful_lifecycle_and_receipt_semantics(transport):
+    worker = _worker(transport, CounterTransform())
+    try:
+        first = await worker.invoke("transform", np.array([10], dtype=np.int64))
+        second = await worker.invoke("transform", np.array([20], dtype=np.int64))
+        assert first.result[0] == 1
+        assert second.result[0] == 2
+        assert np.array_equal(first.result[1], np.array([11], dtype=np.int64))
+        assert np.array_equal(second.result[1], np.array([22], dtype=np.int64))
+        assert second.receipt.request_id == 2
+        assert second.receipt.outcome == "success"
+    finally:
+        worker.close()
+    assert not worker.is_alive
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["pickle", "shared_memory"])
+async def test_process_transports_preserve_remote_exception_type_without_killing_worker(transport):
+    worker = _worker(transport, FailingTransform())
+    try:
+        with pytest.raises(ProcessWorkerRemoteError) as caught:
+            await worker.invoke("transform", np.array([7], dtype=np.int64))
+        assert caught.value.remote_error_type == "LookupError"
+        assert worker.last_receipt is not None
+        assert worker.last_receipt.outcome == "error"
+        assert worker.last_receipt.remote_error_type == "LookupError"
+        assert worker.is_alive
+    finally:
+        worker.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["pickle", "shared_memory"])
+async def test_process_transports_timeout_with_same_terminal_authority(transport):
+    worker = _worker(transport, SleepTransform(), timeout_s=0.05)
+    with pytest.raises(ProcessWorkerTimeoutError):
+        await worker.invoke("transform", np.array([1], dtype=np.int64))
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "timeout"
+    assert not worker.is_alive
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["pickle", "shared_memory"])
+async def test_process_transports_cancel_with_same_terminal_authority(transport):
+    worker = _worker(transport, SleepTransform(), timeout_s=5.0)
+    await worker.heartbeat()
+    task = asyncio.create_task(
+        worker.invoke("transform", np.array([1], dtype=np.int64))
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "cancelled"
+    assert not worker.is_alive
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["pickle", "shared_memory"])
+async def test_process_transports_crash_with_same_terminal_authority(transport):
+    worker = _worker(transport, CrashTransform())
+    with pytest.raises(Exception, match="worker"):
+        await worker.invoke("transform", np.array([1], dtype=np.int64))
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "crashed"
+    assert not worker.is_alive
+
+
+@pytest.mark.parametrize("transport", ["pickle", "shared_memory"])
+def test_common_control_plane_rejects_bool_as_integer_identity(transport):
+    worker = _worker(transport, CounterTransform())
+    base = {
+        "protocol": 1,
+        "node_id": "transform",
+        "generation": 0,
+        "kind": "heartbeat",
+    }
+
+    corrupted = {**base, "protocol": True}
+    with pytest.raises(ProcessWorkerProtocolError, match="exact integer"):
+        worker._identity(corrupted, None)
+
+    corrupted = {**base, "generation": False}
+    with pytest.raises(ProcessWorkerProtocolError, match="exact integer"):
+        worker._identity(corrupted, None)
+
+    corrupted = {**base, "request_id": 1}
+    with pytest.raises(ProcessWorkerProtocolError, match="unexpectedly carries"):
+        worker._identity(corrupted, None)
+
+    call = {
+        "protocol": 1,
+        "node_id": "transform",
+        "generation": 0,
+        "request_id": True,
+        "kind": "result",
+    }
+    with pytest.raises(ProcessWorkerProtocolError, match="exact integer"):
+        worker._identity(call, 1)
+
+
+class FailOnceCleanupTransport(_PickleParentTransport):
+    def __init__(self):
+        self.cleanup_calls = 0
+
+    def cleanup(self):
+        self.cleanup_calls += 1
+        if self.cleanup_calls == 1:
+            raise _PayloadTransportFailure("synthetic unlink failure")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_after_proven_child_death_does_not_mask_timeout():
+    transport = FailOnceCleanupTransport()
+    worker = PersistentProcessWorker(
+        "transform",
+        SleepTransform(),
+        execution_timeout_s=0.05,
+        _payload_transport=transport,
+    )
+
+    with pytest.raises(ProcessWorkerTimeoutError):
+        await worker.invoke("transform", np.array([1], dtype=np.int64))
+
+    assert worker.last_receipt is not None
+    assert worker.last_receipt.outcome == "timeout"
+    assert isinstance(worker.last_cleanup_error, ProcessWorkerTransportError)
+    assert "synthetic unlink failure" in str(worker.last_cleanup_error)
+    assert not worker.is_alive
+
+    # Executor-owned close authority can retry a cleanup that failed after death.
+    worker.close()
+    assert transport.cleanup_calls >= 2
+
+
+def test_cleanup_failure_without_primary_operation_is_not_silenced():
+    transport = FailOnceCleanupTransport()
+    worker = PersistentProcessWorker(
+        "transform",
+        CounterTransform(),
+        execution_timeout_s=1.0,
+        _payload_transport=transport,
+    )
+    with pytest.raises(ProcessWorkerTransportError, match="synthetic unlink failure"):
+        worker.close()
+
+
+class FailingChildSpecTransport(_PickleParentTransport):
+    def __init__(self):
+        self.prepared = False
+        self.cleanup_calls = 0
+
+    def prepare(self):
+        self.prepared = True
+
+    def child_spec(self):
+        raise _PayloadTransportFailure("synthetic child spec failure")
+
+    def cleanup(self):
+        self.cleanup_calls += 1
+        self.prepared = False
+
+
+@pytest.mark.asyncio
+async def test_startup_child_spec_failure_releases_prepared_transport():
+    transport = FailingChildSpecTransport()
+    worker = PersistentProcessWorker(
+        "transform",
+        CounterTransform(),
+        execution_timeout_s=1.0,
+        _payload_transport=transport,
+    )
+    with pytest.raises(ProcessWorkerTransportError, match="child payload transport specification"):
+        await worker.heartbeat()
+    assert transport.cleanup_calls >= 1
+    assert not transport.prepared
+    assert not worker.is_alive

--- a/tests/test_runtime_shared_transport_integration.py
+++ b/tests/test_runtime_shared_transport_integration.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+from neuros.runtime.shared_process_worker import SharedMemoryProcessWorker
+
+
+class ItemsSource:
+    def __init__(self, items):
+        self.items = list(items)
+        self.started = False
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.started = False
+
+    async def frames(self):
+        for item in self.items:
+            await asyncio.sleep(0)
+            yield item
+
+
+class CollectSink:
+    def __init__(self):
+        self.items = []
+
+    async def write(self, item):
+        self.items.append(item)
+
+
+class FrameScaleTransform:
+    def __init__(self, factor: float):
+        self.factor = float(factor)
+
+    def transform(self, frame: SignalFrame):
+        return replace(frame, data=np.asarray(frame.data) * self.factor)
+
+
+class BatchShapeDecoder:
+    def infer(self, X):
+        array = np.asarray(X)
+        return DecoderOutput(
+            prediction=int(float(array.mean()) >= 0.0),
+            confidence=0.9,
+            metadata={
+                "observed_shape": tuple(int(value) for value in array.shape),
+                "observed_sum": float(array.sum()),
+            },
+        )
+
+
+class PairEmitter:
+    def transform(self, frame: SignalFrame):
+        return TransformEmission(
+            (
+                replace(frame, data=np.asarray(frame.data) + 1.0),
+                replace(frame, data=np.asarray(frame.data) + 2.0),
+            )
+        )
+
+
+class FileSink:
+    def __init__(self, path: str):
+        self.path = path
+
+    def write(self, item):
+        if isinstance(item, SignalFrame):
+            value = float(np.asarray(item.data).reshape(-1)[0])
+            line = f"{item.stream_id}:{item.sequence_id}:{value}\n"
+        else:
+            line = f"{type(item).__name__}\n"
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+
+
+class FileMonitor:
+    def __init__(self, path: str):
+        self.path = path
+
+    def update(self, payload):
+        line = (
+            f"{payload['node_id']}:{payload['kind']}:"
+            f"{type(payload['item']).__name__}\n"
+        )
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class DelayedFailTransform:
+    def transform(self, item):
+        time.sleep(0.5)
+        raise ValueError("shared runtime synthetic failure")
+
+
+class SlowTransform:
+    def transform(self, item):
+        time.sleep(5.0)
+        return item
+
+
+def _frame(sequence_id: int = 0, value: float = 1.0) -> SignalFrame:
+    return SignalFrame(
+        stream_id="eeg",
+        sequence_id=sequence_id,
+        data=np.array([value, value + 0.5], dtype=np.float32),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=1_000 + sequence_id,
+        metadata={"channel_names": ("C3", "C4")},
+    )
+
+
+def _window() -> NeuralWindow:
+    return NeuralWindow(
+        stream_id="eeg",
+        window_id=17,
+        data=np.arange(8, dtype=np.float32).reshape(2, 4),
+        sample_rate_hz=250.0,
+        start_time_ns=1_000,
+        end_time_ns=16_001_000,
+        channel_names=("C3", "C4"),
+        source_sequence_ids=(10, 11),
+        metadata={"trial": "shared-runtime"},
+    )
+
+
+def _shared_node(
+    node_id: str,
+    kind: NodeKind,
+    operator,
+    *,
+    request_capacity: int = 64 * 1024,
+    response_capacity: int = 64 * 1024,
+    timeout_s: float = 3.0,
+) -> RuntimeNode:
+    return RuntimeNode(
+        node_id,
+        kind,
+        operator,
+        executor="process",
+        execution_timeout_s=timeout_s,
+        process_transport="shared_memory",
+        process_request_capacity_bytes=request_capacity,
+        process_response_capacity_bytes=response_capacity,
+    )
+
+
+def test_shared_memory_runtime_configuration_is_explicit_and_fail_closed():
+    with pytest.raises(ValueError, match="positive process_request_capacity_bytes"):
+        RuntimeNode(
+            "missing-capacity",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.0,
+            process_transport="shared_memory",
+            process_response_capacity_bytes=4096,
+        )
+
+    with pytest.raises(ValueError, match="only valid for executor='process'"):
+        RuntimeNode(
+            "inline-shared",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            process_transport="shared_memory",
+            process_request_capacity_bytes=4096,
+            process_response_capacity_bytes=4096,
+        )
+
+    with pytest.raises(ValueError, match="only valid for process_transport='shared_memory'"):
+        RuntimeNode(
+            "pickle-capacity",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.0,
+            process_request_capacity_bytes=4096,
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_transform_round_trips_signal_frames_and_closes_worker():
+    sink = CollectSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame(0, 1.0), _frame(1, 2.0)])))
+    graph.add_node(_shared_node("transform", NodeKind.TRANSFORM, FrameScaleTransform(3.0)))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+    graph.connect(RuntimeEdge("transform", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    snapshot = await executor.run()
+
+    assert [item.sequence_id for item in sink.items] == [0, 1]
+    assert np.allclose(sink.items[0].data, np.array([3.0, 4.5], dtype=np.float32))
+    assert np.allclose(sink.items[1].data, np.array([6.0, 7.5], dtype=np.float32))
+    assert snapshot["state"] == "stopped"
+    assert [receipt["outcome"] for receipt in snapshot["process_receipts"]["transform"]] == [
+        "success",
+        "success",
+    ]
+    worker = executor._process_workers["transform"]
+    assert isinstance(worker, SharedMemoryProcessWorker)
+    assert not worker.is_alive
+    assert worker.shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_decoder_preserves_neural_window_batching_and_provenance():
+    window = _window()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([window])))
+    graph.add_node(_shared_node("decoder", NodeKind.DECODER, BatchShapeDecoder()))
+    graph.connect(RuntimeEdge("source", "decoder", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    await executor.start()
+    outputs = [output async for output in executor.outputs()]
+    await executor.wait()
+
+    assert len(outputs) == 1
+    output = outputs[0]
+    assert output.metadata["observed_shape"] == (1, 2, 4)
+    assert output.metadata["observed_sum"] == pytest.approx(float(window.data.sum()))
+    assert output.metadata["neuros_stream_id"] == "eeg"
+    assert output.metadata["neuros_window_id"] == 17
+    assert output.metadata["window_channel_names"] == ("C3", "C4")
+    assert output.metadata["source_sequence_ids"] == (10, 11)
+    assert executor.snapshot()["process_receipts"]["decoder"][0]["outcome"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_transform_emission_preserves_fanout_semantics():
+    sink = CollectSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame()])))
+    graph.add_node(_shared_node("emit", NodeKind.TRANSFORM, PairEmitter()))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.connect(RuntimeEdge("source", "emit", overflow="block"))
+    graph.connect(RuntimeEdge("emit", "sink", overflow="block"))
+
+    snapshot = await RuntimeExecutor(graph).run()
+
+    assert snapshot["state"] == "stopped"
+    assert len(sink.items) == 2
+    assert np.allclose(sink.items[0].data, np.array([2.0, 2.5], dtype=np.float32))
+    assert np.allclose(sink.items[1].data, np.array([3.0, 3.5], dtype=np.float32))
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_process_sink_executes_side_effect_and_closes(tmp_path):
+    destination = tmp_path / "sink.txt"
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame(3, 4.0)])))
+    graph.add_node(_shared_node("sink", NodeKind.SINK, FileSink(str(destination))))
+    graph.connect(RuntimeEdge("source", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    snapshot = await executor.run()
+
+    assert destination.read_text(encoding="utf-8") == "eeg:3:4.0\n"
+    assert snapshot["process_receipts"]["sink"][0]["outcome"] == "success"
+    assert not executor._process_workers["sink"].is_alive
+    assert executor._process_workers["sink"].shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_process_monitor_observes_canonical_payload(tmp_path):
+    destination = tmp_path / "monitor.txt"
+    sink = CollectSink()
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([_frame()])))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, sink))
+    graph.add_node(_shared_node("monitor", NodeKind.MONITOR, FileMonitor(str(destination))))
+    graph.connect(RuntimeEdge("source", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    snapshot = await executor.run()
+
+    assert destination.read_text(encoding="utf-8") == "source:source:SignalFrame\n"
+    assert snapshot["process_receipts"]["monitor"][0]["outcome"] == "success"
+    assert not executor._process_workers["monitor"].is_alive
+    assert executor._process_workers["monitor"].shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_attributes_shared_request_capacity_failure_to_owning_node():
+    graph = RuntimeGraph()
+    graph.add_node(
+        RuntimeNode(
+            "source",
+            NodeKind.SOURCE,
+            ItemsSource([np.arange(100, dtype=np.float64)]),
+        )
+    )
+    graph.add_node(
+        _shared_node(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            request_capacity=64,
+            response_capacity=4096,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="ProcessWorkerTransportError"):
+        await executor.run()
+
+    snapshot = executor.snapshot()
+    assert snapshot["state"] == "failed"
+    assert snapshot["failure"]["node_id"] == "transform"
+    assert snapshot["failure"]["error_type"] == "ProcessWorkerTransportError"
+    assert snapshot["process_receipts"]["transform"][-1]["outcome"] == "transport_error"
+    worker = executor._process_workers["transform"]
+    assert not worker.is_alive
+    assert worker.shared_memory_names is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_shared_failure_cancels_peer_worker_without_overwriting_culprit():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, ItemsSource([np.array([1.0], dtype=np.float32)])))
+    graph.add_node(
+        _shared_node(
+            "fail",
+            NodeKind.TRANSFORM,
+            DelayedFailTransform(),
+            timeout_s=3.0,
+        )
+    )
+    graph.add_node(
+        _shared_node(
+            "slow",
+            NodeKind.TRANSFORM,
+            SlowTransform(),
+            timeout_s=10.0,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "fail", overflow="block"))
+    graph.connect(RuntimeEdge("source", "slow", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    with pytest.raises(RuntimeError, match="shared runtime synthetic failure"):
+        await executor.run()
+
+    snapshot = executor.snapshot()
+    assert snapshot["failure"]["node_id"] == "fail"
+    assert snapshot["failure"]["error_type"] == "ValueError"
+    assert snapshot["process_receipts"]["fail"][-1]["outcome"] == "error"
+    assert snapshot["process_receipts"]["fail"][-1]["remote_error_type"] == "ValueError"
+    assert snapshot["process_receipts"]["slow"][-1]["outcome"] == "cancelled"
+    for worker in executor._process_workers.values():
+        assert not worker.is_alive
+        assert worker.shared_memory_names is None

--- a/tests/test_runtime_transport_protocol_corruption.py
+++ b/tests/test_runtime_transport_protocol_corruption.py
@@ -37,7 +37,7 @@ def test_transport_manifest_rejects_coerced_and_misaligned_array_geometry():
         box.close_and_unlink()
 
 
-def test_transport_envelope_rejects_integer_coercion_for_identity_and_boundary():
+def test_transport_envelope_rejects_integer_coercion_and_unreferenced_tail_bytes():
     box = SharedMemoryMailbox(4096)
     try:
         envelope = box.encode(np.arange(4, dtype=np.float32), lease_id=3)
@@ -56,8 +56,27 @@ def test_transport_envelope_rejects_integer_coercion_for_identity_and_boundary()
         corrupted["bytes_used"] = True
         with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
             box.decode(corrupted, expected_lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["bytes_used"] += 64
+        with pytest.raises(NeuralTransportProtocolError, match="referenced payload boundary"):
+            box.decode(corrupted, expected_lease_id=3)
     finally:
         box.close_and_unlink()
+
+
+def test_mailbox_ownership_cannot_be_forged_when_attaching():
+    owner = SharedMemoryMailbox(4096)
+    try:
+        with pytest.raises(TypeError, match="unexpected keyword argument 'owner'"):
+            SharedMemoryMailbox(
+                4096,
+                name=owner.name,
+                create=False,
+                owner=True,
+            )
+    finally:
+        owner.close_and_unlink()
 
 
 def test_canonical_frame_manifest_rejects_lossy_field_coercion():

--- a/tests/test_runtime_transport_protocol_corruption.py
+++ b/tests/test_runtime_transport_protocol_corruption.py
@@ -9,6 +9,14 @@ from neuros.contracts import DecoderOutput, SignalFrame
 from neuros.runtime.transport import NeuralTransportProtocolError, SharedMemoryMailbox
 
 
+class DictSubclass(dict):
+    pass
+
+
+class ListSubclass(list):
+    pass
+
+
 def test_transport_manifest_rejects_coerced_and_misaligned_array_geometry():
     box = SharedMemoryMailbox(4096)
     try:
@@ -31,7 +39,12 @@ def test_transport_manifest_rejects_coerced_and_misaligned_array_geometry():
 
         corrupted = copy.deepcopy(envelope)
         corrupted["manifest"]["shape"] = tuple(envelope["manifest"]["shape"])
-        with pytest.raises(NeuralTransportProtocolError, match="shape must be a list"):
+        with pytest.raises(NeuralTransportProtocolError, match="exact list"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["shape"] = ListSubclass(envelope["manifest"]["shape"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact list"):
             box.decode(corrupted, expected_lease_id=7)
     finally:
         box.close_and_unlink()
@@ -61,6 +74,36 @@ def test_transport_envelope_rejects_integer_coercion_and_unreferenced_tail_bytes
         corrupted["bytes_used"] += 64
         with pytest.raises(NeuralTransportProtocolError, match="referenced payload boundary"):
             box.decode(corrupted, expected_lease_id=3)
+    finally:
+        box.close_and_unlink()
+
+
+@pytest.mark.parametrize(
+    "expected_lease_id",
+    (True, np.bool_(True), "3", 3.0, np.int64(3), 0, -1),
+)
+def test_expected_lease_identity_rejects_coercion(expected_lease_id):
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(np.arange(4, dtype=np.float32), lease_id=3)
+        with pytest.raises((TypeError, ValueError), match="expected_lease_id"):
+            box.decode(envelope, expected_lease_id=expected_lease_id)
+    finally:
+        box.close_and_unlink()
+
+
+def test_transport_rejects_mapping_subclasses_not_emitted_by_writer():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(np.arange(4, dtype=np.float32), lease_id=4)
+
+        with pytest.raises(NeuralTransportProtocolError, match="exact mapping"):
+            box.decode(DictSubclass(envelope), expected_lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"] = DictSubclass(corrupted["manifest"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact mapping"):
+            box.decode(corrupted, expected_lease_id=4)
     finally:
         box.close_and_unlink()
 
@@ -128,7 +171,12 @@ def test_sequence_manifest_requires_writer_container_shape():
         envelope = box.encode((1, 2, 3), lease_id=6)
         corrupted = copy.deepcopy(envelope)
         corrupted["manifest"]["items"] = tuple(corrupted["manifest"]["items"])
-        with pytest.raises(NeuralTransportProtocolError, match="items must be a list"):
+        with pytest.raises(NeuralTransportProtocolError, match="exact list"):
+            box.decode(corrupted, expected_lease_id=6)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["items"] = ListSubclass(corrupted["manifest"]["items"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact list"):
             box.decode(corrupted, expected_lease_id=6)
     finally:
         box.close_and_unlink()

--- a/tests/test_runtime_transport_protocol_corruption.py
+++ b/tests/test_runtime_transport_protocol_corruption.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderOutput, SignalFrame
+from neuros.runtime.transport import NeuralTransportProtocolError, SharedMemoryMailbox
+
+
+def test_transport_manifest_rejects_coerced_and_misaligned_array_geometry():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(np.arange(8, dtype=np.float32), lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["offset"] = 1
+        with pytest.raises(NeuralTransportProtocolError, match="aligned"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["offset"] = "0"
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["nbytes"] = float(envelope["manifest"]["nbytes"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=7)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["shape"] = tuple(envelope["manifest"]["shape"])
+        with pytest.raises(NeuralTransportProtocolError, match="shape must be a list"):
+            box.decode(corrupted, expected_lease_id=7)
+    finally:
+        box.close_and_unlink()
+
+
+def test_transport_envelope_rejects_integer_coercion_for_identity_and_boundary():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(np.arange(4, dtype=np.float32), lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["lease_id"] = "3"
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["bytes_used"] = float(envelope["bytes_used"])
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=3)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["bytes_used"] = True
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=3)
+    finally:
+        box.close_and_unlink()
+
+
+def test_canonical_frame_manifest_rejects_lossy_field_coercion():
+    frame = SignalFrame(
+        stream_id="eeg",
+        sequence_id=8,
+        data=np.arange(4, dtype=np.float32),
+        sample_rate_hz=250.0,
+        host_receive_time_ns=1000,
+    )
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(frame, lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["stream_id"] = 123
+        with pytest.raises(NeuralTransportProtocolError, match="stream_id must be a string"):
+            box.decode(corrupted, expected_lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["sequence_id"] = 8.9
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=4)
+
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["host_receive_time_ns"] = "1000"
+        with pytest.raises(NeuralTransportProtocolError, match="exact integer"):
+            box.decode(corrupted, expected_lease_id=4)
+    finally:
+        box.close_and_unlink()
+
+
+def test_canonical_constructor_rejection_is_reported_as_protocol_failure():
+    output = DecoderOutput(prediction=1, confidence=0.5)
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode(output, lease_id=5)
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["confidence"]["value"] = 2.0
+        with pytest.raises(NeuralTransportProtocolError, match="DecoderOutput"):
+            box.decode(corrupted, expected_lease_id=5)
+    finally:
+        box.close_and_unlink()
+
+
+def test_sequence_manifest_requires_writer_container_shape():
+    box = SharedMemoryMailbox(4096)
+    try:
+        envelope = box.encode((1, 2, 3), lease_id=6)
+        corrupted = copy.deepcopy(envelope)
+        corrupted["manifest"]["items"] = tuple(corrupted["manifest"]["items"])
+        with pytest.raises(NeuralTransportProtocolError, match="items must be a list"):
+            box.decode(corrupted, expected_lease_id=6)
+    finally:
+        box.close_and_unlink()


### PR DESCRIPTION
## Status

**Exact-head qualified and ready for review. Do not merge without an explicit merge decision.**

This PR reconstructs Phase C of #126 directly on exact-qualified Phase B `e4d924223870959db88ef903b02f04244c42f9ff`.

Unlike the disposable staging implementation, this production reconstruction does **not** duplicate process lifecycle authority. `PersistentProcessWorker` owns one common spawn/control/identity/receipt/timeout/cancellation/crash/termination state machine, while pickle and shared memory differ through payload transport adapters.

Current exact production head: `0acd5733e594d1694401d727aed6482a0ae86a48`.

## Promoted surface

- transport-agnostic persistent process worker core;
- canonical shared-memory mailbox codec for NumPy arrays, `SignalFrame`, `NeuralWindow`, `DecoderOutput`, `TransformEmission`, and deterministic containers/scalars;
- thin shared-memory parent/child payload adapter using parent-owned duplex mailboxes;
- explicit `RuntimeNode.process_transport` plus request/response mailbox capacities;
- runtime process-transport provenance and semantic receipts;
- detached/read-only `NeuralWindow` data with recursively frozen metadata;
- exact control-plane request/response identity with defense-in-depth result admission;
- structural shared-memory unlink ownership: creator owns, attacher never owns;
- exact lease identity and writer-shaped manifest/container validation;
- exact shared-memory byte-boundary validation with no unreferenced tail bytes;
- primary-failure precedence that preserves execution failure over secondary cleanup degradation unless direct-child termination authority itself is lost;
- finite-positive-real authority for node/process/startup/termination/drain/run durations, rejecting bools, strings, NaN, infinities, zero, and negatives;
- one dual-transport lifecycle qualification surface for pickle and shared memory;
- public contract documentation in `docs/RUNTIME_PROCESS_TRANSPORT.md`.

## Exact-head qualification

`Runtime Fault Qualification` run #54 passed on exact head `0acd5733...` across all maintained lanes:

- Ubuntu 24.04 × Python 3.10 / 3.11 / 3.12;
- macOS 14 × Python 3.10 / 3.11 / 3.12;
- Windows 2025 × Python 3.10 / 3.11 / 3.12.

The semantic-head matrix immediately before the documentation-only tranche executed **195 tests per verified lane**; the final head changes no runtime source or test bytes relative to that semantic head and re-passed every fault lane.

Every pull-request workflow associated with exact head `0acd5733...` is green:

- neurOS CI;
- Runtime Fault Qualification;
- Whole Package Qualification;
- Neural Window Contracts;
- Braindecode Compatibility;
- Ecosystem Compatibility;
- External Plugin Contract;
- neurOS driver contracts;
- Public Trust Contracts;
- Developer Preview Journey;
- Reproducible Release Build;
- Release Candidate Artifacts.

The final documentation tranche differs from fully semantic-qualified head `d5e16588f2b6e1abc256ad47ccb943d32c641531` only by:

1. `docs/RUNTIME_PROCESS_TRANSPORT.md`;
2. two workflow path entries binding that document to Runtime Fault Qualification.

No production runtime source or test byte changed in that final tranche.

## Performance evidence boundary

Performance is descriptive and non-gating.

The original #128 experiment measures contiguous `float32` ndarray round trips. It establishes a platform-dependent raw-array crossover and must not be generalized into a blanket neural-payload speedup claim.

The source-bound canonical benchmark in draft #132 separately measures support and latency for raw ndarray, `SignalFrame`, `NeuralWindow`, and multi-array `DecoderOutput` while requiring zero production-source drift from semantic commit `d5e16588...`.

Across Ubuntu, macOS, and Windows:

- raw ndarray is supported by pickle and shared memory;
- canonical `SignalFrame`, `NeuralWindow`, and current `DecoderOutput` fail generic pickle preflight with `TypeError` because of immutable provenance representation;
- shared memory round-trips all four workloads successfully;
- canonical reconstruction adds measurable workload-dependent overhead and is not equivalent to naked ndarray transport.

Immutable benchmark artifact digests and cross-platform timing tables are recorded on #132 and summarized in `docs/RUNTIME_PROCESS_TRANSPORT.md`.

## Deliberate boundaries / non-blocking follow-ups

- `process_transport="pickle"` remains the compatibility default for payloads it can represent.
- shared memory remains explicit opt-in with explicit positive capacities.
- no silent pickle fallback or mailbox resizing is permitted.
- callback inputs are materialized locally; this is **not** an end-to-end zero-copy contract.
- parent unlink authority remains subordinate to proven direct-child death.
- the v1 shared-memory reader admits the concrete protocol language emitted by its writer; incompatible post-promotion changes should require an explicit protocol-version decision.
- YAML / `PipelineConfig -> resolve_config` does not yet expose process execution/transport authority: #131.
- canonical `DecoderOutput` immutability remains #129.
- historical cleanup-degradation snapshot telemetry remains #133. This is provenance observability, not a containment-authority defect.
- older RuntimeGraph fail-late input coercions such as bool queue capacity / node-kind normalization are isolated as #134.
- future internal factoring of the enlarged common worker should preserve behavior and be qualified independently rather than refactoring the now-proven state machine during this promotion.
- no Kumar2024 model/fleet execution is authorized by this transport tranche; ORION remains outside comparison authority.

## Review conclusion

The production reconstruction now has stronger architecture and stronger adversarial evidence than the disposable staging branch: one process lifecycle authority, exact identity/ownership semantics, a narrower versioned wire language, finite deadline authority, a 9-lane cross-platform fault matrix, full repository compatibility, and support-aware performance evidence.

This PR is ready for human review as the Phase C runtime primitive. It should remain unmerged until an explicit merge decision is made against this exact head.

Refs #123, #126, #128, #129, #131, #132, #133, #134.