### PR TITLE
Configuration authority v2: compile explicit execution policy

### DIFF
--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -7,10 +7,14 @@ on:
       - "docs/DECODER_OUTPUT_CONTRACT.md"
       - "docs/RUNTIME_GRAPH_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
+      - "packages/neuros-core/src/neuros/config/**"
       - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
+      - "tests/test_config_execution_authority.py"
+      - "tests/test_config_resolution.py"
+      - "tests/test_config_schema.py"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
       - "tests/test_runtime_graph_authority.py"
@@ -33,10 +37,14 @@ on:
       - "docs/DECODER_OUTPUT_CONTRACT.md"
       - "docs/RUNTIME_GRAPH_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
+      - "packages/neuros-core/src/neuros/config/**"
       - "packages/neuros-core/src/neuros/contracts/models.py"
       - "packages/neuros-core/src/neuros/contracts/window.py"
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
+      - "tests/test_config_execution_authority.py"
+      - "tests/test_config_resolution.py"
+      - "tests/test_config_schema.py"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
       - "tests/test_runtime_graph_authority.py"
@@ -108,11 +116,14 @@ jobs:
           python -m pip install -e "packages/neuros-core[test]"
           python -m pip check
 
-      - name: Exercise runtime and queue fault contracts
+      - name: Exercise configuration, runtime, and queue fault contracts
         shell: bash
         run: |
           set -euo pipefail
           python -m pytest -q \
+            tests/test_config_execution_authority.py \
+            tests/test_config_resolution.py \
+            tests/test_config_schema.py \
             tests/test_decoder_output_immutability.py \
             tests/test_runtime_executor.py \
             tests/test_runtime_graph_authority.py \

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -16,6 +16,7 @@ on:
       - "tests/test_config_schema.py"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
+      - "tests/test_runtime_execution_evidence.py"
       - "tests/test_runtime_graph_authority.py"
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
@@ -45,6 +46,7 @@ on:
       - "tests/test_config_schema.py"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
+      - "tests/test_runtime_execution_evidence.py"
       - "tests/test_runtime_graph_authority.py"
       - "tests/test_runtime_queues.py"
       - "tests/test_runtime_fault_qualification.py"
@@ -123,6 +125,7 @@ jobs:
             tests/test_config_schema.py \
             tests/test_decoder_output_immutability.py \
             tests/test_runtime_executor.py \
+            tests/test_runtime_execution_evidence.py \
             tests/test_runtime_graph_authority.py \
             tests/test_runtime_queues.py \
             tests/test_runtime_fault_qualification.py \

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -13,7 +13,6 @@ on:
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_config_execution_authority.py"
-      - "tests/test_config_resolution.py"
       - "tests/test_config_schema.py"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
@@ -43,7 +42,6 @@ on:
       - "packages/neuros-core/src/neuros/runtime/**"
       - "packages/neuros-core/pyproject.toml"
       - "tests/test_config_execution_authority.py"
-      - "tests/test_config_resolution.py"
       - "tests/test_config_schema.py"
       - "tests/test_decoder_output_immutability.py"
       - "tests/test_runtime_executor.py"
@@ -122,7 +120,6 @@ jobs:
           set -euo pipefail
           python -m pytest -q \
             tests/test_config_execution_authority.py \
-            tests/test_config_resolution.py \
             tests/test_config_schema.py \
             tests/test_decoder_output_immutability.py \
             tests/test_runtime_executor.py \

--- a/.github/workflows/runtime-fault-qualification.yml
+++ b/.github/workflows/runtime-fault-qualification.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "docs/CONFIG_EXECUTION_AUTHORITY.md"
       - "docs/DECODER_OUTPUT_CONTRACT.md"
       - "docs/RUNTIME_GRAPH_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"
@@ -34,6 +35,7 @@ on:
       - main
     paths:
       - ".github/workflows/runtime-fault-qualification.yml"
+      - "docs/CONFIG_EXECUTION_AUTHORITY.md"
       - "docs/DECODER_OUTPUT_CONTRACT.md"
       - "docs/RUNTIME_GRAPH_CONTRACT.md"
       - "docs/RUNTIME_PROCESS_TRANSPORT.md"

