### PR TITLE
RuntimeGraph authority: canonicalize kinds, identities, and capacities

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
       - "docs/DECODER_OUTPUT_CONTRACT.md"
+      - "docs/RUNTIME_GRAPH_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
       - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"
@@ -30,6 +31,7 @@ on:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
       - "docs/DECODER_OUTPUT_CONTRACT.md"
+      - "docs/RUNTIME_GRAPH_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
       - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -12,6 +12,7 @@ on:
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
+      - "tests/test_runtime_graph_authority.py"
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
       - "tests/test_runtime_fusion_cancellation.py"
@@ -36,6 +37,7 @@ on:
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
+      - "tests/test_runtime_graph_authority.py"
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
       - "tests/test_runtime_fusion_cancellation.py"
@@ -111,6 +113,7 @@ jobs:
           python -m pytest -q \
             tests/test_decoder_output_immutability.py \
             tests/test_runtime_executor.py \
+            tests/test_runtime_graph_authority.py \
             tests/test_runtime_queues.py \
             tests/test_runtime_fault_qualification.py \
             tests/test_runtime_fusion_cancellation.py \

--- a/docs/RUNTIME_GRAPH_CONTRACT.md
+++ b/docs/RUNTIME_GRAPH_CONTRACT.md
@@ -1,0 +1,202 @@
+# RuntimeGraph Authority Contract
+
+This document defines the promoted programmatic contract for constructing and validating neurOS runtime graphs.
+
+The short version:
+
+- node and edge identities are explicit strings, not values silently coerced into strings;
+- node kinds are canonical `NodeKind` values before topology or execution rules inspect them;
+- queue and shared-memory mailbox capacities are explicit positive integral authority;
+- booleans, floats, text and non-positive values cannot masquerade as capacities;
+- graph constructor containers are detached from caller-owned dict/list aliases;
+- public graph containers remain intentionally mutable, so authoritative graph operations re-establish structural integrity before trusting them;
+- structural integrity and semantic DAG validity are related but distinct contracts;
+- `RuntimeExecutor` validates the graph before creating runtime channels, tasks or process workers;
+- configuration/YAML authority is a separate compiler boundary and is not promoted by this contract.
+
+## RuntimeNode identity and kind authority
+
+`RuntimeNode.node_id` must be an explicit nonblank string.
+
+The validator checks blankness without stripping or otherwise rewriting a valid identifier. For example, a deliberately supplied nonblank identifier containing leading/trailing spaces retains those exact string bytes. neurOS rejects malformed identity rather than silently manufacturing a different identity.
+
+`RuntimeNode.kind` accepts either:
+
+- a `NodeKind` value; or
+- a valid plain string such as `"transform"`.
+
+A valid string is immediately canonicalized to `NodeKind`. Unknown strings and non-string/non-enum values fail during construction.
+
+This matters because runtime topology and dispatch use enum identity. A plain string must never survive construction and then fail later because code expects `node.kind.value` or uses `node.kind is NodeKind.TRANSFORM`.
+
+Canonicalization also closes policy bypasses. For example, `kind="source"` is canonicalized to `NodeKind.SOURCE` before source execution restrictions are evaluated, so a string declaration cannot bypass the current inline-only source boundary.
+
+## Executor and process-transport declarations
+
+`executor` and `process_transport` require explicit strings before their values are checked.
+
+The runtime currently recognizes executors:
+
+- `inline`
+- `thread`
+- `process`
+- `gpu`
+
+and process transports:
+
+- `pickle`
+- `shared_memory`
+
+These names do not all represent equivalent isolation guarantees.
+
+In the current executor, `inline` and `gpu` both invoke operator code directly on the runtime execution thread. `thread` uses the thread execution domain and `process` uses the persistent process-worker authority. Therefore `gpu` is **not** a promoted process/thread isolation guarantee merely because it is a valid `RuntimeNode.executor` value.
+
+Source lifecycle isolation is not implemented. Source nodes therefore require `executor="inline"`.
+
+Process execution requires an explicit finite positive `execution_timeout_s`. Process-only transport declarations on non-process nodes fail closed.
+
+For the detailed process lifecycle and payload contract, see [`RUNTIME_PROCESS_TRANSPORT.md`](RUNTIME_PROCESS_TRANSPORT.md).
+
+## Integral capacity authority
+
+Runtime capacities use one canonical integer rule.
+
+A capacity must be:
+
+1. an integral numeric scalar;
+2. not a boolean;
+3. strictly greater than zero.
+
+Valid scientific-Python integral scalars such as NumPy integer types are accepted and stored as ordinary Python `int` values.
+
+The following are rejected rather than coerced:
+
+- `True` / `False`;
+- floating-point values such as `8.0`;
+- text such as `"8"`;
+- zero;
+- negative values;
+- `None` and unsupported objects.
+
+This rule applies to `RuntimeEdge.capacity` and to shared-memory request/response mailbox capacities declared through `RuntimeNode`.
+
+Shared-memory mailbox validation preserves its transport-specific public failure semantics while using the same underlying integral authority. Both request and response capacities are required for `process_transport="shared_memory"`.
+
+## RuntimeEdge canonicalization
+
+`RuntimeEdge.source` and `RuntimeEdge.target` must be explicit nonblank strings. They are not coerced from integers, booleans or arbitrary objects.
+
+A valid overflow declaration may be supplied as an `OverflowPolicy` or its valid string value. It is stored canonically as the policy's string value.
+
+Self edges are rejected during `RuntimeEdge` construction.
+
+Registered-endpoint and duplicate-edge authority belongs to `RuntimeGraph`, because those checks depend on graph state rather than one standalone edge.
+
+## RuntimeGraph constructor ownership
+
+`RuntimeGraph` requires:
+
+- `nodes` to be a `dict[str, RuntimeNode]` container;
+- `edges` to be a `list[RuntimeEdge]` container.
+
+When caller-owned containers are supplied to the constructor, neurOS copies the dict/list containers before retaining them.
+
+This is **container alias detachment**, not deep immutability.
+
+Mutating the original constructor dict/list after graph construction cannot mutate the graph. The graph's own `nodes` and `edges` containers, however, remain intentionally public and mutable in this contract revision.
+
+The reason for retaining that mutability is compatibility and incremental graph construction. The corresponding authority rule is that neurOS cannot cache a permanent "validated" bit while external mutation remains possible.
+
+## Structural integrity
+
+Authoritative graph operations establish structural integrity before trusting public containers.
+
+Structural integrity requires:
+
+- `nodes` remains a dict;
+- `edges` remains a list;
+- every node key is a nonblank string;
+- every node value is a `RuntimeNode`;
+- every node dict key exactly equals the contained `RuntimeNode.node_id`;
+- every edge value is a `RuntimeEdge`;
+- no duplicate `(source, target)` edge exists;
+- every edge endpoint refers to a registered node.
+
+These checks protect against direct public-container mutation as well as ordinary method calls.
+
+For example, injecting an arbitrary object into `graph.edges` and then calling `topological_order()`, `incoming()`, `outgoing()`, `add_node()`, `connect()` or `validate()` fails with a graph-contract error before traversal or mutation proceeds. It must not leak an incidental `AttributeError` from deeper implementation code.
+
+Likewise, replacing `graph.nodes` or `graph.edges` themselves with incompatible container types is detected before the graph operation continues.
+
+## Structural integrity vs semantic graph validity
+
+Structural integrity answers:
+
+> Is this object a coherent graph representation whose identities and endpoints can be trusted?
+
+Full `RuntimeGraph.validate()` additionally answers:
+
+> Does this coherent representation satisfy neurOS runtime topology semantics?
+
+Semantic validation includes:
+
+- the graph is acyclic;
+- source nodes have no incoming edges;
+- fusion nodes have at least two inputs;
+- transforms, decoders and sinks have exactly one input;
+- sinks have no outgoing edges;
+- monitors are observational and own no data edges.
+
+Public topology/query operations require structural integrity, but they do not all imply every semantic node-cardinality rule. `validate()` is the complete runtime-graph acceptance gate.
+
+## Execution handoff
+
+`RuntimeExecutor.__init__` calls `graph.validate()` before it builds runtime channels, queues, process-worker receipt state or execution tasks.
+
+Therefore a malformed or externally corrupted graph is rejected before runtime execution authority is created.
+
+This is the key fail-early boundary promoted by this contract: invalid programmatic graph declarations should not survive until an operator callback, queue operation or child process exposes the defect.
+
+## Configuration compiler boundary
+
+This contract governs the **programmatic runtime graph**.
+
+The current `PipelineConfig -> resolve_config -> RuntimeGraph` path has its own versioned schema/parser responsibilities. Runtime graph hardening does not make YAML parsing automatically strict, and it does not authorize configuration fields that the compiler does not expose.
+
+In particular, legacy configuration parsing still has coercion/versioning questions that must be resolved as a separate configuration-authority tranche.
+
+The intended dependency direction is:
+
+1. configuration parses and validates its declared schema;
+2. the compiler deterministically translates that declaration to `RuntimeNode` / `RuntimeEdge` values;
+3. the runtime graph constructors remain the final programmatic authority;
+4. `RuntimeGraph.validate()` proves the resolved graph before execution.
+
+The configuration layer must not invent a second, weaker definition of strings, numeric durations or integral capacities.
+
+## Deliberate non-goals
+
+This contract does not claim:
+
+- graph metadata is recursively immutable;
+- operator objects are immutable or trusted against malicious code;
+- `gpu` is a distinct process/thread/device isolation domain;
+- YAML/configuration parsing is no-coercion authoritative;
+- runtime queue capacity is automatically sized;
+- a structurally valid graph is scientifically valid;
+- graph validation proves hardware, closed-loop, safety or clinical behavior.
+
+Metadata provenance, configuration execution policy, process cleanup-history telemetry and scientific/model contracts have separate authority surfaces.
+
+## Qualification boundary
+
+The promoted graph authority is exercised in `tests/test_runtime_graph_authority.py` and bound into Runtime Fault Qualification across:
+
+- Ubuntu 24.04;
+- macOS 14;
+- Windows 2025;
+- Python 3.10, 3.11 and 3.12.
+
+The suite includes malformed identities, enum declarations, capacities, constructor aliases, public-container corruption, topology queries, mutation methods and shared-memory capacity normalization.
+
+Cross-platform qualification proves the declared software contract on the maintained runtime matrix. It does not convert that contract into a scientific-performance or real-time guarantee.

