### PR TITLE
Representation authority: T-PHATE vs PCA, autoencoder, and temporal SSL

### DIFF
--- a/.github/workflows/representation-qualification.yml
+++ b/.github/workflows/representation-qualification.yml
@@ -1,0 +1,122 @@
+name: Representation Qualification
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/representation-qualification.yml"
+      - "docs/REPRESENTATION_BENCHMARK.md"
+      - "packages/neuros-mechint/src/neuros_mechint/representations/**"
+      - "packages/neuros-mechint/tests/test_mechint_representations.py"
+      - "packages/neuros-mechint/tests/test_mechint_representation_authority.py"
+      - "packages/neuros-mechint/examples/11_representation_benchmark.py"
+      - "packages/neuros-mechint/pyproject.toml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/representation-qualification.yml"
+      - "docs/REPRESENTATION_BENCHMARK.md"
+      - "packages/neuros-mechint/src/neuros_mechint/representations/**"
+      - "packages/neuros-mechint/tests/test_mechint_representations.py"
+      - "packages/neuros-mechint/tests/test_mechint_representation_authority.py"
+      - "packages/neuros-mechint/examples/11_representation_benchmark.py"
+      - "packages/neuros-mechint/pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  representation-contracts:
+    name: Representation contracts / Python 3.11
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            packages/neuros-core/pyproject.toml
+            packages/neuros-mechint/pyproject.toml
+      - name: Install representation qualification surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e "packages/neuros-core[test]"
+          python -m pip install -e "packages/neuros-mechint"
+          python -m pip check
+      - name: Compile representation modules and example
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m compileall -q packages/neuros-mechint/src/neuros_mechint/representations
+          python -m py_compile packages/neuros-mechint/examples/11_representation_benchmark.py
+      - name: Exercise representation authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            packages/neuros-mechint/tests/test_mechint_representations.py \
+            packages/neuros-mechint/tests/test_mechint_representation_authority.py
+      - name: Exercise controlled reference-manifold benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="${RUNNER_TEMP}/representation-benchmark.json"
+          python packages/neuros-mechint/examples/11_representation_benchmark.py \
+            --noise 0.35 \
+            --seed 7 \
+            --components 3 \
+            --ae-epochs 4 > "${OUT}"
+          python - "${OUT}" <<'PY'
+          import json
+          import math
+          import pathlib
+          import sys
+
+          payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          metadata = payload["benchmark_metadata"]
+          assert metadata["ranking_policy"] == "none"
+          assert metadata["claim_scope"] == "representation_geometry"
+          assert metadata["reference_geometry"] == "provided"
+          assert "winner" not in payload
+
+          methods = payload["methods"]
+          assert set(methods) == {"pca", "autoencoder", "tphate"}
+          required = {
+              "local_knn_preservation",
+              "pairwise_distance_rank",
+              "temporal_continuity_ratio",
+              "reference_local_knn_preservation",
+              "reference_pairwise_distance_rank",
+          }
+          for method_id in ("pca", "autoencoder"):
+              outcome = methods[method_id]
+              assert outcome["status"] == "ok", (method_id, outcome)
+              assert outcome["fit_regime"] == "train_only_inductive"
+              metrics = outcome["metrics"]
+              assert required <= set(metrics), (method_id, metrics)
+              for key in required:
+                  value = metrics[key]
+                  assert value is None or math.isfinite(value), (method_id, key, value)
+
+          tphate = methods["tphate"]
+          assert tphate["fit_regime"] == "transductive_target_observed"
+          assert tphate["status"] == "unavailable"
+          assert tphate["error_type"] == "TPHATEUnavailableError"
+          assert "Non-Commercial License" in tphate["error_message"]
+
+          diagnostics = {
+              method_id: {
+                  key: methods[method_id]["metrics"].get(key)
+                  for key in sorted(required)
+              }
+              for method_id in ("pca", "autoencoder")
+          }
+          print("REPRESENTATION_DIAGNOSTICS=" + json.dumps(diagnostics, sort_keys=True))
+          PY

--- a/docs/REPRESENTATION_BENCHMARK.md
+++ b/docs/REPRESENTATION_BENCHMARK.md
@@ -1,0 +1,257 @@
+# Neural Representation Benchmark Authority
+
+This document defines the neurOS research contract for comparing temporal neural representations across PCA, a train-only autoencoder, upstream T-PHATE, and fixed external temporal self-supervised representations.
+
+The benchmark is intentionally not a leaderboard. These methods operate under different information regimes, and collapsing them into one scalar winner would hide the most important scientific distinction: **what data each representation was allowed to observe while it was constructed**.
+
+## Why T-PHATE is interesting
+
+Temporal PHATE (T-PHATE) was introduced by Busch et al. in *Nature Computational Science* (2023), “Multi-view manifold learning of human brain-state trajectories” (DOI: 10.1038/s43588-023-00419-0).
+
+The upstream implementation is maintained at:
+
+- https://github.com/KrishnaswamyLab/TPHATE
+
+At a high level, T-PHATE constructs two views of an ordered trajectory:
+
+1. a PHATE-style geometry diffusion operator derived from similarity in observed feature space;
+2. a temporal transition operator derived from the mean autocorrelation function across features.
+
+The method combines those views, diffuses the resulting transition operator, converts the diffusion probabilities to an information-potential representation, and embeds that potential using MDS.
+
+The temporal view is the key distinction from ordinary PHATE. Nearby timepoints can reinforce one another even when observation noise makes them less similar in the raw feature space.
+
+## neurOS integration boundary
+
+neurOS does **not** vendor, copy, or reimplement T-PHATE.
+
+At integration time, the upstream repository's `LICENSE.md` contains a Yale Non-Commercial License, while upstream package metadata still advertises a GPL classifier. neurOS itself is MIT licensed. Because those surfaces do not present a clean permissive dependency boundary, neurOS treats T-PHATE as an optional external package:
+
+- `tphate` is not a default neurOS dependency;
+- normal neurOS CI does not install it;
+- the adapter lazily imports a separately installed upstream package;
+- missing T-PHATE is represented as an explicit `unavailable` method outcome;
+- users are responsible for reviewing the current upstream terms for their intended use.
+
+This is an engineering boundary, not legal advice or a license grant.
+
+## Sequence authority
+
+T-PHATE assumes rows form one ordered temporal sequence. Its temporal kernel uses sample-index lag as temporal distance.
+
+Therefore neurOS never creates a T-PHATE input by concatenating independent subjects, sessions, runs, or trials into one artificial timeline.
+
+`SequenceBatch` preserves trajectories as separate arrays with explicit unique sequence IDs. The T-PHATE adapter creates a **fresh upstream estimator for each evaluation trajectory**.
+
+This is stricter than the older exploratory `ManifoldAnalyzer`, whose generic 3-D path can flatten multiple trajectories for order-independent geometry analyses. That flattening must not be used as T-PHATE temporal authority.
+
+## Fit regimes
+
+Every method exposes a `FitRegime`.
+
+| Method | neurOS fit regime | What observes evaluation structure? | Coordinate frame |
+| --- | --- | --- | --- |
+| PCA | `train_only_inductive` | only the fixed train-fitted transform is applied | shared train-fitted axes |
+| Autoencoder | `train_only_inductive` | only the fixed train-fitted encoder is applied | shared train-fitted encoder |
+| T-PHATE | `transductive_target_observed` | the unlabeled evaluation trajectory is itself fit | independently fit MDS frame per trajectory |
+| Temporal SSL | `external_pretrained` | depends on the external model and its pretraining/adaptation history | shared external encoder when the provider is fixed |
+
+A T-PHATE result must not be described as train-only zero-shot transfer. Its target trajectory participates in representation construction even when no target labels are used.
+
+Likewise, an external temporal SSL embedding is not automatically clean zero-shot evidence. neurOS records a model ID, model version, known pretraining datasets, and a pretraining-lineage audit status. Dataset overlap remains a scientific-authority question outside the geometry metric itself.
+
+## T-PHATE parameter evidence
+
+The adapter forwards the maintained upstream estimator parameters and disables landmarking so temporal continuity is not routed through a landmark approximation.
+
+`n_pca` receives extra evidence because upstream defaults can exceed a short trajectory's dimensions. neurOS records:
+
+- `requested_n_pca`;
+- `effective_n_pca_by_sequence`;
+- `n_pca_policy`.
+
+When requested `n_pca` is not strictly smaller than both dimensions of a trajectory, the adapter disables upstream PCA for that trajectory and records the effective value as `None`. This prevents a necessary compatibility adjustment from becoming invisible preprocessing drift.
+
+## Upstream failure boundary
+
+The current upstream temporal-kernel path finds the first negative crossing of a smoothed mean autocorrelation function. A trajectory whose smoothed ACF never crosses zero can therefore fail during the upstream dropoff calculation.
+
+neurOS does not invent a replacement dropoff or silently switch to a different temporal kernel. The adapter translates that failure into a method-scoped `TPHATEEmbeddingError` explaining that no negative crossing was available.
+
+More generally, a single unavailable or failed representation method does not erase the other benchmark results. Every requested method receives one explicit outcome:
+
+- `ok`;
+- `failed`;
+- `unavailable`.
+
+## Real-valued representation contract
+
+The common comparison surface accepts finite **real-valued** arrays only.
+
+Complex inputs are rejected before method dispatch. This matters because otherwise NumPy linear algebra could preserve complex values while a torch autoencoder or real-valued geometry metric silently projected them to a different space.
+
+Caller-owned arrays are copied and made read-only. Nested metadata is detached recursively, and metadata keys must already be explicit nonblank strings rather than being coerced.
+
+## Geometry metrics
+
+The initial common metrics are deliberately coordinate-frame agnostic.
+
+### Local neighborhood preservation
+
+For each trajectory, compare the source-space `k` nearest neighbors of each timepoint with its latent-space neighbors. The metric is the mean retained-neighbor fraction.
+
+### Pairwise-distance rank preservation
+
+Compute Spearman correlation between pairwise distances in source and latent space. The metric uses a deterministic temporal subsample for very long trajectories.
+
+### Temporal continuity ratio
+
+Compare median adjacent-step distance in latent space with median distance between non-adjacent timepoints.
+
+Lower values mean adjacent states are relatively close, but this is **not** a universal optimization objective. A representation can score extremely smoothly by over-smoothing away meaningful state transitions.
+
+### Known-reference geometry
+
+Controlled simulations may supply a separate `reference=SequenceBatch` containing the known clean latent trajectory. Reference IDs and timepoint counts must exactly match the evaluation batch.
+
+The benchmark then adds:
+
+- `reference_local_knn_preservation`;
+- `reference_pairwise_distance_rank`.
+
+These metrics are inspired by the same scientific question as controlled-manifold fidelity analyses such as DeMAP: does an embedding recover known latent geometry despite noisy observations? neurOS does not claim these two metrics are a reimplementation of DeMAP.
+
+## Why metrics are trajectory-local
+
+An independently fitted MDS embedding can rotate, reflect, or translate without changing its geometry. T-PHATE embeddings fit separately to different trajectories therefore do not share meaningful raw axes by default.
+
+The initial benchmark computes distance/neighborhood metrics inside each trajectory and aggregates the scalar metrics afterward. It does **not** concatenate latent coordinates across independently fitted trajectories.
+
+Cross-subject coordinate comparison requires a separate alignment protocol with explicit anchors or correspondence assumptions.
+
+## PCA baseline
+
+`PCARepresentation` is a dependency-light NumPy/SVD baseline.
+
+It concatenates training trajectories only for the order-independent PCA fit, records the train mean/components, and applies the resulting fixed transform separately to each evaluation trajectory.
+
+Changing evaluation observations cannot change the fitted PCA state.
+
+## Autoencoder baseline
+
+`AutoencoderRepresentation` is a small deterministic torch MLP autoencoder.
+
+It is intentionally a baseline rather than a claim that one MLP architecture represents the entire autoencoder literature. The model:
+
+- standardizes using training observations only;
+- uses a seeded CPU training path;
+- trains only on the declared training sequences;
+- applies the fixed encoder to evaluation trajectories;
+- records optimizer/training configuration and final training loss.
+
+Reconstruction loss is not used as a universal cross-method score because T-PHATE and arbitrary SSL embeddings do not necessarily define inverse decoders.
+
+## Temporal SSL / foundation representations
+
+`PrecomputedTemporalSSLRepresentation` binds fixed external embeddings to exact evaluation sequence IDs and timepoint counts.
+
+This is intentionally a consumption adapter, not a training framework. A representation generated by EEGPT, LaBraM, REVE, CSBrain, LUNA, NeuroFM-X, or another temporal model should be extracted under that model's own qualified pipeline, then supplied with explicit provenance.
+
+Required identity includes:
+
+- `model_id`;
+- `model_version`;
+- exact per-sequence embedding arrays.
+
+Pretraining metadata includes known pretraining dataset IDs and one explicit lineage status:
+
+- `disjoint_verified`;
+- `overlap_detected`;
+- `possible_overlap`;
+- `unknown_lineage`;
+- `not_audited`.
+
+The benchmark must not reinterpret `unknown_lineage` as clean transfer evidence.
+
+## Controlled example
+
+A deterministic synthetic benchmark is available at:
+
+```bash
+python packages/neuros-mechint/examples/11_representation_benchmark.py
+```
+
+It creates a clean temporal latent trajectory, maps it nonlinearly into a higher-dimensional observation space, adds Gaussian noise, and compares the observed embeddings with both observed-space and known-reference geometry.
+
+Without a separately installed T-PHATE package, the output will contain an explicit `tphate: unavailable` record while PCA and the autoencoder continue to run.
+
+An external temporal SSL embedding can be supplied as an `.npz` file containing an `eval` array with one row per evaluation timepoint. The model/version and pretraining-lineage fields should identify the actual external representation rather than a synthetic stand-in.
+
+## Noise-sweep experiment design
+
+The highest-value first scientific experiment is a controlled noise sweep rather than a single visualization.
+
+For several fixed noise levels and random seeds:
+
+1. generate train and evaluation observations from a known smooth latent trajectory;
+2. fit PCA and the autoencoder on train observations only;
+3. fit T-PHATE transductively on each evaluation trajectory;
+4. consume a fixed temporal SSL representation only when a genuine model embedding is available;
+5. report both observed-space and known-reference geometry metrics;
+6. retain fit-regime and lineage fields next to every metric;
+7. plot metric distributions/curves with uncertainty across seeds, not one cherry-picked embedding.
+
+This directly tests the hypothesis that T-PHATE's temporal prior is especially useful when observation noise damages raw geometric neighborhood structure.
+
+## No scalar winner
+
+`RepresentationBenchmarkResult` intentionally has no `winner` field.
+
+Different metrics answer different questions, and the methods use different information regimes. A useful result might show, for example:
+
+- T-PHATE recovers reference geometry best under high noise but is transductive;
+- PCA transfers most cleanly across held-out trajectories but misses nonlinear geometry;
+- the autoencoder improves nonlinear compression after sufficient train data;
+- a pretrained temporal SSL model transfers well, but its pretraining lineage is only partially known.
+
+Those statements should remain visible rather than being collapsed into a single number.
+
+## Qualification boundary
+
+Normal neurOS qualification validates:
+
+- sequence identity and immutability;
+- PCA and autoencoder train-only fitting;
+- failure-preserving orchestration;
+- rigid-transform-invariant metrics;
+- known-reference identity;
+- T-PHATE adapter parameter forwarding through a fake upstream seam;
+- missing-upstream behavior;
+- upstream-error translation;
+- temporal SSL identity and lineage metadata;
+- import/build behavior without T-PHATE installed.
+
+Normal CI does **not** install the upstream non-commercial T-PHATE package. Therefore a green neurOS workflow proves adapter contracts, not compatibility with every current/future upstream T-PHATE release.
+
+A separately authorized upstream-compatibility study should name the exact upstream T-PHATE version/commit and environment it exercised.
+
+## Claim boundaries
+
+This benchmark establishes representation-analysis plumbing and evidence discipline. It does **not** establish:
+
+- that one representation method is universally superior;
+- a decoder-performance advantage;
+- causal neural mechanisms;
+- biological interpretation of embedding axes;
+- clinical validity or safety;
+- cross-subject alignment from unaligned T-PHATE coordinates;
+- zero-shot status for transductive T-PHATE;
+- clean transfer for a pretrained model with unknown/overlapping pretraining lineage;
+- commercial permission to use upstream T-PHATE.
+
+## Related neurOS surfaces
+
+- `docs/SCIENTIFIC_AUTHORITY_V2.md` defines dataset/model lineage and evidence-domain rules.
+- `neuros_mechint.dynamics.ManifoldAnalyzer` remains a generic exploratory manifold tool; it is not the T-PHATE sequence-authority boundary.
+- `neuros.foundation_models` catalogs temporal/foundation representation methods and their integration/access status.
+- issue #141 owns this representation benchmark tranche.