--- a/docs/CONFIG_EXECUTION_AUTHORITY.md
+++ b/docs/CONFIG_EXECUTION_AUTHORITY.md
@@ -1,0 +1,344 @@
+# Configuration Execution Authority
+
+This document defines the promoted configuration contract for declaring runtime execution policy in neurOS.
+
+The contract is intentionally narrow. It describes how a serialized pipeline configuration becomes a validated `RuntimeGraph`, which execution declarations the runtime can currently honor, and how the accepted policy is represented in runtime evidence. It does not turn configuration into a security sandbox, a hardware qualification, or a scientific-validity claim.
+
+## Authority boundary
+
+The authoritative path is:
+
+```text
+YAML / mapping
+    -> PipelineConfig
+    -> PluginConfig + ExecutionConfig
+    -> resolve_config(...)
+    -> RuntimeNode
+    -> RuntimeExecutor
+    -> snapshot()["execution"]
+```
+
+Each stage must preserve or reject execution policy explicitly. neurOS does not silently reinterpret an unsupported execution declaration as a weaker execution mode.
+
+`RuntimeNode` remains the final programmatic authority for node execution semantics. Configuration deliberately reuses that authority instead of maintaining a second normalization system.
+
+## Schema versions
+
+### Schema version 1
+
+Schema v1 is the legacy compatibility contract.
+
+Valid v1 configurations continue to resolve with the historical inline execution defaults. A v1 plugin configuration may not contain an `execution:` declaration, even if that declaration only requests `inline`.
+
+This prohibition is deliberate. Older neurOS readers may ignore unknown plugin keys. If execution authority were added to schema v1, an older reader could silently discard a newer isolation declaration and execute the operator inline. A schema-version boundary prevents that downgrade from looking valid.
+
+### Schema version 2
+
+Schema v2 is the first serialized configuration version that can declare per-plugin execution policy.
+
+For v2, unknown keys fail closed at the following authority-bearing layers:
+
+- configuration root;
+- stream declaration;
+- plugin declaration;
+- runtime declaration;
+- execution declaration.
+
+Schema v2 also rejects ambiguous coercions for authority-bearing values. For example, text is not converted to an integer queue capacity and a numeric stream ID is not converted to a string identity.
+
+## Execution declaration
+
+A v2 plugin may contain:
+
+```yaml
+execution:
+  executor: process
+  execution_timeout_s: 2.0
+  process_transport: shared_memory
+  process_request_capacity_bytes: 4194304
+  process_response_capacity_bytes: 4194304
+```
+
+The complete promoted `ExecutionConfig` surface is:
+
+- `executor`;
+- `execution_timeout_s`;
+- `process_transport`;
+- `process_request_capacity_bytes`;
+- `process_response_capacity_bytes`.
+
+These field names intentionally match `RuntimeNode` rather than introducing configuration-only aliases.
+
+## Executor classes
+
+### `inline`
+
+The callback executes in the runtime event-loop domain.
+
+This is the default execution class.
+
+### `thread`
+
+The callback executes in a worker thread through the runtime's thread-dispatch authority.
+
+Synchronous and asynchronous callbacks are both supported by the qualified runtime path. Async callbacks execute inside the worker thread rather than being bounced back to the main runtime event loop.
+
+### `process`
+
+The callback executes through a persistent direct child process owned by the `RuntimeExecutor` for that node.
+
+Process execution requires an explicit finite positive `execution_timeout_s`.
+
+The timeout is hard execution-containment authority. It is distinct from latency telemetry or a latency service-level objective. Expiry causes the process execution path to fail closed and invoke the worker termination authority rather than merely recording that the callback was slow.
+
+neurOS does not automatically retry scientific operator calls after a process failure.
+
+### `gpu`
+
+`gpu` currently preserves scheduling intent but does **not** create a distinct GPU isolation domain.
+
+The callback is invoked in the event-loop execution domain and the operator or framework owns its device/context behavior.
+
+Runtime evidence therefore reports both facts:
+
+```text
+requested_executor: gpu
+execution_domain: event_loop
+```
+
+A `gpu` declaration must not be cited as proof of process isolation, thread isolation, device placement, CUDA-stream isolation, or GPU fault containment.
+
+## Process transports
+
+### `pickle`
+
+`pickle` is the default process transport.
+
+Process requests and results cross the direct parent/child boundary using the maintained process-worker protocol.
+
+### `shared_memory`
+
+`shared_memory` uses explicitly bounded shared-memory mailboxes for process request and response payloads.
+
+A shared-memory process declaration requires both:
+
+- `process_request_capacity_bytes`;
+- `process_response_capacity_bytes`.
+
+Both capacities must be genuine positive integral scalars. Boolean, floating-point, textual, zero, and negative values fail closed. Valid scientific-Python integral scalars are normalized to ordinary Python `int` values.
+
+Mailbox capacity is protocol authority, not an adaptive allocation hint. Oversized payloads fail rather than silently expanding the declared mailbox.
+
+## Plugin-role semantics
+
+### Sources
+
+Configured sources are currently inline-only.
+
+Source lifecycle owns `start()`, async frame iteration, and `stop()`. neurOS does not yet provide a separate source lifecycle isolation domain, so schema v2 rejects non-default execution policy for source plugins.
+
+This is an explicit limitation rather than an implicit fallback.
+
+### Transforms
+
+Transforms can use the runtime execution classes supported by `RuntimeNode`, including thread and process execution.
+
+### Decoders
+
+Decoders can use the same runtime execution authority. Process-backed decoder inference therefore uses the qualified persistent per-node worker path and explicit hard timeout semantics.
+
+### Sinks
+
+Sink `write(...)` callbacks are dispatched through the declared execution authority.
+
+### Monitors
+
+Monitors are executable observational callbacks, not independent graph data-plane tasks.
+
+When the runtime emits an item, the executor routes the observation through its monitor notification path and invokes `monitor.update(payload)` using the monitor node's declared execution authority.
+
+A monitor may therefore validly request inline, thread, process, or GPU-intent execution subject to the same runtime execution rules.
+
+Runtime evidence reports monitor scheduling as:
+
+```text
+scheduling_mode: observation_callback
+```
+
+A monitor owns no data edges and does not acquire data-plane routing authority merely because its callback executes in another domain.
+
+## Runtime-owned fusion
+
+Configuration-created implicit fusion nodes are runtime-owned and use the runtime default policy.
+
+For direct programmatic `RuntimeGraph` construction, a fusion node can currently carry an execution label even when it has no custom `fuse()` operator. The built-in concatenate-latest fusion path executes on the event loop in that case.
+
+The resolved execution evidence reports the effective domain truthfully rather than converting the requested label into a false isolation claim. Broader executor protection against post-construction graph drift and unhonored direct fusion declarations is tracked separately in issue #140.
+
+## Runtime configuration
+
+`RuntimeConfig.queue_capacity` and `RuntimeConfig.overflow_policy` reuse `RuntimeEdge` canonicalization.
+
+That means configuration and direct runtime graph construction share the same bounded-queue authority instead of implementing parallel definitions of valid capacity and overflow behavior.
+
+## Strict identity and scalar handling
+
+Authority-bearing configuration values are not normalized through convenience coercions.
+
+Examples:
+
+- `schema_version` must be an integral scalar and must be a supported version;
+- booleans are not accepted as integers;
+- stream IDs must already be explicit nonblank strings;
+- plugin IDs must already be explicit nonblank strings;
+- queue and mailbox capacities must already satisfy exact positive-integral semantics;
+- process timeout must satisfy the runtime's finite-positive-real contract.
+
+This is intended to make a configuration's meaning inspectable before execution rather than dependent on Python coercion behavior.
+
+## Example v2 configuration
+
+```yaml
+schema_version: 2
+
+streams:
+  - id: eeg
+    source:
+      plugin: my-eeg-source
+    transforms:
+      - plugin: preprocess
+        execution:
+          executor: thread
+
+decoder:
+  plugin: my-decoder
+  execution:
+    executor: process
+    execution_timeout_s: 2.0
+    process_transport: shared_memory
+    process_request_capacity_bytes: 4194304
+    process_response_capacity_bytes: 4194304
+
+sinks:
+  - plugin: archive-sink
+    execution:
+      executor: inline
+
+monitors:
+  - plugin: quality-monitor
+    execution:
+      executor: thread
+
+runtime:
+  queue_capacity: 128
+  overflow_policy: drop_oldest
+```
+
+Plugin names in this example are illustrative. Configuration validity does not imply that a named plugin is installed or qualified for a particular device, model, operating system, dataset, or scientific use.
+
+## Resolved execution evidence
+
+`RuntimeExecutor.snapshot()` exposes an all-node `execution` section captured from the validated graph accepted by the executor constructor.
+
+Each node record contains:
+
+- `kind`;
+- `requested_executor`;
+- `execution_domain`;
+- `scheduling_mode`;
+- `execution_timeout_s`;
+- `process_transport`;
+- `process_request_capacity_bytes`;
+- `process_response_capacity_bytes`.
+
+Execution domains currently include:
+
+```text
+event_loop
+worker_thread
+persistent_process
+```
+
+Scheduling modes currently include:
+
+```text
+source_task
+unary_task
+fusion_task
+observation_callback
+```
+
+The manifest describes **accepted execution authority**, not observed activity. A node may have accepted policy even if a particular run processes zero items. Actual activity and failure information remain in node telemetry, process receipts, and runtime failure records.
+
+## Evidence capture point
+
+The all-node execution manifest is captured immediately after `RuntimeExecutor` validates the supplied graph.
+
+This avoids recomputing the manifest later from externally mutable `RuntimeGraph.nodes` or `RuntimeGraph.edges` containers.
+
+The snapshot returns a fresh dictionary representation so mutating one returned snapshot does not mutate the executor's internally captured authority record.
+
+This guarantee is narrower than full executor graph immutability. `RuntimeExecutor` still retains the public mutable graph object. Issue #140 owns the broader requirement that external post-construction graph mutation cannot make actual execution drift from the graph accepted at construction.
+
+## Process-specific compatibility surface
+
+The existing `snapshot()["process_execution"]` section remains available for backward compatibility.
+
+The new `execution` section is additive and all-node. It does not replace process semantic receipts, process cleanup telemetry, or the existing process-specific execution view.
+
+## Recording and replay
+
+The maintained recording path persists the complete runtime snapshot as runtime metrics. The replay path returns the normal executor snapshot.
+
+Recording graph decoration replaces source operators while retaining the frozen runtime node fields, so accepted execution declarations survive that decoration path.
+
+As a result, the resolved `execution` manifest participates in the existing recording/provenance surface without a second execution-policy serialization format.
+
+This does not imply that a replay uses the same hardware, operating-system scheduling, process identifiers, or wall-clock timing as the original run. The execution manifest deliberately excludes host-, PID-, and wall-clock-specific operational metadata.
+
+## Failure semantics
+
+An invalid execution declaration fails before runtime execution authority is created.
+
+A valid process declaration may still fail at execution time because of operator serialization, request/result serialization, protocol mismatch, child crash, timeout, cancellation, mailbox capacity, cleanup, or operator exceptions. Those failures remain governed by the qualified process-worker contracts.
+
+The configuration layer does not convert such failures into retries or alternate execution modes.
+
+## Claim boundaries
+
+This contract establishes configuration and runtime execution semantics. It does **not** establish:
+
+- a security sandbox for untrusted Python;
+- containment of arbitrary descendants created by user code;
+- hardware or driver qualification;
+- GPU device placement or GPU isolation;
+- real-time operating-system guarantees;
+- clinical safety;
+- model correctness;
+- scientific validity;
+- causal or biological interpretation;
+- reproducibility of numerical results across arbitrary hardware/software environments.
+
+Process containment authority applies to executor-owned direct child processes under the maintained worker contract.
+
+## Qualification
+
+The promoted configuration/runtime authority surface is bound to Runtime Fault Qualification across:
+
+- Ubuntu 24.04;
+- macOS 14;
+- Windows 2025;
+- Python 3.10;
+- Python 3.11;
+- Python 3.12.
+
+The matrix exercises configuration authority together with graph, queue, process, transport, provenance, duration, and DecoderOutput fault contracts. Broader repository qualification additionally covers installed-wheel clean rooms, compatibility, recording, BCI smoke, release artifacts, and workspace build ownership.
+
+A green workflow on one historical commit is not evidence for a later changed head. Qualification claims must name the exact source revision that produced them.
+
+## Related contracts
+
+- `docs/RUNTIME_GRAPH_CONTRACT.md` defines programmatic graph identity, topology, and structural trust.
+- `docs/RUNTIME_PROCESS_TRANSPORT.md` defines process transport and containment semantics.
+- `docs/DECODER_OUTPUT_CONTRACT.md` defines DecoderOutput value authority.
+- issue #140 tracks post-construction executor graph drift and direct fusion execution-authority reconciliation.

--- a/packages/neuros-core/src/neuros/config/__init__.py
+++ b/packages/neuros-core/src/neuros/config/__init__.py
@@ -1,9 +1,17 @@
 """Configuration contracts and compilation for neurOS."""
 
 from .build import ResolvedPipeline, ResolvedStream, resolve_config
-from .schema import PipelineConfig, PluginConfig, RuntimeConfig, StreamConfig, load_config
+from .schema import (
+    ExecutionConfig,
+    PipelineConfig,
+    PluginConfig,
+    RuntimeConfig,
+    StreamConfig,
+    load_config,
+)
 
 __all__ = [
+    "ExecutionConfig",
     "PipelineConfig",
     "PluginConfig",
     "ResolvedPipeline",

--- a/packages/neuros-core/src/neuros/config/build.py
+++ b/packages/neuros-core/src/neuros/config/build.py
@@ -49,11 +49,6 @@ def _execution_kwargs(config: PluginConfig, *, role: str) -> dict[str, Any]:
             f"source plugin '{config.plugin}' cannot declare non-inline execution; "
             "source lifecycle isolation is not implemented"
         )
-    if role == "monitor" and not execution.is_default:
-        raise ConfigurationError(
-            f"monitor plugin '{config.plugin}' cannot declare execution policy until "
-            "the runtime monitor observation contract is implemented"
-        )
     return execution.runtime_kwargs()
 
 
@@ -200,8 +195,6 @@ def resolve_config(
             )
         )
 
-    for monitor_config in config.monitors:
-        _execution_kwargs(monitor_config, role="monitor")
     monitors = tuple(
         _create(plugin_registry, PluginKind.MONITOR, item) for item in config.monitors
     )

--- a/packages/neuros-core/src/neuros/config/build.py
+++ b/packages/neuros-core/src/neuros/config/build.py
@@ -41,6 +41,22 @@ def _create(
         ) from exc
 
 