--- a/packages/neuros-core/src/neuros/runtime/_validation.py
+++ b/packages/neuros-core/src/neuros/runtime/_validation.py
@@ -1,9 +1,30 @@
-"""Internal validation helpers for runtime authority-bearing numeric fields."""
+"""Internal validators for runtime authority-bearing fields."""
 from __future__ import annotations
 
 import math
-from numbers import Real
+from numbers import Integral, Real
 from typing import Any
+
+
+def nonblank_string(value: Any, *, field_name: str) -> str:
+    """Require an explicit nonblank string without rewriting its identity."""
+
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{field_name} must be nonblank")
+    return value
+
+
+def positive_integral(value: Any, *, field_name: str) -> int:
+    """Return a canonical positive Python int without bool/text coercion."""
+
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{field_name} must be an integer")
+    resolved = int(value)
+    if resolved <= 0:
+        raise ValueError(f"{field_name} must be positive")
+    return resolved
 
 
 def positive_finite_real(value: Any, *, field_name: str) -> float:

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -150,55 +150,30 @@ class RuntimeGraph:
     nodes: dict[str, RuntimeNode] = field(default_factory=dict)
     edges: list[RuntimeEdge] = field(default_factory=list)
 
-    def add_node(self, node: RuntimeNode) -> None:
-        if not isinstance(node, RuntimeNode):
-            raise TypeError("node must be a RuntimeNode")
-        if node.node_id in self.nodes:
-            raise ValueError(f"Duplicate node_id: {node.node_id}")
-        self.nodes[node.node_id] = node
+    def __post_init__(self) -> None:
+        if not isinstance(self.nodes, dict):
+            raise TypeError("RuntimeGraph nodes must be a dict")
+        if not isinstance(self.edges, list):
+            raise TypeError("RuntimeGraph edges must be a list")
+        # Detach constructor-owned containers. The graph remains intentionally
+        # mutable through its own public containers and mutation methods, but a
+        # caller retaining the constructor arguments must not mutate it by alias.
+        self.nodes = dict(self.nodes)
+        self.edges = list(self.edges)
+        self._validate_structure()
 