--- a/packages/neuros-mechint/examples/11_representation_benchmark.py
+++ b/packages/neuros-mechint/examples/11_representation_benchmark.py
@@ -1,0 +1,189 @@
+"""Compare neural representations on a controlled temporal manifold.
+
+The example runs without T-PHATE installed. In that case its outcome is recorded
+as unavailable rather than dropped. T-PHATE is an optional external dependency
+with upstream license terms that must be reviewed separately.
+
+An optional fixed temporal-SSL embedding can be supplied as an ``.npz`` file
+containing an ``eval`` array with shape [time, latent]. This example never trains
+or downloads a foundation model, so model/pretraining provenance remains
+explicit and user-supplied.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from neuros_mechint.representations import (
+    AutoencoderRepresentation,
+    PCARepresentation,
+    PrecomputedTemporalSSLRepresentation,
+    RepresentationBenchmark,
+    SequenceBatch,
+    TPHATERepresentation,
+)
+
+
+def _latent_trajectory(n: int, phase: float) -> np.ndarray:
+    t = np.linspace(0.0, 4.0 * np.pi, n, endpoint=False) + phase
+    return np.column_stack(
+        [
+            np.cos(t),
+            np.sin(t),
+            0.35 * np.sin(2.0 * t),
+        ]
+    )
+
+
+def _observations(
+    latent: np.ndarray,
+    *,
+    rng: np.random.Generator,
+    mixing: np.ndarray,
+    noise: float,
+) -> np.ndarray:
+    nonlinear = np.column_stack(
+        [
+            latent,
+            latent[:, 0] * latent[:, 1],
+            latent[:, 0] ** 2 - latent[:, 1] ** 2,
+            np.sin(1.5 * latent[:, 2]),
+        ]
+    )
+    return nonlinear @ mixing + rng.normal(scale=noise, size=(latent.shape[0], mixing.shape[1]))
+
+
+def _build_data(noise: float, seed: int) -> tuple[SequenceBatch, SequenceBatch, SequenceBatch]:
+    rng = np.random.default_rng(seed)
+    mixing = rng.normal(size=(6, 24))
+    train_latent = _latent_trajectory(160, phase=0.0)
+    eval_latent = _latent_trajectory(140, phase=0.37)
+    train = SequenceBatch(
+        sequences=(
+            _observations(train_latent, rng=rng, mixing=mixing, noise=noise),
+        ),
+        sequence_ids=("train",),
+        metadata={"generator": "controlled_temporal_manifold", "noise_std": noise},
+    )
+    evaluation = SequenceBatch(
+        sequences=(
+            _observations(eval_latent, rng=rng, mixing=mixing, noise=noise),
+        ),
+        sequence_ids=("eval",),
+        metadata={"generator": "controlled_temporal_manifold", "noise_std": noise},
+    )
+    reference = SequenceBatch(
+        sequences=(eval_latent,),
+        sequence_ids=("eval",),
+        metadata={"authority": "known_clean_latent_geometry"},
+    )
+    return train, evaluation, reference
+
+
+def _ssl_method(args: argparse.Namespace, evaluation: SequenceBatch):
+    if args.ssl_npz is None:
+        return None
+    with np.load(args.ssl_npz, allow_pickle=False) as payload:
+        if "eval" not in payload:
+            raise ValueError("--ssl-npz must contain an 'eval' array")
+        embedding = np.array(payload["eval"], copy=True)
+    if embedding.shape[0] != evaluation.sequences[0].shape[0]:
+        raise ValueError(
+            "--ssl-npz 'eval' timepoint count must match the generated evaluation sequence"
+        )
+    return PrecomputedTemporalSSLRepresentation(
+        {"eval": embedding},
+        model_id=args.ssl_model_id,
+        model_version=args.ssl_model_version,
+        pretraining_datasets=tuple(args.ssl_pretraining_dataset),
+        pretraining_lineage_status=args.ssl_lineage,
+        method_id="temporal_ssl",
+    )
+
+
+def _serializable_result(result) -> dict[str, object]:
+    methods: dict[str, object] = {}
+    for outcome in result.outcomes:
+        methods[outcome.method_id] = {
+            "fit_regime": outcome.fit_regime.value,
+            "status": outcome.status.value,
+            "metrics": dict(outcome.metrics),
+            "error_type": outcome.error_type,
+            "error_message": outcome.error_message,
+            "metadata": dict(outcome.metadata),
+            "embedding_metadata": (
+                dict(outcome.embedding.metadata) if outcome.embedding is not None else None
+            ),
+        }
+    return {
+        "train_sequence_ids": list(result.train_sequence_ids),
+        "evaluation_sequence_ids": list(result.evaluation_sequence_ids),
+        "benchmark_metadata": dict(result.metadata),
+        "methods": methods,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--noise", type=float, default=0.35)
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--components", type=int, default=3)
+    parser.add_argument("--ae-epochs", type=int, default=20)
+    parser.add_argument("--ssl-npz", type=Path)
+    parser.add_argument("--ssl-model-id", default="external-temporal-ssl")
+    parser.add_argument("--ssl-model-version", default="unspecified")
+    parser.add_argument(
+        "--ssl-lineage",
+        choices=(
+            "disjoint_verified",
+            "overlap_detected",
+            "possible_overlap",
+            "unknown_lineage",
+            "not_audited",
+        ),
+        default="not_audited",
+    )
+    parser.add_argument(
+        "--ssl-pretraining-dataset",
+        action="append",
+        default=[],
+        help="Repeat for every known pretraining dataset ID.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if not np.isfinite(args.noise) or args.noise < 0:
+        raise ValueError("--noise must be finite and nonnegative")
+
+    train, evaluation, reference = _build_data(args.noise, args.seed)
+    methods = [
+        PCARepresentation(args.components),
+        AutoencoderRepresentation(
+            args.components,
+            hidden_dim=32,
+            epochs=args.ae_epochs,
+            batch_size=64,
+            seed=args.seed,
+        ),
+        TPHATERepresentation(args.components, random_state=args.seed),
+    ]
+    ssl = _ssl_method(args, evaluation)
+    if ssl is not None:
+        methods.append(ssl)
+
+    result = RepresentationBenchmark(methods, neighborhood_k=8).run(
+        train,
+        evaluation,
+        reference=reference,
+    )
+    print(json.dumps(_serializable_result(result), indent=2, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/neuros-mechint/src/neuros_mechint/representations/__init__.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/__init__.py
@@ -1,0 +1,57 @@
+"""Boundary-preserving neural representation comparison tools."""
+
+from .autoencoder import AutoencoderRepresentation
+from .benchmark import RepresentationBenchmark
+from .contracts import (
+    FitRegime,
+    MethodOutcome,
+    MethodStatus,
+    RepresentationBenchmarkResult,
+    RepresentationEmbedding,
+    RepresentationError,
+    RepresentationMethod,
+    RepresentationUnavailableError,
+    SequenceBatch,
+)
+from .external import PrecomputedTemporalSSLRepresentation
+from .metrics import (
+    aggregate_geometry_metrics,
+    aggregate_reference_metrics,
+    local_neighborhood_preservation,
+    pairwise_distance_rank_preservation,
+    temporal_continuity_ratio,
+)
+from .pca import PCARepresentation
+from .tphate import (
+    TPHATEEmbeddingError,
+    TPHATERepresentation,
+    TPHATEUnavailableError,
+    UPSTREAM_LICENSE_NOTICE,
+    UPSTREAM_REPOSITORY,
+)
+
+__all__ = [
+    "AutoencoderRepresentation",
+    "FitRegime",
+    "MethodOutcome",
+    "MethodStatus",
+    "PCARepresentation",
+    "PrecomputedTemporalSSLRepresentation",
+    "RepresentationBenchmark",
+    "RepresentationBenchmarkResult",
+    "RepresentationEmbedding",
+    "RepresentationError",
+    "RepresentationMethod",
+    "RepresentationUnavailableError",
+    "SequenceBatch",
+    "TPHATEEmbeddingError",
+    "TPHATERepresentation",
+    "TPHATEUnavailableError",
+    "UPSTREAM_LICENSE_NOTICE",
+    "UPSTREAM_REPOSITORY",
+    "aggregate_geometry_metrics",
+    "aggregate_reference_metrics",
+    "local_neighborhood_preservation",
+    "pairwise_distance_rank_preservation",
+    "temporal_continuity_ratio",
+]

--- a/packages/neuros-mechint/src/neuros_mechint/representations/autoencoder.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/autoencoder.py
@@ -1,0 +1,161 @@
+"""Native train-only autoencoder representation baseline."""
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from .contracts import FitRegime, RepresentationEmbedding, SequenceBatch
+from .pca import _positive_int
+
+
+class _MLPAutoencoder(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, latent_dim: int) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, latent_dim),
+        )
+        self.decoder = nn.Sequential(
+            nn.Linear(latent_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, input_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.decoder(self.encoder(x))
+
+
+class AutoencoderRepresentation:
+    """Small deterministic CPU autoencoder fit only on declared train samples."""
+
+    fit_regime = FitRegime.TRAIN_ONLY_INDUCTIVE
+
+    def __init__(
+        self,
+        n_components: int = 2,
+        *,
+        hidden_dim: int | None = None,
+        epochs: int = 50,
+        batch_size: int = 128,
+        learning_rate: float = 1e-3,
+        seed: int = 0,
+        method_id: str = "autoencoder",
+    ) -> None:
+        self.n_components = _positive_int(n_components, name="n_components")
+        self.hidden_dim = (
+            None if hidden_dim is None else _positive_int(hidden_dim, name="hidden_dim")
+        )
+        self.epochs = _positive_int(epochs, name="epochs")
+        self.batch_size = _positive_int(batch_size, name="batch_size")
+        if isinstance(learning_rate, bool) or not isinstance(
+            learning_rate, (int, float, np.integer, np.floating)
+        ):
+            raise TypeError("learning_rate must be a finite positive real")
+        self.learning_rate = float(learning_rate)
+        if not np.isfinite(self.learning_rate) or self.learning_rate <= 0:
+            raise ValueError("learning_rate must be a finite positive real")
+        if isinstance(seed, bool) or not isinstance(seed, (int, np.integer)):
+            raise TypeError("seed must be an integer")
+        self.seed = int(seed)
+        if not isinstance(method_id, str) or not method_id.strip():
+            raise ValueError("method_id must be a nonblank string")
+        self.method_id = method_id
+
+        self.mean_: np.ndarray | None = None
+        self.scale_: np.ndarray | None = None
+        self.training_loss_: float | None = None
+        self.model_: _MLPAutoencoder | None = None
+
+    def embed(
+        self,
+        train: SequenceBatch,
+        evaluation: SequenceBatch,
+    ) -> RepresentationEmbedding:
+        if train.feature_count != evaluation.feature_count:
+            raise ValueError("train and evaluation feature dimensions must match")
+
+        train_x = np.asarray(train.concatenate(), dtype=np.float32)
+        mean = np.mean(train_x, axis=0, dtype=np.float64).astype(np.float32)
+        scale = np.std(train_x, axis=0, dtype=np.float64).astype(np.float32)
+        scale[scale < 1e-6] = 1.0
+        standardized = (train_x - mean) / scale
+
+        hidden_dim = self.hidden_dim
+        if hidden_dim is None:
+            hidden_dim = max(8, min(128, max(self.n_components * 2, train.feature_count)))
+
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(self.seed)
+            model = _MLPAutoencoder(train.feature_count, hidden_dim, self.n_components)
+            optimizer = torch.optim.Adam(model.parameters(), lr=self.learning_rate)
+            criterion = nn.MSELoss()
+            tensor = torch.from_numpy(np.array(standardized, copy=True))
+            dataset = TensorDataset(tensor)
+            generator = torch.Generator(device="cpu")
+            generator.manual_seed(self.seed)
+            loader = DataLoader(
+                dataset,
+                batch_size=min(self.batch_size, len(dataset)),
+                shuffle=True,
+                generator=generator,
+                num_workers=0,
+                drop_last=False,
+            )
+            model.train()
+            last_loss = 0.0
+            for _ in range(self.epochs):
+                loss_total = 0.0
+                sample_total = 0
+                for (batch,) in loader:
+                    optimizer.zero_grad(set_to_none=True)
+                    reconstructed = model(batch)
+                    loss = criterion(reconstructed, batch)
+                    if not torch.isfinite(loss):
+                        raise RuntimeError("autoencoder training produced a non-finite loss")
+                    loss.backward()
+                    optimizer.step()
+                    count = int(batch.shape[0])
+                    loss_total += float(loss.detach()) * count
+                    sample_total += count
+                last_loss = loss_total / max(sample_total, 1)
+
+            model.eval()
+            embedded: list[np.ndarray] = []
+            with torch.no_grad():
+                for sequence in evaluation.sequences:
+                    x = np.asarray(sequence, dtype=np.float32)
+                    x = (x - mean) / scale
+                    z = model.encoder(torch.from_numpy(np.array(x, copy=True)))
+                    embedded.append(z.cpu().numpy())
+
+        mean_copy = np.array(mean, copy=True)
+        scale_copy = np.array(scale, copy=True)
+        mean_copy.setflags(write=False)
+        scale_copy.setflags(write=False)
+        self.mean_ = mean_copy
+        self.scale_ = scale_copy
+        self.training_loss_ = float(last_loss)
+        self.model_ = model
+
+        return RepresentationEmbedding(
+            method_id=self.method_id,
+            sequences=tuple(embedded),
+            sequence_ids=evaluation.sequence_ids,
+            fit_regime=self.fit_regime,
+            metadata={
+                "n_components": self.n_components,
+                "hidden_dim": hidden_dim,
+                "epochs": self.epochs,
+                "batch_size": self.batch_size,
+                "learning_rate": self.learning_rate,
+                "seed": self.seed,
+                "fit_sample_count": train.sample_count,
+                "target_specific_fit_observations": 0,
+                "training_loss": self.training_loss_,
+                "coordinate_frame": "shared_train_fitted_encoder",
+                "implementation": "torch_mlp_autoencoder",
+            },
+        )

--- a/packages/neuros-mechint/src/neuros_mechint/representations/benchmark.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/benchmark.py
@@ -1,0 +1,140 @@
+"""Failure-preserving comparison of neural representation methods."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .contracts import (
+    MethodOutcome,
+    MethodStatus,
+    RepresentationBenchmarkResult,
+    RepresentationMethod,
+    RepresentationUnavailableError,
+    SequenceBatch,
+)
+from .metrics import aggregate_geometry_metrics, aggregate_reference_metrics
+from .pca import _positive_int
+
+
+class RepresentationBenchmark:
+    """Run requested methods under their declared fit regimes.
+
+    The result intentionally does not rank methods. T-PHATE's transductive
+    target fit, train-only PCA/autoencoder fitting, and fixed pretrained
+    encoders represent different information regimes and must remain visible.
+    """
+
+    def __init__(
+        self,
+        methods: Iterable[RepresentationMethod],
+        *,
+        neighborhood_k: int = 5,
+    ) -> None:
+        methods = tuple(methods)
+        if not methods:
+            raise ValueError("at least one representation method is required")
+        ids = [method.method_id for method in methods]
+        if any(not isinstance(method_id, str) or not method_id.strip() for method_id in ids):
+            raise ValueError("every method must expose a nonblank method_id")
+        if len(set(ids)) != len(ids):
+            raise ValueError("representation method IDs must be unique")
+        self.methods = methods
+        self.neighborhood_k = _positive_int(neighborhood_k, name="neighborhood_k")
+
+    def run(
+        self,
+        train: SequenceBatch,
+        evaluation: SequenceBatch,
+        *,
+        reference: SequenceBatch | None = None,
+    ) -> RepresentationBenchmarkResult:
+        if train.feature_count != evaluation.feature_count:
+            raise ValueError("train and evaluation feature dimensions must match")
+        if reference is not None:
+            if reference.sequence_ids != evaluation.sequence_ids:
+                raise ValueError(
+                    "reference sequence identity must exactly match evaluation identity"
+                )
+            for source, reference_sequence in zip(
+                evaluation.sequences,
+                reference.sequences,
+                strict=True,
+            ):
+                if source.shape[0] != reference_sequence.shape[0]:
+                    raise ValueError(
+                        "reference and evaluation sequences must have matching timepoints"
+                    )
+
+        outcomes: list[MethodOutcome] = []
+        for method in self.methods:
+            try:
+                embedding = method.embed(train, evaluation)
+                if embedding.sequence_ids != evaluation.sequence_ids:
+                    raise ValueError(
+                        "representation output sequence identity does not match evaluation batch"
+                    )
+                for source, latent in zip(
+                    evaluation.sequences,
+                    embedding.sequences,
+                    strict=True,
+                ):
+                    if source.shape[0] != latent.shape[0]:
+                        raise ValueError(
+                            "representation output changed the evaluation timepoint count"
+                        )
+                metrics = aggregate_geometry_metrics(
+                    evaluation.sequences,
+                    embedding.sequences,
+                    k=self.neighborhood_k,
+                )
+                if reference is not None:
+                    metrics.update(
+                        aggregate_reference_metrics(
+                            reference.sequences,
+                            embedding.sequences,
+                            k=self.neighborhood_k,
+                        )
+                    )
+                outcomes.append(
+                    MethodOutcome(
+                        method_id=method.method_id,
+                        fit_regime=method.fit_regime,
+                        status=MethodStatus.OK,
+                        embedding=embedding,
+                        metrics=metrics,
+                        metadata={
+                            "metric_scope": "trajectory_local_rigid_transform_invariant",
+                        },
+                    )
+                )
+            except RepresentationUnavailableError as exc:
+                outcomes.append(
+                    MethodOutcome(
+                        method_id=method.method_id,
+                        fit_regime=method.fit_regime,
+                        status=MethodStatus.UNAVAILABLE,
+                        error_type=type(exc).__name__,
+                        error_message=str(exc),
+                    )
+                )
+            except Exception as exc:
+                outcomes.append(
+                    MethodOutcome(
+                        method_id=method.method_id,
+                        fit_regime=method.fit_regime,
+                        status=MethodStatus.FAILED,
+                        error_type=type(exc).__name__,
+                        error_message=str(exc),
+                    )
+                )
+
+        return RepresentationBenchmarkResult(
+            train_sequence_ids=train.sequence_ids,
+            evaluation_sequence_ids=evaluation.sequence_ids,
+            outcomes=tuple(outcomes),
+            metadata={
+                "neighborhood_k": self.neighborhood_k,
+                "ranking_policy": "none",
+                "claim_scope": "representation_geometry",
+                "reference_geometry": "provided" if reference is not None else "none",
+            },
+        )