+def _execution_kwargs(config: PluginConfig, *, role: str) -> dict[str, Any]:
+    """Return runtime execution kwargs after role-specific feasibility checks."""
+    execution = config.execution
+    if role == "source" and not execution.is_default:
+        raise ConfigurationError(
+            f"source plugin '{config.plugin}' cannot declare non-inline execution; "
+            "source lifecycle isolation is not implemented"
+        )
+    if role == "monitor" and not execution.is_default:
+        raise ConfigurationError(
+            f"monitor plugin '{config.plugin}' cannot declare execution policy until "
+            "the runtime monitor observation contract is implemented"
+        )
+    return execution.runtime_kwargs()
+
+
 def resolve_config(
     config: PipelineConfig,
     *,
@@ -55,6 +71,9 @@ def resolve_config(
     not have the original device SDK installed.
     """
 
+    if not isinstance(config, PipelineConfig):
+        raise ConfigurationError("config must be a PipelineConfig")
+
     plugin_registry = registry or default_registry
     plugin_registry.discover()
     overrides = dict(source_overrides or {})
@@ -67,6 +86,7 @@ def resolve_config(
     stream_tails: list[str] = []
 
     for stream in config.streams:
+        source_execution = _execution_kwargs(stream.source, role="source")
         source = overrides.get(stream.stream_id)
         if source is None:
             source = _create(plugin_registry, PluginKind.SOURCE, stream.source)
@@ -81,6 +101,7 @@ def resolve_config(
                 kind=NodeKind.SOURCE,
                 operator=source,
                 metadata={"stream_id": stream.stream_id, "plugin": stream.source.plugin},
+                **source_execution,
             )
         )
         tail = source_id
@@ -94,6 +115,7 @@ def resolve_config(
                     kind=NodeKind.TRANSFORM,
                     operator=transform,
                     metadata={"plugin": transform_config.plugin},
+                    **_execution_kwargs(transform_config, role="transform"),
                 )
             )
             graph.connect(
@@ -122,6 +144,7 @@ def resolve_config(
             kind=NodeKind.DECODER,
             operator=decoder,
             metadata={"plugin": config.decoder.plugin},
+            **_execution_kwargs(config.decoder, role="decoder"),
         )
     )
 
@@ -165,6 +188,7 @@ def resolve_config(
                 kind=NodeKind.SINK,
                 operator=sink,
                 metadata={"plugin": sink_config.plugin},
+                **_execution_kwargs(sink_config, role="sink"),
             )
         )
         graph.connect(
@@ -176,6 +200,8 @@ def resolve_config(
             )
         )
 
+    for monitor_config in config.monitors:
+        _execution_kwargs(monitor_config, role="monitor")
     monitors = tuple(
         _create(plugin_registry, PluginKind.MONITOR, item) for item in config.monitors
     )
@@ -186,6 +212,7 @@ def resolve_config(
                 kind=NodeKind.MONITOR,
                 operator=monitor,
                 metadata={"plugin": monitor_config.plugin},
+                **_execution_kwargs(monitor_config, role="monitor"),
             )
         )
 

--- a/packages/neuros-core/src/neuros/config/schema.py
+++ b/packages/neuros-core/src/neuros/config/schema.py
@@ -66,11 +66,14 @@ def _schema_version(value: Any) -> int:
 
 
 def _reject_unknown_keys(
-    value: Mapping[str, Any], *, allowed: frozenset[str], context: str
+    value: Mapping[Any, Any], *, allowed: frozenset[str], context: str
 ) -> None:
-    unknown = sorted(set(value) - allowed)
+    unknown = [
+        key for key in value if not isinstance(key, str) or key not in allowed
+    ]
     if unknown:
-        raise ConfigurationError(f"Unknown {context} keys: {unknown}")
+        rendered = sorted(repr(key) for key in unknown)
+        raise ConfigurationError(f"Unknown {context} keys: {rendered}")
 
 
 def _plugin_sequence(value: Any, *, field_name: str) -> tuple[PluginConfig, ...]:
@@ -98,7 +101,11 @@ class ExecutionConfig:
     process_response_capacity_bytes: int | None = None
 
     def __post_init__(self) -> None:
-        executor = self.executor.value if isinstance(self.executor, ExecutionClass) else self.executor
+        executor = (
+            self.executor.value
+            if isinstance(self.executor, ExecutionClass)
+            else self.executor
+        )
         try:
             probe = RuntimeNode(
                 node_id="__config_execution__",
@@ -291,7 +298,7 @@ class PipelineConfig:
                 ),
             )
 
-        def parse_plugin(item: Any) -> PluginConfig:
+        def parse_plugin(item: Any, *, role: str) -> PluginConfig:
             if not isinstance(item, Mapping):
                 raise ConfigurationError("plugin configuration must be a mapping")
             if schema_version == 1 and "execution" in item:
@@ -302,6 +309,11 @@ class PipelineConfig:
                 _reject_unknown_keys(
                     item, allowed=_PLUGIN_V2_KEYS, context="plugin configuration"
                 )
+                if role == "monitor" and "execution" in item:
+                    raise ConfigurationError(
+                        "monitor execution policy is unavailable until the runtime "
+                        "monitor observation contract is implemented"
+                    )
             plugin = item.get("plugin")
             options = item.get("options", {})
             execution = (
@@ -327,8 +339,10 @@ class PipelineConfig:
             streams.append(
                 StreamConfig(
                     stream_id=stream.get("id"),
-                    source=parse_plugin(stream.get("source", {})),
-                    transforms=tuple(parse_plugin(item) for item in transforms_raw),
+                    source=parse_plugin(stream.get("source", {}), role="source"),
+                    transforms=tuple(
+                        parse_plugin(item, role="transform") for item in transforms_raw
+                    ),
                 )
             )
 
@@ -346,11 +360,11 @@ class PipelineConfig:
             ),
         )
 
-        def parse_many(key: str) -> tuple[PluginConfig, ...]:
+        def parse_many(key: str, *, role: str) -> tuple[PluginConfig, ...]:
             values = raw.get(key, [])
             if not isinstance(values, list):
                 raise ConfigurationError(f"{key} must be a list")
-            return tuple(parse_plugin(item) for item in values)
+            return tuple(parse_plugin(item, role=role) for item in values)
 
         metadata = raw.get("metadata", {})
         if not isinstance(metadata, Mapping):
@@ -359,9 +373,9 @@ class PipelineConfig:
         return cls(
             schema_version=schema_version,
             streams=tuple(streams),
-            decoder=parse_plugin(decoder_raw),
-            sinks=parse_many("sinks"),
-            monitors=parse_many("monitors"),
+            decoder=parse_plugin(decoder_raw, role="decoder"),
+            sinks=parse_many("sinks", role="sink"),
+            monitors=parse_many("monitors", role="monitor"),
             runtime=runtime,
             metadata=metadata,
         )

--- a/packages/neuros-core/src/neuros/config/schema.py
+++ b/packages/neuros-core/src/neuros/config/schema.py
@@ -309,11 +309,6 @@ class PipelineConfig:
                 _reject_unknown_keys(
                     item, allowed=_PLUGIN_V2_KEYS, context="plugin configuration"
                 )
-                if role == "monitor" and "execution" in item:
-                    raise ConfigurationError(
-                        "monitor execution policy is unavailable until the runtime "
-                        "monitor observation contract is implemented"
-                    )
             plugin = item.get("plugin")
             options = item.get("options", {})
             execution = (

--- a/packages/neuros-core/src/neuros/config/schema.py
+++ b/packages/neuros-core/src/neuros/config/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from numbers import Integral
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Mapping
@@ -10,19 +11,159 @@ from typing import Any, Mapping
 import yaml
 
 from neuros.errors import ConfigurationError
-from neuros.runtime import OverflowPolicy
+from neuros.runtime import (
+    ExecutionClass,
+    NodeKind,
+    OverflowPolicy,
+    RuntimeEdge,
+    RuntimeNode,
+)
+
+_SUPPORTED_SCHEMA_VERSIONS = frozenset({1, 2})
+_TOP_LEVEL_V2_KEYS = frozenset(
+    {
+        "schema_version",
+        "streams",
+        "decoder",
+        "sinks",
+        "monitors",
+        "runtime",
+        "metadata",
+    }
+)
+_STREAM_V2_KEYS = frozenset({"id", "source", "transforms"})
+_PLUGIN_V2_KEYS = frozenset({"plugin", "options", "execution"})
+_RUNTIME_V2_KEYS = frozenset({"queue_capacity", "overflow_policy"})
+_EXECUTION_V2_KEYS = frozenset(
+    {
+        "executor",
+        "execution_timeout_s",
+        "process_transport",
+        "process_request_capacity_bytes",
+        "process_response_capacity_bytes",
+    }
+)
+
+
+def _nonblank_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ConfigurationError(f"{field_name} must be a string")
+    if not value.strip():
+        raise ConfigurationError(f"{field_name} must be nonblank")
+    return value
+
+
+def _schema_version(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ConfigurationError("schema_version must be an integer")
+    resolved = int(value)
+    if resolved not in _SUPPORTED_SCHEMA_VERSIONS:
+        expected = ", ".join(str(item) for item in sorted(_SUPPORTED_SCHEMA_VERSIONS))
+        raise ConfigurationError(
+            f"Unsupported config schema_version={resolved}; expected one of: {expected}"
+        )
+    return resolved
+
+
+def _reject_unknown_keys(
+    value: Mapping[str, Any], *, allowed: frozenset[str], context: str
+) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ConfigurationError(f"Unknown {context} keys: {unknown}")
+
+
+def _plugin_sequence(value: Any, *, field_name: str) -> tuple[PluginConfig, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ConfigurationError(f"{field_name} must be a list or tuple")
+    resolved = tuple(value)
+    if any(not isinstance(item, PluginConfig) for item in resolved):
+        raise ConfigurationError(f"{field_name} must contain PluginConfig values")
+    return resolved
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionConfig:
+    """Canonical execution declaration for one runtime-backed plugin.
+
+    The runtime node constructor remains the final authority for execution
+    semantics. Configuration reuses that constructor here so serialized and
+    programmatic declarations cannot drift into two normalization systems.
+    """
+
+    executor: ExecutionClass = ExecutionClass.INLINE
+    execution_timeout_s: float | None = None
+    process_transport: str = "pickle"
+    process_request_capacity_bytes: int | None = None
+    process_response_capacity_bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        executor = self.executor.value if isinstance(self.executor, ExecutionClass) else self.executor
+        try:
+            probe = RuntimeNode(
+                node_id="__config_execution__",
+                kind=NodeKind.TRANSFORM,
+                operator=None,
+                executor=executor,
+                execution_timeout_s=self.execution_timeout_s,
+                process_transport=self.process_transport,
+                process_request_capacity_bytes=self.process_request_capacity_bytes,
+                process_response_capacity_bytes=self.process_response_capacity_bytes,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ConfigurationError(f"invalid execution configuration: {exc}") from exc
+
+        object.__setattr__(self, "executor", ExecutionClass(probe.executor))
+        object.__setattr__(self, "execution_timeout_s", probe.execution_timeout_s)
+        object.__setattr__(self, "process_transport", probe.process_transport)
+        object.__setattr__(
+            self,
+            "process_request_capacity_bytes",
+            probe.process_request_capacity_bytes,
+        )
+        object.__setattr__(
+            self,
+            "process_response_capacity_bytes",
+            probe.process_response_capacity_bytes,
+        )
+
+    @property
+    def is_default(self) -> bool:
+        return (
+            self.executor is ExecutionClass.INLINE
+            and self.execution_timeout_s is None
+            and self.process_transport == "pickle"
+            and self.process_request_capacity_bytes is None
+            and self.process_response_capacity_bytes is None
+        )
+
+    def runtime_kwargs(self) -> dict[str, Any]:
+        """Return canonical ``RuntimeNode`` keyword arguments."""
+        return {
+            "executor": self.executor.value,
+            "execution_timeout_s": self.execution_timeout_s,
+            "process_transport": self.process_transport,
+            "process_request_capacity_bytes": self.process_request_capacity_bytes,
+            "process_response_capacity_bytes": self.process_response_capacity_bytes,
+        }
 
 
 @dataclass(frozen=True, slots=True)
 class PluginConfig:
-    """Reference to a plugin plus constructor options."""
+    """Reference to a plugin plus constructor and execution options."""
 
     plugin: str
     options: Mapping[str, Any] = field(default_factory=dict)
+    execution: ExecutionConfig = field(default_factory=ExecutionConfig)
 
     def __post_init__(self) -> None:
-        if not self.plugin:
-            raise ConfigurationError("plugin must be non-empty")
+        object.__setattr__(
+            self, "plugin", _nonblank_string(self.plugin, field_name="plugin")
+        )
+        if not isinstance(self.options, Mapping):
+            raise ConfigurationError("plugin options must be a mapping")
+        if not isinstance(self.execution, ExecutionConfig):
+            raise ConfigurationError("plugin execution must be an ExecutionConfig")
         object.__setattr__(self, "options", MappingProxyType(dict(self.options)))
 
 
@@ -35,8 +176,16 @@ class StreamConfig:
     transforms: tuple[PluginConfig, ...] = ()
 
     def __post_init__(self) -> None:
-        if not self.stream_id:
-            raise ConfigurationError("stream id must be non-empty")
+        object.__setattr__(
+            self, "stream_id", _nonblank_string(self.stream_id, field_name="stream id")
+        )
+        if not isinstance(self.source, PluginConfig):
+            raise ConfigurationError("stream source must be a PluginConfig")
+        object.__setattr__(
+            self,
+            "transforms",
+            _plugin_sequence(self.transforms, field_name="stream transforms"),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,8 +194,17 @@ class RuntimeConfig:
     overflow_policy: OverflowPolicy = OverflowPolicy.DROP_OLDEST
 
     def __post_init__(self) -> None:
-        if self.queue_capacity <= 0:
-            raise ConfigurationError("runtime.queue_capacity must be positive")
+        try:
+            edge = RuntimeEdge(
+                "__config_runtime_source__",
+                "__config_runtime_target__",
+                capacity=self.queue_capacity,
+                overflow=self.overflow_policy,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ConfigurationError(f"invalid runtime configuration: {exc}") from exc
+        object.__setattr__(self, "queue_capacity", edge.capacity)
+        object.__setattr__(self, "overflow_policy", OverflowPolicy(edge.overflow))
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,36 +220,96 @@ class PipelineConfig:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if self.schema_version != 1:
-            raise ConfigurationError(
-                f"Unsupported config schema_version={self.schema_version}; expected 1"
-            )
-        if not self.streams:
+        object.__setattr__(self, "schema_version", _schema_version(self.schema_version))
+
+        if not isinstance(self.streams, (list, tuple)):
+            raise ConfigurationError("streams must be a list or tuple")
+        streams = tuple(self.streams)
+        if not streams:
             raise ConfigurationError("At least one stream is required")
-        ids = [stream.stream_id for stream in self.streams]
+        if any(not isinstance(stream, StreamConfig) for stream in streams):
+            raise ConfigurationError("streams must contain StreamConfig values")
+        object.__setattr__(self, "streams", streams)
+
+        if not isinstance(self.decoder, PluginConfig):
+            raise ConfigurationError("decoder must be a PluginConfig")
+        sinks = _plugin_sequence(self.sinks, field_name="sinks")
+        monitors = _plugin_sequence(self.monitors, field_name="monitors")
+        object.__setattr__(self, "sinks", sinks)
+        object.__setattr__(self, "monitors", monitors)
+
+        if not isinstance(self.runtime, RuntimeConfig):
+            raise ConfigurationError("runtime must be a RuntimeConfig")
+        if not isinstance(self.metadata, Mapping):
+            raise ConfigurationError("metadata must be a mapping")
+
+        ids = [stream.stream_id for stream in streams]
         if len(ids) != len(set(ids)):
             raise ConfigurationError("stream ids must be unique")
+
+        if self.schema_version == 1:
+            plugins = [self.decoder, *sinks, *monitors]
+            for stream in streams:
+                plugins.append(stream.source)
+                plugins.extend(stream.transforms)
+            if any(not plugin.execution.is_default for plugin in plugins):
+                raise ConfigurationError(
+                    "schema_version 1 is legacy-inline and cannot carry execution policy"
+                )
+
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, Any]) -> "PipelineConfig":
-        try:
-            schema_version = int(raw.get("schema_version", 1))
-            streams_raw = raw["streams"]
-            decoder_raw = raw["decoder"]
-        except (KeyError, TypeError, ValueError) as exc:
-            raise ConfigurationError("config requires streams and decoder") from exc
+        if not isinstance(raw, Mapping):
+            raise ConfigurationError("configuration root must be a mapping")
+        schema_version = _schema_version(raw.get("schema_version", 1))
+        if schema_version == 2:
+            _reject_unknown_keys(
+                raw, allowed=_TOP_LEVEL_V2_KEYS, context="configuration"
+            )
+        if "streams" not in raw or "decoder" not in raw:
+            raise ConfigurationError("config requires streams and decoder")
+        streams_raw = raw["streams"]
+        decoder_raw = raw["decoder"]
 
-        def parse_plugin(item: Mapping[str, Any]) -> PluginConfig:
+        def parse_execution(item: Any) -> ExecutionConfig:
+            if not isinstance(item, Mapping):
+                raise ConfigurationError("plugin execution must be a mapping")
+            _reject_unknown_keys(
+                item, allowed=_EXECUTION_V2_KEYS, context="execution"
+            )
+            return ExecutionConfig(
+                executor=item.get("executor", ExecutionClass.INLINE.value),
+                execution_timeout_s=item.get("execution_timeout_s"),
+                process_transport=item.get("process_transport", "pickle"),
+                process_request_capacity_bytes=item.get(
+                    "process_request_capacity_bytes"
+                ),
+                process_response_capacity_bytes=item.get(
+                    "process_response_capacity_bytes"
+                ),
+            )
+
+        def parse_plugin(item: Any) -> PluginConfig:
             if not isinstance(item, Mapping):
                 raise ConfigurationError("plugin configuration must be a mapping")
+            if schema_version == 1 and "execution" in item:
+                raise ConfigurationError(
+                    "schema_version 1 cannot declare plugin execution policy; use schema_version 2"
+                )
+            if schema_version == 2:
+                _reject_unknown_keys(
+                    item, allowed=_PLUGIN_V2_KEYS, context="plugin configuration"
+                )
             plugin = item.get("plugin")
-            if not isinstance(plugin, str):
-                raise ConfigurationError("plugin configuration requires a string 'plugin'")
             options = item.get("options", {})
-            if not isinstance(options, Mapping):
-                raise ConfigurationError("plugin options must be a mapping")
-            return PluginConfig(plugin=plugin, options=options)
+            execution = (
+                parse_execution(item.get("execution", {}))
+                if schema_version == 2
+                else ExecutionConfig()
+            )
+            return PluginConfig(plugin=plugin, options=options, execution=execution)
 
         streams: list[StreamConfig] = []
         if not isinstance(streams_raw, list):
@@ -99,14 +317,17 @@ class PipelineConfig:
         for stream in streams_raw:
             if not isinstance(stream, Mapping):
                 raise ConfigurationError("each stream must be a mapping")
-            source = parse_plugin(stream.get("source", {}))
+            if schema_version == 2:
+                _reject_unknown_keys(
+                    stream, allowed=_STREAM_V2_KEYS, context="stream configuration"
+                )
             transforms_raw = stream.get("transforms", [])
             if not isinstance(transforms_raw, list):
                 raise ConfigurationError("stream transforms must be a list")
             streams.append(
                 StreamConfig(
-                    stream_id=str(stream.get("id", "")),
-                    source=source,
+                    stream_id=stream.get("id"),
+                    source=parse_plugin(stream.get("source", {})),
                     transforms=tuple(parse_plugin(item) for item in transforms_raw),
                 )
             )
@@ -114,15 +335,16 @@ class PipelineConfig:
         runtime_raw = raw.get("runtime", {})
         if not isinstance(runtime_raw, Mapping):
             raise ConfigurationError("runtime must be a mapping")
-        try:
-            runtime = RuntimeConfig(
-                queue_capacity=int(runtime_raw.get("queue_capacity", 100)),
-                overflow_policy=OverflowPolicy(
-                    runtime_raw.get("overflow_policy", OverflowPolicy.DROP_OLDEST.value)
-                ),
+        if schema_version == 2:
+            _reject_unknown_keys(
+                runtime_raw, allowed=_RUNTIME_V2_KEYS, context="runtime configuration"
             )
-        except (TypeError, ValueError) as exc:
-            raise ConfigurationError("invalid runtime configuration") from exc
+        runtime = RuntimeConfig(
+            queue_capacity=runtime_raw.get("queue_capacity", 100),
+            overflow_policy=runtime_raw.get(
+                "overflow_policy", OverflowPolicy.DROP_OLDEST.value
+            ),
+        )
 
         def parse_many(key: str) -> tuple[PluginConfig, ...]:
             values = raw.get(key, [])

--- a/packages/neuros-core/src/neuros/runtime/_execution_evidence.py
+++ b/packages/neuros-core/src/neuros/runtime/_execution_evidence.py
@@ -1,0 +1,97 @@
+"""Deterministic execution-authority evidence for runtime snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .graph import NodeKind, RuntimeNode
+
+_EXECUTION_DOMAINS = {
+    "inline": "event_loop",
+    "gpu": "event_loop",
+    "thread": "worker_thread",
+    "process": "persistent_process",
+}
+
+_SCHEDULING_MODES = {
+    NodeKind.SOURCE: "source_task",
+    NodeKind.TRANSFORM: "unary_task",
+    NodeKind.FUSION: "fusion_task",
+    NodeKind.DECODER: "unary_task",
+    NodeKind.SINK: "unary_task",
+    NodeKind.MONITOR: "observation_callback",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthority:
+    """Execution policy accepted for one node at executor construction."""
+
+    node_id: str
+    kind: str
+    requested_executor: str
+    execution_domain: str
+    scheduling_mode: str
+    execution_timeout_s: float | None
+    process_transport: str | None
+    process_request_capacity_bytes: int | None
+    process_response_capacity_bytes: int | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "requested_executor": self.requested_executor,
+            "execution_domain": self.execution_domain,
+            "scheduling_mode": self.scheduling_mode,
+            "execution_timeout_s": self.execution_timeout_s,
+            "process_transport": self.process_transport,
+            "process_request_capacity_bytes": self.process_request_capacity_bytes,
+            "process_response_capacity_bytes": self.process_response_capacity_bytes,
+        }
+
+
+def _effective_domain(node: RuntimeNode) -> str:
+    # Runtime-owned concatenate-latest fusion does not dispatch through the
+    # node executor unless a custom fuse() operator exists. Preserve that truth
+    # in evidence even for direct programmatic graphs. #140 owns making such
+    # declarations fail closed or fully authoritative at the runtime boundary.
+    if node.kind is NodeKind.FUSION and not hasattr(node.operator, "fuse"):
+        return "event_loop"
+    return _EXECUTION_DOMAINS[node.executor]
+
+
+def capture_execution_authority(
+    nodes: Mapping[str, RuntimeNode],
+) -> tuple[ExecutionAuthority, ...]:
+    """Capture deterministic execution authority from an already validated graph."""
+
+    authority: list[ExecutionAuthority] = []
+    for node_id, node in sorted(nodes.items()):
+        is_process = node.executor == "process"
+        authority.append(
+            ExecutionAuthority(
+                node_id=node_id,
+                kind=node.kind.value,
+                requested_executor=node.executor,
+                execution_domain=_effective_domain(node),
+                scheduling_mode=_SCHEDULING_MODES[node.kind],
+                execution_timeout_s=node.execution_timeout_s if is_process else None,
+                process_transport=node.process_transport if is_process else None,
+                process_request_capacity_bytes=(
+                    node.process_request_capacity_bytes if is_process else None
+                ),
+                process_response_capacity_bytes=(
+                    node.process_response_capacity_bytes if is_process else None
+                ),
+            )
+        )
+    return tuple(authority)
+
+
+def execution_authority_snapshot(
+    authority: tuple[ExecutionAuthority, ...],
+) -> dict[str, dict[str, Any]]:
+    """Return a fresh JSON-compatible mapping for one captured authority set."""
+
+    return {item.node_id: item.as_dict() for item in authority}

--- a/packages/neuros-core/src/neuros/runtime/executor.py
+++ b/packages/neuros-core/src/neuros/runtime/executor.py
@@ -20,6 +20,10 @@ import numpy as np
 
 from neuros.contracts import DecoderOutput, NeuralWindow, SignalFrame, TransformEmission
 from neuros.errors import ProcessingError
+from neuros.runtime._execution_evidence import (
+    capture_execution_authority,
+    execution_authority_snapshot,
+)
 from neuros.runtime._validation import positive_finite_real
 from neuros.runtime.graph import NodeKind, RuntimeEdge, RuntimeGraph, RuntimeNode
 from neuros.runtime.process_worker import PersistentProcessWorker
@@ -188,6 +192,7 @@ class RuntimeExecutor:
             drain_timeout_s, field_name="drain_timeout_s"
         )
         graph.validate()
+        self._execution_authority = capture_execution_authority(graph.nodes)
         self.graph = graph
         self.drain_timeout_s = drain_timeout_s
         self.state = RuntimeState.CREATED
@@ -885,6 +890,7 @@ class RuntimeExecutor:
                 for node_id, stats in self._node_stats.items()
             },
             "edges": edge_metrics,