-    def connect(self, edge: RuntimeEdge) -> None:
-        if not isinstance(edge, RuntimeEdge):
-            raise TypeError("edge must be a RuntimeEdge")
-        if edge.source not in self.nodes or edge.target not in self.nodes:
-            raise ValueError("Both edge endpoints must be registered nodes")
-        if any(
-            existing.source == edge.source and existing.target == edge.target
-            for existing in self.edges
-        ):
-            raise ValueError(f"Duplicate edge: {edge.source} -> {edge.target}")
-        self.edges.append(edge)
+    def _validate_container_types(self) -> None:
+        if not isinstance(self.nodes, dict):
+            raise TypeError("RuntimeGraph nodes must be a dict")
+        if not isinstance(self.edges, list):
+            raise TypeError("RuntimeGraph edges must be a list")
 
-    def incoming(self, node_id: str) -> tuple[RuntimeEdge, ...]:
-        return tuple(edge for edge in self.edges if edge.target == node_id)
+    def _validate_structure(self) -> None:
+        """Prove graph container, identity, edge-type, and endpoint integrity."""
 
-    def outgoing(self, node_id: str) -> tuple[RuntimeEdge, ...]:
-        return tuple(edge for edge in self.edges if edge.source == node_id)
-
-    def topological_order(self) -> tuple[str, ...]:
-        indegree = {node_id: 0 for node_id in self.nodes}
-        adjacency: dict[str, list[str]] = {node_id: [] for node_id in self.nodes}
-        for edge in self.edges:
-            indegree[edge.target] += 1
-            adjacency[edge.source].append(edge.target)
-        ready = sorted(node_id for node_id, degree in indegree.items() if degree == 0)
-        order: list[str] = []
-        while ready:
-            node_id = ready.pop(0)
-            order.append(node_id)
-            for target in adjacency[node_id]:
-                indegree[target] -= 1
-                if indegree[target] == 0:
-                    ready.append(target)
-                    ready.sort()
-        if len(order) != len(self.nodes):
-            raise ValueError("RuntimeGraph must be acyclic")
-        return tuple(order)
-
-    def validate(self) -> None:
+        self._validate_container_types()
         for node_id, node in self.nodes.items():
-            if not isinstance(node_id, str):
-                raise TypeError("RuntimeGraph node keys must be strings")
+            nonblank_string(node_id, field_name="RuntimeGraph node key")
             if not isinstance(node, RuntimeNode):
                 raise TypeError(f"RuntimeGraph node {node_id!r} must be a RuntimeNode")
             if node_id != node.node_id:
@@ -218,11 +193,72 @@ class RuntimeGraph:
             if edge.source not in self.nodes or edge.target not in self.nodes:
                 raise ValueError(f"Invalid edge: {edge.source} -> {edge.target}")
 
-        self.topological_order()
+    def add_node(self, node: RuntimeNode) -> None:
+        if not isinstance(node, RuntimeNode):
+            raise TypeError("node must be a RuntimeNode")
+        self._validate_structure()
+        if node.node_id in self.nodes:
+            raise ValueError(f"Duplicate node_id: {node.node_id}")
+        self.nodes[node.node_id] = node
+
+    def connect(self, edge: RuntimeEdge) -> None:
+        if not isinstance(edge, RuntimeEdge):
+            raise TypeError("edge must be a RuntimeEdge")
+        self._validate_structure()
+        if edge.source not in self.nodes or edge.target not in self.nodes:
+            raise ValueError("Both edge endpoints must be registered nodes")
+        if any(
+            existing.source == edge.source and existing.target == edge.target
+            for existing in self.edges
+        ):
+            raise ValueError(f"Duplicate edge: {edge.source} -> {edge.target}")
+        self.edges.append(edge)
+
+    def _incoming_unchecked(self, node_id: str) -> tuple[RuntimeEdge, ...]:
+        return tuple(edge for edge in self.edges if edge.target == node_id)
+
+    def _outgoing_unchecked(self, node_id: str) -> tuple[RuntimeEdge, ...]:
+        return tuple(edge for edge in self.edges if edge.source == node_id)
+
+    def incoming(self, node_id: str) -> tuple[RuntimeEdge, ...]:
+        self._validate_structure()
+        return self._incoming_unchecked(node_id)
+
+    def outgoing(self, node_id: str) -> tuple[RuntimeEdge, ...]:
+        self._validate_structure()
+        return self._outgoing_unchecked(node_id)
+
+    def _topological_order_unchecked(self) -> tuple[str, ...]:
+        indegree = {node_id: 0 for node_id in self.nodes}
+        adjacency: dict[str, list[str]] = {node_id: [] for node_id in self.nodes}
+        for edge in self.edges:
+            indegree[edge.target] += 1
+            adjacency[edge.source].append(edge.target)
+        ready = sorted(node_id for node_id, degree in indegree.items() if degree == 0)
+        order: list[str] = []
+        while ready:
+            node_id = ready.pop(0)
+            order.append(node_id)
+            for target in adjacency[node_id]:
+                indegree[target] -= 1
+                if indegree[target] == 0:
+                    ready.append(target)
+                    ready.sort()
+        if len(order) != len(self.nodes):
+            raise ValueError("RuntimeGraph must be acyclic")
+        return tuple(order)
+
+    def topological_order(self) -> tuple[str, ...]:
+        self._validate_structure()
+        return self._topological_order_unchecked()
+
+    def validate(self) -> None:
+        self._validate_structure()
+        self._topological_order_unchecked()
 
         for node_id, node in self.nodes.items():