--- a/packages/neuros-mechint/src/neuros_mechint/representations/contracts.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/contracts.py
@@ -1,0 +1,246 @@
+"""Immutable representation-benchmark contracts."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+
+
+class FitRegime(str, Enum):
+    TRAIN_ONLY_INDUCTIVE = "train_only_inductive"
+    TRANSDUCTIVE_TARGET_OBSERVED = "transductive_target_observed"
+    EXTERNAL_PRETRAINED = "external_pretrained"
+
+
+class MethodStatus(str, Enum):
+    OK = "ok"
+    FAILED = "failed"
+    UNAVAILABLE = "unavailable"
+
+
+class RepresentationError(RuntimeError):
+    """Base error for representation methods."""
+
+
+class RepresentationUnavailableError(RepresentationError):
+    """Optional external representation capability is unavailable."""
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("metadata keys must be nonblank strings")
+            frozen[key] = _freeze_value(item)
+        return MappingProxyType(frozen)
+    if isinstance(value, tuple):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, list):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_value(item) for item in value)
+    if isinstance(value, np.ndarray):
+        array = np.array(value, copy=True, subok=False)
+        array.setflags(write=False)
+        return array
+    return value
+
+
+def _freeze_metadata(metadata: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if metadata is None:
+        return MappingProxyType({})
+    if not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping")
+    frozen: dict[str, Any] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError("metadata keys must be nonblank strings")
+        frozen[key] = _freeze_value(value)
+    return MappingProxyType(frozen)
+
+
+def _validated_array(value: Any, *, name: str, min_rows: int) -> np.ndarray:
+    array = np.array(value, copy=True, subok=False)
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be a 2-D [time, features] array")
+    if array.shape[0] < min_rows:
+        raise ValueError(f"{name} must contain at least {min_rows} timepoints")
+    if array.shape[1] < 1:
+        raise ValueError(f"{name} must contain at least one feature")
+    if array.dtype.kind not in "iuf":
+        raise TypeError(f"{name} must contain real numeric, non-boolean values")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    array.setflags(write=False)
+    return array
+
+
+@dataclass(frozen=True, slots=True)
+class SequenceBatch:
+    """Independent, ordered trajectories with a common feature geometry."""
+
+    sequences: tuple[np.ndarray, ...]
+    sequence_ids: tuple[str, ...]
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        sequences = tuple(self.sequences)
+        sequence_ids = tuple(self.sequence_ids)
+        if not sequences:
+            raise ValueError("SequenceBatch requires at least one sequence")
+        if len(sequences) != len(sequence_ids):
+            raise ValueError("sequence_ids must match the number of sequences")
+        normalized_ids: list[str] = []
+        for sequence_id in sequence_ids:
+            if not isinstance(sequence_id, str) or not sequence_id.strip():
+                raise ValueError("sequence IDs must be explicit nonblank strings")
+            normalized_ids.append(sequence_id)
+        if len(set(normalized_ids)) != len(normalized_ids):
+            raise ValueError("sequence IDs must be unique")
+        validated = tuple(
+            _validated_array(sequence, name=f"sequence {sequence_id!r}", min_rows=3)
+            for sequence_id, sequence in zip(normalized_ids, sequences, strict=True)
+        )
+        if len({array.shape[1] for array in validated}) != 1:
+            raise ValueError("all sequences must share the same feature dimension")
+        object.__setattr__(self, "sequences", validated)
+        object.__setattr__(self, "sequence_ids", tuple(normalized_ids))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+    @property
+    def feature_count(self) -> int:
+        return int(self.sequences[0].shape[1])
+
+    @property
+    def sample_count(self) -> int:
+        return int(sum(sequence.shape[0] for sequence in self.sequences))
+
+    def concatenate(self) -> np.ndarray:
+        """Return detached samples for order-independent train fitting only."""
+        return np.concatenate([np.asarray(sequence) for sequence in self.sequences], axis=0)
+
+
+@dataclass(frozen=True, slots=True)
+class RepresentationEmbedding:
+    method_id: str
+    sequences: tuple[np.ndarray, ...]
+    sequence_ids: tuple[str, ...]
+    fit_regime: FitRegime
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.method_id, str) or not self.method_id.strip():
+            raise ValueError("method_id must be a nonblank string")
+        sequences = tuple(self.sequences)
+        ids = tuple(self.sequence_ids)
+        if not sequences or len(sequences) != len(ids):
+            raise ValueError("embedding sequences and IDs must be nonempty and aligned")
+        if len(set(ids)) != len(ids):
+            raise ValueError("embedding sequence IDs must be unique")
+        validated: list[np.ndarray] = []
+        latent_dims: set[int] = set()
+        for sequence_id, sequence in zip(ids, sequences, strict=True):
+            if not isinstance(sequence_id, str) or not sequence_id.strip():
+                raise ValueError("embedding sequence IDs must be nonblank strings")
+            array = _validated_array(sequence, name=f"embedding {sequence_id!r}", min_rows=3)
+            validated.append(array)
+            latent_dims.add(int(array.shape[1]))
+        if len(latent_dims) != 1:
+            raise ValueError("all embedding sequences must share one latent dimension")
+        object.__setattr__(self, "sequences", tuple(validated))
+        object.__setattr__(self, "sequence_ids", ids)
+        object.__setattr__(self, "fit_regime", FitRegime(self.fit_regime))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+    @property
+    def n_components(self) -> int:
+        return int(self.sequences[0].shape[1])
+
+
+@dataclass(frozen=True, slots=True)
+class MethodOutcome:
+    method_id: str
+    fit_regime: FitRegime
+    status: MethodStatus
+    embedding: RepresentationEmbedding | None = None
+    metrics: Mapping[str, float | None] | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.method_id, str) or not self.method_id.strip():
+            raise ValueError("method_id must be a nonblank string")
+        regime = FitRegime(self.fit_regime)
+        status = MethodStatus(self.status)
+        if status is MethodStatus.OK:
+            if self.embedding is None:
+                raise ValueError("successful outcomes require an embedding")
+            if self.embedding.method_id != self.method_id:
+                raise ValueError("outcome and embedding method IDs must match")
+            if self.embedding.fit_regime is not regime:
+                raise ValueError("outcome and embedding fit regimes must match")
+            if self.error_type is not None or self.error_message is not None:
+                raise ValueError("successful outcomes cannot carry an error")
+        else:
+            if self.embedding is not None:
+                raise ValueError("failed/unavailable outcomes cannot carry an embedding")
+            if not self.error_type or not self.error_message:
+                raise ValueError("failed/unavailable outcomes require explicit error evidence")
+        metric_values: dict[str, float | None] = {}
+        if self.metrics is not None:
+            if not isinstance(self.metrics, Mapping):
+                raise TypeError("metrics must be a mapping")
+            for key, value in self.metrics.items():
+                if not isinstance(key, str) or not key.strip():
+                    raise ValueError("metric IDs must be nonblank strings")
+                if value is None:
+                    metric_values[key] = None
+                else:
+                    numeric = float(value)
+                    if not np.isfinite(numeric):
+                        raise ValueError("metric values must be finite or None")
+                    metric_values[key] = numeric
+        object.__setattr__(self, "fit_regime", regime)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "metrics", MappingProxyType(metric_values))
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class RepresentationBenchmarkResult:
+    """Complete method result set with no scalar winner/ranking field."""
+
+    train_sequence_ids: tuple[str, ...]
+    evaluation_sequence_ids: tuple[str, ...]
+    outcomes: tuple[MethodOutcome, ...]
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        outcomes = tuple(self.outcomes)
+        if not outcomes:
+            raise ValueError("benchmark result requires at least one method outcome")
+        method_ids = [outcome.method_id for outcome in outcomes]
+        if len(set(method_ids)) != len(method_ids):
+            raise ValueError("benchmark outcomes must have unique method IDs")
+        object.__setattr__(self, "train_sequence_ids", tuple(self.train_sequence_ids))
+        object.__setattr__(self, "evaluation_sequence_ids", tuple(self.evaluation_sequence_ids))
+        object.__setattr__(self, "outcomes", outcomes)
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+
+    def by_method(self) -> dict[str, MethodOutcome]:
+        return {outcome.method_id: outcome for outcome in self.outcomes}
+
+
+@runtime_checkable
+class RepresentationMethod(Protocol):
+    method_id: str
+    fit_regime: FitRegime
+
+    def embed(self, train: SequenceBatch, evaluation: SequenceBatch) -> RepresentationEmbedding:
+        ...

--- a/packages/neuros-mechint/src/neuros_mechint/representations/external.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/external.py
@@ -1,0 +1,132 @@
+"""Adapters for externally computed temporal self-supervised representations."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
+from typing import Any
+
+import numpy as np
+
+from .contracts import FitRegime, RepresentationEmbedding, SequenceBatch, _freeze_metadata
+
+_ALLOWED_LINEAGE_STATUS = {
+    "disjoint_verified",
+    "overlap_detected",
+    "possible_overlap",
+    "unknown_lineage",
+    "not_audited",
+}
+
+
+class PrecomputedTemporalSSLRepresentation:
+    """Use fixed external/pretrained embeddings without retraining in the benchmark.
+
+    The adapter deliberately does not call an external model. It binds already
+    computed per-sequence embeddings to exact sequence identities and carries
+    model/pretraining metadata for a higher-level scientific authority layer to
+    audit separately.
+    """
+
+    fit_regime = FitRegime.EXTERNAL_PRETRAINED
+
+    def __init__(
+        self,
+        embeddings: Mapping[str, Any],
+        *,
+        model_id: str,
+        model_version: str,
+        method_id: str = "temporal_ssl",
+        pretraining_datasets: Sequence[str] = (),
+        pretraining_lineage_status: str = "not_audited",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model_id must be a nonblank string")
+        if not isinstance(model_version, str) or not model_version.strip():
+            raise ValueError("model_version must be a nonblank string")
+        if not isinstance(method_id, str) or not method_id.strip():
+            raise ValueError("method_id must be a nonblank string")
+        if pretraining_lineage_status not in _ALLOWED_LINEAGE_STATUS:
+            raise ValueError(
+                "pretraining_lineage_status must be an explicit audit status"
+            )
+        if not isinstance(embeddings, Mapping) or not embeddings:
+            raise ValueError("embeddings must be a nonempty sequence-ID mapping")
+
+        stored: dict[str, np.ndarray] = {}
+        latent_dims: set[int] = set()
+        for sequence_id, value in embeddings.items():
+            if not isinstance(sequence_id, str) or not sequence_id.strip():
+                raise ValueError("embedding keys must be nonblank sequence IDs")
+            array = np.array(value, copy=True, subok=False)
+            if array.ndim != 2 or array.shape[0] < 3 or array.shape[1] < 1:
+                raise ValueError(
+                    f"external embedding {sequence_id!r} must be 2-D [time, latent]"
+                )
+            if array.dtype.kind not in "iuf":
+                raise TypeError(
+                    "external embeddings must contain real numeric, non-boolean values"
+                )
+            if not np.all(np.isfinite(array)):
+                raise ValueError("external embeddings must contain only finite values")
+            array.setflags(write=False)
+            stored[sequence_id] = array
+            latent_dims.add(int(array.shape[1]))
+        if len(latent_dims) != 1:
+            raise ValueError("all external embeddings must share one latent dimension")
+
+        datasets: list[str] = []
+        for dataset in pretraining_datasets:
+            if not isinstance(dataset, str) or not dataset.strip():
+                raise ValueError("pretraining dataset IDs must be nonblank strings")
+            datasets.append(dataset)
+        if len(set(datasets)) != len(datasets):
+            raise ValueError("pretraining dataset IDs must be unique")
+
+        self._embeddings = MappingProxyType(stored)
+        self.model_id = model_id
+        self.model_version = model_version
+        self.method_id = method_id
+        self.pretraining_datasets = tuple(datasets)
+        self.pretraining_lineage_status = pretraining_lineage_status
+        self.metadata = _freeze_metadata(metadata)
+
+    def embed(
+        self,
+        train: SequenceBatch,
+        evaluation: SequenceBatch,
+    ) -> RepresentationEmbedding:
+        del train
+        selected: list[np.ndarray] = []
+        for sequence_id, source in zip(
+            evaluation.sequence_ids,
+            evaluation.sequences,
+            strict=True,
+        ):
+            if sequence_id not in self._embeddings:
+                raise KeyError(
+                    f"external representation is missing sequence {sequence_id!r}"
+                )
+            embedding = self._embeddings[sequence_id]
+            if embedding.shape[0] != source.shape[0]:
+                raise ValueError(
+                    f"external embedding {sequence_id!r} has {embedding.shape[0]} "
+                    f"timepoints; evaluation sequence has {source.shape[0]}"
+                )
+            selected.append(embedding)
+
+        return RepresentationEmbedding(
+            method_id=self.method_id,
+            sequences=tuple(selected),
+            sequence_ids=evaluation.sequence_ids,
+            fit_regime=self.fit_regime,
+            metadata={
+                "model_id": self.model_id,
+                "model_version": self.model_version,
+                "pretraining_datasets": self.pretraining_datasets,
+                "pretraining_lineage_status": self.pretraining_lineage_status,
+                "target_specific_fit_observations": 0,
+                "coordinate_frame": "shared_external_encoder",
+                "external_metadata": dict(self.metadata),
+            },
+        )

--- a/packages/neuros-mechint/src/neuros_mechint/representations/metrics.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/metrics.py
@@ -1,0 +1,152 @@
+"""Orientation-invariant representation geometry metrics."""
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.distance import pdist, squareform
+from scipy.stats import spearmanr
+
+
+def _paired_arrays(
+    source: np.ndarray,
+    embedding: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    source_raw = np.asarray(source)
+    embedding_raw = np.asarray(embedding)
+    if source_raw.ndim != 2 or embedding_raw.ndim != 2:
+        raise ValueError("source and embedding must both be 2-D")
+    if source_raw.dtype.kind not in "iuf" or embedding_raw.dtype.kind not in "iuf":
+        raise TypeError("metric inputs must contain real numeric values")
+    source = np.asarray(source_raw, dtype=np.float64)
+    embedding = np.asarray(embedding_raw, dtype=np.float64)
+    if source.shape[0] != embedding.shape[0]:
+        raise ValueError("source and embedding must have matching timepoints")
+    if source.shape[0] < 3:
+        raise ValueError("at least three timepoints are required")
+    if not np.all(np.isfinite(source)) or not np.all(np.isfinite(embedding)):
+        raise ValueError("metric inputs must be finite")
+    return source, embedding
+
+
+def pairwise_distance_rank_preservation(
+    source: np.ndarray,
+    embedding: np.ndarray,
+    *,
+    max_points: int = 512,
+) -> float | None:
+    """Spearman correlation between source and latent pairwise distances."""
+    source, embedding = _paired_arrays(source, embedding)
+    if isinstance(max_points, bool) or not isinstance(max_points, (int, np.integer)):
+        raise TypeError("max_points must be an integer")
+    max_points = int(max_points)
+    if max_points < 3:
+        raise ValueError("max_points must be at least 3")
+    if source.shape[0] > max_points:
+        indices = np.linspace(0, source.shape[0] - 1, max_points, dtype=int)
+        source = source[indices]
+        embedding = embedding[indices]
+    source_dist = pdist(source)
+    embedding_dist = pdist(embedding)
+    if np.allclose(source_dist, source_dist[0]) or np.allclose(embedding_dist, embedding_dist[0]):
+        return None
+    statistic = spearmanr(source_dist, embedding_dist).statistic
+    if statistic is None or not np.isfinite(statistic):
+        return None
+    return float(statistic)
+
+
+def local_neighborhood_preservation(
+    source: np.ndarray,
+    embedding: np.ndarray,
+    *,
+    k: int = 5,
+) -> float:
+    """Mean fraction of source-space kNNs retained in latent space."""
+    source, embedding = _paired_arrays(source, embedding)
+    if isinstance(k, bool) or not isinstance(k, (int, np.integer)):
+        raise TypeError("k must be an integer")
+    k = int(k)
+    if k <= 0:
+        raise ValueError("k must be positive")
+    k = min(k, source.shape[0] - 1)
+    source_dist = squareform(pdist(source))
+    embedding_dist = squareform(pdist(embedding))
+    np.fill_diagonal(source_dist, np.inf)
+    np.fill_diagonal(embedding_dist, np.inf)
+    source_neighbors = np.argpartition(source_dist, kth=k - 1, axis=1)[:, :k]
+    embedding_neighbors = np.argpartition(embedding_dist, kth=k - 1, axis=1)[:, :k]
+    overlaps = [
+        len(set(source_neighbors[row]) & set(embedding_neighbors[row])) / k
+        for row in range(source.shape[0])
+    ]
+    return float(np.mean(overlaps))
+
+
+def temporal_continuity_ratio(embedding: np.ndarray) -> float | None:
+    """Adjacent-step distance divided by nonlocal temporal distance."""
+    raw = np.asarray(embedding)
+    if raw.ndim != 2 or raw.shape[0] < 3:
+        raise ValueError("embedding must be 2-D with at least three timepoints")
+    if raw.dtype.kind not in "iuf":
+        raise TypeError("embedding must contain real numeric values")
+    embedding = np.asarray(raw, dtype=np.float64)
+    if not np.all(np.isfinite(embedding)):
+        raise ValueError("embedding must contain only finite values")
+    adjacent = np.linalg.norm(np.diff(embedding, axis=0), axis=1)
+    distances = squareform(pdist(embedding))
+    mask = np.triu(np.ones(distances.shape, dtype=bool), k=2)
+    nonlocal_distances = distances[mask]
+    if nonlocal_distances.size == 0:
+        return None
+    denominator = float(np.median(nonlocal_distances))
+    if denominator <= np.finfo(float).eps:
+        return None
+    return float(np.median(adjacent) / denominator)
+
+
+def aggregate_geometry_metrics(
+    sources: tuple[np.ndarray, ...],
+    embeddings: tuple[np.ndarray, ...],
+    *,
+    k: int = 5,
+) -> dict[str, float | None]:
+    """Aggregate trajectory-local metrics without pooling coordinate axes."""
+    if len(sources) != len(embeddings) or not sources:
+        raise ValueError("sources and embeddings must be aligned and nonempty")
+    neighborhood: list[float] = []
+    rank: list[float] = []
+    continuity: list[float] = []
+    for source, embedding in zip(sources, embeddings, strict=True):
+        neighborhood.append(local_neighborhood_preservation(source, embedding, k=k))
+        rank_value = pairwise_distance_rank_preservation(source, embedding)
+        if rank_value is not None:
+            rank.append(rank_value)
+        continuity_value = temporal_continuity_ratio(embedding)
+        if continuity_value is not None:
+            continuity.append(continuity_value)
+    return {
+        "local_knn_preservation": float(np.mean(neighborhood)),
+        "pairwise_distance_rank": float(np.mean(rank)) if rank else None,
+        "temporal_continuity_ratio": float(np.mean(continuity)) if continuity else None,
+    }
+
+
+def aggregate_reference_metrics(
+    references: tuple[np.ndarray, ...],
+    embeddings: tuple[np.ndarray, ...],
+    *,
+    k: int = 5,
+) -> dict[str, float | None]:
+    """Compare embeddings to known clean/reference trajectory geometry."""
+    if len(references) != len(embeddings) or not references:
+        raise ValueError("references and embeddings must be aligned and nonempty")
+    neighborhood: list[float] = []
+    rank: list[float] = []
+    for reference, embedding in zip(references, embeddings, strict=True):
+        neighborhood.append(local_neighborhood_preservation(reference, embedding, k=k))
+        rank_value = pairwise_distance_rank_preservation(reference, embedding)
+        if rank_value is not None:
+            rank.append(rank_value)
+    return {
+        "reference_local_knn_preservation": float(np.mean(neighborhood)),
+        "reference_pairwise_distance_rank": float(np.mean(rank)) if rank else None,
+    }

--- a/packages/neuros-mechint/src/neuros_mechint/representations/pca.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/pca.py
@@ -1,0 +1,78 @@
+"""Native train-only PCA representation baseline."""
+from __future__ import annotations
+
+import numpy as np
+
+from .contracts import FitRegime, RepresentationEmbedding, SequenceBatch
+
+
+def _positive_int(value: int, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+class PCARepresentation:
+    """SVD PCA fit only from declared training observations."""
+
+    fit_regime = FitRegime.TRAIN_ONLY_INDUCTIVE
+
+    def __init__(self, n_components: int = 2, *, method_id: str = "pca") -> None:
+        self.n_components = _positive_int(n_components, name="n_components")
+        if not isinstance(method_id, str) or not method_id.strip():
+            raise ValueError("method_id must be a nonblank string")
+        self.method_id = method_id
+        self.mean_: np.ndarray | None = None
+        self.components_: np.ndarray | None = None
+        self.singular_values_: np.ndarray | None = None
+
+    def _fit(self, train: SequenceBatch) -> None:
+        samples = np.asarray(train.concatenate(), dtype=np.float64)
+        max_components = min(samples.shape)
+        if self.n_components > max_components:
+            raise ValueError(
+                f"n_components={self.n_components} exceeds train rank bound {max_components}"
+            )
+        mean = np.mean(samples, axis=0)
+        centered = samples - mean
+        _, singular_values, vh = np.linalg.svd(centered, full_matrices=False)
+        components = np.array(vh[: self.n_components], copy=True)
+        mean = np.array(mean, copy=True)
+        singular_values = np.array(singular_values[: self.n_components], copy=True)
+        mean.setflags(write=False)
+        components.setflags(write=False)
+        singular_values.setflags(write=False)
+        self.mean_ = mean
+        self.components_ = components
+        self.singular_values_ = singular_values
+
+    def embed(
+        self,
+        train: SequenceBatch,
+        evaluation: SequenceBatch,
+    ) -> RepresentationEmbedding:
+        if train.feature_count != evaluation.feature_count:
+            raise ValueError("train and evaluation feature dimensions must match")
+        self._fit(train)
+        assert self.mean_ is not None
+        assert self.components_ is not None
+        embedded = tuple(
+            (np.asarray(sequence, dtype=np.float64) - self.mean_) @ self.components_.T
+            for sequence in evaluation.sequences
+        )
+        return RepresentationEmbedding(
+            method_id=self.method_id,
+            sequences=embedded,
+            sequence_ids=evaluation.sequence_ids,
+            fit_regime=self.fit_regime,
+            metadata={
+                "n_components": self.n_components,
+                "fit_sample_count": train.sample_count,
+                "target_specific_fit_observations": 0,
+                "coordinate_frame": "shared_train_fitted_axes",
+                "implementation": "numpy_svd",
+            },
+        )

--- a/packages/neuros-mechint/src/neuros_mechint/representations/tphate.py
+++ b/packages/neuros-mechint/src/neuros_mechint/representations/tphate.py
@@ -1,0 +1,237 @@
+"""Optional upstream T-PHATE adapter.
+
+No T-PHATE implementation is vendored here. The upstream project currently
+ships a Yale non-commercial license, while neurOS is MIT licensed. Users must
+review and satisfy upstream terms before separately installing ``tphate``.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+import numpy as np
+
+from .contracts import (
+    FitRegime,
+    RepresentationEmbedding,
+    RepresentationError,
+    RepresentationUnavailableError,
+    SequenceBatch,
+)
+from .pca import _positive_int
+
+UPSTREAM_REPOSITORY = "https://github.com/KrishnaswamyLab/TPHATE"
+UPSTREAM_LICENSE_NOTICE = (
+    "TPHATE is an optional external dependency. Its upstream repository currently "
+    "ships a Yale Non-Commercial License. neurOS does not vendor TPHATE; review "
+    "the upstream license and install the package separately if your use is permitted."
+)
+
+
+class TPHATEUnavailableError(RepresentationUnavailableError):
+    """The optional upstream T-PHATE package is not installed."""
+
+
+class TPHATEEmbeddingError(RepresentationError):
+    """Upstream T-PHATE failed for one preserved trajectory."""
+
+
+class TPHATERepresentation:
+    """Transductive T-PHATE embedding, fit independently per trajectory.
+
+    T-PHATE's autocorrelation view treats row order as temporal adjacency. This
+    adapter therefore never concatenates independent trajectories. Each
+    evaluation sequence receives a fresh upstream estimator. Resulting MDS
+    coordinate frames are sequence-local and must not be pooled across
+    sequences without an explicit alignment protocol.
+    """
+
+    fit_regime = FitRegime.TRANSDUCTIVE_TARGET_OBSERVED
+
+    def __init__(
+        self,
+        n_components: int = 2,
+        *,
+        knn: int = 5,
+        decay: int | None = 40,
+        t: int | str = "auto",
+        gamma: float = 1.0,
+        n_pca: int | None = 100,
+        mds_solver: str = "sgd",
+        knn_dist: str = "euclidean",
+        mds_dist: str = "euclidean",
+        mds: str = "metric",
+        n_jobs: int = 1,
+        random_state: int = 0,
+        smooth_window: int = 1,
+        method_id: str = "tphate",
+    ) -> None:
+        self.n_components = _positive_int(n_components, name="n_components")
+        self.knn = _positive_int(knn, name="knn")
+        self.decay = None if decay is None else _positive_int(decay, name="decay")
+        if t != "auto":
+            t = _positive_int(t, name="t")
+        self.t = t
+        if isinstance(gamma, bool) or not isinstance(
+            gamma, (int, float, np.integer, np.floating)
+        ):
+            raise TypeError("gamma must be a finite real between -1 and 1")
+        self.gamma = float(gamma)
+        if not np.isfinite(self.gamma) or not -1 <= self.gamma <= 1:
+            raise ValueError("gamma must be a finite real between -1 and 1")
+        self.n_pca = None if n_pca is None else _positive_int(n_pca, name="n_pca")
+        if mds_solver not in {"sgd", "smacof"}:
+            raise ValueError("mds_solver must be 'sgd' or 'smacof'")
+        if mds not in {"classic", "metric", "nonmetric"}:
+            raise ValueError("mds must be 'classic', 'metric', or 'nonmetric'")
+        if not isinstance(knn_dist, str) or not knn_dist:
+            raise ValueError("knn_dist must be a nonblank string")
+        if not isinstance(mds_dist, str) or not mds_dist:
+            raise ValueError("mds_dist must be a nonblank string")
+        if isinstance(n_jobs, bool) or not isinstance(n_jobs, (int, np.integer)):
+            raise TypeError("n_jobs must be an integer")
+        if int(n_jobs) == 0:
+            raise ValueError("n_jobs cannot be zero")
+        if isinstance(random_state, bool) or not isinstance(
+            random_state, (int, np.integer)
+        ):
+            raise TypeError("random_state must be an integer")
+        self.mds_solver = mds_solver
+        self.knn_dist = knn_dist
+        self.mds_dist = mds_dist
+        self.mds = mds
+        self.n_jobs = int(n_jobs)
+        self.random_state = int(random_state)
+        self.smooth_window = _positive_int(smooth_window, name="smooth_window")
+        if not isinstance(method_id, str) or not method_id.strip():
+            raise ValueError("method_id must be a nonblank string")
+        self.method_id = method_id
+
+    def _load_upstream(self) -> tuple[Any, str]:
+        try:
+            module = import_module("tphate")
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise TPHATEUnavailableError(
+                f"{UPSTREAM_LICENSE_NOTICE} Upstream: {UPSTREAM_REPOSITORY}"
+            ) from exc
+        estimator = getattr(module, "TPHATE", None)
+        if estimator is None or not callable(estimator):
+            raise TPHATEUnavailableError(
+                "Installed 'tphate' module does not expose callable TPHATE; "
+                "upstream API compatibility cannot be established."
+            )
+        version = str(getattr(module, "__version__", "unknown"))
+        return estimator, version
+
+    def _effective_n_pca(self, sequence: np.ndarray) -> int | None:
+        if self.n_pca is None:
+            return None
+        if self.n_pca >= min(sequence.shape):
+            return None
+        return self.n_pca
+
+    def _embed_one(
+        self,
+        estimator_type: Any,
+        sequence_id: str,
+        sequence: np.ndarray,
+        *,
+        effective_n_pca: int | None,
+    ) -> np.ndarray:
+        estimator = estimator_type(
+            n_components=self.n_components,
+            knn=self.knn,
+            decay=self.decay,
+            n_landmark=None,
+            t=self.t,
+            gamma=self.gamma,
+            n_pca=effective_n_pca,
+            mds_solver=self.mds_solver,
+            knn_dist=self.knn_dist,
+            mds_dist=self.mds_dist,
+            mds=self.mds,
+            n_jobs=self.n_jobs,
+            random_state=self.random_state,
+            verbose=0,
+            smooth_window=self.smooth_window,
+        )
+        try:
+            embedding = np.asarray(
+                estimator.fit_transform(np.array(sequence, copy=True)),
+                dtype=np.float64,
+            )
+        except IndexError as exc:
+            raise TPHATEEmbeddingError(
+                f"T-PHATE failed for sequence {sequence_id!r}. The upstream "
+                "autocorrelation dropoff calculation can fail when its smoothed "
+                "ACF has no negative crossing; no fallback or fabricated temporal "
+                "kernel was applied."
+            ) from exc
+        except Exception as exc:
+            raise TPHATEEmbeddingError(
+                f"T-PHATE failed for sequence {sequence_id!r}: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+        expected = (sequence.shape[0], self.n_components)
+        if embedding.shape != expected:
+            raise TPHATEEmbeddingError(
+                f"T-PHATE returned shape {embedding.shape} for sequence "
+                f"{sequence_id!r}; expected {expected}"
+            )
+        if not np.all(np.isfinite(embedding)):
+            raise TPHATEEmbeddingError(
+                f"T-PHATE returned non-finite coordinates for sequence {sequence_id!r}"
+            )
+        return embedding
+
+    def embed(
+        self,
+        train: SequenceBatch,
+        evaluation: SequenceBatch,
+    ) -> RepresentationEmbedding:
+        if train.feature_count != evaluation.feature_count:
+            raise ValueError("train and evaluation feature dimensions must match")
+        estimator_type, version = self._load_upstream()
+        effective_n_pca = {
+            sequence_id: self._effective_n_pca(sequence)
+            for sequence_id, sequence in zip(
+                evaluation.sequence_ids,
+                evaluation.sequences,
+                strict=True,
+            )
+        }
+        embedded = tuple(
+            self._embed_one(
+                estimator_type,
+                sequence_id,
+                sequence,
+                effective_n_pca=effective_n_pca[sequence_id],
+            )
+            for sequence_id, sequence in zip(
+                evaluation.sequence_ids,
+                evaluation.sequences,
+                strict=True,
+            )
+        )
+        return RepresentationEmbedding(
+            method_id=self.method_id,
+            sequences=embedded,
+            sequence_ids=evaluation.sequence_ids,
+            fit_regime=self.fit_regime,
+            metadata={
+                "upstream_package": "TPHATE",
+                "upstream_version": version,
+                "upstream_repository": UPSTREAM_REPOSITORY,
+                "license_boundary": "upstream_yale_noncommercial_review_required",
+                "n_components": self.n_components,
+                "requested_n_pca": self.n_pca,
+                "effective_n_pca_by_sequence": effective_n_pca,
+                "n_pca_policy": "disable_when_not_strictly_below_sequence_shape",
+                "target_specific_fit_observations": evaluation.sample_count,
+                "fit_sequence_count": len(evaluation.sequences),
+                "coordinate_frame": "per_sequence_unaligned_mds",
+                "sequence_boundary_policy": "fresh_estimator_per_sequence",
+                "landmarking": "disabled",
+            },
+        )

--- a/packages/neuros-mechint/tests/test_mechint_representation_authority.py
+++ b/packages/neuros-mechint/tests/test_mechint_representation_authority.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from neuros_mechint.representations import (
+    PrecomputedTemporalSSLRepresentation,
+    SequenceBatch,
+    TPHATERepresentation,
+    pairwise_distance_rank_preservation,
+    temporal_continuity_ratio,
+)
+import neuros_mechint.representations.tphate as tphate_module
+
+
+def test_sequence_batch_rejects_complex_values_before_method_dispatch() -> None:
+    values = np.ones((5, 3), dtype=np.complex128) * (1 + 2j)
+    with pytest.raises(TypeError, match="real numeric"):
+        SequenceBatch(sequences=(values,), sequence_ids=("complex",))
+
+
+def test_nested_metadata_keys_are_not_coerced_to_strings() -> None:
+    with pytest.raises(ValueError, match="metadata keys"):
+        SequenceBatch(
+            sequences=(np.ones((5, 3)),),
+            sequence_ids=("s1",),
+            metadata={"nested": {7: "ambiguous"}},
+        )
+
+
+def test_external_ssl_rejects_complex_latent_coordinates() -> None:
+    with pytest.raises(TypeError, match="real numeric"):
+        PrecomputedTemporalSSLRepresentation(
+            {"eval": np.ones((5, 2), dtype=np.complex128)},
+            model_id="ssl",
+            model_version="1",
+        )
+
+
+def test_public_geometry_metrics_reject_complex_inputs_without_projection() -> None:
+    source = np.arange(15, dtype=float).reshape(5, 3)
+    complex_embedding = np.ones((5, 2), dtype=np.complex128) * (1 + 1j)
+    with pytest.raises(TypeError, match="real numeric"):
+        pairwise_distance_rank_preservation(source, complex_embedding)
+    with pytest.raises(TypeError, match="real numeric"):
+        temporal_continuity_ratio(complex_embedding)
+
+
+def test_tphate_records_requested_and_effective_pca_per_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_n_pca: list[int | None] = []
+
+    class FakeTPHATE:
+        def __init__(self, **kwargs):
+            seen_n_pca.append(kwargs["n_pca"])
+            self.n_components = kwargs["n_components"]
+
+        def fit_transform(self, x):
+            return np.asarray(x)[:, : self.n_components]
+
+    monkeypatch.setattr(
+        tphate_module,
+        "import_module",
+        lambda _: SimpleNamespace(TPHATE=FakeTPHATE, __version__="test"),
+    )
+    train = SequenceBatch(
+        sequences=(np.arange(60, dtype=float).reshape(12, 5),),
+        sequence_ids=("train",),
+    )
+    evaluation = SequenceBatch(
+        sequences=(
+            np.arange(40, dtype=float).reshape(8, 5),
+            np.arange(72, dtype=float).reshape(12, 6)[:, :5],
+        ),
+        sequence_ids=("short", "long"),
+    )
+    embedding = TPHATERepresentation(n_components=2, n_pca=4).embed(train, evaluation)
+
+    assert seen_n_pca == [4, 4]
+    assert embedding.metadata["requested_n_pca"] == 4
+    assert embedding.metadata["effective_n_pca_by_sequence"] == {
+        "short": 4,
+        "long": 4,
+    }
+
+
+def test_tphate_disables_invalid_pca_and_records_the_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_n_pca: list[int | None] = []
+
+    class FakeTPHATE:
+        def __init__(self, **kwargs):
+            seen_n_pca.append(kwargs["n_pca"])
+            self.n_components = kwargs["n_components"]
+
+        def fit_transform(self, x):
+            return np.asarray(x)[:, : self.n_components]
+
+    monkeypatch.setattr(
+        tphate_module,
+        "import_module",
+        lambda _: SimpleNamespace(TPHATE=FakeTPHATE, __version__="test"),
+    )
+    train = SequenceBatch(
+        sequences=(np.arange(60, dtype=float).reshape(12, 5),),
+        sequence_ids=("train",),
+    )
+    evaluation = SequenceBatch(
+        sequences=(np.arange(40, dtype=float).reshape(8, 5),),
+        sequence_ids=("short",),
+    )
+    embedding = TPHATERepresentation(n_components=2, n_pca=5).embed(train, evaluation)
+
+    assert seen_n_pca == [None]
+    assert embedding.metadata["requested_n_pca"] == 5
+    assert embedding.metadata["effective_n_pca_by_sequence"] == {"short": None}
+    assert (
+        embedding.metadata["n_pca_policy"]
+        == "disable_when_not_strictly_below_sequence_shape"
+    )

--- a/packages/neuros-mechint/tests/test_mechint_representations.py
+++ b/packages/neuros-mechint/tests/test_mechint_representations.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from neuros_mechint.representations import (
+    AutoencoderRepresentation,
+    FitRegime,
+    MethodStatus,
+    PCARepresentation,
+    PrecomputedTemporalSSLRepresentation,
+    RepresentationBenchmark,
+    SequenceBatch,
+    TPHATEEmbeddingError,
+    TPHATERepresentation,
+    TPHATEUnavailableError,
+    aggregate_geometry_metrics,
+)
+import neuros_mechint.representations.tphate as tphate_module
+
+
+def _batches() -> tuple[SequenceBatch, SequenceBatch]:
+    rng = np.random.default_rng(12)
+    train = SequenceBatch(
+        sequences=(
+            rng.normal(size=(12, 4)),
+            rng.normal(loc=0.5, size=(10, 4)),
+        ),
+        sequence_ids=("train-a", "train-b"),
+        metadata={"nested": {"roles": ["train"]}},
+    )
+    evaluation = SequenceBatch(
+        sequences=(
+            rng.normal(size=(9, 4)),
+            rng.normal(loc=-0.5, size=(8, 4)),
+        ),
+        sequence_ids=("eval-a", "eval-b"),
+    )
+    return train, evaluation
+
+
+def test_sequence_batch_detaches_arrays_and_nested_metadata() -> None:
+    array = np.arange(20, dtype=float).reshape(5, 4)
+    nested = ["train"]
+    batch = SequenceBatch(
+        sequences=(array,),
+        sequence_ids=("s1",),
+        metadata={"nested": {"roles": nested}},
+    )
+    array[:] = -99
+    nested.append("mutated")
+
+    np.testing.assert_array_equal(
+        batch.sequences[0],
+        np.arange(20, dtype=float).reshape(5, 4),
+    )
+    assert batch.metadata["nested"]["roles"] == ("train",)
+    with pytest.raises(ValueError):
+        batch.sequences[0][0, 0] = 1
+
+
+@pytest.mark.parametrize(
+    ("sequences", "ids", "error"),
+    [
+        ((), (), ValueError),
+        ((np.ones((2, 3)),), ("short",), ValueError),
+        ((np.ones((3, 3)), np.ones((3, 4))), ("a", "b"), ValueError),
+        ((np.ones((3, 3)), np.ones((3, 3))), ("same", "same"), ValueError),
+        ((np.array([[1, 2], [3, 4], [5, np.nan]]),), ("nan",), ValueError),
+        ((np.ones((3, 3), dtype=bool),), ("bool",), TypeError),
+        ((np.array([["a"], ["b"], ["c"]], dtype=object),), ("obj",), TypeError),
+    ],
+)
+def test_sequence_batch_rejects_invalid_authority(
+    sequences: tuple[np.ndarray, ...],
+    ids: tuple[str, ...],
+    error: type[Exception],
+) -> None:
+    with pytest.raises(error):
+        SequenceBatch(sequences=sequences, sequence_ids=ids)
+
+
+def test_pca_is_train_only_and_preserves_sequence_boundaries() -> None:
+    train, evaluation = _batches()
+    method = PCARepresentation(n_components=2)
+    embedding = method.embed(train, evaluation)
+
+    assert embedding.fit_regime is FitRegime.TRAIN_ONLY_INDUCTIVE
+    assert embedding.sequence_ids == evaluation.sequence_ids
+    assert [x.shape for x in embedding.sequences] == [(9, 2), (8, 2)]
+    np.testing.assert_allclose(method.mean_, np.mean(train.concatenate(), axis=0))
+    assert embedding.metadata["target_specific_fit_observations"] == 0
+
+    extreme = SequenceBatch(
+        sequences=(np.full((9, 4), 1e9), np.full((8, 4), -1e9)),
+        sequence_ids=evaluation.sequence_ids,
+    )
+    second = PCARepresentation(n_components=2)
+    second.embed(train, extreme)
+    np.testing.assert_allclose(second.mean_, method.mean_)
+    np.testing.assert_allclose(
+        np.abs(second.components_),
+        np.abs(method.components_),
+        atol=1e-12,
+    )
+
+
+def test_autoencoder_is_train_only_deterministic_and_boundary_preserving() -> None:
+    train, evaluation = _batches()
+    first = AutoencoderRepresentation(
+        n_components=2,
+        hidden_dim=8,
+        epochs=4,
+        batch_size=7,
+        learning_rate=5e-3,
+        seed=17,
+    )
+    second = AutoencoderRepresentation(
+        n_components=2,
+        hidden_dim=8,
+        epochs=4,
+        batch_size=7,
+        learning_rate=5e-3,
+        seed=17,
+    )
+    z1 = first.embed(train, evaluation)
+    z2 = second.embed(train, evaluation)
+
+    assert z1.fit_regime is FitRegime.TRAIN_ONLY_INDUCTIVE
+    assert [x.shape for x in z1.sequences] == [(9, 2), (8, 2)]
+    np.testing.assert_allclose(first.mean_, np.mean(train.concatenate(), axis=0), atol=1e-6)
+    assert first.training_loss_ is not None and np.isfinite(first.training_loss_)
+    for a, b in zip(z1.sequences, z2.sequences, strict=True):
+        np.testing.assert_allclose(a, b, atol=1e-6, rtol=1e-6)
+
+
+def test_tphate_fits_each_evaluation_sequence_independently(monkeypatch: pytest.MonkeyPatch) -> None:
+    train, evaluation = _batches()
+    instances: list[object] = []
+
+    class FakeTPHATE:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.inputs: list[np.ndarray] = []
+            instances.append(self)
+
+        def fit_transform(self, x):
+            x = np.asarray(x)
+            self.inputs.append(np.array(x, copy=True))
+            return x[:, : self.kwargs["n_components"]]
+
+    fake_module = SimpleNamespace(TPHATE=FakeTPHATE, __version__="test-1.2.1")
+    monkeypatch.setattr(tphate_module, "import_module", lambda _: fake_module)
+
+    embedding = TPHATERepresentation(n_components=2).embed(train, evaluation)
+
+    assert embedding.fit_regime is FitRegime.TRANSDUCTIVE_TARGET_OBSERVED
+    assert len(instances) == len(evaluation.sequences)
+    for instance, sequence in zip(instances, evaluation.sequences, strict=True):
+        assert len(instance.inputs) == 1
+        np.testing.assert_array_equal(instance.inputs[0], sequence)
+        assert instance.kwargs["n_landmark"] is None
+        assert instance.kwargs["random_state"] == 0
+    assert embedding.metadata["target_specific_fit_observations"] == evaluation.sample_count
+    assert embedding.metadata["coordinate_frame"] == "per_sequence_unaligned_mds"
+    assert embedding.metadata["sequence_boundary_policy"] == "fresh_estimator_per_sequence"
+
+
+def test_tphate_records_requested_and_effective_n_pca(monkeypatch: pytest.MonkeyPatch) -> None:
+    train, evaluation = _batches()
+    instances: list[object] = []
+
+    class FakeTPHATE:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            instances.append(self)
+
+        def fit_transform(self, x):
+            x = np.asarray(x)
+            return x[:, : self.kwargs["n_components"]]
+
+    monkeypatch.setattr(
+        tphate_module,
+        "import_module",
+        lambda _: SimpleNamespace(TPHATE=FakeTPHATE, __version__="test"),
+    )
+    embedding = TPHATERepresentation(n_components=2, n_pca=2).embed(train, evaluation)
+
+    assert [instance.kwargs["n_pca"] for instance in instances] == [2, 2]
+    assert embedding.metadata["requested_n_pca"] == 2
+    assert dict(embedding.metadata["effective_n_pca_by_sequence"]) == {
+        "eval-a": 2,
+        "eval-b": 2,
+    }
+
+
+def test_tphate_records_when_n_pca_is_disabled_per_sequence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    train, evaluation = _batches()
+    instances: list[object] = []
+
+    class FakeTPHATE:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            instances.append(self)
+
+        def fit_transform(self, x):
+            x = np.asarray(x)
+            return x[:, : self.kwargs["n_components"]]
+
+    monkeypatch.setattr(
+        tphate_module,
+        "import_module",
+        lambda _: SimpleNamespace(TPHATE=FakeTPHATE, __version__="test"),
+    )
+    embedding = TPHATERepresentation(n_components=2, n_pca=4).embed(train, evaluation)
+
+    assert [instance.kwargs["n_pca"] for instance in instances] == [None, None]
+    assert embedding.metadata["requested_n_pca"] == 4
+    assert dict(embedding.metadata["effective_n_pca_by_sequence"]) == {
+        "eval-a": None,
+        "eval-b": None,
+    }
+    assert (
+        embedding.metadata["n_pca_policy"]
+        == "disable_when_not_strictly_below_sequence_shape"
+    )
+
+
+def test_tphate_missing_dependency_fails_with_license_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    train, evaluation = _batches()
+
+    def missing(_: str):
+        raise ModuleNotFoundError("no tphate")
+
+    monkeypatch.setattr(tphate_module, "import_module", missing)
+    with pytest.raises(TPHATEUnavailableError, match="Non-Commercial License"):
+        TPHATERepresentation().embed(train, evaluation)
+
+
+def test_tphate_translates_upstream_autocorrelation_dropoff_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    train, evaluation = _batches()
+
+    class NoDropoffTPHATE:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def fit_transform(self, x):
+            raise IndexError("index 0 is out of bounds")
+
+    monkeypatch.setattr(
+        tphate_module,
+        "import_module",
+        lambda _: SimpleNamespace(TPHATE=NoDropoffTPHATE, __version__="test"),
+    )
+    with pytest.raises(TPHATEEmbeddingError, match="no negative crossing"):
+        TPHATERepresentation().embed(train, evaluation)
+
+
+def test_external_temporal_ssl_binds_exact_sequence_identity_and_lineage() -> None:
+    train, evaluation = _batches()
+    original = {
+        sequence_id: np.column_stack(
+            [np.arange(sequence.shape[0]), np.arange(sequence.shape[0]) ** 2]
+        ).astype(float)
+        for sequence_id, sequence in zip(
+            evaluation.sequence_ids,
+            evaluation.sequences,
+            strict=True,
+        )
+    }
+    method = PrecomputedTemporalSSLRepresentation(
+        original,
+        model_id="eegpt",
+        model_version="checkpoint-sha256:test",
+        pretraining_datasets=("TUEG",),
+        pretraining_lineage_status="possible_overlap",
+        metadata={"provider": {"name": "external"}},
+    )
+    original["eval-a"][:] = -100
+    embedding = method.embed(train, evaluation)
+
+    assert embedding.fit_regime is FitRegime.EXTERNAL_PRETRAINED
+    assert embedding.metadata["model_id"] == "eegpt"
+    assert embedding.metadata["pretraining_lineage_status"] == "possible_overlap"
+    assert embedding.metadata["target_specific_fit_observations"] == 0
+    assert not np.all(embedding.sequences[0] == -100)
+
+
+def test_external_temporal_ssl_rejects_timepoint_identity_mismatch() -> None:
+    train, evaluation = _batches()
+    method = PrecomputedTemporalSSLRepresentation(
+        {"eval-a": np.ones((8, 2)), "eval-b": np.ones((8, 2))},
+        model_id="ssl",
+        model_version="1",
+    )
+    with pytest.raises(ValueError, match="timepoints"):
+        method.embed(train, evaluation)
+
+
+def test_geometry_metrics_are_invariant_to_rigid_coordinate_transforms() -> None:
+    rng = np.random.default_rng(3)
+    source = rng.normal(size=(30, 6))
+    embedding = rng.normal(size=(30, 3))
+    q, _ = np.linalg.qr(rng.normal(size=(3, 3)))
+    transformed = embedding @ q + np.array([10.0, -4.0, 2.0])
+
+    first = aggregate_geometry_metrics((source,), (embedding,), k=4)
+    second = aggregate_geometry_metrics((source,), (transformed,), k=4)
+    assert first.keys() == second.keys()
+    for key in first:
+        if first[key] is None:
+            assert second[key] is None
+        else:
+            assert second[key] == pytest.approx(first[key], abs=1e-12)
+
+
+def test_benchmark_preserves_unavailable_methods_and_has_no_winner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    train, evaluation = _batches()
+
+    def missing(_: str):
+        raise ModuleNotFoundError("no tphate")
+
+    monkeypatch.setattr(tphate_module, "import_module", missing)
+    result = RepresentationBenchmark(
+        [PCARepresentation(2), TPHATERepresentation(2)],
+        neighborhood_k=3,
+    ).run(train, evaluation)
+
+    outcomes = result.by_method()
+    assert outcomes["pca"].status is MethodStatus.OK
+    assert outcomes["tphate"].status is MethodStatus.UNAVAILABLE
+    assert "Non-Commercial License" in outcomes["tphate"].error_message
+    assert result.metadata["ranking_policy"] == "none"
+    assert not hasattr(result, "winner")
+
+
+def test_benchmark_preserves_method_failure_without_dropping_other_results() -> None:
+    train, evaluation = _batches()
+
+    class Broken:
+        method_id = "broken"
+        fit_regime = FitRegime.EXTERNAL_PRETRAINED
+
+        def embed(self, train, evaluation):
+            raise RuntimeError("deliberate")
+
+    result = RepresentationBenchmark(
+        [PCARepresentation(2), Broken()],
+        neighborhood_k=3,
+    ).run(train, evaluation)
+
+    outcomes = result.by_method()
+    assert outcomes["pca"].status is MethodStatus.OK
+    assert outcomes["broken"].status is MethodStatus.FAILED
+    assert outcomes["broken"].error_type == "RuntimeError"
+    assert outcomes["broken"].error_message == "deliberate"
+
+
+def test_benchmark_can_score_known_reference_geometry() -> None:
+    train, evaluation = _batches()
+    reference = SequenceBatch(
+        sequences=tuple(
+            np.column_stack(
+                [
+                    np.linspace(0.0, 1.0, sequence.shape[0]),
+                    np.sin(np.linspace(0.0, np.pi, sequence.shape[0])),
+                ]
+            )
+            for sequence in evaluation.sequences
+        ),
+        sequence_ids=evaluation.sequence_ids,
+    )
+
+    result = RepresentationBenchmark(
+        [PCARepresentation(2)],
+        neighborhood_k=3,
+    ).run(train, evaluation, reference=reference)
+
+    outcome = result.by_method()["pca"]
+    assert outcome.status is MethodStatus.OK
+    assert "reference_local_knn_preservation" in outcome.metrics
+    assert "reference_pairwise_distance_rank" in outcome.metrics
+    assert result.metadata["reference_geometry"] == "provided"
+
+
+def test_reference_geometry_must_preserve_evaluation_identity() -> None:
+    train, evaluation = _batches()
+    reference = SequenceBatch(
+        sequences=(np.ones((9, 2)), np.ones((8, 2))),
+        sequence_ids=("eval-a", "wrong-id"),
+    )
+    with pytest.raises(ValueError, match="reference sequence identity"):
+        RepresentationBenchmark([PCARepresentation(2)]).run(
+            train,
+            evaluation,
+            reference=reference,
+        )


### PR DESCRIPTION
## Summary

Adds a boundary-preserving neural representation benchmark for PCA, a native train-only autoencoder, optional upstream T-PHATE, and fixed external temporal self-supervised representations.

This PR is deliberately a **representation-geometry** tranche, not a decoder leaderboard or mechanism claim. It preserves the different information regimes of the methods instead of collapsing them into one winner score.

Refs #141. Follow-up scientific work is tracked in #143.

## Exact composition

Production head: `3ec682e10c02c98fced4eff7a39d7da9321b81cf`

Exact parent: `ec8c37be5d218ab7a434c3d156b5d99bcd58c2be`

The production branch is exactly one commit ahead of that parent and contains 13 additive files / 2302 additions / 0 deletions. It was reconstructed directly from validated staging blobs; the disposable staging workflow is not present.

## Representation contracts

- `SequenceBatch` preserves independent ordered trajectories, exact sequence IDs, common feature geometry, real finite data, and recursively frozen provenance.
- `RepresentationEmbedding` preserves per-sequence identity and fit regime.
- `MethodOutcome` preserves `ok`, `failed`, and `unavailable` methods instead of silently dropping them.
- `RepresentationBenchmarkResult` intentionally has no `winner` or scalar ranking field.

Fit regimes are explicit:

- PCA: `train_only_inductive`
- native autoencoder: `train_only_inductive`
- T-PHATE: `transductive_target_observed`
- external temporal SSL: `external_pretrained`

## T-PHATE integration

The upstream implementation is not vendored or copied. neurOS lazily imports a separately installed `tphate` package.

The current upstream repository ships a Yale Non-Commercial License while upstream package metadata advertises a GPL classifier. This PR therefore does not add T-PHATE as a default dependency and normal CI does not install it. Users must review upstream terms separately.

T-PHATE is fit with a fresh estimator for each preserved evaluation trajectory. Independent participants/sessions/runs are never concatenated into an artificial timeline. Landmarking is disabled for this contract.

The adapter records upstream package/version/repository, target-specific fit observation count, sequence-local unaligned MDS coordinate-frame semantics, requested `n_pca`, effective `n_pca` per sequence, and the explicit policy when upstream PCA preprocessing is disabled because it is not valid for a sequence shape.

The known upstream no-negative-ACF-crossing edge is translated into a method-scoped `TPHATEEmbeddingError`. neurOS does not manufacture a replacement temporal kernel.

## Baselines and temporal SSL

PCA is implemented with NumPy SVD and fit exclusively on declared training observations.

The autoencoder is a deterministic CPU torch baseline with train-only normalization/training and a fixed evaluation encoder.

Temporal SSL is represented by `PrecomputedTemporalSSLRepresentation`, which consumes exact per-sequence fixed embeddings and carries model/version/pretraining-lineage metadata. It deliberately does not retrain or download EEG foundation models inside this benchmark.

## Metrics

Universal trajectory-local metrics are rigid-transform invariant:

- local kNN preservation;
- pairwise-distance rank preservation;
- temporal continuity ratio.

When a controlled experiment supplies a known clean latent trajectory, the benchmark also emits reference local-kNN preservation and reference pairwise-distance rank preservation. These are controlled reference-geometry metrics, not a claim of exact DeMAP reproduction.

## Controlled benchmark

`packages/neuros-mechint/examples/11_representation_benchmark.py` generates a deterministic smooth latent trajectory, maps it nonlinearly into a 24-dimensional observed space, adds Gaussian noise, and keeps the clean evaluation trajectory as reference geometry.

Normal dependency-clean CI expects T-PHATE to be explicitly `unavailable`; PCA and autoencoder remain executable. An optional named temporal-SSL `.npz` embedding can be supplied with model/version/pretraining metadata.

At the fixed smoke point (`noise=0.35`, seed 7, 3 components, AE 4 epochs), production qualification reproduced these diagnostics:

- PCA observed pairwise-distance rank: `0.9818946139`
- PCA clean-reference pairwise-distance rank: `0.5998986480`
- PCA clean-reference local kNN: `0.7982142857`
- AE observed pairwise-distance rank: `0.7272977499`
- AE clean-reference pairwise-distance rank: `0.5277602836`
- AE clean-reference local kNN: `0.3616071429`

These are deterministic smoke diagnostics only. They are not a promoted method ordering or scientific superiority claim.

## Staging evidence, diagnostic only

Disposable staging head `bc81ae767c13aaba52c2560b69529524f968f43d` passed dependency checks, compilation, **28/28 adversarial tests**, and controlled reference-manifold JSON export. This evidence is diagnostic only and is not borrowed as production qualification.

## Exact production qualification

**QUALIFIED** production head `3ec682e10c02c98fced4eff7a39d7da9321b81cf` against exact base `ec8c37be5d218ab7a434c3d156b5d99bcd58c2be`.

All **5/5 triggered workflow suites succeeded**:

1. Public Trust Contracts `33456648709`
2. neurOS CI `33456648688`
3. neuros-mechint research evidence `33456648710`
4. Representation Qualification `33456648772`
5. Whole Package Qualification `33456648716`

Concrete qualification:

- **Representation Qualification:** 28/28 adversarial tests, compile/pip checks, controlled reference-manifold JSON/evidence contract, and deterministic diagnostics green. The pull-request workflow checked GitHub's synthetic merge ref `687cb17d6a94305ad5b02651ba1322c42e2cfb0b`, which is exactly head `3ec682e1...` merged into base `ec8c37be...`.
- **neurOS CI:** all 14/14 jobs green, including workspace wheels, repository hygiene, scientific/latency gates, model/mech-int contracts, BCI smoke, foundation interoperability, recording, kernel Python 3.10/3.11/3.12, SourceWeigher Python 3.10/3.11/3.12, and existing ORION contract/tokenization CI.
- **neuros-mechint research evidence:** all 8/8 jobs green, including maintained package tests + scientific CLI/lint on Python 3.10/3.11/3.12, CPU evidence tutorials, ecosystem imports, and existing ORION/NeuroFM integration tests.
- **Public Trust Contracts:** 2/2 jobs green, including strict documentation build with warnings as failures.
- **Whole Package Qualification:** all 13/13 jobs green. Property/corruption contracts, qualification-harness contracts, workspace distribution ownership, and all **9/9 clean-room OS/Python lanes** succeeded: Ubuntu 24.04, macOS 14, and Windows 2025 × Python 3.10, 3.11, and 3.12. Each clean-room lane first enforced an exact clean qualification source and then exercised the installed-wheel product.

No production qualification installs upstream T-PHATE automatically. Existing ORION CI/integration jobs are compatibility evidence only and do not promote ORION into this representation comparison authority.

## Claim boundary

This PR does not establish:

- T-PHATE superiority;
- decoder/task superiority;
- cross-subject aligned T-PHATE axes;
- zero-shot semantics for target-fitted T-PHATE;
- causal or biological mechanism evidence;
- clinical or online BCI efficacy;
- a commercial license grant for upstream T-PHATE.

## Follow-up

Issue #143 owns the next empirical tranche: method × sequence failure-preserving evidence, a multi-seed/noise sweep, a user-invoked separately licensed T-PHATE runner, and at least one real fixed temporal-SSL representation with explicit checkpoint/pretraining lineage.