+            "execution": execution_authority_snapshot(self._execution_authority),
             "process_execution": {
                 node_id: {
                     "transport": node.process_transport,

--- a/tests/test_config_execution_authority.py
+++ b/tests/test_config_execution_authority.py
@@ -46,6 +46,9 @@ class Sink:
 
 
 class Monitor:
+    def update(self, payload):
+        return None
+
     def result(self):
         return {}
 
@@ -295,6 +298,7 @@ def test_schema_v2_compiles_mixed_execution_policy_to_runtime_nodes():
         "process_transport": "pickle",
     }
     raw["sinks"][0]["execution"] = {"executor": "gpu"}
+    raw["monitors"][0]["execution"] = {"executor": "thread"}
 
     config = PipelineConfig.from_mapping(raw)
     resolved = resolve_config(config, registry=_registry())
@@ -311,7 +315,7 @@ def test_schema_v2_compiles_mixed_execution_policy_to_runtime_nodes():
     assert decoder.execution_timeout_s == pytest.approx(1.5)
     assert decoder.process_transport == "pickle"
     assert sink.executor == "gpu"
-    assert monitor.executor == "inline"
+    assert monitor.executor == "thread"
 
 
 def test_schema_v2_compiles_shared_memory_policy_without_loss():
@@ -355,39 +359,54 @@ def test_source_nondefault_execution_fails_at_compilation(executor):
 
 
 @pytest.mark.parametrize(
-    "declaration",
+    ("declaration", "expected_executor", "expected_timeout"),
     [
-        {},
-        {"executor": "inline"},
-        {"executor": "thread"},
-        {"executor": "process", "execution_timeout_s": 1.0},
+        ({}, "inline", None),
+        ({"executor": "inline"}, "inline", None),
+        ({"executor": "thread"}, "thread", None),
+        ({"executor": "gpu"}, "gpu", None),
+        ({"executor": "process", "execution_timeout_s": 1.25}, "process", 1.25),
     ],
 )
-def test_serialized_monitor_execution_policy_is_rejected_until_monitor_authority(
-    declaration,
+def test_serialized_monitor_execution_policy_compiles_losslessly(
+    declaration, expected_executor, expected_timeout
 ):
     raw = _raw_config(schema_version=2)
     raw["monitors"][0]["execution"] = declaration
-    with pytest.raises(ConfigurationError, match="monitor execution policy is unavailable"):
-        PipelineConfig.from_mapping(raw)
+    config = PipelineConfig.from_mapping(raw)
+    resolved = resolve_config(config, registry=_registry())
+    monitor = resolved.graph.nodes["monitor:0"]
+
+    assert monitor.executor == expected_executor
+    assert monitor.execution_timeout_s == expected_timeout
 
 
-@pytest.mark.parametrize("executor", ["thread", "gpu", "process"])
-def test_direct_monitor_nondefault_execution_fails_at_compilation(executor):
-    kwargs = {"executor": executor}
-    if executor == "process":
-        kwargs["execution_timeout_s"] = 1.0
+def test_direct_process_monitor_execution_policy_compiles_losslessly():
     config = PipelineConfig(
         schema_version=2,
         streams=(StreamConfig("eeg", PluginConfig("source")),),
         decoder=PluginConfig("decoder"),
         monitors=(
-            PluginConfig("monitor", execution=ExecutionConfig(**kwargs)),
+            PluginConfig(
+                "monitor",
+                execution=ExecutionConfig(
+                    executor="process",
+                    execution_timeout_s=2.0,
+                    process_transport="shared_memory",
+                    process_request_capacity_bytes=np.int64(32768),
+                    process_response_capacity_bytes=np.int64(32768),
+                ),
+            ),
         ),
     )
+    resolved = resolve_config(config, registry=_registry())
+    monitor = resolved.graph.nodes["monitor:0"]
 
-    with pytest.raises(ConfigurationError, match="monitor observation contract"):
-        resolve_config(config, registry=_registry())
+    assert monitor.executor == "process"
+    assert monitor.execution_timeout_s == 2.0
+    assert monitor.process_transport == "shared_memory"
+    assert monitor.process_request_capacity_bytes == 32768
+    assert monitor.process_response_capacity_bytes == 32768
 
 
 def test_execution_config_and_direct_runtime_node_have_identical_canonical_fields():

--- a/tests/test_config_execution_authority.py
+++ b/tests/test_config_execution_authority.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from neuros.config import (
+    ExecutionConfig,
+    PipelineConfig,
+    PluginConfig,
+    RuntimeConfig,
+    StreamConfig,
+    resolve_config,
+)
+from neuros.errors import ConfigurationError
+from neuros.plugins import PluginKind, PluginRegistry
+from neuros.runtime import ExecutionClass, NodeKind, OverflowPolicy, RuntimeNode
+
+
+class Source:
+    async def start(self):
+        return None
+
+    async def stop(self):
+        return None
+
+    async def frames(self):
+        if False:
+            yield None
+
+
+class Transform:
+    def transform(self, item):
+        return item
+
+
+class Decoder:
+    def infer(self, item):
+        return item
+
+
+class Sink:
+    def write(self, item):
+        return None
+
+
+class Monitor:
+    def result(self):
+        return {}
+
+
+def _registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry.register(name="source", kind=PluginKind.SOURCE, factory=Source)
+    registry.register(name="transform", kind=PluginKind.TRANSFORM, factory=Transform)
+    registry.register(name="decoder", kind=PluginKind.DECODER, factory=Decoder)
+    registry.register(name="sink", kind=PluginKind.SINK, factory=Sink)
+    registry.register(name="monitor", kind=PluginKind.MONITOR, factory=Monitor)
+    return registry
+
+
+def _raw_config(*, schema_version: int = 2) -> dict:
+    return {
+        "schema_version": schema_version,
+        "metadata": {"fixture": "config-execution-authority"},
+        "streams": [
+            {
+                "id": "eeg",
+                "source": {"plugin": "source"},
+                "transforms": [{"plugin": "transform"}],
+            }
+        ],
+        "decoder": {"plugin": "decoder"},
+        "sinks": [{"plugin": "sink"}],
+        "monitors": [{"plugin": "monitor"}],
+        "runtime": {"queue_capacity": 8, "overflow_policy": "drop_oldest"},
+    }
+
+
+def test_schema_v1_remains_legacy_inline_after_resolution():
+    config = PipelineConfig.from_mapping(_raw_config(schema_version=1))
+    resolved = resolve_config(config, registry=_registry())
+
+    assert config.schema_version == 1
+    assert config.runtime.queue_capacity == 8
+    assert config.runtime.overflow_policy is OverflowPolicy.DROP_OLDEST
+    assert all(node.executor == "inline" for node in resolved.graph.nodes.values())
+    assert all(node.execution_timeout_s is None for node in resolved.graph.nodes.values())
+    assert all(node.process_transport == "pickle" for node in resolved.graph.nodes.values())
+
+
+def test_schema_v1_rejects_any_serialized_execution_declaration():
+    raw = _raw_config(schema_version=1)
+    raw["decoder"]["execution"] = {"executor": "inline"}
+    with pytest.raises(ConfigurationError, match="schema_version 1 cannot declare"):
+        PipelineConfig.from_mapping(raw)
+
+
+@pytest.mark.parametrize("value", [True, False, "1", 1.0, 0, 3, None])
+def test_schema_version_rejects_coercible_or_unsupported_values(value):
+    raw = _raw_config(schema_version=2)
+    raw["schema_version"] = value
+    with pytest.raises(ConfigurationError):
+        PipelineConfig.from_mapping(raw)
+
+
+def test_schema_version_accepts_integral_scalar_and_canonicalizes_to_int():
+    raw = _raw_config(schema_version=2)
+    raw["schema_version"] = np.int64(2)
+    config = PipelineConfig.from_mapping(raw)
+    assert type(config.schema_version) is int
+    assert config.schema_version == 2
+
+
+@pytest.mark.parametrize(
+    ("location", "key"),
+    [
+        ("root", "surprise"),
+        ("stream", "surprise"),
+        ("plugin", "surprise"),
+        ("runtime", "surprise"),
+        ("execution", "surprise"),
+    ],
+)
+def test_schema_v2_rejects_unknown_authority_keys(location, key):
+    raw = _raw_config(schema_version=2)
+    if location == "root":
+        raw[key] = 1
+    elif location == "stream":
+        raw["streams"][0][key] = 1
+    elif location == "plugin":
+        raw["decoder"][key] = 1
+    elif location == "runtime":
+        raw["runtime"][key] = 1
+    else:
+        raw["decoder"]["execution"] = {"executor": "inline", key: 1}
+
+    with pytest.raises(ConfigurationError, match="Unknown"):
+        PipelineConfig.from_mapping(raw)
+
+
+@pytest.mark.parametrize("stream_id", [1, True, None, object()])
+def test_stream_id_is_never_string_coerced(stream_id):
+    raw = _raw_config(schema_version=2)
+    raw["streams"][0]["id"] = stream_id
+    with pytest.raises(ConfigurationError, match="stream id must be a string"):
+        PipelineConfig.from_mapping(raw)
+
+
+@pytest.mark.parametrize("stream_id", ["", " ", "\t\n"])
+def test_stream_id_rejects_blank_identity(stream_id):
+    raw = _raw_config(schema_version=2)
+    raw["streams"][0]["id"] = stream_id
+    with pytest.raises(ConfigurationError, match="stream id must be nonblank"):
+        PipelineConfig.from_mapping(raw)
+
+
+@pytest.mark.parametrize("plugin", [1, True, None, object()])
+def test_plugin_identity_is_never_string_coerced(plugin):
+    raw = _raw_config(schema_version=2)
+    raw["decoder"]["plugin"] = plugin
+    with pytest.raises(ConfigurationError, match="plugin must be a string"):
+        PipelineConfig.from_mapping(raw)
+
+
+@pytest.mark.parametrize("plugin", ["", " ", "\n"])
+def test_plugin_identity_rejects_blank_strings(plugin):
+    raw = _raw_config(schema_version=2)
+    raw["decoder"]["plugin"] = plugin
+    with pytest.raises(ConfigurationError, match="plugin must be nonblank"):
+        PipelineConfig.from_mapping(raw)
+
+
+def test_runtime_config_reuses_runtime_edge_canonicalization():
+    runtime = RuntimeConfig(
+        queue_capacity=np.int64(16), overflow_policy="drop_newest"
+    )
+    assert type(runtime.queue_capacity) is int
+    assert runtime.queue_capacity == 16
+    assert runtime.overflow_policy is OverflowPolicy.DROP_NEWEST
+
+
+@pytest.mark.parametrize("capacity", [True, False, 8.0, "8", 0, -1, None])
+def test_runtime_config_rejects_ambiguous_queue_capacities(capacity):
+    with pytest.raises(ConfigurationError, match="invalid runtime configuration"):
+        RuntimeConfig(queue_capacity=capacity)
+
+
+@pytest.mark.parametrize("overflow", ["unknown", "", None, True, 1])
+def test_runtime_config_rejects_invalid_overflow_policy(overflow):
+    with pytest.raises(ConfigurationError, match="invalid runtime configuration"):
+        RuntimeConfig(overflow_policy=overflow)
+
+
+def test_execution_config_canonicalizes_thread_and_gpu_intent():
+    thread = ExecutionConfig(executor="thread")
+    gpu = ExecutionConfig(executor=ExecutionClass.GPU)
+
+    assert thread.executor is ExecutionClass.THREAD
+    assert gpu.executor is ExecutionClass.GPU
+    assert thread.process_transport == "pickle"
+    assert thread.execution_timeout_s is None
+
+
+def test_execution_config_canonicalizes_process_timeout():
+    execution = ExecutionConfig(executor="process", execution_timeout_s=np.float64(1.25))
+    assert execution.executor is ExecutionClass.PROCESS
+    assert type(execution.execution_timeout_s) is float
+    assert execution.execution_timeout_s == pytest.approx(1.25)
+
+
+def test_execution_config_canonicalizes_shared_memory_integral_capacities():
+    execution = ExecutionConfig(
+        executor="process",
+        execution_timeout_s=1.0,
+        process_transport="shared_memory",
+        process_request_capacity_bytes=np.int32(4096),
+        process_response_capacity_bytes=np.int64(8192),
+    )
+    assert execution.executor is ExecutionClass.PROCESS
+    assert execution.process_transport == "shared_memory"
+    assert type(execution.process_request_capacity_bytes) is int
+    assert type(execution.process_response_capacity_bytes) is int
+    assert execution.process_request_capacity_bytes == 4096
+    assert execution.process_response_capacity_bytes == 8192
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"executor": "process"},
+        {"executor": "process", "execution_timeout_s": 0},
+        {"executor": "process", "execution_timeout_s": -1},
+        {"executor": "process", "execution_timeout_s": True},
+        {"executor": "process", "execution_timeout_s": "1"},
+        {"executor": "process", "execution_timeout_s": math.nan},
+        {"executor": "process", "execution_timeout_s": math.inf},
+        {"executor": "inline", "execution_timeout_s": 1.0},
+        {"executor": "thread", "process_transport": "shared_memory"},
+        {
+            "executor": "process",
+            "execution_timeout_s": 1.0,
+            "process_transport": "shared_memory",
+        },
+        {
+            "executor": "process",
+            "execution_timeout_s": 1.0,
+            "process_transport": "pickle",
+            "process_request_capacity_bytes": 4096,
+        },
+        {"executor": "unknown"},
+    ],
+)
+def test_execution_config_rejects_runtime_invalid_declarations(kwargs):
+    with pytest.raises(ConfigurationError, match="invalid execution configuration"):
+        ExecutionConfig(**kwargs)
+
+
+def test_direct_schema_v1_rejects_nondefault_execution_policy():
+    with pytest.raises(ConfigurationError, match="legacy-inline"):
+        PipelineConfig(
+            schema_version=1,
+            streams=(
+                StreamConfig(
+                    "eeg",
+                    PluginConfig("source"),
+                    (PluginConfig("transform", execution=ExecutionConfig(executor="thread")),),
+                ),
+            ),
+            decoder=PluginConfig("decoder"),
+        )
+
+
+def test_schema_v2_compiles_mixed_execution_policy_to_runtime_nodes():
+    raw = _raw_config(schema_version=2)
+    raw["streams"][0]["transforms"][0]["execution"] = {"executor": "thread"}
+    raw["decoder"]["execution"] = {
+        "executor": "process",
+        "execution_timeout_s": 1.5,
+        "process_transport": "pickle",
+    }
+    raw["sinks"][0]["execution"] = {"executor": "gpu"}
+
+    config = PipelineConfig.from_mapping(raw)
+    resolved = resolve_config(config, registry=_registry())
+
+    source = resolved.graph.nodes["source:eeg"]
+    transform = resolved.graph.nodes["transform:eeg:0"]
+    decoder = resolved.graph.nodes["decoder:primary"]
+    sink = resolved.graph.nodes["sink:0"]
+    monitor = resolved.graph.nodes["monitor:0"]
+
+    assert source.executor == "inline"
+    assert transform.executor == "thread"
+    assert decoder.executor == "process"
+    assert decoder.execution_timeout_s == pytest.approx(1.5)
+    assert decoder.process_transport == "pickle"
+    assert sink.executor == "gpu"
+    assert monitor.executor == "inline"
+
+
+def test_schema_v2_compiles_shared_memory_policy_without_loss():
+    config = PipelineConfig(
+        schema_version=2,
+        streams=(StreamConfig("eeg", PluginConfig("source")),),
+        decoder=PluginConfig(
+            "decoder",
+            execution=ExecutionConfig(
+                executor="process",
+                execution_timeout_s=2.0,
+                process_transport="shared_memory",
+                process_request_capacity_bytes=np.int64(65536),
+                process_response_capacity_bytes=np.int32(131072),
+            ),
+        ),
+    )
+    resolved = resolve_config(config, registry=_registry())
+    decoder = resolved.graph.nodes["decoder:primary"]
+
+    assert decoder.executor == "process"
+    assert decoder.execution_timeout_s == 2.0
+    assert decoder.process_transport == "shared_memory"
+    assert decoder.process_request_capacity_bytes == 65536
+    assert decoder.process_response_capacity_bytes == 131072
+    assert type(decoder.process_request_capacity_bytes) is int
+    assert type(decoder.process_response_capacity_bytes) is int
+
+
+@pytest.mark.parametrize("executor", ["thread", "gpu", "process"])
+def test_source_nondefault_execution_fails_at_compilation(executor):
+    kwargs = {"executor": executor}
+    if executor == "process":
+        kwargs["execution_timeout_s"] = 1.0
+    raw = _raw_config(schema_version=2)
+    raw["streams"][0]["source"]["execution"] = kwargs
+    config = PipelineConfig.from_mapping(raw)
+
+    with pytest.raises(ConfigurationError, match="source lifecycle isolation"):
+        resolve_config(config, registry=_registry())
+
+
+@pytest.mark.parametrize("executor", ["thread", "gpu", "process"])
+def test_monitor_nondefault_execution_fails_until_monitor_authority_exists(executor):
+    kwargs = {"executor": executor}
+    if executor == "process":
+        kwargs["execution_timeout_s"] = 1.0
+    raw = _raw_config(schema_version=2)
+    raw["monitors"][0]["execution"] = kwargs
+    config = PipelineConfig.from_mapping(raw)
+
+    with pytest.raises(ConfigurationError, match="monitor observation contract"):
+        resolve_config(config, registry=_registry())
+
+
+def test_execution_config_and_direct_runtime_node_have_identical_canonical_fields():
+    execution = ExecutionConfig(
+        executor="process",
+        execution_timeout_s=np.float64(1.75),
+        process_transport="shared_memory",
+        process_request_capacity_bytes=np.int32(4096),
+        process_response_capacity_bytes=np.int64(8192),
+    )
+    node = RuntimeNode(
+        "decoder",
+        NodeKind.DECODER,
+        Decoder(),
+        **execution.runtime_kwargs(),
+    )
+
+    assert node.executor == execution.executor.value
+    assert node.execution_timeout_s == execution.execution_timeout_s
+    assert node.process_transport == execution.process_transport
+    assert node.process_request_capacity_bytes == execution.process_request_capacity_bytes
+    assert node.process_response_capacity_bytes == execution.process_response_capacity_bytes