-            incoming = self.incoming(node_id)
-            outgoing = self.outgoing(node_id)
+            incoming = self._incoming_unchecked(node_id)
+            outgoing = self._outgoing_unchecked(node_id)
             if node.kind is NodeKind.SOURCE and incoming:
                 raise ValueError(f"Source node {node_id} cannot have incoming edges")
             if node.kind is NodeKind.FUSION and len(incoming) < 2:

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -151,11 +151,15 @@ class RuntimeGraph:
     edges: list[RuntimeEdge] = field(default_factory=list)
 
     def add_node(self, node: RuntimeNode) -> None:
+        if not isinstance(node, RuntimeNode):
+            raise TypeError("node must be a RuntimeNode")
         if node.node_id in self.nodes:
             raise ValueError(f"Duplicate node_id: {node.node_id}")
         self.nodes[node.node_id] = node
 
     def connect(self, edge: RuntimeEdge) -> None:
+        if not isinstance(edge, RuntimeEdge):
+            raise TypeError("edge must be a RuntimeEdge")
         if edge.source not in self.nodes or edge.target not in self.nodes:
             raise ValueError("Both edge endpoints must be registered nodes")
         if any(
@@ -192,9 +196,28 @@ class RuntimeGraph:
         return tuple(order)
 
     def validate(self) -> None:
+        for node_id, node in self.nodes.items():
+            if not isinstance(node_id, str):
+                raise TypeError("RuntimeGraph node keys must be strings")
+            if not isinstance(node, RuntimeNode):
+                raise TypeError(f"RuntimeGraph node {node_id!r} must be a RuntimeNode")
+            if node_id != node.node_id:
+                raise ValueError(
+                    f"RuntimeGraph node key {node_id!r} does not match "
+                    f"node_id {node.node_id!r}"
+                )
+
+        seen_edges: set[tuple[str, str]] = set()
         for edge in self.edges:
+            if not isinstance(edge, RuntimeEdge):
+                raise TypeError("RuntimeGraph edges must be RuntimeEdge instances")
+            edge_key = (edge.source, edge.target)
+            if edge_key in seen_edges:
+                raise ValueError(f"Duplicate edge: {edge.source} -> {edge.target}")
+            seen_edges.add(edge_key)
             if edge.source not in self.nodes or edge.target not in self.nodes:
                 raise ValueError(f"Invalid edge: {edge.source} -> {edge.target}")
+
         self.topological_order()
 
         for node_id, node in self.nodes.items():

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -104,10 +104,13 @@ class RuntimeNode:
                 )
         elif self.process_transport == "shared_memory":
             for field_name, value in capacities:
