### PR TITLE
Canonical DecoderOutput: detach arrays and freeze provenance

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -5,9 +5,11 @@ on:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
+      - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
+      - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
@@ -26,9 +28,11 @@ on:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
+      - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
+      - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
@@ -103,6 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pytest -q \
+            tests/test_decoder_output_immutability.py \
             tests/test_runtime_executor.py \
             tests/test_runtime_queues.py \
             tests/test_runtime_fault_qualification.py \

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "docs/DECODER_OUTPUT_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
       - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"
@@ -27,6 +28,7 @@ on:
       - main
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "docs/DECODER_OUTPUT_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
       - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"

--- a/docs/DECODER_OUTPUT_CONTRACT.md
+++ b/docs/DECODER_OUTPUT_CONTRACT.md
@@ -1,0 +1,128 @@
+# DecoderOutput canonical contract
+
+`DecoderOutput` is the neurOS inference-result boundary. It records what a decoder produced without inventing confidence, calibration, uncertainty, or biological meaning that the decoder did not supply.
+
+This document describes the **representation and immutability** contract. It is not a model-performance or scientific-validity claim.
+
+## Construction boundary
+
+A constructed `DecoderOutput` must not retain caller-owned mutable state that can later change the canonical result.
+
+The contract therefore canonicalizes fields at construction:
+
+| Field | Canonical representation |
+| --- | --- |
+| numeric / boolean ndarray `prediction` | detached read-only NumPy array |
+| string / object ndarray `prediction` | recursively validated immutable sequence |
+| prediction list / tuple | immutable tuple |
+| prediction mapping | immutable string-key mapping with recursively frozen values |
+| `probabilities` | detached read-only numeric / boolean NumPy array when present |
+| `logits` | detached read-only numeric / boolean NumPy array when present |
+| `embedding` | detached read-only numeric / boolean NumPy array when present |
+| `metadata` | recursively detached immutable deterministic provenance mapping |
+
+Unordered sets, non-string prediction mapping keys, unsupported opaque prediction objects, and nonnumeric score / embedding arrays fail closed.
+
+## Why numeric predictions stay arrays but string arrays become sequences
+
+`prediction` intentionally has a broader semantic domain than score tensors. Classification labels may be integers, strings, scalars, arrays, or deterministic structured values.
+
+For numeric and boolean ndarray predictions, neurOS preserves ndarray geometry while copying the backing storage and marking the canonical array read-only.
+
+String and object ndarrays cannot use the qualified shared-memory ndarray byte lane. They are therefore recursively canonicalized through deterministic immutable sequences when their contents are supported. For example, a batch prediction equivalent to:
+
+```python
+np.array(["left", "right"])
+```
+
+has canonical prediction semantics equivalent to:
+
+```python
+("left", "right")
+```
+
+This preserves the ordered labels without pretending that string-label storage is a numeric tensor.
+
+## Detachment is stronger than a read-only view
+
+Calling `setflags(write=False)` on a view is not enough if the view still shares writable caller-owned storage. neurOS first copies canonical numeric arrays and only then marks the detached copy read-only.
+
+Therefore this must not change the output:
+
+```python
+source = np.array([0.2, 0.8], dtype=np.float32)
+output = DecoderOutput(prediction=1, probabilities=source)
+source[:] = 0
+
+assert output.probabilities.tolist() == [0.2, 0.8]
+```
+
+Direct writes through the canonical array are also rejected by NumPy.
+
+## Metadata provenance
+
+Metadata uses the same recursively frozen deterministic provenance semantics as canonical signal/window contracts:
+
+- mappings require string keys and become immutable mappings;
+- lists and tuples become immutable tuples;
+- NumPy scalar values are detached to scalar values;
+- NumPy metadata arrays are converted to immutable nested values;
+- non-finite metadata floats/arrays, bytes, unordered sets, object-dtype metadata arrays, and unsupported opaque objects fail closed.
+
+A caller retaining the original nested dict/list/array objects cannot mutate the canonical `DecoderOutput.metadata` afterward.
+
+## `dataclasses.replace(...)`
+
+`DecoderOutput` remains a frozen dataclass and can be evolved with `dataclasses.replace(...)`.
+
+Replacement invokes the constructor again. Array fields are therefore copied and frozen again, and replacement metadata is recursively canonicalized. The replacement object does not silently acquire writable aliases to the original output's arrays.
+
+This is important for compatibility layers that add runtime provenance such as adaptive-threshold metadata after inference.
+
+## Shared-memory transport
+
+The Phase C shared-memory codec reconstructs a fresh `DecoderOutput` on decode. Reconstruction passes through the same constructor contract, so received arrays are detached/read-only and metadata is recursively frozen again.
+
+The transport does not weaken canonical immutability and does not require a separate mutable wire representation to become authoritative.
+
+This remains shared-memory **transport**, not an end-to-end zero-copy callback contract. See [`RUNTIME_PROCESS_TRANSPORT.md`](RUNTIME_PROCESS_TRANSPORT.md).
+
+## Generic pickle
+
+Canonical provenance mappings use immutable mapping proxies. Generic pickle should not be treated as a universal serializer for canonical `DecoderOutput` objects. Process nodes using pickle remain valid when the actual process payload is pickle-representable, such as the standard numeric decoder input batch.
+
+Use the qualified shared-memory transport when a canonical `DecoderOutput` itself must cross the process payload boundary.
+
+## Scientific boundary
+
+Canonical immutability proves that the represented result cannot be silently changed through retained Python aliases. It does **not** prove that:
+
+- probabilities sum to one;
+- probabilities are calibrated;
+- logits have a particular probabilistic interpretation;
+- embeddings encode a stable neural mechanism;
+- uncertainty is statistically valid;
+- a model generalizes across subjects, sessions, sites, or devices.
+
+Those claims require model/evidence contracts and empirical qualification.
+
+## Scalar authority follow-up
+
+The immutability tranche deliberately preserves the pre-existing scalar validation for `confidence`, `uncertainty`, model identity, and `inference_time_ns` rather than changing two contract dimensions at once.
+
+Issue #136 tracks stricter scalar authority, including finite uncertainty and exact non-negative inference timing. That follow-up is independent of the array/container immutability established here.
+
+## Qualification
+
+The maintained adversarial contract suite verifies:
+
+- mutation of caller arrays after construction cannot change canonical output fields;
+- direct writes through canonical numeric arrays fail;
+- nested prediction and metadata sources cannot mutate canonical state;
+- deterministic string-label batches remain supported;
+- `dataclasses.replace(...)` recanonicalizes and redetaches storage;
+- unsupported mutable/nondeterministic prediction values fail closed;
+- shared-memory mailbox round trips preserve the immutable contract;
+- the full runtime fault surface remains green across Ubuntu, macOS, and Windows on Python 3.10, 3.11, and 3.12.
+
+The implementation and its adversarial tests are bound to Runtime Fault Qualification so changes to this canonical output boundary cannot bypass the cross-platform process/transport gate.