--- a/tests/test_config_execution_authority.py
+++ b/tests/test_config_execution_authority.py
@@ -140,6 +140,13 @@ def test_schema_v2_rejects_unknown_authority_keys(location, key):
         PipelineConfig.from_mapping(raw)
 
 
+def test_schema_v2_unknown_key_reporting_handles_nonstring_yaml_keys():
+    raw = _raw_config(schema_version=2)
+    raw[1] = "unexpected"
+    with pytest.raises(ConfigurationError, match="Unknown configuration keys"):
+        PipelineConfig.from_mapping(raw)
+
+
 @pytest.mark.parametrize("stream_id", [1, True, None, object()])
 def test_stream_id_is_never_string_coerced(stream_id):
     raw = _raw_config(schema_version=2)
@@ -204,7 +211,9 @@ def test_execution_config_canonicalizes_thread_and_gpu_intent():
 
 
 def test_execution_config_canonicalizes_process_timeout():
-    execution = ExecutionConfig(executor="process", execution_timeout_s=np.float64(1.25))
+    execution = ExecutionConfig(
+        executor="process", execution_timeout_s=np.float64(1.25)
+    )
     assert execution.executor is ExecutionClass.PROCESS
     assert type(execution.execution_timeout_s) is float
     assert execution.execution_timeout_s == pytest.approx(1.25)