-                if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                try:
+                    resolved = positive_integral(value, field_name=field_name)
+                except (TypeError, ValueError) as exc:
                     raise ValueError(
                         f"shared_memory transport requires positive {field_name}"
-                    )
+                    ) from exc
+                object.__setattr__(self, field_name, resolved)
         elif any_capacity:
             raise ValueError(
                 "process mailbox capacities are only valid for "

--- a/packages/neuros-core/src/neuros/runtime/graph.py
+++ b/packages/neuros-core/src/neuros/runtime/graph.py
@@ -7,7 +7,7 @@ from enum import Enum
 from types import MappingProxyType
 from typing import Any, Mapping
 
-from ._validation import positive_finite_real
+from ._validation import nonblank_string, positive_finite_real, positive_integral
 from .queues import OverflowPolicy
 
 
@@ -21,6 +21,7 @@ class NodeKind(str, Enum):
 
 
 _PROCESS_TRANSPORTS = frozenset({"pickle", "shared_memory"})
+_EXECUTORS = frozenset({"inline", "thread", "process", "gpu"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,8 +38,18 @@ class RuntimeNode:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.node_id:
-            raise ValueError("node_id must be non-empty")
+        object.__setattr__(
+            self, "node_id", nonblank_string(self.node_id, field_name="node_id")
+        )
+
+        if not isinstance(self.kind, (NodeKind, str)):
+            raise TypeError("kind must be a NodeKind or node-kind string")
+        try:
+            kind = NodeKind(self.kind)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported node kind: {self.kind}") from exc
+        object.__setattr__(self, "kind", kind)
+
         if self.latency_budget_ms is not None:
             object.__setattr__(
                 self,
@@ -55,7 +66,10 @@ class RuntimeNode:
                     self.execution_timeout_s, field_name="execution_timeout_s"
                 ),
             )
-        if self.executor not in {"inline", "thread", "process", "gpu"}:
+
+        if not isinstance(self.executor, str):
+            raise TypeError("executor must be a string")
+        if self.executor not in _EXECUTORS:
             raise ValueError(f"Unsupported executor: {self.executor}")
         if self.kind is NodeKind.SOURCE and self.executor != "inline":
             raise ValueError(
@@ -72,6 +86,8 @@ class RuntimeNode:
                 "latency_budget_ms is an SLO and is not termination authority"
             )
 
+        if not isinstance(self.process_transport, str):
+            raise TypeError("process_transport must be a string")
         if self.process_transport not in _PROCESS_TRANSPORTS:
             raise ValueError(
                 f"Unsupported process_transport: {self.process_transport}"
@@ -109,9 +125,20 @@ class RuntimeEdge:
     overflow: str = "drop_oldest"
 
     def __post_init__(self) -> None:
-        if self.capacity <= 0:
-            raise ValueError("capacity must be positive")
-        OverflowPolicy(self.overflow)
+        object.__setattr__(
+            self, "source", nonblank_string(self.source, field_name="source")
+        )
+        object.__setattr__(
+            self, "target", nonblank_string(self.target, field_name="target")
+        )
+        object.__setattr__(
+            self, "capacity", positive_integral(self.capacity, field_name="capacity")
+        )
+        try:
+            overflow = OverflowPolicy(self.overflow)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Unsupported overflow policy: {self.overflow}") from exc
+        object.__setattr__(self, "overflow", overflow.value)
         if self.source == self.target:
             raise ValueError("self edges are not allowed")
 

--- a/tests/test_runtime_graph_authority.py
+++ b/tests/test_runtime_graph_authority.py
@@ -275,3 +275,64 @@ def test_graph_mutation_rejects_replaced_container_types():
     graph.edges = ()
     with pytest.raises(TypeError, match="edges must be a list"):
         graph.connect(RuntimeEdge("a", "b"))
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("process_request_capacity_bytes", np.int32(4096)),
+        ("process_request_capacity_bytes", np.int64(8192)),
+        ("process_response_capacity_bytes", np.int32(4096)),
+        ("process_response_capacity_bytes", np.int64(8192)),
+    ],
+)
+def test_shared_memory_capacities_normalize_integral_scalars(field_name, value):
+    kwargs = {
+        "process_request_capacity_bytes": 16 * 1024,
+        "process_response_capacity_bytes": 16 * 1024,
+    }
+    kwargs[field_name] = value
+    node = RuntimeNode(
+        "transform",
+        NodeKind.TRANSFORM,
+        IdentityTransform(),
+        executor="process",
+        execution_timeout_s=1.0,
+        process_transport="shared_memory",
+        **kwargs,
+    )
+
+    resolved = getattr(node, field_name)
+    assert type(resolved) is int
+    assert resolved == int(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 4096.0, "4096", 0, -1, None],
+)
+@pytest.mark.parametrize(
+    "field_name",
+    ["process_request_capacity_bytes", "process_response_capacity_bytes"],
+)
+def test_shared_memory_capacities_reject_ambiguous_or_nonpositive_values(
+    field_name, value
+):
+    kwargs = {
+        "process_request_capacity_bytes": 16 * 1024,
+        "process_response_capacity_bytes": 16 * 1024,
+    }
+    kwargs[field_name] = value
+    with pytest.raises(
+        ValueError,
+        match=rf"shared_memory transport requires positive {field_name}",
+    ):
+        RuntimeNode(
+            "transform",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            executor="process",
+            execution_timeout_s=1.0,
+            process_transport="shared_memory",
+            **kwargs,
+        )

--- a/tests/test_runtime_graph_authority.py
+++ b/tests/test_runtime_graph_authority.py
@@ -208,3 +208,70 @@ def test_graph_validate_rejects_duplicate_edges_even_when_public_list_is_mutated
     graph.edges.extend([edge, edge])
     with pytest.raises(ValueError, match="Duplicate edge: source -> sink"):
         graph.validate()
+
+
+@pytest.mark.parametrize(
+    ("nodes", "edges", "message"),
+    [
+        ([], [], "nodes must be a dict"),
+        ({}, (), "edges must be a list"),
+        (None, [], "nodes must be a dict"),
+        ({}, None, "edges must be a list"),
+    ],
+)
+def test_graph_constructor_rejects_wrong_container_types(nodes, edges, message):
+    with pytest.raises(TypeError, match=message):
+        RuntimeGraph(nodes=nodes, edges=edges)
+
+
+def test_graph_constructor_detaches_caller_owned_containers():
+    source = RuntimeNode("source", NodeKind.SOURCE, Source())
+    nodes = {"source": source}
+    edges: list[RuntimeEdge] = []
+    graph = RuntimeGraph(nodes=nodes, edges=edges)
+
+    nodes["other"] = RuntimeNode("other", NodeKind.SOURCE, Source())
+    edges.append(RuntimeEdge("source", "other"))
+
+    assert tuple(graph.nodes) == ("source",)
+    assert graph.edges == []
+
+
+def test_graph_constructor_rejects_invalid_initial_edge_endpoints():
+    source = RuntimeNode("source", NodeKind.SOURCE, Source())
+    with pytest.raises(ValueError, match="Invalid edge: source -> missing"):
+        RuntimeGraph(
+            nodes={"source": source},
+            edges=[RuntimeEdge("source", "missing")],
+        )
+
+
+def test_topological_order_rejects_corrupted_public_edge_list_before_traversal():
+    graph = RuntimeGraph()
+    graph.nodes["source"] = RuntimeNode("source", NodeKind.SOURCE, Source())
+    graph.edges.append(object())
+
+    with pytest.raises(TypeError, match="edges must be RuntimeEdge instances"):
+        graph.topological_order()
+
+
+@pytest.mark.parametrize("method_name", ["incoming", "outgoing"])
+def test_edge_queries_reject_corrupted_graph_structure(method_name):
+    graph = RuntimeGraph()
+    graph.nodes["source"] = RuntimeNode("source", NodeKind.SOURCE, Source())
+    graph.edges.append(object())
+
+    with pytest.raises(TypeError, match="edges must be RuntimeEdge instances"):
+        getattr(graph, method_name)("source")
+
+
+def test_graph_mutation_rejects_replaced_container_types():
+    graph = RuntimeGraph()
+    graph.nodes = []
+    with pytest.raises(TypeError, match="nodes must be a dict"):
+        graph.add_node(RuntimeNode("source", NodeKind.SOURCE, Source()))
+
+    graph = RuntimeGraph()
+    graph.edges = ()
+    with pytest.raises(TypeError, match="edges must be a list"):
+        graph.connect(RuntimeEdge("a", "b"))