--- a/packages/neuros-core/src/neuros/contracts/models.py
+++ b/packages/neuros-core/src/neuros/contracts/models.py
@@ -9,6 +9,64 @@ from typing import Any, Mapping, Protocol, runtime_checkable
 import numpy as np
 from numpy.typing import NDArray
 
+from .signal import _freeze_metadata_mapping
+
+
+_SUPPORTED_OUTPUT_ARRAY_KINDS = frozenset("biufc")
+
+
+def _freeze_output_array(value: Any, *, field_name: str) -> NDArray[np.generic]:
+    """Detach one canonical output array from caller-owned storage."""
+
+    array = np.array(value, copy=True, subok=False)
+    if array.dtype.kind not in _SUPPORTED_OUTPUT_ARRAY_KINDS:
+        raise TypeError(
+            f"{field_name} must use a boolean or numeric dtype; received {array.dtype}"
+        )
+    array.setflags(write=False)
+    return array
+
+
+def _freeze_prediction(value: Any, *, path: str = "prediction") -> Any:
+    """Freeze deterministic prediction values without retaining mutable aliases.
+
+    ``prediction`` remains intentionally more flexible than the typed numeric
+    score arrays because class labels may be strings.  Its accepted container
+    language matches the shared-memory transport: scalar primitives, numeric
+    arrays, string-key mappings, and deterministic sequences.
+    """
+
+    if isinstance(value, np.generic):
+        return _freeze_prediction(value.item(), path=path)
+    if isinstance(value, np.ndarray):
+        return _freeze_output_array(value, field_name=path)
+    if value is None or isinstance(value, (str, bool, int, float, complex)):
+        return value
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} mapping keys must be strings")
+            frozen[key] = _freeze_prediction(item, path=f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _freeze_prediction(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        )
+    if isinstance(value, (set, frozenset)):
+        raise TypeError(f"{path} cannot contain unordered set values")
+    raise TypeError(
+        f"{path} contains unsupported value type {type(value).__module__}."
+        f"{type(value).__qualname__}; use deterministic prediction primitives"
+    )
+
+
+def _optional_output_array(value: Any, *, field_name: str) -> NDArray[np.generic] | None:
+    if value is None:
+        return None
+    return _freeze_output_array(value, field_name=field_name)
+
 
 @dataclass(frozen=True, slots=True)
 class DecoderCapabilities:
@@ -23,7 +81,15 @@ class DecoderCapabilities:
 
 @dataclass(frozen=True, slots=True)
 class DecoderOutput:
-    """Structured decoder output without fabricated certainty."""
+    """Structured decoder output with detached immutable result/provenance state.
+
+    Array-bearing fields are copied at construction and marked read-only, so a
+    caller cannot mutate a canonical output through a retained input buffer.
+    Deterministic prediction containers and metadata are recursively frozen for
+    the same reason.  This is representation immutability; it does not invent
+    confidence, calibration, or scientific validity that a decoder did not
+    provide.
+    """
 
     prediction: Any
     confidence: float | None = None
@@ -41,7 +107,24 @@ class DecoderOutput:
             raise ValueError("confidence must be in [0, 1]")
         if self.uncertainty is not None and self.uncertainty < 0:
             raise ValueError("uncertainty must be non-negative")
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+        object.__setattr__(self, "prediction", _freeze_prediction(self.prediction))
+        object.__setattr__(
+            self,
+            "probabilities",
+            _optional_output_array(self.probabilities, field_name="probabilities"),
+        )
+        object.__setattr__(
+            self,
+            "logits",
+            _optional_output_array(self.logits, field_name="logits"),
+        )
+        object.__setattr__(
+            self,
+            "embedding",
+            _optional_output_array(self.embedding, field_name="embedding"),
+        )
+        object.__setattr__(self, "metadata", _freeze_metadata_mapping(self.metadata))
 
 
 @runtime_checkable

--- a/packages/neuros-core/src/neuros/contracts/models.py
+++ b/packages/neuros-core/src/neuros/contracts/models.py
@@ -16,7 +16,7 @@ _SUPPORTED_OUTPUT_ARRAY_KINDS = frozenset("biufc")
 
 
 def _freeze_output_array(value: Any, *, field_name: str) -> NDArray[np.generic]:
-    """Detach one canonical output array from caller-owned storage."""
+    """Detach one canonical numeric output array from caller-owned storage."""
 
     array = np.array(value, copy=True, subok=False)
     if array.dtype.kind not in _SUPPORTED_OUTPUT_ARRAY_KINDS:
@@ -31,15 +31,20 @@ def _freeze_prediction(value: Any, *, path: str = "prediction") -> Any:
     """Freeze deterministic prediction values without retaining mutable aliases.
 
     ``prediction`` remains intentionally more flexible than the typed numeric
-    score arrays because class labels may be strings.  Its accepted container
-    language matches the shared-memory transport: scalar primitives, numeric
-    arrays, string-key mappings, and deterministic sequences.
+    score arrays because class labels may be strings. Numeric/bool ndarrays stay
+    arrays; string/object arrays are canonicalized through nested immutable
+    sequences when every contained value belongs to the deterministic prediction
+    language supported by the shared-memory codec.
     """
 
     if isinstance(value, np.generic):
         return _freeze_prediction(value.item(), path=path)
     if isinstance(value, np.ndarray):
-        return _freeze_output_array(value, field_name=path)
+        if value.dtype.kind in _SUPPORTED_OUTPUT_ARRAY_KINDS:
+            return _freeze_output_array(value, field_name=path)
+        if value.dtype.kind in "USO":
+            return _freeze_prediction(value.tolist(), path=path)
+        raise TypeError(f"{path} uses unsupported ndarray dtype {value.dtype}")
     if value is None or isinstance(value, (str, bool, int, float, complex)):
         return value
     if isinstance(value, Mapping):
@@ -86,7 +91,7 @@ class DecoderOutput:
     Array-bearing fields are copied at construction and marked read-only, so a
     caller cannot mutate a canonical output through a retained input buffer.
     Deterministic prediction containers and metadata are recursively frozen for
-    the same reason.  This is representation immutability; it does not invent
+    the same reason. This is representation immutability; it does not invent
     confidence, calibration, or scientific validity that a decoder did not
     provide.
     """

--- a/tests/test_decoder_output_immutability.py
+++ b/tests/test_decoder_output_immutability.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import MappingProxyType
+
+import numpy as np
+import pytest
+
+from neuros.contracts import DecoderOutput
+from neuros.runtime.transport import SharedMemoryMailbox
+
+
+def _output() -> DecoderOutput:
+    return DecoderOutput(
+        prediction=np.array([1, 2], dtype=np.int64),
+        confidence=0.75,
+        uncertainty=0.25,
+        probabilities=np.array([0.25, 0.75], dtype=np.float32),
+        logits=np.array([-0.5, 0.5], dtype=np.float32),
+        embedding=np.arange(6, dtype=np.float32).reshape(2, 3),
+        model_id="immutability-test",
+        model_version="1",
+        inference_time_ns=123,
+        metadata={
+            "labels": ["left", "right"],
+            "nested": {"session": "A", "trial": 3},
+            "array": np.array([4, 5], dtype=np.int16),
+        },
+    )
+
+
+def test_decoder_output_detaches_all_array_fields_from_caller_storage():
+    prediction = np.array([1, 2], dtype=np.int64)
+    probabilities = np.array([0.2, 0.8], dtype=np.float32)
+    logits = np.array([-1.0, 1.0], dtype=np.float32)
+    embedding = np.arange(4, dtype=np.float32).reshape(2, 2)
+
+    output = DecoderOutput(
+        prediction=prediction,
+        probabilities=probabilities,
+        logits=logits,
+        embedding=embedding,
+    )
+
+    prediction[:] = 99
+    probabilities[:] = 99
+    logits[:] = 99
+    embedding[:] = 99
+
+    assert np.array_equal(output.prediction, np.array([1, 2], dtype=np.int64))
+    assert np.array_equal(output.probabilities, np.array([0.2, 0.8], dtype=np.float32))
+    assert np.array_equal(output.logits, np.array([-1.0, 1.0], dtype=np.float32))
+    assert np.array_equal(output.embedding, np.arange(4, dtype=np.float32).reshape(2, 2))
+    assert not output.prediction.flags.writeable
+    assert not output.probabilities.flags.writeable
+    assert not output.logits.flags.writeable
+    assert not output.embedding.flags.writeable
+
+
+@pytest.mark.parametrize("field_name", ["prediction", "probabilities", "logits", "embedding"])
+def test_decoder_output_array_fields_reject_direct_mutation(field_name):
+    output = _output()
+    array = getattr(output, field_name)
+    with pytest.raises(ValueError):
+        array.reshape(-1)[0] = 123
+
+
+def test_decoder_output_recursively_detaches_prediction_and_metadata_containers():
+    prediction = {
+        "labels": ["left", "right"],
+        "scores": np.array([1, 2], dtype=np.int64),
+    }
+    metadata = {
+        "nested": {"labels": ["C3", "C4"]},
+        "array": np.array([7, 8], dtype=np.int16),
+    }
+
+    output = DecoderOutput(prediction=prediction, metadata=metadata)
+
+    prediction["labels"].append("mutated")
+    prediction["scores"][:] = 99
+    metadata["nested"]["labels"].append("mutated")
+    metadata["array"][:] = 99
+
+    assert isinstance(output.prediction, MappingProxyType)
+    assert output.prediction["labels"] == ("left", "right")
+    assert np.array_equal(output.prediction["scores"], np.array([1, 2], dtype=np.int64))
+    assert not output.prediction["scores"].flags.writeable
+    assert isinstance(output.metadata, MappingProxyType)
+    assert isinstance(output.metadata["nested"], MappingProxyType)
+    assert output.metadata["nested"]["labels"] == ("C3", "C4")
+    assert output.metadata["array"] == (7, 8)
+
+    with pytest.raises(TypeError):
+        output.prediction["new"] = 1
+    with pytest.raises(TypeError):
+        output.metadata["new"] = 1
+
+
+def test_decoder_output_string_prediction_arrays_become_transportable_immutable_sequences():
+    labels = np.array(["left", "right"], dtype="U5")
+    output = DecoderOutput(prediction=labels)
+    labels[:] = "other"
+    assert output.prediction == ("left", "right")
+
+
+def test_decoder_output_replace_recanonicalizes_and_does_not_share_array_storage():
+    original = _output()
+    replaced = replace(original, metadata={**dict(original.metadata), "phase": "replaced"})
+
+    assert replaced is not original
+    assert replaced.prediction is not original.prediction
+    assert replaced.probabilities is not original.probabilities
+    assert replaced.logits is not original.logits
+    assert replaced.embedding is not original.embedding
+    assert np.array_equal(replaced.prediction, original.prediction)
+    assert np.array_equal(replaced.probabilities, original.probabilities)
+    assert np.array_equal(replaced.logits, original.logits)
+    assert np.array_equal(replaced.embedding, original.embedding)
+    assert not replaced.prediction.flags.writeable
+    assert not replaced.probabilities.flags.writeable
+    assert replaced.metadata["phase"] == "replaced"
+
+
+def test_decoder_output_rejects_nondeterministic_or_nonnumeric_mutable_payloads():
+    with pytest.raises(TypeError, match="unordered set"):
+        DecoderOutput(prediction={"left", "right"})
+
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        DecoderOutput(prediction={1: "left"})
+
+    with pytest.raises(TypeError, match="probabilities must use a boolean or numeric dtype"):
+        DecoderOutput(prediction=1, probabilities=["bad", "data"])
+
+
+@pytest.mark.parametrize("field_name", ["probabilities", "logits", "embedding"])
+def test_decoder_output_numeric_array_fields_accept_array_like_and_canonicalize(field_name):
+    output = DecoderOutput(prediction=1, **{field_name: [1, 2, 3]})
+    value = getattr(output, field_name)
+    assert isinstance(value, np.ndarray)
+    assert np.array_equal(value, np.array([1, 2, 3]))
+    assert not value.flags.writeable
+
+
+def test_decoder_output_shared_mailbox_round_trip_preserves_immutability():
+    output = _output()
+    box = SharedMemoryMailbox(32 * 1024)
+    try:
+        envelope = box.encode(output, lease_id=41)
+        decoded = box.decode(envelope, expected_lease_id=41)
+    finally:
+        box.close_and_unlink()
+
+    assert isinstance(decoded, DecoderOutput)
+    assert np.array_equal(decoded.prediction, output.prediction)
+    assert np.array_equal(decoded.probabilities, output.probabilities)
+    assert np.array_equal(decoded.logits, output.logits)
+    assert np.array_equal(decoded.embedding, output.embedding)
+    assert decoded.metadata["labels"] == ("left", "right")
+    assert decoded.metadata["nested"]["session"] == "A"
+    assert not decoded.prediction.flags.writeable
+    assert not decoded.probabilities.flags.writeable
+    assert not decoded.logits.flags.writeable
+    assert not decoded.embedding.flags.writeable
+
+
+def test_decoder_output_keeps_existing_confidence_and_uncertainty_validation():
+    with pytest.raises(ValueError, match="confidence"):
+        DecoderOutput(prediction=1, confidence=1.01)
+    with pytest.raises(ValueError, match="uncertainty"):
+        DecoderOutput(prediction=1, uncertainty=-0.01)


### PR DESCRIPTION
## Status

**Exact-head qualified and ready for review. Do not merge without an explicit merge decision.**

This contract tranche is stacked directly on exact-qualified Phase C #130 (`0acd5733e594d1694401d727aed6482a0ae86a48`).

Current exact head: `be3f4e9f45794fdbfae2fe1727f0959b8ec46540`.
Fully semantic-qualified checkpoint before the final documentation-only tranche: `614c503ebb62eb1cadc0bf006bbf08a714879f09`.

## Promoted contract

`DecoderOutput` is no longer merely a frozen dataclass shell around caller-owned mutable objects.

The qualified contract now:

- copies numeric/bool ndarray predictions at construction and marks them read-only;
- canonicalizes supported string/object ndarray predictions through deterministic immutable sequences;
- recursively freezes prediction lists/tuples and string-key mappings;
- copies `probabilities`, `logits`, and `embedding` into independent read-only numeric arrays;
- recursively freezes metadata using the same deterministic provenance semantics used by canonical signal/window contracts;
- makes `dataclasses.replace(...)` recanonicalize and redetach array storage;
- rejects unordered prediction sets, non-string prediction mapping keys, unsupported opaque prediction values, and nonnumeric score/embedding arrays;
- preserves existing scalar confidence/uncertainty semantics rather than silently changing two contract dimensions at once.

This is **representation/provenance immutability**. It does not certify probability calibration, uncertainty validity, model generalization, or biological mechanism.

## Adversarial qualification

`tests/test_decoder_output_immutability.py` proves:

1. mutating caller arrays after construction cannot change canonical output fields;
2. direct writes through canonical numeric arrays fail;
3. nested prediction and metadata sources cannot mutate canonical state;
4. string-label ndarray batches remain supported through immutable ordered sequences;
5. `dataclasses.replace(...)` creates independent immutable array storage;
6. nondeterministic/unsupported prediction structures fail closed;
7. array-like score fields canonicalize deterministically;
8. shared-memory mailbox round trips reconstruct the same immutable contract;
9. the pre-existing confidence/uncertainty range behavior remains unchanged in this tranche.

## Exact-head evidence

The semantic checkpoint `614c503...` passed:

- all 9 Runtime Fault Qualification lanes: Ubuntu 24.04, macOS 14, Windows 2025 × Python 3.10/3.11/3.12;
- a verified Ubuntu/Python 3.10 lane executed **209 tests and passed 209/209**, up from 195 in the Phase C transport tranche;
- Whole Package Qualification, including exact installed-wheel clean-room qualification across all maintained OS/Python lanes;
- neurOS CI and all repository compatibility/release workflows.

The final exact head `be3f4e9...` also passed **every associated pull-request workflow**:

- neurOS CI;
- Runtime Fault Qualification, 9/9 lanes;
- Whole Package Qualification;
- Neural Window Contracts;
- Braindecode Compatibility;
- Ecosystem Compatibility;
- External Plugin Contract;
- neurOS driver contracts;
- Public Trust Contracts;
- Developer Preview Journey;
- Reproducible Release Build;
- Release Candidate Artifacts.

The final tranche from semantic checkpoint `614c503...` to `be3f4e9...` changes only:

1. `docs/DECODER_OUTPUT_CONTRACT.md`;
2. two Runtime Fault Qualification path entries binding that public contract document to the exact-head gate.

No production source or test byte changed after the semantic checkpoint.

## Public contract

`docs/DECODER_OUTPUT_CONTRACT.md` now documents:

- detach-then-freeze semantics rather than read-only aliases;
- numeric prediction ndarray vs string-label sequence canonicalization;
- recursive metadata provenance;
- `dataclasses.replace(...)` behavior;
- shared-memory reconstruction;
- generic-pickle boundary;
- scientific claim boundary;
- the independent scalar-authority follow-up.

## Deliberate boundaries / follow-ups

- no process lifecycle or shared-memory wire-format change;
- no executor/config/schema change;
- no model architecture or training change;
- no probability normalization/calibration claim;
- #136 owns stricter scalar authority for non-finite uncertainty, exact inference timing, and model-identity normalization;
- #134 remains RuntimeGraph authority/input normalization;
- #131 remains configuration execution/transport authority and should also reconcile existing YAML coercions discovered during this audit;
- #133 remains historical process-cleanup degradation snapshot telemetry;
- duplicated internal canonical-provenance helper patterns are maintainability debt, not a blocker for this qualified contract tranche.

## Review conclusion

This PR is intentionally narrow: one canonical result contract, one adversarial test surface, one public contract document, and one cross-platform qualification binding. Maintained model/runtime/evidence integrations remain green, and the shared-memory transport reconstructs the same immutable contract.

The tranche is ready for human review on exact head `be3f4e9...`. It remains unmerged until an explicit merge decision is made.

Refs #129, #130, #136.