@@ -265,7 +274,12 @@ def test_direct_schema_v1_rejects_nondefault_execution_policy():
                 StreamConfig(
                     "eeg",
                     PluginConfig("source"),
-                    (PluginConfig("transform", execution=ExecutionConfig(executor="thread")),),
+                    (
+                        PluginConfig(
+                            "transform",
+                            execution=ExecutionConfig(executor="thread"),
+                        ),
+                    ),
                 ),
             ),
             decoder=PluginConfig("decoder"),
@@ -340,14 +354,37 @@ def test_source_nondefault_execution_fails_at_compilation(executor):
         resolve_config(config, registry=_registry())
 
 
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        {},
+        {"executor": "inline"},
+        {"executor": "thread"},
+        {"executor": "process", "execution_timeout_s": 1.0},
+    ],
+)
+def test_serialized_monitor_execution_policy_is_rejected_until_monitor_authority(
+    declaration,
+):
+    raw = _raw_config(schema_version=2)
+    raw["monitors"][0]["execution"] = declaration
+    with pytest.raises(ConfigurationError, match="monitor execution policy is unavailable"):
+        PipelineConfig.from_mapping(raw)
+
+
 @pytest.mark.parametrize("executor", ["thread", "gpu", "process"])
-def test_monitor_nondefault_execution_fails_until_monitor_authority_exists(executor):
+def test_direct_monitor_nondefault_execution_fails_at_compilation(executor):
     kwargs = {"executor": executor}
     if executor == "process":
         kwargs["execution_timeout_s"] = 1.0