--- a/tests/test_runtime_graph_authority.py
+++ b/tests/test_runtime_graph_authority.py
@@ -143,7 +143,14 @@ def test_graph_with_plain_string_node_kinds_validates_with_canonical_topology():
     graph.add_node(RuntimeNode("source", "source", Source()))
     graph.add_node(RuntimeNode("transform", "transform", IdentityTransform()))
     graph.add_node(RuntimeNode("sink", "sink", object()))
-    graph.connect(RuntimeEdge("source", "transform", capacity=np.int64(2), overflow=OverflowPolicy.BLOCK))
+    graph.connect(
+        RuntimeEdge(
+            "source",
+            "transform",
+            capacity=np.int64(2),
+            overflow=OverflowPolicy.BLOCK,
+        )
+    )
     graph.connect(RuntimeEdge("transform", "sink", capacity=2, overflow="block"))
 
     graph.validate()
@@ -161,3 +168,43 @@ def test_unknown_edge_endpoint_still_fails_before_runtime_execution():
     edge = RuntimeEdge("a", "missing")
     with pytest.raises(ValueError, match="Both edge endpoints must be registered nodes"):
         graph.connect(edge)
+
+
+def test_graph_mutation_methods_require_typed_node_and_edge_objects():
+    graph = RuntimeGraph()
+    with pytest.raises(TypeError, match="node must be a RuntimeNode"):
+        graph.add_node(object())
+
+    with pytest.raises(TypeError, match="edge must be a RuntimeEdge"):
+        graph.connect(object())
+
+
+def test_graph_validate_rejects_externally_corrupted_node_value():
+    graph = RuntimeGraph()
+    graph.nodes["corrupt"] = object()
+    with pytest.raises(TypeError, match="must be a RuntimeNode"):
+        graph.validate()
+
+
+def test_graph_validate_rejects_node_key_identity_drift():
+    graph = RuntimeGraph()
+    graph.nodes["alias"] = RuntimeNode("actual", NodeKind.SOURCE, Source())
+    with pytest.raises(ValueError, match="does not match node_id"):
+        graph.validate()
+
+
+def test_graph_validate_rejects_externally_corrupted_edge_value():
+    graph = RuntimeGraph()
+    graph.edges.append(object())
+    with pytest.raises(TypeError, match="edges must be RuntimeEdge instances"):
+        graph.validate()
+
+
+def test_graph_validate_rejects_duplicate_edges_even_when_public_list_is_mutated():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, Source()))
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, object()))
+    edge = RuntimeEdge("source", "sink")
+    graph.edges.extend([edge, edge])
+    with pytest.raises(ValueError, match="Duplicate edge: source -> sink"):
+        graph.validate()

--- a/tests/test_runtime_graph_authority.py
+++ b/tests/test_runtime_graph_authority.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuros.runtime import NodeKind, OverflowPolicy, RuntimeEdge, RuntimeGraph, RuntimeNode
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class Source:
+    async def start(self):
+        return None
+
+    async def stop(self):
+        return None
+
+    async def frames(self):
+        if False:
+            yield None
+
+
+def test_runtime_node_canonicalizes_valid_plain_string_kind():
+    node = RuntimeNode("transform", "transform", IdentityTransform())
+    assert node.kind is NodeKind.TRANSFORM
+
+
+def test_runtime_node_string_source_kind_cannot_bypass_source_execution_authority():
+    with pytest.raises(ValueError, match="Source nodes currently require executor='inline'"):
+        RuntimeNode("source", "source", Source(), executor="thread")
+
+
+@pytest.mark.parametrize("kind", ["unknown", "", 1, True, object()])
+def test_runtime_node_rejects_unknown_or_nonauthoritative_kinds(kind):
+    expected = TypeError if not isinstance(kind, str) else ValueError
+    with pytest.raises(expected):
+        RuntimeNode("node", kind, IdentityTransform())
+
+
+@pytest.mark.parametrize("node_id", [None, 7, True, object()])
+def test_runtime_node_rejects_nonstring_identifiers(node_id):
+    with pytest.raises(TypeError, match="node_id must be a string"):
+        RuntimeNode(node_id, NodeKind.TRANSFORM, IdentityTransform())
+
+
+@pytest.mark.parametrize("node_id", ["", " ", "\t\n"])
+def test_runtime_node_rejects_blank_identifiers(node_id):
+    with pytest.raises(ValueError, match="node_id must be nonblank"):
+        RuntimeNode(node_id, NodeKind.TRANSFORM, IdentityTransform())
+
+
+def test_runtime_node_preserves_nonblank_identifier_bytes_without_silent_stripping():
+    node = RuntimeNode(" transform ", NodeKind.TRANSFORM, IdentityTransform())
+    assert node.node_id == " transform "
+
+
+@pytest.mark.parametrize("executor", [None, True, 1, ["inline"]])
+def test_runtime_node_executor_requires_explicit_string(executor):
+    with pytest.raises(TypeError, match="executor must be a string"):
+        RuntimeNode("node", NodeKind.TRANSFORM, IdentityTransform(), executor=executor)
+
+
+@pytest.mark.parametrize("process_transport", [None, True, 1, ["pickle"]])
+def test_runtime_node_process_transport_requires_explicit_string(process_transport):
+    with pytest.raises(TypeError, match="process_transport must be a string"):
+        RuntimeNode(
+            "node",
+            NodeKind.TRANSFORM,
+            IdentityTransform(),
+            process_transport=process_transport,
+        )
+
+
+@pytest.mark.parametrize("field_name", ["source", "target"])
+@pytest.mark.parametrize("value", [None, 7, True, object()])
+def test_runtime_edge_rejects_nonstring_endpoints(field_name, value):
+    kwargs = {"source": "a", "target": "b"}
+    kwargs[field_name] = value
+    with pytest.raises(TypeError, match=rf"{field_name} must be a string"):
+        RuntimeEdge(**kwargs)
+
+
+@pytest.mark.parametrize("field_name", ["source", "target"])
+@pytest.mark.parametrize("value", ["", " ", "\t\n"])
+def test_runtime_edge_rejects_blank_endpoints(field_name, value):
+    kwargs = {"source": "a", "target": "b"}
+    kwargs[field_name] = value
+    with pytest.raises(ValueError, match=rf"{field_name} must be nonblank"):
+        RuntimeEdge(**kwargs)
+
+
+@pytest.mark.parametrize("capacity", [True, False, 1.0, 8.0, "8", None, object()])
+def test_runtime_edge_rejects_nonintegral_or_bool_capacity(capacity):
+    with pytest.raises(TypeError, match="capacity must be an integer"):
+        RuntimeEdge("a", "b", capacity=capacity)
+
+
+@pytest.mark.parametrize("capacity", [0, -1, -10, np.int64(0), np.int64(-4)])
+def test_runtime_edge_rejects_nonpositive_integral_capacity(capacity):
+    with pytest.raises(ValueError, match="capacity must be positive"):
+        RuntimeEdge("a", "b", capacity=capacity)
+
+
+@pytest.mark.parametrize("capacity", [1, 8, np.int32(3), np.int64(64)])
+def test_runtime_edge_normalizes_valid_integral_capacity_to_python_int(capacity):
+    edge = RuntimeEdge("a", "b", capacity=capacity)
+    assert type(edge.capacity) is int
+    assert edge.capacity == int(capacity)
+
+
+@pytest.mark.parametrize(
+    ("overflow", "expected"),
+    [
+        ("block", "block"),
+        (OverflowPolicy.BLOCK, "block"),
+        ("drop_oldest", "drop_oldest"),
+        (OverflowPolicy.DROP_NEWEST, "drop_newest"),
+        (OverflowPolicy.FAIL, "fail"),
+    ],
+)
+def test_runtime_edge_canonicalizes_valid_overflow_declarations(overflow, expected):
+    edge = RuntimeEdge("a", "b", overflow=overflow)
+    assert type(edge.overflow) is str
+    assert edge.overflow == expected
+
+
+@pytest.mark.parametrize("overflow", ["unknown", "", None, True, 1])
+def test_runtime_edge_rejects_invalid_overflow_declarations(overflow):
+    with pytest.raises(ValueError, match="Unsupported overflow policy"):
+        RuntimeEdge("a", "b", overflow=overflow)
+
+
+def test_runtime_edge_still_rejects_self_edges_after_endpoint_normalization():
+    with pytest.raises(ValueError, match="self edges are not allowed"):
+        RuntimeEdge("same", "same")
+
+
+def test_graph_with_plain_string_node_kinds_validates_with_canonical_topology():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", "source", Source()))
+    graph.add_node(RuntimeNode("transform", "transform", IdentityTransform()))
+    graph.add_node(RuntimeNode("sink", "sink", object()))
+    graph.connect(RuntimeEdge("source", "transform", capacity=np.int64(2), overflow=OverflowPolicy.BLOCK))
+    graph.connect(RuntimeEdge("transform", "sink", capacity=2, overflow="block"))
+
+    graph.validate()
+
+    assert graph.nodes["source"].kind is NodeKind.SOURCE
+    assert graph.nodes["transform"].kind is NodeKind.TRANSFORM
+    assert graph.nodes["sink"].kind is NodeKind.SINK
+    assert graph.edges[0].capacity == 2
+    assert graph.edges[0].overflow == "block"
+
+
+def test_unknown_edge_endpoint_still_fails_before_runtime_execution():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("a", NodeKind.TRANSFORM, IdentityTransform()))
+    edge = RuntimeEdge("a", "missing")
+    with pytest.raises(ValueError, match="Both edge endpoints must be registered nodes"):
+        graph.connect(edge)


### PR DESCRIPTION
## Status

**Exact-head qualified and ready for review. Do not merge without an explicit merge decision.**

This tranche is stacked directly on exact-qualified DecoderOutput authority #135 (`be3f4e9f45794fdbfae2fe1727f0959b8ec46540`).

Final exact head: `988255d7429d7c3136d0e244def4e2871894d16f`.
Fully semantic-qualified checkpoint before the final documentation-only tranche: `40ed5396cf499c99918cec9c33a2c6364d6102fe`.

## Promoted RuntimeGraph authority

This PR hardens the programmatic runtime graph boundary so malformed Python values and externally corrupted public graph containers fail before runtime execution authority exists.

### RuntimeNode

- `node_id` must be an explicit nonblank string; valid identifiers are not silently stripped or rewritten.
- valid plain node-kind strings canonicalize immediately to `NodeKind`.
- unknown/non-string kinds fail at construction.
- `kind="source"` cannot bypass the current inline-only source lifecycle boundary.
- `executor` and `process_transport` require explicit strings before value validation.
- process execution still requires an explicit finite positive hard timeout.
- process-only transport declarations fail on non-process nodes.
- shared-memory request/response capacities use the same exact positive-integral rule as runtime edge capacity while preserving the existing transport-specific `ValueError` surface.