-    raw = _raw_config(schema_version=2)
-    raw["monitors"][0]["execution"] = kwargs
-    config = PipelineConfig.from_mapping(raw)
+    config = PipelineConfig(
+        schema_version=2,
+        streams=(StreamConfig("eeg", PluginConfig("source")),),
+        decoder=PluginConfig("decoder"),
+        monitors=(
+            PluginConfig("monitor", execution=ExecutionConfig(**kwargs)),
+        ),
+    )
 
     with pytest.raises(ConfigurationError, match="monitor observation contract"):
         resolve_config(config, registry=_registry())

--- a/tests/test_runtime_execution_evidence.py
+++ b/tests/test_runtime_execution_evidence.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from neuros.config import PipelineConfig, resolve_config
+from neuros.plugins import PluginKind, PluginRegistry
+from neuros.runtime import NodeKind, RuntimeEdge, RuntimeExecutor, RuntimeGraph, RuntimeNode
+
+
+class FiniteSource:
+    def __init__(self, values=(1,)):
+        self.values = tuple(values)
+
+    async def start(self):
+        return None
+
+    async def stop(self):
+        return None
+
+    async def frames(self):
+        for value in self.values:
+            await asyncio.sleep(0)
+            yield value
+
+
+class IdentityTransform:
+    def transform(self, item):
+        return item
+
+
+class FailingTransform:
+    def transform(self, item):
+        raise LookupError(f"evidence failure {item}")
+
+
+class IdentityDecoder:
+    def infer(self, item):
+        return item
+
+
+class Sink:
+    def __init__(self):
+        self.items = []
+
+    def write(self, item):
+        self.items.append(item)
+
+
+class Monitor:
+    def update(self, payload):
+        return None
+
+
+def _manifest_graph(*, transform=IdentityTransform()):
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource()))
+    graph.add_node(
+        RuntimeNode("transform", NodeKind.TRANSFORM, transform, executor="thread")
+    )
+    graph.add_node(
+        RuntimeNode("decoder", NodeKind.DECODER, IdentityDecoder(), executor="gpu")
+    )
+    graph.add_node(
+        RuntimeNode(
+            "sink",
+            NodeKind.SINK,
+            Sink(),
+            executor="process",
+            execution_timeout_s=2.5,
+        )
+    )
+    graph.add_node(
+        RuntimeNode(
+            "monitor",
+            NodeKind.MONITOR,
+            Monitor(),
+            executor="process",
+            execution_timeout_s=1.25,
+            process_transport="shared_memory",
+            process_request_capacity_bytes=8192,
+            process_response_capacity_bytes=16384,
+        )
+    )
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+    graph.connect(RuntimeEdge("transform", "decoder", overflow="block"))
+    graph.connect(RuntimeEdge("decoder", "sink", overflow="block"))
+    return graph
+
+
+def test_snapshot_exposes_all_node_execution_authority_before_start():
+    snapshot = RuntimeExecutor(_manifest_graph()).snapshot()
+
+    assert snapshot["execution"] == {
+        "decoder": {
+            "kind": "decoder",
+            "requested_executor": "gpu",
+            "execution_domain": "event_loop",
+            "scheduling_mode": "unary_task",
+            "execution_timeout_s": None,
+            "process_transport": None,
+            "process_request_capacity_bytes": None,
+            "process_response_capacity_bytes": None,
+        },
+        "monitor": {
+            "kind": "monitor",
+            "requested_executor": "process",
+            "execution_domain": "persistent_process",
+            "scheduling_mode": "observation_callback",
+            "execution_timeout_s": 1.25,
+            "process_transport": "shared_memory",
+            "process_request_capacity_bytes": 8192,
+            "process_response_capacity_bytes": 16384,
+        },
+        "sink": {
+            "kind": "sink",
+            "requested_executor": "process",
+            "execution_domain": "persistent_process",
+            "scheduling_mode": "unary_task",
+            "execution_timeout_s": 2.5,
+            "process_transport": "pickle",
+            "process_request_capacity_bytes": None,
+            "process_response_capacity_bytes": None,
+        },
+        "source": {
+            "kind": "source",
+            "requested_executor": "inline",
+            "execution_domain": "event_loop",
+            "scheduling_mode": "source_task",
+            "execution_timeout_s": None,
+            "process_transport": None,
+            "process_request_capacity_bytes": None,
+            "process_response_capacity_bytes": None,
+        },
+        "transform": {
+            "kind": "transform",
+            "requested_executor": "thread",
+            "execution_domain": "worker_thread",
+            "scheduling_mode": "unary_task",
+            "execution_timeout_s": None,
+            "process_transport": None,
+            "process_request_capacity_bytes": None,
+            "process_response_capacity_bytes": None,
+        },
+    }
+
+
+def test_execution_snapshot_preserves_existing_process_execution_surface():
+    snapshot = RuntimeExecutor(_manifest_graph()).snapshot()
+    assert snapshot["process_execution"] == {
+        "monitor": {
+            "transport": "shared_memory",
+            "execution_timeout_s": 1.25,
+            "request_capacity_bytes": 8192,
+            "response_capacity_bytes": 16384,
+        },
+        "sink": {
+            "transport": "pickle",
+            "execution_timeout_s": 2.5,
+            "request_capacity_bytes": None,
+            "response_capacity_bytes": None,
+        },
+    }
+
+
+def test_snapshot_returns_fresh_execution_mapping_without_mutating_authority():
+    executor = RuntimeExecutor(_manifest_graph())
+    first = executor.snapshot()["execution"]
+    first["decoder"]["execution_domain"] = "invented"
+    first["extra"] = {"fake": True}
+
+    second = executor.snapshot()["execution"]
+    assert "extra" not in second
+    assert second["decoder"]["execution_domain"] == "event_loop"
+
+
+@pytest.mark.asyncio
+async def test_execution_authority_is_stable_across_successful_lifecycle():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource((3, 4))))
+    graph.add_node(
+        RuntimeNode(
+            "transform", NodeKind.TRANSFORM, IdentityTransform(), executor="thread"
+        )
+    )
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, Sink(), executor="gpu"))
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+    graph.connect(RuntimeEdge("transform", "sink", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    before = executor.snapshot()["execution"]
+    await executor.run()
+    after = executor.snapshot()["execution"]
+
+    assert after == before
+    assert after["sink"]["requested_executor"] == "gpu"
+    assert after["sink"]["execution_domain"] == "event_loop"
+
+
+@pytest.mark.asyncio
+async def test_execution_authority_is_stable_after_runtime_failure():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("source", NodeKind.SOURCE, FiniteSource((9,))))
+    graph.add_node(RuntimeNode("transform", NodeKind.TRANSFORM, FailingTransform()))
+    graph.connect(RuntimeEdge("source", "transform", overflow="block"))
+
+    executor = RuntimeExecutor(graph)
+    before = executor.snapshot()["execution"]
+    with pytest.raises(RuntimeError, match="evidence failure 9"):
+        await executor.run()
+    assert executor.snapshot()["execution"] == before
+
+
+def _registry() -> PluginRegistry:
+    registry = PluginRegistry()
+    registry.register(name="source", kind=PluginKind.SOURCE, factory=FiniteSource)
+    registry.register(name="transform", kind=PluginKind.TRANSFORM, factory=IdentityTransform)
+    registry.register(name="decoder", kind=PluginKind.DECODER, factory=IdentityDecoder)
+    registry.register(name="sink", kind=PluginKind.SINK, factory=Sink)
+    registry.register(name="monitor", kind=PluginKind.MONITOR, factory=Monitor)
+    return registry
+
+
+def test_schema_v2_resolved_policy_survives_into_runtime_snapshot():
+    config = PipelineConfig.from_mapping(
+        {
+            "schema_version": 2,
+            "streams": [
+                {
+                    "id": "eeg",
+                    "source": {"plugin": "source"},
+                    "transforms": [
+                        {"plugin": "transform", "execution": {"executor": "thread"}}
+                    ],
+                }
+            ],
+            "decoder": {"plugin": "decoder", "execution": {"executor": "gpu"}},
+            "sinks": [
+                {
+                    "plugin": "sink",
+                    "execution": {
+                        "executor": "process",
+                        "execution_timeout_s": 2.0,
+                    },
+                }
+            ],
+            "monitors": [
+                {"plugin": "monitor", "execution": {"executor": "thread"}}
+            ],
+        }
+    )
+    resolved = resolve_config(config, registry=_registry())
+    execution = RuntimeExecutor(resolved.graph).snapshot()["execution"]
+
+    assert execution["source:eeg"]["execution_domain"] == "event_loop"
+    assert execution["transform:eeg:0"]["execution_domain"] == "worker_thread"
+    assert execution["decoder:primary"] == {
+        "kind": "decoder",
+        "requested_executor": "gpu",
+        "execution_domain": "event_loop",
+        "scheduling_mode": "unary_task",
+        "execution_timeout_s": None,
+        "process_transport": None,
+        "process_request_capacity_bytes": None,
+        "process_response_capacity_bytes": None,
+    }
+    assert execution["sink:0"]["execution_domain"] == "persistent_process"
+    assert execution["sink:0"]["execution_timeout_s"] == 2.0
+    assert execution["monitor:0"]["requested_executor"] == "thread"
+    assert execution["monitor:0"]["scheduling_mode"] == "observation_callback"
+
+
+def test_builtin_fusion_evidence_does_not_claim_ignored_process_domain():
+    graph = RuntimeGraph()
+    graph.add_node(RuntimeNode("a", NodeKind.SOURCE, FiniteSource()))
+    graph.add_node(RuntimeNode("b", NodeKind.SOURCE, FiniteSource()))
+    graph.add_node(
+        RuntimeNode(
+            "fusion",
+            NodeKind.FUSION,
+            None,
+            executor="process",
+            execution_timeout_s=1.0,
+        )
+    )
+    graph.add_node(RuntimeNode("sink", NodeKind.SINK, Sink()))
+    graph.connect(RuntimeEdge("a", "fusion"))
+    graph.connect(RuntimeEdge("b", "fusion"))
+    graph.connect(RuntimeEdge("fusion", "sink"))
+
+    evidence = RuntimeExecutor(graph).snapshot()["execution"]["fusion"]
+    assert evidence["requested_executor"] == "process"
+    assert evidence["execution_domain"] == "event_loop"
+    assert evidence["scheduling_mode"] == "fusion_task"


### PR DESCRIPTION
## Status

**Draft configuration-authority tranche stacked on exact-qualified RuntimeGraph #137. Do not merge yet.**

Base: `988255d7429d7c3136d0e244def4e2871894d16f`.
Current semantic head: `63698d32c25915262374fe2b708bcde74c0c2b69`.

Runtime Fault Qualification on this corrected head is **9/9 green** across Ubuntu 24.04 / macOS 14 / Windows 2025 × Python 3.10 / 3.11 / 3.12. Verified Ubuntu/Python 3.10: **381/381 passed**. Public Trust, Developer Preview, Release Candidate Artifacts, External Plugin Contract, Ecosystem Compatibility, Reproducible Release Build and Neural Window Contracts are also green. The remaining heavyweight repository-wide queues must still close before this checkpoint is called fully repository-qualified.

This begins #131 as a versioned configuration authority boundary rather than merely adding process fields to the existing permissive parser.

## Architecture

### Schema v1 remains legacy-inline

Valid v1 configurations remain supported with existing inline execution semantics. Schema v1 explicitly rejects any serialized `execution:` declaration. Older neurOS versions currently ignore unknown plugin keys, so reusing v1 for execution policy could let older software silently discard isolation intent.

### Schema v2 owns execution declaration

`ExecutionConfig` is an immutable public config contract whose fields match `RuntimeNode` 1:1:

- `executor`;
- `execution_timeout_s`;
- `process_transport`;
- `process_request_capacity_bytes`;
- `process_response_capacity_bytes`.

It canonicalizes through the already-qualified `RuntimeNode` constructor. `RuntimeConfig` likewise canonicalizes queue capacity and overflow policy through `RuntimeEdge`. Configuration therefore does not create parallel timeout, transport, overflow, or integral-capacity semantics.

### Strict authority instead of coercion

Authority-bearing parser coercions such as `int(schema_version)`, `str(stream_id)`, and `int(queue_capacity)` are removed.

- schema version must be an actual integral scalar; bool is rejected;
- stream/plugin identities must be explicit nonblank strings;
- queue and mailbox capacities reuse runtime positive-integral semantics;
- process timeout reuses runtime finite-positive-real semantics;
- v2 unknown top-level, stream, plugin, runtime, and execution keys fail closed;
- malformed non-string YAML keys fail as `ConfigurationError`, not an error inside error reporting;
- direct Python dataclass construction is held to the same authority standard as parsed mappings.

## Compiler semantics

Execution policy is attached to plugin declarations, not compiler-generated runtime IDs. `resolve_config(...)` carries canonical policy directly into `RuntimeNode` for transforms, decoder, sinks **and monitors**.

Sources remain inline-only because source lifecycle/stream isolation is genuinely not implemented. Runtime-owned implicit fusion nodes remain inline defaults.

### Monitor audit correction

An earlier audit incorrectly inferred that monitor nodes were inert because `RuntimeExecutor.start()` does not create independent monitor tasks. The deeper trace showed the actual contract: `_emit()` calls `_notify_monitors()`, which invokes `monitor.update(payload)` through `_invoke_callable(...)`.

Existing runtime qualification already proves thread-backed monitor execution, exact monitor culprit attribution, successful monitor accounting, process-backed monitor execution, and process receipts. Issue #138 was corrected and closed to record this. The correct model is **observational callback scheduling at emission boundaries**, not an independent monitor task.

Accordingly, schema v2 now permits valid inline/thread/GPU/process monitor execution declarations. GPU remains scheduling intent with event-loop execution, not a distinct isolation guarantee.

## Adversarial qualification

`tests/test_config_execution_authority.py` covers:

- v1 legacy-inline resolution and v1 execution-declaration rejection;
- coercible/unsupported schema versions and NumPy integral normalization;
- unknown-key rejection across all v2 authority layers, including non-string YAML keys;
- stream/plugin identity coercion and blank identity attacks;
- runtime queue/overflow canonicalization;
- thread/GPU/process execution declarations;
- process timeout and shared-memory mailbox normalization;
- invalid timeout/transport/mailbox combinations;
- direct v1 non-default execution rejection;
- mixed transform/decoder/sink/monitor execution compilation;
- shared-memory compilation without loss;
- source isolation rejection;
- serialized and direct monitor execution compilation;
- canonical equality between `ExecutionConfig` and direct `RuntimeNode` fields.

Runtime Fault Qualification binds `neuros/config/**`, the new authority suite, and legacy `test_config_schema.py` across all nine OS/Python lanes. The old `test_config_resolution.py` is intentionally not in this core-only matrix because it requires the packaged `mock` entry-point plugin; v1 resolution is independently proven in the new suite with an explicit in-memory registry, while packaged plugin resolution remains covered by broader CI/Whole Package qualification.

## Qualified checkpoints

- `efdbffcfebde095f63fcb61bf30ccebc67a86ae9`: first fully repository-qualified schema/compiler checkpoint, 382/382 verified Ubuntu/Python 3.10 Runtime Fault lane. This checkpoint contained the subsequently corrected monitor restriction.
- `63698d32c25915262374fe2b708bcde74c0c2b69`: monitor-corrected semantic head, 9/9 Runtime Fault lanes green and 381/381 verified Ubuntu/Python 3.10. Remaining repository-wide queues are still pending.

No green evidence from the earlier checkpoint is being borrowed for the corrected monitor surface.

## Next semantic tranche

After the corrected checkpoint closes repository-wide, add canonical **all-node resolved execution authority** to `RuntimeExecutor.snapshot()` while preserving the existing `process_execution` surface.

The planned evidence records, per accepted node:

- node kind;
- requested executor;
- effective execution domain (`event_loop`, `worker_thread`, `persistent_process`);
- scheduling mode (`source_task`, `unary_task`, `fusion_task`, `observation_callback`);
- process timeout/transport/mailbox authority where applicable.

This will explicitly show that requested `gpu` currently executes in the event-loop domain. The manifest will be captured from the graph accepted at executor construction rather than recomputed from later mutable graph containers. Broader post-construction graph-drift authority is tracked separately in #140.

A disposable staging branch is validating this implementation. Staging results are diagnostic only and will not count as PR qualification evidence.

## Non-goals

- no source lifecycle isolation;
- no new GPU isolation claim;
- no process transport/wire-format change;
- no DecoderOutput/scientific model change;
- no claim that #140 is solved by this tranche;
- no merge decision.

Refs #131, #137, #138, #140.