### RuntimeEdge

- source/target endpoints must be explicit nonblank strings.
- capacity must be a genuine positive integral scalar; booleans, floats, text and non-positive values fail closed.
- legitimate scientific-Python integral scalars such as NumPy integers canonicalize to ordinary Python `int`.
- valid overflow enums/strings canonicalize to one stored string value.
- self edges remain rejected at edge construction.

### RuntimeGraph

- constructor requires `nodes` dict + `edges` list and detaches those containers from caller-owned aliases.
- public `nodes` / `edges` remain intentionally mutable for compatibility; this PR does **not** pretend the graph is deeply immutable.
- one structural-integrity path now protects construction, mutation, topology queries and full validation.
- structural integrity verifies container types, typed contents, node-key ↔ `node_id` identity, duplicate edges and registered endpoints.
- `add_node`, `connect`, `incoming`, `outgoing`, `topological_order`, and `validate` re-establish structural trust before consuming potentially externally mutated public containers.
- full `validate()` additionally proves acyclicity and neurOS node-cardinality/topology semantics.

`RuntimeExecutor.__init__` calls `graph.validate()` before it creates channels, task state or process-worker authority, so malformed graph state fails before execution begins.

## Critique-driven hardening after the first green checkpoint

The first semantic checkpoint `6feb0d017ad0000cf77826e67a46c9ed7acce7ec` had already passed every workflow with a 280/280 verified Runtime Fault lane. We deliberately did **not** stop at green.

A red-team review found three additional authority seams:

1. `topological_order()` / edge queries could have a weaker structural precondition than `validate()` after direct public-container mutation;
2. the RuntimeGraph dataclass constructor could retain caller-owned mutable containers / accept structurally invalid initial state;
3. edge capacity and shared-memory mailbox capacity had two subtly different definitions of integer authority.

The final semantic checkpoint `40ed539...` closes all three and was requalified from scratch.

## Adversarial qualification

`tests/test_runtime_graph_authority.py` now covers, among other cases:

- bool/float/text/null/object edge capacities;
- valid Python and NumPy integral normalization;
- malformed node IDs and edge endpoints;
- plain-string node-kind canonicalization;
- source-kind policy bypass attempts;
- executor/process-transport type authority;
- overflow canonicalization;
- wrong objects passed to graph mutation methods;
- corrupted node/edge entries injected through public containers;
- node-key identity drift;
- duplicate edges injected directly into the public list;
- wrong constructor/public container types;
- constructor alias detachment;
- invalid initial endpoints;
- topology/incoming/outgoing operations failing closed on corrupted structure;
- shared-memory NumPy integer capacities normalizing to Python `int`;
- ambiguous/non-positive shared-memory capacities retaining the qualified transport-specific failure contract.

A verified Ubuntu 24.04 / Python 3.10 Runtime Fault lane on semantic head `40ed539...` ran **308 tests and passed 308/308**.

Qualified adversarial progression:

- Phase C transport: 195 tests;
- #135 DecoderOutput: 209 tests;
- initial #137 checkpoint: 280 tests;
- final critique-hardened #137 checkpoint: **308 tests**.

## Exact-head evidence

The final semantic checkpoint `40ed539...` passed every associated workflow, including:

- Runtime Fault Qualification: **9/9** Ubuntu 24.04 / macOS 14 / Windows 2025 × Python 3.10 / 3.11 / 3.12;
- Whole Package Qualification with maintained clean-room installed-wheel lanes;
- neurOS CI;
- Neural Window Contracts;
- Braindecode Compatibility;
- Ecosystem Compatibility;
- External Plugin Contract;
- neurOS driver contracts;
- Public Trust Contracts;
- Developer Preview Journey;
- Reproducible Release Build;
- Release Candidate Artifacts.

The final exact head `988255d...` then passed **every associated workflow again** after the documentation-only tranche.

The only changes from semantic checkpoint `40ed539...` to final head `988255d...` are:

1. `docs/RUNTIME_GRAPH_CONTRACT.md` — 202 documentation lines;
2. two Runtime Fault Qualification path entries binding that public contract to the exact-head gate.

No production source or test byte changed after the semantic checkpoint.

## Public contract

`docs/RUNTIME_GRAPH_CONTRACT.md` now documents:

- explicit identity/kind authority;
- integral capacity semantics;
- constructor container detachment;
- intentional public graph mutability;
- structural integrity vs semantic DAG validity;
- executor validation handoff;
- why `gpu` is currently scheduling intent rather than a distinct process/thread isolation guarantee;
- the separate configuration compiler boundary;
- scientific and operational claim boundaries.

## Deliberate boundaries / follow-ups

- no YAML/configuration execution authority in this PR; #131 owns that boundary;
- no graph metadata recursive deep-freeze change;
- no source lifecycle isolation;
- no GPU isolation claim;
- no process lifecycle/wire-format change;
- no DecoderOutput/scientific model contract change;
- #138 now tracks the discovered runtime-monitor correctness gap: monitor graph nodes are currently observational/declarative but are skipped by RuntimeExecutor task scheduling, so #131 must not advertise non-default monitor execution until a real observation protocol exists;
- #136 remains DecoderOutput scalar authority;
- #133 remains historical process-cleanup degradation telemetry.

## Review conclusion

This tranche now has a clean authority boundary: **typed/canonical node + edge declarations, structurally trustworthy mutable graph state, semantic DAG validation, and fail-early executor handoff**.

It is exact-head qualified and ready for human review on `988255d7429d7c3136d0e244def4e2871894d16f`. It remains unmerged until an explicit merge decision is made.

Refs #134, #135, #131, #138.