### PR TITLE
Runtime: content-addressed source provenance v1

### DIFF
--- a/.github/workflows/rust-runtime-ci.yml
+++ b/.github/workflows/rust-runtime-ci.yml
@@ -56,9 +56,10 @@ jobs:
           maturin build --release --manifest-path rust/neuros-runtime-py/Cargo.toml --interpreter python
       - name: Install native wheel
         run: python -m pip install target/wheels/*.whl
-      - name: Native Arrow smoke test
+      - name: Native Arrow and provenance smoke test
         run: |
           python - <<'PY'
+          import hashlib
           import json
           import struct
           import tempfile
@@ -69,7 +70,9 @@ jobs:
           with tempfile.TemporaryDirectory() as directory:
               root = Path(directory)
               values = [float(value) for value in range(24)]
-              (root / "fmri.f32").write_bytes(b"".join(struct.pack("<f", value) for value in values))
+              source = b"".join(struct.pack("<f", value) for value in values)
+              source_sha256 = hashlib.sha256(source).hexdigest()
+              (root / "fmri.f32").write_bytes(source)
               manifest = {
                   "schema_version": 1,
                   "dataset_id": "ci-smoke",
@@ -79,6 +82,7 @@ jobs:
                           "subject": "sub-01",
                           "modality": "fmri",
                           "path": "fmri.f32",
+                          "source_sha256": source_sha256,
                           "dtype": "float32-le",
                           "shape": [6, 4],
                           "sampling_hz": 0.5,
@@ -94,4 +98,8 @@ jobs:
               assert len(arrow) == 8
               assert first.modality == "fmri"
               assert len(first.manifest_sha256) == 64
+              assert first.source_size_bytes == len(source)
+              assert first.declared_source_sha256 == source_sha256
+              assert first.verified_source_sha256 == source_sha256
+              assert first.source_verification_state == "verified_at_open"
           PY

--- a/.github/workflows/rust-runtime-ci.yml
+++ b/.github/workflows/rust-runtime-ci.yml
@@ -9,6 +9,7 @@ on:
       - "packages/neuros/src/neuros/dataset.py"
       - "packages/neuros/src/neuros/__init__.py"
       - "packages/neuros/pyproject.toml"
+      - "tests/test_runtime_content_provenance.py"
       - ".github/workflows/rust-runtime-ci.yml"
   push:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - "packages/neuros/src/neuros/dataset.py"
       - "packages/neuros/src/neuros/__init__.py"
       - "packages/neuros/pyproject.toml"
+      - "tests/test_runtime_content_provenance.py"
       - ".github/workflows/rust-runtime-ci.yml"
 
 permissions:
@@ -91,15 +93,27 @@ jobs:
               }
               (root / "neuros.dataset.json").write_text(json.dumps(manifest))
               dataset = native.NativeDataset.open(root)
+              declared_dataset_sha256 = dataset.declared_dataset_content_sha256
+              assert declared_dataset_sha256 is not None
+              assert dataset.verified_dataset_content_sha256 is None
+              assert dataset.verify_content() == declared_dataset_sha256
+              assert dataset.verified_dataset_content_sha256 == declared_dataset_sha256
+
               stream = dataset.stream(modalities=["fmri"], window=2, stride=2, prefetch=2)
               first = next(stream)
               arrow = first.to_arrow()
               assert first.shape == [2, 4]
               assert len(arrow) == 8
               assert first.modality == "fmri"
+              assert first.start_frame == 0
+              assert first.end_frame_exclusive == 2
+              assert first.record_byte_start == 0
+              assert first.record_byte_end_exclusive == len(source)
               assert len(first.manifest_sha256) == 64
               assert first.source_size_bytes == len(source)
               assert first.declared_source_sha256 == source_sha256
               assert first.verified_source_sha256 == source_sha256
               assert first.source_verification_state == "verified_at_open"
+              assert first.declared_dataset_content_sha256 == declared_dataset_sha256
+              assert first.verified_dataset_content_sha256 == declared_dataset_sha256
           PY

--- a/.github/workflows/rust-runtime-ci.yml
+++ b/.github/workflows/rust-runtime-ci.yml
@@ -26,11 +26,27 @@ on:
 permissions:
   contents: read
 
+env:
+  RUNTIME_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+concurrency:
+  group: rust-runtime-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   native-core:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.RUNTIME_SOURCE_SHA }}
+          persist-credentials: false
+      - name: Require exact clean runtime source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${RUNTIME_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt, clippy
@@ -46,6 +62,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.RUNTIME_SOURCE_SHA }}
+          persist-credentials: false
+      - name: Require exact clean runtime source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${RUNTIME_SOURCE_SHA}"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -123,6 +148,7 @@ jobs:
           python - <<'PY'
           import hashlib
           import json
+          import os
           import resource
           import tempfile
           import time
@@ -191,6 +217,7 @@ jobs:
               evidence = {
                   "kind": "neuros_runtime_provenance_performance_evidence",
                   "schema_version": 1,
+                  "source_revision": os.environ["RUNTIME_SOURCE_SHA"],
                   "scientific_boundary": (
                       "Measurement-only systems evidence. Runner timing is not a scientific "
                       "promotion threshold and must not be compared as model performance."
@@ -217,7 +244,7 @@ jobs:
       - name: Upload provenance performance evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: runtime-provenance-performance-${{ github.sha }}
+          name: runtime-provenance-performance-${{ env.RUNTIME_SOURCE_SHA }}
           path: artifacts/runtime-provenance-benchmark.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/rust-runtime-ci.yml
+++ b/.github/workflows/rust-runtime-ci.yml
@@ -117,3 +117,107 @@ jobs:
               assert first.declared_dataset_content_sha256 == declared_dataset_sha256
               assert first.verified_dataset_content_sha256 == declared_dataset_sha256
           PY
+      - name: Measure provenance verification and warm iteration
+        run: |
+          mkdir -p artifacts
+          python - <<'PY'
+          import hashlib
+          import json
+          import resource
+          import tempfile
+          import time
+          from pathlib import Path
+
+          import neuros_runtime_native as native
+
+          source_bytes = 32 * 1024 * 1024
+          chunk = bytes(range(256)) * 4096
+          repeats = source_bytes // len(chunk)
+          hasher = hashlib.sha256()
+
+          with tempfile.TemporaryDirectory() as directory:
+              root = Path(directory)
+              source_path = root / "benchmark.f32"
+              with source_path.open("wb") as stream:
+                  for _ in range(repeats):
+                      stream.write(chunk)
+                      hasher.update(chunk)
+              assert source_path.stat().st_size == source_bytes
+              source_sha256 = hasher.hexdigest()
+              manifest = {
+                  "schema_version": 1,
+                  "dataset_id": "provenance-benchmark",
+                  "records": [
+                      {
+                          "id": "r1",
+                          "subject": "sub-01",
+                          "modality": "fmri",
+                          "path": "benchmark.f32",
+                          "source_sha256": source_sha256,
+                          "dtype": "float32-le",
+                          "shape": [source_bytes // 4],
+                          "sampling_hz": 1.0,
+                      }
+                  ],
+              }
+              (root / "neuros.dataset.json").write_text(json.dumps(manifest))
+              dataset = native.NativeDataset.open(root)
+              declared = dataset.declared_dataset_content_sha256
+              assert declared is not None
+
+              rss_before_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+              started = time.perf_counter()
+              verified = dataset.verify_content()
+              verify_seconds = time.perf_counter() - started
+              rss_after_verify_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+              assert verified == declared
+              assert verify_seconds > 0.0
+
+              window = 4096
+              stream = dataset.stream(
+                  modalities=["fmri"], window=window, stride=window, prefetch=8
+              )
+              first = next(stream)
+              assert first.verified_source_sha256 == source_sha256
+              expected_windows = (source_bytes // 4) // window
+              started = time.perf_counter()
+              remaining = sum(1 for _ in stream)
+              warm_iteration_seconds = time.perf_counter() - started
+              assert remaining + 1 == expected_windows
+              assert warm_iteration_seconds > 0.0
+              rss_after_iteration_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+              mib = source_bytes / (1024 * 1024)
+              evidence = {
+                  "kind": "neuros_runtime_provenance_performance_evidence",
+                  "schema_version": 1,
+                  "scientific_boundary": (
+                      "Measurement-only systems evidence. Runner timing is not a scientific "
+                      "promotion threshold and must not be compared as model performance."
+                  ),
+                  "source_bytes": source_bytes,
+                  "source_mib": mib,
+                  "declared_dataset_content_sha256": declared,
+                  "verified_dataset_content_sha256": verified,
+                  "cold_verify_seconds": verify_seconds,
+                  "cold_verify_mib_per_second": mib / verify_seconds,
+                  "warm_window_count_after_first": remaining,
+                  "warm_iteration_seconds": warm_iteration_seconds,
+                  "warm_windows_per_second": remaining / warm_iteration_seconds,
+                  "rss_before_kb": rss_before_kb,
+                  "rss_after_verify_kb": rss_after_verify_kb,
+                  "rss_after_iteration_kb": rss_after_iteration_kb,
+                  "maxrss_growth_kb": max(0, rss_after_iteration_kb - rss_before_kb),
+              }
+              Path("artifacts/runtime-provenance-benchmark.json").write_text(
+                  json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+              )
+              print(json.dumps(evidence, sort_keys=True))
+          PY
+      - name: Upload provenance performance evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runtime-provenance-performance-${{ github.sha }}
+          path: artifacts/runtime-provenance-benchmark.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/RUST_DATA_PLANE.md
+++ b/docs/RUST_DATA_PLANE.md
@@ -23,13 +23,13 @@ Arrow C Data / DLPack
 PyTorch / JAX / Polars / analytics
 ```
 
-## v0 contract
+## v0 transport contract
 
 The first implementation intentionally keeps the scientific surface narrow. A study directory contains `neuros.dataset.json` and one or more raw little-endian float32 payloads. The native runtime validates the manifest, rejects path traversal and malformed shapes, memory-maps source files read-only, plans deterministic windows, and hands windows to Python through a bounded prefetch queue.
 
 Each exported Arrow array is constructed over the mmap using Arrow's externally owned `Buffer`. An `Arc` to the mapping is installed as the Arrow allocation owner. The Python Arrow capsule therefore extends the lifetime of the mapping and the values do not need to be copied at the Rust/Python boundary.
 
-The v0 public API is:
+The public API remains intentionally small:
 
 ```python
 from neuros import Dataset
@@ -49,9 +49,9 @@ for window in study.stream(
 
 Multiple modalities are rejected by the high-level v0 stream. This is deliberate. fMRI volumes, behavioral events, EEG samples, eye tracking, and video frames usually live on different clocks. neurOS must never claim that samples are aligned merely because two arrays have matching indices. The next multimodal contract will require explicit clock identities, synchronization edges, interpolation/resampling policy, and tolerance bounds.
 
-## Manifest
+## Manifest and source identity
 
-A minimal manifest is:
+A manifest may optionally declare a strict lowercase full-file SHA-256 for each record source:
 
 ```json
 {
@@ -63,6 +63,7 @@ A minimal manifest is:
       "subject": "sub-01",
       "modality": "fmri",
       "path": "sub-01/bold.f32",
+      "source_sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       "dtype": "float32-le",
       "shape": [1200, 91282],
       "sampling_hz": 0.5,
@@ -78,9 +79,101 @@ A minimal manifest is:
 
 The first dimension is the windowing axis. Remaining dimensions are a frame and stay described by `shape`; the Arrow values array is flat so the runtime does not impose NumPy, PyTorch, or JAX tensor semantics.
 
+When `source_sha256` is present, neurOS canonicalizes and validates the source path, creates the read-only mmap that will back the Arrow view, hashes that exact mapped byte region, and rejects a mismatch before returning a scientific window. Verification state is cached separately from mmap existence, so a source first opened through an unhashed record can later be upgraded when another record requires verification.
+
+`verified_at_open` means the mapped regular file matched its declared digest when the runtime verified that mapping. It does **not** mean the surrounding mutable filesystem has become immutable against later external writers. Strong immutable stores, Merkle structures, remote attestation, and cryptographic signatures remain separate future contracts.
+
+## Three distinct identities
+
+The runtime deliberately keeps three concepts separate.
+
+### Manifest identity
+
+`manifest_sha256` hashes the exact `neuros.dataset.json` bytes. It therefore binds path names, sampling metadata, clock declarations, record order in the serialized file, and every other manifest field.
+
+### Dataset content identity
+
+When every record declares a source hash, neurOS derives a domain-separated canonical `declared_dataset_content_sha256` under:
+
+```text
+neuros.dataset_content.v1
+```
+
+Records are stable-sorted by `record_id`. Each descriptor binds:
+
+```text
+record_id
+source_sha256
+record offset_bytes
+dtype
+shape
+```
+
+Path is intentionally excluded. Renaming an identical source does not change byte/interpretation identity. Sampling rate and clock metadata are also excluded because they remain part of manifest/semantic identity. Changing offset, dtype, or shape changes the dataset content identity even when the underlying source bytes are unchanged.
+
+A manifest containing even one unhashed record has no complete dataset content identity. neurOS does not synthesize a partial digest and label it complete.
+
+### Verified dataset content identity
+
+`declared_dataset_content_sha256` proves only what the manifest claims. `Dataset.verify_content()` explicitly verifies every source required by that identity. Only after all declared sources match does `verified_content_sha256` become available.
+
+```python
+study = Dataset.open("study/")
+assert study.declared_content_sha256 is not None
+assert study.verified_content_sha256 is None
+
+verified = study.verify_content()
+assert verified == study.declared_content_sha256
+assert study.verified_content_sha256 == verified
+```
+
+This explicit promotion step prevents lazy verification of one record from being mistaken for proof that an entire dataset was verified.
+
+## Window provenance
+
+Each `DataWindow.provenance` record carries enough identity to bind downstream evidence to what the runtime consumed:
+
+```text
+record_id
+subject
+modality
+shape
+sampling_hz
+manifest_sha256
+source_size_bytes
+declared_source_sha256
+verified_source_sha256
+source_verification_state
+declared_dataset_content_sha256
+verified_dataset_content_sha256
+record_byte_interval {start, end_exclusive}
+window_frame_interval {start, end_exclusive}
+```
+
+The dataset-level verified hash appears on windows only after explicit whole-dataset verification has completed.
+
+## ORION lineage bridge
+
+A fully verified native dataset can be projected into ORION without inventing a second content vocabulary:
+
+```python
+study.verify_content()
+lineage = study.to_orion_lineage(
+    upstream_source="authorized-local-export",
+    preprocessing_history=("producer preprocessing described externally",),
+    sampling_assumptions={"sampling_rate_hz": 0.5},
+)
+```
+
+The bridge maps the verified dataset content identity to ORION `DatasetLineage.content_sha256` and records native manifest/content identities in ORION metadata. It always emits `LineageCompleteness.UNKNOWN`.
+
+That conservatism is intentional. Local byte verification proves which bytes/interpretation neurOS consumed. It does not establish original acquisition provenance, upstream preprocessing ancestry, participant/stimulus identity completeness, licensing, or pretraining-overlap closure. Stronger lineage claims require independent evidence and should be constructed through ORION's scientific authority directly.
+
 ## Ownership and concurrency invariants
 
 The runtime follows several non-negotiable rules. Input mappings are read-only. Prefetch queues are bounded. Dropping a consumer cancels production naturally because the producer cannot send into a disconnected channel. Source paths must remain inside the dataset root. Window arithmetic uses checked integer operations. The GIL is released while Python waits for the next native window. Arrow owns a reference to every mapping it can expose. No multimodal temporal relationship is inferred without a declared synchronization policy.
+
+Source hashing is performed over the exact mmap exposed downstream. The global mmap-cache lock is not held while hashing; verification has its own per-mapping lock. Two records referencing the same live mapping therefore share verification state without blocking unrelated sources behind a whole-file hash.
 
 `tokio` is intentionally not in the v0 dependency graph. Local memory-mapped files and CPU decoding do not benefit from introducing an async executor by default, and an extra scheduler can fight PyTorch/JAX thread pools. Tokio should enter behind source adapters that actually need asynchronous network or live-stream I/O. Rayon is reserved for bounded CPU transforms and decoders once those adapters land.
 
@@ -88,9 +181,9 @@ The runtime follows several non-negotiable rules. Input mappings are read-only. 
 
 The runtime kernel should stay format-agnostic. Adapters implement source discovery and decoding, then produce the same internal clocked array contract. The implementation order should be NIfTI/BIDS first, then EEG files and NWB, DICOM series, video, remote/object-store shards, and finally live acquisition transports. Uncompressed `.nii` can use direct mapping where layout permits it. `.nii.gz` should decode once into a content-addressed cache rather than repeatedly inflate on every epoch. DICOM requires a study/series index plus an explicit PHI boundary. EEG and video require clock semantics from the beginning.
 
-## Cache and provenance roadmap
+## Derived-cache provenance roadmap
 
-The next provenance revision should add an optional source SHA-256 to each manifest record and verify it once when a mapping enters the process. Derived artifacts should use immutable content-addressed keys containing source digest, adapter version, transform graph digest, parameters, and runtime version. Cache writes must be atomic and checksummed. Scientific claims should be able to report the exact manifest digest and transform lineage that produced a tensor.
+Source identity is only the first cryptographic layer. Derived artifacts should use immutable content-addressed keys containing source digest, adapter version, transform graph digest, parameters, and runtime version. Cache writes must be atomic and checksummed. Scientific claims should be able to report the exact source identity, manifest identity, transform lineage, and runtime version that produced a tensor.
 
 ## Zero-copy interoperability roadmap
 
@@ -98,6 +191,8 @@ Arrow is the canonical columnar interchange boundary. DLPack should be added for
 
 ## Qualification gates
 
-A runtime adapter should not be promoted because it is faster on one benchmark. Promotion requires correctness against trusted readers, property tests for window and clock arithmetic, malformed-input tests, cancellation tests, memory/lifetime tests, deterministic ordering tests, and throughput/RSS measurements. Format adapters should include tiny distributable golden fixtures. Large public neuroscience datasets belong in integration or benchmark workflows, not unit tests.
+A runtime adapter should not be promoted because it is faster on one benchmark. Promotion requires correctness against trusted readers, property tests for window and clock arithmetic, malformed-input tests, source-mutation tests, content-identity invariance tests, cancellation tests, memory/lifetime tests, deterministic ordering tests, and throughput/RSS measurements. Format adapters should include tiny distributable golden fixtures. Large public neuroscience datasets belong in integration or benchmark workflows, not unit tests.
+
+For source provenance specifically, qualification must distinguish cold verified open from warm iteration. Hash throughput is a separately reported systems cost; it is not hidden inside a claim of zero-copy transport.
 
 This separation is the core product thesis: neurOS can become a scientific control plane over a high-performance, trustworthy neural data substrate rather than a collection of Python loaders that each reinvent caching, alignment, and provenance.

--- a/packages/neuros/src/neuros/dataset.py
+++ b/packages/neuros/src/neuros/dataset.py
@@ -92,6 +92,8 @@ class DataWindow:
             "record_id": self.record_id,
             "subject": self.subject,
             "modality": self.modality,
+            "start_frame": self.start_frame,
+            "end_frame_exclusive": self.end_frame_exclusive,
             "shape": self.shape,
             "sampling_hz": self.sampling_hz,
             "manifest_sha256": str(self._native_window.manifest_sha256),

--- a/packages/neuros/src/neuros/dataset.py
+++ b/packages/neuros/src/neuros/dataset.py
@@ -8,7 +8,7 @@ multimodal batches.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -51,6 +51,10 @@ class DataWindow:
         return int(self._native_window.start_frame)
 
     @property
+    def end_frame_exclusive(self) -> int:
+        return int(self._native_window.end_frame_exclusive)
+
+    @property
     def shape(self) -> tuple[int, ...]:
         return tuple(int(value) for value in self._native_window.shape)
 
@@ -72,28 +76,49 @@ class DataWindow:
 
     @property
     def provenance(self) -> dict[str, Any]:
-        """Return explicit source and runtime identity for this window.
+        """Return explicit source, dataset, and interval identity for this window.
 
-        ``verified_at_open`` means the complete regular file matched the SHA-256
-        declared by the dataset manifest when the native runtime first verified
-        that mapped source. It does not claim the surrounding filesystem is
-        immutable against later external writers.
+        ``verified_at_open`` means the complete mapped regular file matched the
+        SHA-256 declared by the dataset manifest when the native runtime verified
+        that mapping. It does not claim the surrounding filesystem is immutable
+        against later external writers.
         """
 
-        declared = self._native_window.declared_source_sha256
-        verified = self._native_window.verified_source_sha256
+        declared_source = self._native_window.declared_source_sha256
+        verified_source = self._native_window.verified_source_sha256
+        declared_dataset = self._native_window.declared_dataset_content_sha256
+        verified_dataset = self._native_window.verified_dataset_content_sha256
         return {
             "record_id": self.record_id,
             "subject": self.subject,
             "modality": self.modality,
-            "start_frame": self.start_frame,
             "shape": self.shape,
             "sampling_hz": self.sampling_hz,
             "manifest_sha256": str(self._native_window.manifest_sha256),
             "source_size_bytes": int(self._native_window.source_size_bytes),
-            "declared_source_sha256": None if declared is None else str(declared),
-            "verified_source_sha256": None if verified is None else str(verified),
-            "source_verification_state": str(self._native_window.source_verification_state),
+            "declared_source_sha256": (
+                None if declared_source is None else str(declared_source)
+            ),
+            "verified_source_sha256": (
+                None if verified_source is None else str(verified_source)
+            ),
+            "source_verification_state": str(
+                self._native_window.source_verification_state
+            ),
+            "declared_dataset_content_sha256": (
+                None if declared_dataset is None else str(declared_dataset)
+            ),
+            "verified_dataset_content_sha256": (
+                None if verified_dataset is None else str(verified_dataset)
+            ),
+            "record_byte_interval": {
+                "start": int(self._native_window.record_byte_start),
+                "end_exclusive": int(self._native_window.record_byte_end_exclusive),
+            },
+            "window_frame_interval": {
+                "start": self.start_frame,
+                "end_exclusive": self.end_frame_exclusive,
+            },
         }
 
     def __getattr__(self, name: str) -> Any:
@@ -127,8 +152,93 @@ class Dataset:
         return str(self._native_dataset.manifest_sha256)
 
     @property
+    def declared_content_sha256(self) -> str | None:
+        value = self._native_dataset.declared_dataset_content_sha256
+        return None if value is None else str(value)
+
+    @property
+    def verified_content_sha256(self) -> str | None:
+        value = self._native_dataset.verified_dataset_content_sha256
+        return None if value is None else str(value)
+
+    @property
     def record_count(self) -> int:
         return int(self._native_dataset.record_count)
+
+    def verify_content(self) -> str | None:
+        """Verify every source needed by the canonical dataset content identity.
+
+        Returns ``None`` when at least one manifest record does not declare a
+        source hash. In that case neurOS intentionally refuses to invent a
+        partially verified dataset content identity.
+        """
+
+        value = self._native_dataset.verify_content()
+        return None if value is None else str(value)
+
+    def to_orion_lineage(
+        self,
+        *,
+        upstream_source: str,
+        version: str | None = None,
+        revision: str | None = None,
+        parent_dataset_ids: Sequence[str] = (),
+        identity_sets: Sequence[Any] = (),
+        preprocessing_history: Sequence[str] = (),
+        sampling_assumptions: Mapping[str, Any] | None = None,
+        license: str | None = None,
+        citation: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Any:
+        """Bridge fully verified native content into conservative ORION lineage.
+
+        The bridge always emits ``LineageCompleteness.UNKNOWN``. Content hashes
+        establish the local bytes/interpretation consumed by neurOS, not upstream
+        acquisition, preprocessing ancestry, or entity-identity completeness.
+        Callers with stronger external evidence may construct a richer ORION
+        ``DatasetLineage`` separately.
+        """
+
+        content_sha256 = self.verified_content_sha256
+        if content_sha256 is None:
+            raise ValueError(
+                "ORION lineage requires a fully verified native dataset; call "
+                "Dataset.verify_content() and require a non-None digest first"
+            )
+        try:
+            from orion.scientific import DatasetLineage, LineageCompleteness
+        except ImportError as exc:  # pragma: no cover - optional extra
+            raise ImportError(
+                "The ORION bridge requires the optional `neuros[orion]` extra."
+            ) from exc
+
+        bridge_metadata = dict(metadata or {})
+        if "neuros_runtime" in bridge_metadata:
+            raise ValueError("metadata key 'neuros_runtime' is reserved by neurOS")
+        bridge_metadata["neuros_runtime"] = {
+            "manifest_sha256": self.manifest_sha256,
+            "declared_dataset_content_sha256": self.declared_content_sha256,
+            "verified_dataset_content_sha256": content_sha256,
+            "content_verification": "verified_at_open",
+            "lineage_boundary": (
+                "local content verification does not establish upstream lineage completeness"
+            ),
+        }
+        return DatasetLineage(
+            dataset_id=self.dataset_id,
+            upstream_source=upstream_source,
+            version=version,
+            revision=revision,
+            content_sha256=content_sha256,
+            parent_dataset_ids=tuple(parent_dataset_ids),
+            identity_sets=tuple(identity_sets),
+            preprocessing_history=tuple(preprocessing_history),
+            sampling_assumptions=dict(sampling_assumptions or {}),
+            license=license,
+            citation=citation,
+            lineage_completeness=LineageCompleteness.UNKNOWN,
+            metadata=bridge_metadata,
+        )
 
     def stream(
         self,

--- a/packages/neuros/src/neuros/dataset.py
+++ b/packages/neuros/src/neuros/dataset.py
@@ -72,6 +72,16 @@ class DataWindow:
 
     @property
     def provenance(self) -> dict[str, Any]:
+        """Return explicit source and runtime identity for this window.
+
+        ``verified_at_open`` means the complete regular file matched the SHA-256
+        declared by the dataset manifest when the native runtime first verified
+        that mapped source. It does not claim the surrounding filesystem is
+        immutable against later external writers.
+        """
+
+        declared = self._native_window.declared_source_sha256
+        verified = self._native_window.verified_source_sha256
         return {
             "record_id": self.record_id,
             "subject": self.subject,
@@ -81,6 +91,9 @@ class DataWindow:
             "sampling_hz": self.sampling_hz,
             "manifest_sha256": str(self._native_window.manifest_sha256),
             "source_size_bytes": int(self._native_window.source_size_bytes),
+            "declared_source_sha256": None if declared is None else str(declared),
+            "verified_source_sha256": None if verified is None else str(verified),
+            "source_verification_state": str(self._native_window.source_verification_state),
         }
 
     def __getattr__(self, name: str) -> Any:

--- a/rust/neuros-runtime-py/src/lib.rs
+++ b/rust/neuros-runtime-py/src/lib.rs
@@ -139,6 +139,21 @@ impl NativeWindow {
         self.inner.source_size_bytes()
     }
 
+    #[getter]
+    fn declared_source_sha256(&self) -> Option<String> {
+        self.inner.declared_source_sha256().map(str::to_owned)
+    }
+
+    #[getter]
+    fn verified_source_sha256(&self) -> Option<String> {
+        self.inner.verified_source_sha256().map(str::to_owned)
+    }
+
+    #[getter]
+    fn source_verification_state(&self) -> &'static str {
+        self.inner.source_verification_state().as_str()
+    }
+
     /// Return an arro3 Array backed directly by the memory-mapped source bytes.
     /// The Arrow allocation retains the mmap owner, so the view remains valid even
     /// after this NativeWindow instance is dropped.

--- a/rust/neuros-runtime-py/src/lib.rs
+++ b/rust/neuros-runtime-py/src/lib.rs
@@ -51,7 +51,8 @@ impl NativeDataset {
     }
 
     fn verify_content(&self, py: Python<'_>) -> PyResult<Option<String>> {
-        py.detach(|| self.inner.verify_content()).map_err(runtime_error)
+        py.detach(|| self.inner.verify_content())
+            .map_err(runtime_error)
     }
 
     #[getter]

--- a/rust/neuros-runtime-py/src/lib.rs
+++ b/rust/neuros-runtime-py/src/lib.rs
@@ -37,6 +37,24 @@ impl NativeDataset {
     }
 
     #[getter]
+    fn declared_dataset_content_sha256(&self) -> Option<String> {
+        self.inner
+            .declared_dataset_content_sha256()
+            .map(str::to_owned)
+    }
+
+    #[getter]
+    fn verified_dataset_content_sha256(&self) -> PyResult<Option<String>> {
+        self.inner
+            .verified_dataset_content_sha256()
+            .map_err(runtime_error)
+    }
+
+    fn verify_content(&self, py: Python<'_>) -> PyResult<Option<String>> {
+        py.detach(|| self.inner.verify_content()).map_err(runtime_error)
+    }
+
+    #[getter]
     fn record_count(&self) -> usize {
         self.inner.manifest().records.len()
     }
@@ -120,6 +138,11 @@ impl NativeWindow {
     }
 
     #[getter]
+    fn end_frame_exclusive(&self) -> usize {
+        self.inner.end_frame_exclusive()
+    }
+
+    #[getter]
     fn shape(&self) -> Vec<usize> {
         self.inner.shape()
     }
@@ -140,6 +163,16 @@ impl NativeWindow {
     }
 
     #[getter]
+    fn record_byte_start(&self) -> u64 {
+        self.inner.record_byte_start()
+    }
+
+    #[getter]
+    fn record_byte_end_exclusive(&self) -> u64 {
+        self.inner.record_byte_end_exclusive()
+    }
+
+    #[getter]
     fn declared_source_sha256(&self) -> Option<String> {
         self.inner.declared_source_sha256().map(str::to_owned)
     }
@@ -152,6 +185,20 @@ impl NativeWindow {
     #[getter]
     fn source_verification_state(&self) -> &'static str {
         self.inner.source_verification_state().as_str()
+    }
+
+    #[getter]
+    fn declared_dataset_content_sha256(&self) -> Option<String> {
+        self.inner
+            .declared_dataset_content_sha256()
+            .map(str::to_owned)
+    }
+
+    #[getter]
+    fn verified_dataset_content_sha256(&self) -> Option<String> {
+        self.inner
+            .verified_dataset_content_sha256()
+            .map(str::to_owned)
     }
 
     /// Return an arro3 Array backed directly by the memory-mapped source bytes.

--- a/rust/neuros-runtime/src/content_identity.rs
+++ b/rust/neuros-runtime/src/content_identity.rs
@@ -17,18 +17,17 @@ pub fn declared_dataset_content_sha256(manifest: &DatasetManifest) -> Result<Opt
     records.sort_by(|left, right| left.id.cmp(&right.id));
 
     let mut hasher = Sha256::new();
-    update_bytes(&mut hasher, DATASET_CONTENT_DOMAIN.as_bytes());
+    update_bytes(&mut hasher, DATASET_CONTENT_DOMAIN.as_bytes())?;
     for record in records {
         let Some(source_sha256) = record.source_sha256.as_deref() else {
             return Ok(None);
         };
-        update_bytes(&mut hasher, record.id.as_bytes());
-        update_bytes(&mut hasher, source_sha256.as_bytes());
+        update_bytes(&mut hasher, record.id.as_bytes())?;
+        update_bytes(&mut hasher, source_sha256.as_bytes())?;
         hasher.update(record.offset_bytes.to_le_bytes());
-        update_bytes(&mut hasher, dtype_tag(record.dtype));
-        let rank = u64::try_from(record.shape.len()).map_err(|_| {
-            RuntimeError::Validation("record rank does not fit in u64".into())
-        })?;
+        update_bytes(&mut hasher, dtype_tag(record.dtype))?;
+        let rank = u64::try_from(record.shape.len())
+            .map_err(|_| RuntimeError::Validation("record rank does not fit in u64".into()))?;
         hasher.update(rank.to_le_bytes());
         for dimension in &record.shape {
             let dimension = u64::try_from(*dimension).map_err(|_| {
@@ -40,10 +39,12 @@ pub fn declared_dataset_content_sha256(manifest: &DatasetManifest) -> Result<Opt
     Ok(Some(format!("{:x}", hasher.finalize())))
 }
 
-fn update_bytes(hasher: &mut Sha256, value: &[u8]) {
-    let length = u64::try_from(value.len()).expect("byte slice length must fit in u64");
+fn update_bytes(hasher: &mut Sha256, value: &[u8]) -> Result<()> {
+    let length = u64::try_from(value.len())
+        .map_err(|_| RuntimeError::Validation("identity field length does not fit in u64".into()))?;
     hasher.update(length.to_le_bytes());
     hasher.update(value);
+    Ok(())
 }
 
 const fn dtype_tag(dtype: DType) -> &'static [u8] {

--- a/rust/neuros-runtime/src/content_identity.rs
+++ b/rust/neuros-runtime/src/content_identity.rs
@@ -40,8 +40,9 @@ pub fn declared_dataset_content_sha256(manifest: &DatasetManifest) -> Result<Opt
 }
 
 fn update_bytes(hasher: &mut Sha256, value: &[u8]) -> Result<()> {
-    let length = u64::try_from(value.len())
-        .map_err(|_| RuntimeError::Validation("identity field length does not fit in u64".into()))?;
+    let length = u64::try_from(value.len()).map_err(|_| {
+        RuntimeError::Validation("identity field length does not fit in u64".into())
+    })?;
     hasher.update(length.to_le_bytes());
     hasher.update(value);
     Ok(())

--- a/rust/neuros-runtime/src/content_identity.rs
+++ b/rust/neuros-runtime/src/content_identity.rs
@@ -1,0 +1,118 @@
+use sha2::{Digest, Sha256};
+
+use crate::error::{Result, RuntimeError};
+use crate::manifest::{DType, DatasetManifest};
+
+pub const DATASET_CONTENT_DOMAIN: &str = "neuros.dataset_content.v1";
+
+/// Return the canonical dataset byte/interpretation identity when every record
+/// declares a source SHA-256.
+///
+/// The identity intentionally excludes path, sampling rate, and clock metadata.
+/// Those remain bound by the manifest SHA-256. This content identity instead
+/// binds the stable record ID, full-file source digest, record byte offset,
+/// dtype, and shape using a domain-separated length-prefixed encoding.
+pub fn declared_dataset_content_sha256(manifest: &DatasetManifest) -> Result<Option<String>> {
+    let mut records: Vec<_> = manifest.records.iter().collect();
+    records.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let mut hasher = Sha256::new();
+    update_bytes(&mut hasher, DATASET_CONTENT_DOMAIN.as_bytes());
+    for record in records {
+        let Some(source_sha256) = record.source_sha256.as_deref() else {
+            return Ok(None);
+        };
+        update_bytes(&mut hasher, record.id.as_bytes());
+        update_bytes(&mut hasher, source_sha256.as_bytes());
+        hasher.update(record.offset_bytes.to_le_bytes());
+        update_bytes(&mut hasher, dtype_tag(record.dtype));
+        let rank = u64::try_from(record.shape.len()).map_err(|_| {
+            RuntimeError::Validation("record rank does not fit in u64".into())
+        })?;
+        hasher.update(rank.to_le_bytes());
+        for dimension in &record.shape {
+            let dimension = u64::try_from(*dimension).map_err(|_| {
+                RuntimeError::Validation("record shape dimension does not fit in u64".into())
+            })?;
+            hasher.update(dimension.to_le_bytes());
+        }
+    }
+    Ok(Some(format!("{:x}", hasher.finalize())))
+}
+
+fn update_bytes(hasher: &mut Sha256, value: &[u8]) {
+    let length = u64::try_from(value.len()).expect("byte slice length must fit in u64");
+    hasher.update(length.to_le_bytes());
+    hasher.update(value);
+}
+
+const fn dtype_tag(dtype: DType) -> &'static [u8] {
+    match dtype {
+        DType::Float32Le => b"float32-le",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{DatasetManifest, Record};
+
+    fn record(id: &str, path: &str, source_sha256: Option<&str>) -> Record {
+        Record {
+            id: id.into(),
+            subject: "sub-01".into(),
+            modality: "fmri".into(),
+            path: path.into(),
+            source_sha256: source_sha256.map(str::to_owned),
+            offset_bytes: 0,
+            dtype: DType::Float32Le,
+            shape: vec![6, 4],
+            sampling_hz: Some(0.5),
+            clock: None,
+        }
+    }
+
+    fn manifest(records: Vec<Record>) -> DatasetManifest {
+        DatasetManifest {
+            schema_version: 1,
+            dataset_id: "example".into(),
+            records,
+        }
+    }
+
+    #[test]
+    fn identity_is_stable_under_record_order_and_path_rename() {
+        let hash_a = "a".repeat(64);
+        let hash_b = "b".repeat(64);
+        let first = manifest(vec![
+            record("r1", "first-name.f32", Some(&hash_a)),
+            record("r2", "second-name.f32", Some(&hash_b)),
+        ]);
+        let renamed_reordered = manifest(vec![
+            record("r2", "renamed-b.f32", Some(&hash_b)),
+            record("r1", "renamed-a.f32", Some(&hash_a)),
+        ]);
+        assert_eq!(
+            declared_dataset_content_sha256(&first).unwrap(),
+            declared_dataset_content_sha256(&renamed_reordered).unwrap()
+        );
+    }
+
+    #[test]
+    fn changed_record_interpretation_changes_identity() {
+        let hash = "c".repeat(64);
+        let first = manifest(vec![record("r1", "shared.f32", Some(&hash))]);
+        let mut changed = first.clone();
+        changed.records[0].shape = vec![4, 6];
+        assert_ne!(
+            declared_dataset_content_sha256(&first).unwrap(),
+            declared_dataset_content_sha256(&changed).unwrap()
+        );
+    }
+
+    #[test]
+    fn unhashed_record_makes_content_identity_unavailable() {
+        let partial = manifest(vec![record("r1", "shared.f32", None)]);
+        assert_eq!(declared_dataset_content_sha256(&partial).unwrap(), None);
+    }
+}

--- a/rust/neuros-runtime/src/dataset.rs
+++ b/rust/neuros-runtime/src/dataset.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
 use std::sync::{Arc, Mutex, Weak};
@@ -14,6 +15,8 @@ use tracing::{debug, instrument};
 
 use crate::error::{Result, RuntimeError};
 use crate::manifest::{DatasetManifest, MANIFEST_FILE, Record};
+
+const SOURCE_HASH_BUFFER_BYTES: usize = 64 * 1024;
 
 #[derive(Clone, Debug, Default)]
 pub struct StreamSelector {
@@ -38,6 +41,21 @@ impl WindowSpec {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceVerificationState {
+    Unverified,
+    VerifiedAtOpen,
+}
+
+impl SourceVerificationState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unverified => "unverified",
+            Self::VerifiedAtOpen => "verified_at_open",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct WindowDescriptor {
     record: Arc<Record>,
@@ -57,6 +75,7 @@ pub struct Dataset {
 #[derive(Debug)]
 struct MappedRegion {
     mmap: Mmap,
+    verified_source_sha256: Mutex<Option<String>>,
 }
 
 #[derive(Clone)]
@@ -68,6 +87,9 @@ pub struct WindowHandle {
     frame_elements: usize,
     source_size_bytes: u64,
     manifest_sha256: String,
+    declared_source_sha256: Option<String>,
+    verified_source_sha256: Option<String>,
+    source_verification_state: SourceVerificationState,
 }
 
 enum StreamMessage {
@@ -282,7 +304,16 @@ impl Dataset {
                 required: required_end,
             });
         }
-        let region = self.map_source(&path)?;
+
+        let declared_source_sha256 = descriptor.record.source_sha256.clone();
+        let (region, verified_source_sha256) =
+            self.map_source(&path, declared_source_sha256.as_deref())?;
+        let source_verification_state = if verified_source_sha256.is_some() {
+            SourceVerificationState::VerifiedAtOpen
+        } else {
+            SourceVerificationState::Unverified
+        };
+
         Ok(WindowHandle {
             region,
             record: descriptor.record,
@@ -291,33 +322,101 @@ impl Dataset {
             frame_elements: descriptor.frame_elements,
             source_size_bytes: metadata.len(),
             manifest_sha256: self.manifest_sha256.clone(),
+            declared_source_sha256,
+            verified_source_sha256,
+            source_verification_state,
         })
     }
 
-    fn map_source(&self, path: &Path) -> Result<Arc<MappedRegion>> {
+    fn map_source(
+        &self,
+        path: &Path,
+        expected_sha256: Option<&str>,
+    ) -> Result<(Arc<MappedRegion>, Option<String>)> {
         {
             let cache = self
                 .mmap_cache
                 .lock()
                 .map_err(|_| RuntimeError::Validation("mmap cache lock was poisoned".into()))?;
             if let Some(region) = cache.get(path).and_then(Weak::upgrade) {
-                return Ok(region);
+                let verified = Self::ensure_source_verified(path, &region, expected_sha256)?;
+                return Ok((region, verified));
             }
         }
 
-        let file = File::open(path).map_err(|source| RuntimeError::io(path, source))?;
+        let mut file = File::open(path).map_err(|source| RuntimeError::io(path, source))?;
+        let verified_source_sha256 = match expected_sha256 {
+            Some(expected) => Some(Self::verify_file_sha256(path, &mut file, expected)?),
+            None => None,
+        };
+
         // SAFETY: this is a read-only mapping of a live File. memmap2 owns the mapping
         // independently after creation, and WindowHandle/Arrow buffers retain the Arc.
         let mmap = unsafe { MmapOptions::new().map(&file) }
             .map_err(|source| RuntimeError::io(path, source))?;
-        let region = Arc::new(MappedRegion { mmap });
+        let region = Arc::new(MappedRegion {
+            mmap,
+            verified_source_sha256: Mutex::new(verified_source_sha256.clone()),
+        });
 
         let mut cache = self
             .mmap_cache
             .lock()
             .map_err(|_| RuntimeError::Validation("mmap cache lock was poisoned".into()))?;
         cache.insert(path.to_path_buf(), Arc::downgrade(&region));
-        Ok(region)
+        Ok((region, verified_source_sha256))
+    }
+
+    fn ensure_source_verified(
+        path: &Path,
+        region: &MappedRegion,
+        expected_sha256: Option<&str>,
+    ) -> Result<Option<String>> {
+        let Some(expected) = expected_sha256 else {
+            return Ok(None);
+        };
+
+        let mut state = region.verified_source_sha256.lock().map_err(|_| {
+            RuntimeError::Validation("source verification cache lock was poisoned".into())
+        })?;
+        if let Some(actual) = state.as_ref() {
+            if actual != expected {
+                return Err(RuntimeError::SourceHashMismatch {
+                    path: path.to_path_buf(),
+                    expected: expected.to_owned(),
+                    actual: actual.clone(),
+                });
+            }
+            return Ok(Some(actual.clone()));
+        }
+
+        let mut file = File::open(path).map_err(|source| RuntimeError::io(path, source))?;
+        let actual = Self::verify_file_sha256(path, &mut file, expected)?;
+        *state = Some(actual.clone());
+        Ok(Some(actual))
+    }
+
+    fn verify_file_sha256(path: &Path, file: &mut File, expected: &str) -> Result<String> {
+        let mut hasher = Sha256::new();
+        let mut buffer = [0_u8; SOURCE_HASH_BUFFER_BYTES];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|source| RuntimeError::io(path, source))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        let actual = format!("{:x}", hasher.finalize());
+        if actual != expected {
+            return Err(RuntimeError::SourceHashMismatch {
+                path: path.to_path_buf(),
+                expected: expected.to_owned(),
+                actual,
+            });
+        }
+        Ok(actual)
     }
 }
 
@@ -354,6 +453,18 @@ impl WindowHandle {
 
     pub fn source_size_bytes(&self) -> u64 {
         self.source_size_bytes
+    }
+
+    pub fn declared_source_sha256(&self) -> Option<&str> {
+        self.declared_source_sha256.as_deref()
+    }
+
+    pub fn verified_source_sha256(&self) -> Option<&str> {
+        self.verified_source_sha256.as_deref()
+    }
+
+    pub const fn source_verification_state(&self) -> SourceVerificationState {
+        self.source_verification_state
     }
 
     pub fn element_len(&self) -> Result<usize> {
@@ -438,13 +549,18 @@ mod tests {
     use super::*;
     use crate::manifest::{DType, DatasetManifest};
 
-    fn fixture() -> (tempfile::TempDir, Arc<Dataset>) {
+    fn fixture_with_declared_hash(
+        declare_hash: bool,
+    ) -> (tempfile::TempDir, Arc<Dataset>, String) {
         let directory = tempdir().unwrap();
         let data_path = directory.path().join("fmri.f32");
         let mut data = File::create(&data_path).unwrap();
         for value in 0..24u32 {
             data.write_all(&(value as f32).to_le_bytes()).unwrap();
         }
+        drop(data);
+        let source_bytes = std::fs::read(&data_path).unwrap();
+        let source_sha256 = format!("{:x}", Sha256::digest(&source_bytes));
 
         let manifest = DatasetManifest {
             schema_version: 1,
@@ -454,6 +570,7 @@ mod tests {
                 subject: "sub-01".into(),
                 modality: "fmri".into(),
                 path: "fmri.f32".into(),
+                source_sha256: declare_hash.then(|| source_sha256.clone()),
                 offset_bytes: 0,
                 dtype: DType::Float32Le,
                 shape: vec![6, 4],
@@ -467,6 +584,11 @@ mod tests {
         )
         .unwrap();
         let dataset = Dataset::open(directory.path()).unwrap();
+        (directory, dataset, source_sha256)
+    }
+
+    fn fixture() -> (tempfile::TempDir, Arc<Dataset>) {
+        let (directory, dataset, _) = fixture_with_declared_hash(false);
         (directory, dataset)
     }
 
@@ -504,6 +626,99 @@ mod tests {
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
         );
         assert_eq!(window.shape(), vec![2, 4]);
+        assert_eq!(
+            window.source_verification_state(),
+            SourceVerificationState::Unverified
+        );
+        assert_eq!(window.declared_source_sha256(), None);
+        assert_eq!(window.verified_source_sha256(), None);
+    }
+
+    #[test]
+    fn declared_source_hash_is_verified_before_window_is_returned() {
+        let (_directory, dataset, source_sha256) = fixture_with_declared_hash(true);
+        let mut stream = dataset
+            .stream(StreamSelector::default(), WindowSpec::new(2, 2).unwrap(), 1)
+            .unwrap();
+        let window = stream.next().unwrap().unwrap();
+        assert_eq!(window.declared_source_sha256(), Some(source_sha256.as_str()));
+        assert_eq!(window.verified_source_sha256(), Some(source_sha256.as_str()));
+        assert_eq!(
+            window.source_verification_state(),
+            SourceVerificationState::VerifiedAtOpen
+        );
+    }
+
+    #[test]
+    fn source_mutation_rejects_before_first_window() {
+        let (directory, dataset, source_sha256) = fixture_with_declared_hash(true);
+        let data_path = directory.path().join("fmri.f32");
+        let mut bytes = std::fs::read(&data_path).unwrap();
+        bytes[0] ^= 0xff;
+        std::fs::write(&data_path, bytes).unwrap();
+
+        let mut stream = dataset
+            .stream(StreamSelector::default(), WindowSpec::new(2, 2).unwrap(), 1)
+            .unwrap();
+        let error = stream.next().unwrap().unwrap_err();
+        match error {
+            RuntimeError::SourceHashMismatch {
+                expected, actual, ..
+            } => {
+                assert_eq!(expected, source_sha256);
+                assert_ne!(actual, expected);
+            }
+            other => panic!("expected source hash mismatch, got {other:?}"),
+        }
+        assert!(stream.next().is_none());
+    }
+
+    #[test]
+    fn cached_mapping_does_not_accept_a_conflicting_declared_hash() {
+        let directory = tempdir().unwrap();
+        let data_path = directory.path().join("shared.f32");
+        let mut data = File::create(&data_path).unwrap();
+        for value in 0..24u32 {
+            data.write_all(&(value as f32).to_le_bytes()).unwrap();
+        }
+        drop(data);
+        let actual = format!("{:x}", Sha256::digest(std::fs::read(&data_path).unwrap()));
+        let wrong = "0".repeat(64);
+        assert_ne!(actual, wrong);
+
+        let record = |id: &str, source_sha256: String| Record {
+            id: id.into(),
+            subject: "sub-01".into(),
+            modality: "fmri".into(),
+            path: "shared.f32".into(),
+            source_sha256: Some(source_sha256),
+            offset_bytes: 0,
+            dtype: DType::Float32Le,
+            shape: vec![6, 4],
+            sampling_hz: Some(0.5),
+            clock: None,
+        };
+        let manifest = DatasetManifest {
+            schema_version: 1,
+            dataset_id: "shared".into(),
+            records: vec![record("r1", actual.clone()), record("r2", wrong)],
+        };
+        std::fs::write(
+            directory.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        let dataset = Dataset::open(directory.path()).unwrap();
+        let mut stream = dataset
+            .stream(StreamSelector::default(), WindowSpec::new(6, 6).unwrap(), 1)
+            .unwrap();
+        let first = stream.next().unwrap().unwrap();
+        assert_eq!(first.verified_source_sha256(), Some(actual.as_str()));
+        assert!(matches!(
+            stream.next().unwrap(),
+            Err(RuntimeError::SourceHashMismatch { .. })
+        ));
+        assert!(stream.next().is_none());
     }
 
     #[test]

--- a/rust/neuros-runtime/src/dataset.rs
+++ b/rust/neuros-runtime/src/dataset.rs
@@ -12,6 +12,7 @@ use memmap2::{Mmap, MmapOptions};
 use sha2::{Digest, Sha256};
 use tracing::{debug, instrument};
 
+use crate::content_identity::declared_dataset_content_sha256 as compute_dataset_content_sha256;
 use crate::error::{Result, RuntimeError};
 use crate::manifest::{DatasetManifest, MANIFEST_FILE, Record};
 
@@ -66,6 +67,8 @@ pub struct Dataset {
     manifest: DatasetManifest,
     records: Vec<Arc<Record>>,
     manifest_sha256: String,
+    declared_dataset_content_sha256: Option<String>,
+    verified_dataset_content_sha256: Mutex<Option<String>>,
     mmap_cache: Mutex<HashMap<PathBuf, Weak<MappedRegion>>>,
 }
 
@@ -80,13 +83,17 @@ pub struct WindowHandle {
     region: Arc<MappedRegion>,
     record: Arc<Record>,
     start_frame: usize,
+    end_frame_exclusive: usize,
     length_frames: usize,
     frame_elements: usize,
+    record_byte_end_exclusive: u64,
     source_size_bytes: u64,
     manifest_sha256: String,
     declared_source_sha256: Option<String>,
     verified_source_sha256: Option<String>,
     source_verification_state: SourceVerificationState,
+    declared_dataset_content_sha256: Option<String>,
+    verified_dataset_content_sha256: Option<String>,
 }
 
 enum StreamMessage {
@@ -125,6 +132,7 @@ impl Dataset {
             .map_err(|source| RuntimeError::io(&manifest_path, source))?;
         let manifest: DatasetManifest = serde_json::from_slice(&bytes)?;
         manifest.validate()?;
+        let declared_dataset_content_sha256 = compute_dataset_content_sha256(&manifest)?;
         let records = manifest.records.iter().cloned().map(Arc::new).collect();
         let manifest_sha256 = format!("{:x}", Sha256::digest(&bytes));
 
@@ -133,6 +141,8 @@ impl Dataset {
             manifest,
             records,
             manifest_sha256,
+            declared_dataset_content_sha256,
+            verified_dataset_content_sha256: Mutex::new(None),
             mmap_cache: Mutex::new(HashMap::new()),
         }))
     }
@@ -143,6 +153,62 @@ impl Dataset {
 
     pub fn manifest_sha256(&self) -> &str {
         &self.manifest_sha256
+    }
+
+    pub fn declared_dataset_content_sha256(&self) -> Option<&str> {
+        self.declared_dataset_content_sha256.as_deref()
+    }
+
+    pub fn verified_dataset_content_sha256(&self) -> Result<Option<String>> {
+        self.verified_dataset_content_sha256
+            .lock()
+            .map(|value| value.clone())
+            .map_err(|_| {
+                RuntimeError::Validation("dataset verification state lock was poisoned".into())
+            })
+    }
+
+    /// Verify every declared source needed by the canonical dataset content identity.
+    ///
+    /// Returns `Ok(None)` for a partially hashed manifest. No dataset-level verified
+    /// identity is claimed unless every record declares a source SHA-256 and every
+    /// referenced mapped source matches its declaration.
+    pub fn verify_content(&self) -> Result<Option<String>> {
+        let Some(expected_dataset_sha256) = self.declared_dataset_content_sha256.clone() else {
+            return Ok(None);
+        };
+
+        let mut records: Vec<_> = self.records.iter().collect();
+        records.sort_by(|left, right| left.id.cmp(&right.id));
+        for record in records {
+            let expected_source_sha256 = record.source_sha256.as_deref().ok_or_else(|| {
+                RuntimeError::Validation(
+                    "declared dataset content identity requires every record source hash".into(),
+                )
+            })?;
+            let (path, required_end) = self.resolve_record_source(record)?;
+            let (region, verified_source_sha256) =
+                self.map_source(&path, Some(expected_source_sha256))?;
+            let mapped_size = mapped_size_bytes(&region)?;
+            if mapped_size < required_end {
+                return Err(RuntimeError::SourceTooShort {
+                    path,
+                    actual: mapped_size,
+                    required: required_end,
+                });
+            }
+            if verified_source_sha256.as_deref() != Some(expected_source_sha256) {
+                return Err(RuntimeError::Validation(
+                    "source verification completed without the declared digest".into(),
+                ));
+            }
+        }
+
+        let mut state = self.verified_dataset_content_sha256.lock().map_err(|_| {
+            RuntimeError::Validation("dataset verification state lock was poisoned".into())
+        })?;
+        *state = Some(expected_dataset_sha256.clone());
+        Ok(Some(expected_dataset_sha256))
     }
 
     pub fn plan_windows(
@@ -273,41 +339,11 @@ impl Dataset {
     }
 
     fn open_window(&self, descriptor: WindowDescriptor) -> Result<WindowHandle> {
-        let requested_path = self.root.join(&descriptor.record.path);
-        let path = std::fs::canonicalize(&requested_path)
-            .map_err(|source| RuntimeError::io(&requested_path, source))?;
-        if !path.starts_with(&self.root) {
-            return Err(RuntimeError::Validation(format!(
-                "record {:?} resolves outside the dataset root: {}",
-                descriptor.record.id,
-                path.display()
-            )));
-        }
-
-        let required_end = descriptor.record.required_end_byte()?;
-        let metadata =
-            std::fs::metadata(&path).map_err(|source| RuntimeError::io(&path, source))?;
-        if !metadata.is_file() {
-            return Err(RuntimeError::Validation(format!(
-                "record {:?} source is not a regular file: {}",
-                descriptor.record.id,
-                path.display()
-            )));
-        }
-        if metadata.len() < required_end {
-            return Err(RuntimeError::SourceTooShort {
-                path,
-                actual: metadata.len(),
-                required: required_end,
-            });
-        }
-
+        let (path, required_end) = self.resolve_record_source(&descriptor.record)?;
         let declared_source_sha256 = descriptor.record.source_sha256.clone();
         let (region, verified_source_sha256) =
             self.map_source(&path, declared_source_sha256.as_deref())?;
-        let mapped_size = u64::try_from(region.mmap.len()).map_err(|_| {
-            RuntimeError::Validation("mapped source size does not fit in u64".into())
-        })?;
+        let mapped_size = mapped_size_bytes(&region)?;
         if mapped_size < required_end {
             return Err(RuntimeError::SourceTooShort {
                 path,
@@ -320,19 +356,60 @@ impl Dataset {
         } else {
             SourceVerificationState::Unverified
         };
+        let end_frame_exclusive = descriptor
+            .start_frame
+            .checked_add(descriptor.length_frames)
+            .ok_or_else(|| RuntimeError::InvalidWindow("window frame extent overflowed usize".into()))?;
+        let verified_dataset_content_sha256 = self.verified_dataset_content_sha256()?;
 
         Ok(WindowHandle {
             region,
             record: descriptor.record,
             start_frame: descriptor.start_frame,
+            end_frame_exclusive,
             length_frames: descriptor.length_frames,
             frame_elements: descriptor.frame_elements,
+            record_byte_end_exclusive: required_end,
             source_size_bytes: mapped_size,
             manifest_sha256: self.manifest_sha256.clone(),
             declared_source_sha256,
             verified_source_sha256,
             source_verification_state,
+            declared_dataset_content_sha256: self.declared_dataset_content_sha256.clone(),
+            verified_dataset_content_sha256,
         })
+    }
+
+    fn resolve_record_source(&self, record: &Record) -> Result<(PathBuf, u64)> {
+        let requested_path = self.root.join(&record.path);
+        let path = std::fs::canonicalize(&requested_path)
+            .map_err(|source| RuntimeError::io(&requested_path, source))?;
+        if !path.starts_with(&self.root) {
+            return Err(RuntimeError::Validation(format!(
+                "record {:?} resolves outside the dataset root: {}",
+                record.id,
+                path.display()
+            )));
+        }
+
+        let required_end = record.required_end_byte()?;
+        let metadata =
+            std::fs::metadata(&path).map_err(|source| RuntimeError::io(&path, source))?;
+        if !metadata.is_file() {
+            return Err(RuntimeError::Validation(format!(
+                "record {:?} source is not a regular file: {}",
+                record.id,
+                path.display()
+            )));
+        }
+        if metadata.len() < required_end {
+            return Err(RuntimeError::SourceTooShort {
+                path,
+                actual: metadata.len(),
+                required: required_end,
+            });
+        }
+        Ok((path, required_end))
     }
 
     fn map_source(
@@ -415,6 +492,11 @@ impl Dataset {
     }
 }
 
+fn mapped_size_bytes(region: &MappedRegion) -> Result<u64> {
+    u64::try_from(region.mmap.len())
+        .map_err(|_| RuntimeError::Validation("mapped source size does not fit in u64".into()))
+}
+
 impl WindowHandle {
     pub fn record_id(&self) -> &str {
         &self.record.id
@@ -430,6 +512,10 @@ impl WindowHandle {
 
     pub fn start_frame(&self) -> usize {
         self.start_frame
+    }
+
+    pub const fn end_frame_exclusive(&self) -> usize {
+        self.end_frame_exclusive
     }
 
     pub fn shape(&self) -> Vec<usize> {
@@ -450,6 +536,14 @@ impl WindowHandle {
         self.source_size_bytes
     }
 
+    pub fn record_byte_start(&self) -> u64 {
+        self.record.offset_bytes
+    }
+
+    pub const fn record_byte_end_exclusive(&self) -> u64 {
+        self.record_byte_end_exclusive
+    }
+
     pub fn declared_source_sha256(&self) -> Option<&str> {
         self.declared_source_sha256.as_deref()
     }
@@ -460,6 +554,14 @@ impl WindowHandle {
 
     pub const fn source_verification_state(&self) -> SourceVerificationState {
         self.source_verification_state
+    }
+
+    pub fn declared_dataset_content_sha256(&self) -> Option<&str> {
+        self.declared_dataset_content_sha256.as_deref()
+    }
+
+    pub fn verified_dataset_content_sha256(&self) -> Option<&str> {
+        self.verified_dataset_content_sha256.as_deref()
     }
 
     pub fn element_len(&self) -> Result<usize> {
@@ -621,17 +723,25 @@ mod tests {
             &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
         );
         assert_eq!(window.shape(), vec![2, 4]);
+        assert_eq!(window.start_frame(), 0);
+        assert_eq!(window.end_frame_exclusive(), 2);
+        assert_eq!(window.record_byte_start(), 0);
+        assert_eq!(window.record_byte_end_exclusive(), 96);
         assert_eq!(
             window.source_verification_state(),
             SourceVerificationState::Unverified
         );
         assert_eq!(window.declared_source_sha256(), None);
         assert_eq!(window.verified_source_sha256(), None);
+        assert_eq!(window.declared_dataset_content_sha256(), None);
+        assert_eq!(window.verified_dataset_content_sha256(), None);
     }
 
     #[test]
     fn declared_source_hash_is_verified_before_window_is_returned() {
         let (_directory, dataset, source_sha256) = fixture_with_declared_hash(true);
+        assert!(dataset.declared_dataset_content_sha256().is_some());
+        assert_eq!(dataset.verified_dataset_content_sha256().unwrap(), None);
         let mut stream = dataset
             .stream(StreamSelector::default(), WindowSpec::new(2, 2).unwrap(), 1)
             .unwrap();
@@ -642,6 +752,40 @@ mod tests {
             window.source_verification_state(),
             SourceVerificationState::VerifiedAtOpen
         );
+        assert!(window.declared_dataset_content_sha256().is_some());
+        assert_eq!(window.verified_dataset_content_sha256(), None);
+    }
+
+    #[test]
+    fn explicit_dataset_verification_promotes_dataset_content_identity() {
+        let (_directory, dataset, source_sha256) = fixture_with_declared_hash(true);
+        let declared = dataset
+            .declared_dataset_content_sha256()
+            .unwrap()
+            .to_owned();
+        assert_eq!(dataset.verify_content().unwrap(), Some(declared.clone()));
+        assert_eq!(
+            dataset.verified_dataset_content_sha256().unwrap(),
+            Some(declared.clone())
+        );
+
+        let mut stream = dataset
+            .stream(StreamSelector::default(), WindowSpec::new(2, 2).unwrap(), 1)
+            .unwrap();
+        let window = stream.next().unwrap().unwrap();
+        assert_eq!(window.verified_source_sha256(), Some(source_sha256.as_str()));
+        assert_eq!(
+            window.verified_dataset_content_sha256(),
+            Some(declared.as_str())
+        );
+    }
+
+    #[test]
+    fn partial_hash_manifest_cannot_claim_verified_dataset_identity() {
+        let (_directory, dataset) = fixture();
+        assert_eq!(dataset.declared_dataset_content_sha256(), None);
+        assert_eq!(dataset.verify_content().unwrap(), None);
+        assert_eq!(dataset.verified_dataset_content_sha256().unwrap(), None);
     }
 
     #[test]

--- a/rust/neuros-runtime/src/dataset.rs
+++ b/rust/neuros-runtime/src/dataset.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::ptr::NonNull;
 use std::sync::{Arc, Mutex, Weak};
@@ -15,8 +14,6 @@ use tracing::{debug, instrument};
 
 use crate::error::{Result, RuntimeError};
 use crate::manifest::{DatasetManifest, MANIFEST_FILE, Record};
-
-const SOURCE_HASH_BUFFER_BYTES: usize = 64 * 1024;
 
 #[derive(Clone, Debug, Default)]
 pub struct StreamSelector {
@@ -308,6 +305,16 @@ impl Dataset {
         let declared_source_sha256 = descriptor.record.source_sha256.clone();
         let (region, verified_source_sha256) =
             self.map_source(&path, declared_source_sha256.as_deref())?;
+        let mapped_size = u64::try_from(region.mmap.len()).map_err(|_| {
+            RuntimeError::Validation("mapped source size does not fit in u64".into())
+        })?;
+        if mapped_size < required_end {
+            return Err(RuntimeError::SourceTooShort {
+                path,
+                actual: mapped_size,
+                required: required_end,
+            });
+        }
         let source_verification_state = if verified_source_sha256.is_some() {
             SourceVerificationState::VerifiedAtOpen
         } else {
@@ -320,7 +327,7 @@ impl Dataset {
             start_frame: descriptor.start_frame,
             length_frames: descriptor.length_frames,
             frame_elements: descriptor.frame_elements,
-            source_size_bytes: metadata.len(),
+            source_size_bytes: mapped_size,
             manifest_sha256: self.manifest_sha256.clone(),
             declared_source_sha256,
             verified_source_sha256,
@@ -333,27 +340,27 @@ impl Dataset {
         path: &Path,
         expected_sha256: Option<&str>,
     ) -> Result<(Arc<MappedRegion>, Option<String>)> {
-        {
+        let cached_region = {
             let cache = self
                 .mmap_cache
                 .lock()
                 .map_err(|_| RuntimeError::Validation("mmap cache lock was poisoned".into()))?;
-            if let Some(region) = cache.get(path).and_then(Weak::upgrade) {
-                let verified = Self::ensure_source_verified(path, &region, expected_sha256)?;
-                return Ok((region, verified));
-            }
+            cache.get(path).and_then(Weak::upgrade)
+        };
+        if let Some(region) = cached_region {
+            let verified = Self::ensure_source_verified(path, &region, expected_sha256)?;
+            return Ok((region, verified));
         }
 
-        let mut file = File::open(path).map_err(|source| RuntimeError::io(path, source))?;
-        let verified_source_sha256 = match expected_sha256 {
-            Some(expected) => Some(Self::verify_file_sha256(path, &mut file, expected)?),
-            None => None,
-        };
-
+        let file = File::open(path).map_err(|source| RuntimeError::io(path, source))?;
         // SAFETY: this is a read-only mapping of a live File. memmap2 owns the mapping
         // independently after creation, and WindowHandle/Arrow buffers retain the Arc.
         let mmap = unsafe { MmapOptions::new().map(&file) }
             .map_err(|source| RuntimeError::io(path, source))?;
+        let verified_source_sha256 = match expected_sha256 {
+            Some(expected) => Some(Self::verify_mapped_sha256(path, &mmap, expected)?),
+            None => None,
+        };
         let region = Arc::new(MappedRegion {
             mmap,
             verified_source_sha256: Mutex::new(verified_source_sha256.clone()),
@@ -390,25 +397,13 @@ impl Dataset {
             return Ok(Some(actual.clone()));
         }
 
-        let mut file = File::open(path).map_err(|source| RuntimeError::io(path, source))?;
-        let actual = Self::verify_file_sha256(path, &mut file, expected)?;
+        let actual = Self::verify_mapped_sha256(path, &region.mmap, expected)?;
         *state = Some(actual.clone());
         Ok(Some(actual))
     }
 
-    fn verify_file_sha256(path: &Path, file: &mut File, expected: &str) -> Result<String> {
-        let mut hasher = Sha256::new();
-        let mut buffer = [0_u8; SOURCE_HASH_BUFFER_BYTES];
-        loop {
-            let read = file
-                .read(&mut buffer)
-                .map_err(|source| RuntimeError::io(path, source))?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-        let actual = format!("{:x}", hasher.finalize());
+    fn verify_mapped_sha256(path: &Path, mmap: &Mmap, expected: &str) -> Result<String> {
+        let actual = format!("{:x}", Sha256::digest(mmap.as_ref()));
         if actual != expected {
             return Err(RuntimeError::SourceHashMismatch {
                 path: path.to_path_buf(),
@@ -671,6 +666,65 @@ mod tests {
             other => panic!("expected source hash mismatch, got {other:?}"),
         }
         assert!(stream.next().is_none());
+    }
+
+    #[test]
+    fn cached_unverified_mapping_is_upgraded_when_hash_is_declared() {
+        let directory = tempdir().unwrap();
+        let data_path = directory.path().join("shared.f32");
+        let mut data = File::create(&data_path).unwrap();
+        for value in 0..24u32 {
+            data.write_all(&(value as f32).to_le_bytes()).unwrap();
+        }
+        drop(data);
+        let actual = format!("{:x}", Sha256::digest(std::fs::read(&data_path).unwrap()));
+
+        let record = |id: &str, source_sha256: Option<String>| Record {
+            id: id.into(),
+            subject: "sub-01".into(),
+            modality: "fmri".into(),
+            path: "shared.f32".into(),
+            source_sha256,
+            offset_bytes: 0,
+            dtype: DType::Float32Le,
+            shape: vec![6, 4],
+            sampling_hz: Some(0.5),
+            clock: None,
+        };
+        let manifest = DatasetManifest {
+            schema_version: 1,
+            dataset_id: "shared-upgrade".into(),
+            records: vec![record("r1", None), record("r2", Some(actual.clone()))],
+        };
+        std::fs::write(
+            directory.path().join(MANIFEST_FILE),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        let dataset = Dataset::open(directory.path()).unwrap();
+        let mut stream = dataset
+            .stream(StreamSelector::default(), WindowSpec::new(6, 6).unwrap(), 1)
+            .unwrap();
+
+        let first = stream.next().unwrap().unwrap();
+        assert_eq!(
+            first.source_verification_state(),
+            SourceVerificationState::Unverified
+        );
+        assert_eq!(first.verified_source_sha256(), None);
+
+        let second = stream.next().unwrap().unwrap();
+        assert_eq!(second.declared_source_sha256(), Some(actual.as_str()));
+        assert_eq!(second.verified_source_sha256(), Some(actual.as_str()));
+        assert_eq!(
+            second.source_verification_state(),
+            SourceVerificationState::VerifiedAtOpen
+        );
+        assert!(stream.next().is_none());
+
+        // Keep the first window alive through the upgrade so the second record must
+        // reuse and upgrade the same cached mmap rather than create a fresh mapping.
+        assert_eq!(first.record_id(), "r1");
     }
 
     #[test]

--- a/rust/neuros-runtime/src/dataset.rs
+++ b/rust/neuros-runtime/src/dataset.rs
@@ -180,6 +180,10 @@ impl Dataset {
 
         let mut records: Vec<_> = self.records.iter().collect();
         records.sort_by(|left, right| left.id.cmp(&right.id));
+        // The process-wide mmap cache intentionally stores weak references. Hold
+        // verified mappings strongly for this pass so multiple records referencing
+        // one source share verification work even when no window is alive yet.
+        let mut verified_regions = Vec::new();
         for record in records {
             let expected_source_sha256 = record.source_sha256.as_deref().ok_or_else(|| {
                 RuntimeError::Validation(
@@ -202,6 +206,7 @@ impl Dataset {
                     "source verification completed without the declared digest".into(),
                 ));
             }
+            verified_regions.push(region);
         }
 
         let mut state = self.verified_dataset_content_sha256.lock().map_err(|_| {
@@ -359,7 +364,9 @@ impl Dataset {
         let end_frame_exclusive = descriptor
             .start_frame
             .checked_add(descriptor.length_frames)
-            .ok_or_else(|| RuntimeError::InvalidWindow("window frame extent overflowed usize".into()))?;
+            .ok_or_else(|| {
+                RuntimeError::InvalidWindow("window frame extent overflowed usize".into())
+            })?;
         let verified_dataset_content_sha256 = self.verified_dataset_content_sha256()?;
 
         Ok(WindowHandle {
@@ -646,9 +653,7 @@ mod tests {
     use super::*;
     use crate::manifest::{DType, DatasetManifest};
 
-    fn fixture_with_declared_hash(
-        declare_hash: bool,
-    ) -> (tempfile::TempDir, Arc<Dataset>, String) {
+    fn fixture_with_declared_hash(declare_hash: bool) -> (tempfile::TempDir, Arc<Dataset>, String) {
         let directory = tempdir().unwrap();
         let data_path = directory.path().join("fmri.f32");
         let mut data = File::create(&data_path).unwrap();
@@ -746,8 +751,14 @@ mod tests {
             .stream(StreamSelector::default(), WindowSpec::new(2, 2).unwrap(), 1)
             .unwrap();
         let window = stream.next().unwrap().unwrap();
-        assert_eq!(window.declared_source_sha256(), Some(source_sha256.as_str()));
-        assert_eq!(window.verified_source_sha256(), Some(source_sha256.as_str()));
+        assert_eq!(
+            window.declared_source_sha256(),
+            Some(source_sha256.as_str())
+        );
+        assert_eq!(
+            window.verified_source_sha256(),
+            Some(source_sha256.as_str())
+        );
         assert_eq!(
             window.source_verification_state(),
             SourceVerificationState::VerifiedAtOpen
@@ -773,7 +784,10 @@ mod tests {
             .stream(StreamSelector::default(), WindowSpec::new(2, 2).unwrap(), 1)
             .unwrap();
         let window = stream.next().unwrap().unwrap();
-        assert_eq!(window.verified_source_sha256(), Some(source_sha256.as_str()));
+        assert_eq!(
+            window.verified_source_sha256(),
+            Some(source_sha256.as_str())
+        );
         assert_eq!(
             window.verified_dataset_content_sha256(),
             Some(declared.as_str())

--- a/rust/neuros-runtime/src/error.rs
+++ b/rust/neuros-runtime/src/error.rs
@@ -24,6 +24,12 @@ pub enum RuntimeError {
         actual: u64,
         required: u64,
     },
+    #[error("source SHA-256 mismatch at {path}: expected {expected}, got {actual}")]
+    SourceHashMismatch {
+        path: PathBuf,
+        expected: String,
+        actual: String,
+    },
     #[error("runtime worker terminated before producing all requested windows")]
     WorkerTerminated,
 }

--- a/rust/neuros-runtime/src/lib.rs
+++ b/rust/neuros-runtime/src/lib.rs
@@ -21,3 +21,15 @@ pub use error::{Result, RuntimeError};
 pub use manifest::{
     ClockSpec, DType, DatasetManifest, MANIFEST_FILE, MANIFEST_SCHEMA_VERSION, Record,
 };
+
+#[cfg(test)]
+impl std::fmt::Debug for WindowHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WindowHandle")
+            .field("record_id", &self.record_id())
+            .field("start_frame", &self.start_frame())
+            .field("end_frame_exclusive", &self.end_frame_exclusive())
+            .finish_non_exhaustive()
+    }
+}

--- a/rust/neuros-runtime/src/lib.rs
+++ b/rust/neuros-runtime/src/lib.rs
@@ -4,14 +4,16 @@
 //!
 //! The crate intentionally owns only transport and representation concerns:
 //! validated dataset manifests, memory mapping, deterministic window planning,
-//! bounded prefetch, and zero-copy Arrow views. Scientific transforms and model
-//! semantics remain in the Python control plane unless promoted into explicit,
-//! versioned runtime adapters.
+//! bounded prefetch, zero-copy Arrow views, and content provenance. Scientific
+//! transforms and model semantics remain in the Python control plane unless
+//! promoted into explicit, versioned runtime adapters.
 
+mod content_identity;
 mod dataset;
 mod error;
 mod manifest;
 
+pub use content_identity::{DATASET_CONTENT_DOMAIN, declared_dataset_content_sha256};
 pub use dataset::{
     Dataset, SourceVerificationState, StreamSelector, WindowHandle, WindowSpec, WindowStream,
 };

--- a/rust/neuros-runtime/src/lib.rs
+++ b/rust/neuros-runtime/src/lib.rs
@@ -12,7 +12,9 @@ mod dataset;
 mod error;
 mod manifest;
 
-pub use dataset::{Dataset, StreamSelector, WindowHandle, WindowSpec, WindowStream};
+pub use dataset::{
+    Dataset, SourceVerificationState, StreamSelector, WindowHandle, WindowSpec, WindowStream,
+};
 pub use error::{Result, RuntimeError};
 pub use manifest::{
     ClockSpec, DType, DatasetManifest, MANIFEST_FILE, MANIFEST_SCHEMA_VERSION, Record,

--- a/rust/neuros-runtime/src/manifest.rs
+++ b/rust/neuros-runtime/src/manifest.rs
@@ -193,7 +193,7 @@ fn is_lowercase_sha256(value: &str) -> bool {
     value.len() == 64
         && value
             .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
 #[cfg(test)]

--- a/rust/neuros-runtime/src/manifest.rs
+++ b/rust/neuros-runtime/src/manifest.rs
@@ -22,6 +22,8 @@ pub struct Record {
     pub modality: String,
     pub path: PathBuf,
     #[serde(default)]
+    pub source_sha256: Option<String>,
+    #[serde(default)]
     pub offset_bytes: u64,
     pub dtype: DType,
     pub shape: Vec<usize>,
@@ -93,6 +95,14 @@ impl Record {
                 "record {:?} path must be a safe relative path: {:?}",
                 self.id, self.path
             )));
+        }
+        if let Some(source_sha256) = &self.source_sha256 {
+            if !is_lowercase_sha256(source_sha256) {
+                return Err(RuntimeError::Validation(format!(
+                    "record {:?} source_sha256 must contain exactly 64 lowercase hexadecimal characters",
+                    self.id
+                )));
+            }
         }
         if self.shape.is_empty() || self.shape.contains(&0) {
             return Err(RuntimeError::Validation(format!(
@@ -179,6 +189,13 @@ fn is_safe_relative_path(path: &Path) -> bool {
             .all(|component| matches!(component, Component::Normal(_) | Component::CurDir))
 }
 
+fn is_lowercase_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +206,7 @@ mod tests {
             subject: "sub-01".into(),
             modality: "fmri".into(),
             path: "sub-01/fmri.f32".into(),
+            source_sha256: None,
             offset_bytes: 0,
             dtype: DType::Float32Le,
             shape: vec![10, 4],
@@ -209,6 +227,23 @@ mod tests {
         let mut candidate = record();
         candidate.offset_bytes = 2;
         assert!(candidate.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_source_sha256() {
+        let mut candidate = record();
+        candidate.source_sha256 = Some("A".repeat(64));
+        assert!(candidate.validate().is_err());
+
+        candidate.source_sha256 = Some("a".repeat(63));
+        assert!(candidate.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_strict_lowercase_source_sha256() {
+        let mut candidate = record();
+        candidate.source_sha256 = Some("0123456789abcdef".repeat(4));
+        assert!(candidate.validate().is_ok());
     }
 
     #[test]

--- a/tests/test_runtime_content_provenance.py
+++ b/tests/test_runtime_content_provenance.py
@@ -52,6 +52,8 @@ def _window() -> DataWindow:
 
 def test_data_window_provenance_exposes_exact_intervals_and_content_identity() -> None:
     provenance = _window().provenance
+    assert provenance["start_frame"] == 4
+    assert provenance["end_frame_exclusive"] == 8
     assert provenance["manifest_sha256"] == SHA_MANIFEST
     assert provenance["declared_source_sha256"] == SHA_SOURCE
     assert provenance["verified_source_sha256"] == SHA_SOURCE

--- a/tests/test_runtime_content_provenance.py
+++ b/tests/test_runtime_content_provenance.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from neuros.dataset import DataWindow, Dataset
+from orion.scientific import LineageCompleteness
+
+
+SHA_MANIFEST = "a" * 64
+SHA_SOURCE = "b" * 64
+SHA_DATASET = "c" * 64
+
+
+class _FakeNativeDataset:
+    dataset_id = "fixture"
+    manifest_sha256 = SHA_MANIFEST
+    declared_dataset_content_sha256 = SHA_DATASET
+    record_count = 1
+
+    def __init__(self) -> None:
+        self.verified_dataset_content_sha256 = None
+
+    def verify_content(self) -> str:
+        self.verified_dataset_content_sha256 = SHA_DATASET
+        return SHA_DATASET
+
+
+def _window() -> DataWindow:
+    native = SimpleNamespace(
+        record_id="r1",
+        subject="sub-01",
+        modality="fmri",
+        start_frame=4,
+        end_frame_exclusive=8,
+        shape=[4, 3],
+        sampling_hz=0.5,
+        manifest_sha256=SHA_MANIFEST,
+        source_size_bytes=4096,
+        declared_source_sha256=SHA_SOURCE,
+        verified_source_sha256=SHA_SOURCE,
+        source_verification_state="verified_at_open",
+        declared_dataset_content_sha256=SHA_DATASET,
+        verified_dataset_content_sha256=SHA_DATASET,
+        record_byte_start=128,
+        record_byte_end_exclusive=512,
+    )
+    return DataWindow(native)
+
+
+def test_data_window_provenance_exposes_exact_intervals_and_content_identity() -> None:
+    provenance = _window().provenance
+    assert provenance["manifest_sha256"] == SHA_MANIFEST
+    assert provenance["declared_source_sha256"] == SHA_SOURCE
+    assert provenance["verified_source_sha256"] == SHA_SOURCE
+    assert provenance["source_verification_state"] == "verified_at_open"
+    assert provenance["declared_dataset_content_sha256"] == SHA_DATASET
+    assert provenance["verified_dataset_content_sha256"] == SHA_DATASET
+    assert provenance["record_byte_interval"] == {"start": 128, "end_exclusive": 512}
+    assert provenance["window_frame_interval"] == {"start": 4, "end_exclusive": 8}
+
+
+def test_orion_bridge_requires_explicit_whole_dataset_verification() -> None:
+    dataset = Dataset(_FakeNativeDataset(), Path("/fixture"))
+    with pytest.raises(ValueError, match="fully verified native dataset"):
+        dataset.to_orion_lineage(upstream_source="fixture-source")
+
+
+def test_orion_bridge_never_promotes_lineage_completeness_from_local_hashes() -> None:
+    dataset = Dataset(_FakeNativeDataset(), Path("/fixture"))
+    assert dataset.verify_content() == SHA_DATASET
+    lineage = dataset.to_orion_lineage(
+        upstream_source="fixture-source",
+        sampling_assumptions={"sampling_rate_hz": 0.5},
+        preprocessing_history=("external preprocessing unknown",),
+    )
+    assert lineage.content_sha256 == SHA_DATASET
+    assert lineage.lineage_completeness is LineageCompleteness.UNKNOWN
+    assert lineage.metadata["neuros_runtime"]["manifest_sha256"] == SHA_MANIFEST
+    assert (
+        lineage.metadata["neuros_runtime"]["verified_dataset_content_sha256"]
+        == SHA_DATASET
+    )
+
+
+def test_orion_bridge_reserves_runtime_metadata_namespace() -> None:
+    dataset = Dataset(_FakeNativeDataset(), Path("/fixture"))
+    dataset.verify_content()
+    with pytest.raises(ValueError, match="reserved"):
+        dataset.to_orion_lineage(
+            upstream_source="fixture-source",
+            metadata={"neuros_runtime": {"spoofed": True}},
+        )


### PR DESCRIPTION
## Purpose

Promote issue #148's first cryptographic source-provenance contract into the neurOS Rust data plane without expanding scientific semantics.

Base authority: exact promoted `main` commit `db96612532da4dafb5726b176420501f4efe0c17`.

Qualified exact candidate: `49fcca7608a490a28172aa3e3aa7b741afcf8c9d`.

This exact head completed the full 9/9 pull-request workflow suite successfully. No green result from a superseded SHA is inherited.

## Source-verification contract

Dataset records may optionally declare a strict lowercase, full-file `source_sha256`.

When a digest is declared, the native runtime must:

1. resolve/canonicalize the regular source path under the dataset root;
2. create the read-only mmap that will back returned Arrow arrays;
3. hash the exact mapped file bytes;
4. reject a mismatch before returning the first scientific window;
5. cache verification independently from mmap existence;
6. permit an existing unverified mmap to be upgraded when a later record for the same path requires verification;
7. reject conflicting declared digests for a cached verified mapping.

`verified_at_open` means the mapped regular file matched its declared digest when verification occurred. It deliberately does **not** claim the surrounding filesystem is immutable against later external writers.

## Three separate identities

This PR deliberately does not collapse distinct provenance claims into one hash.

### 1. Manifest identity

`manifest_sha256` hashes the exact `neuros.dataset.json` bytes. It binds serialized path names, sampling/clock metadata, record order, and all other manifest fields.

### 2. Declared dataset content identity

When every record declares a source digest, neurOS derives a domain-separated canonical identity under:

```text
neuros.dataset_content.v1
```

Records are stable-sorted by record ID. The canonical descriptor binds:

- record ID;
- full-file source SHA-256;
- `offset_bytes`;
- dtype;
- shape.

Path is intentionally excluded, so renaming identical bytes does not alter byte/interpretation identity. Sampling and clock metadata remain separately bound by the manifest contract. Changing offset/dtype/shape changes dataset content identity even if the source-file digest is unchanged.

A manifest with any unhashed record has no complete declared dataset content identity; neurOS does not synthesize a partial digest and call it complete.

### 3. Verified dataset content identity

A declared dataset digest is still only a manifest claim. `Dataset.verify_content()` verifies every source needed by the canonical identity. Only after all sources match is `verified_content_sha256` promoted.

This prevents lazy verification of one record/window from being mistaken for proof that an entire dataset has been verified.

## Window provenance contract

Each `DataWindow.provenance` exposes:

- record ID / subject / modality;
- exact window frame interval `[start, end_exclusive)`;
- exact record byte interval `[start, end_exclusive)`;
- shape and sampling metadata;
- manifest SHA-256;
- mapped source byte size;
- declared source SHA-256;
- verified source SHA-256;
- source verification state (`unverified` or `verified_at_open`);
- declared dataset content SHA-256 when derivable;
- verified dataset content SHA-256 only after explicit whole-dataset verification.

## ORION lineage bridge

A fully verified native dataset can be projected into ORION `DatasetLineage` through `Dataset.to_orion_lineage(...)`.

The bridge:

- fails closed unless the native dataset has been explicitly and completely verified;
- maps the canonical verified dataset content identity to `DatasetLineage.content_sha256`;
- preserves manifest/content verification metadata under the reserved `neuros_runtime` namespace;
- prevents callers from spoofing that reserved namespace;
- always emits `LineageCompleteness.UNKNOWN`.

That final rule is intentional. Local byte verification proves which bytes and declared interpretation neurOS consumed. It does **not** prove original acquisition provenance, upstream preprocessing ancestry, participant/stimulus identity completeness, licensing, or pretraining-overlap closure. Stronger scientific lineage remains an independent authority claim.

## Adversarial coverage

The implementation/tests cover:

- malformed/uppercase digest rejection;
- valid strict lowercase digest acceptance;
- declared digest verification before a scientific window is returned;
- one-byte mutation before first access produces `SourceHashMismatch`;
- cached unverified mmap upgrades when a later record declares the correct digest;
- conflicting declared digest on a cached mapping is rejected;
- stable dataset identity under record permutation and source-path rename;
- changed record interpretation changes dataset content identity;
- partially hashed manifests cannot claim a complete dataset identity;
- explicit whole-dataset verification is required before the ORION bridge;
- ORION bridge never upgrades local hashes into `LineageCompleteness.COMPLETE`;
- existing zero-copy, deterministic-window, source-length, cancellation, and root/symlink containment contracts remain covered by repository qualification.

## Exact-head systems evidence

Rust Runtime CI on exact source `49fcca7608a490a28172aa3e3aa7b741afcf8c9d` produced the immutable artifact:

- artifact: `runtime-provenance-performance-49fcca7608a490a28172aa3e3aa7b741afcf8c9d`;
- artifact ID: `9874235065`;
- artifact digest: `sha256:3101d68424e024bb9e62970394bc02cc4516ccc406acaf513ed2c774bc8914ac`;
- fixture size: 32 MiB;
- cold whole-source verification: `0.022064359 s`, `1450.3027 MiB/s`;
- warm verified iteration: `2047` windows in `0.014830372 s`, `138027.56 windows/s`;
- Linux max-RSS: `21072 KiB` before verification, `53840 KiB` after verification, `54032 KiB` after warm iteration, growth `32960 KiB`;
- declared dataset content SHA-256: `98d0a4d18d9c9dfcdbda8eab1711c1186edd4d2fe7afe936f2cce9e75d1ae113`;
- verified dataset content SHA-256: `98d0a4d18d9c9dfcdbda8eab1711c1186edd4d2fe7afe936f2cce9e75d1ae113`.

These are **systems measurements only**. Runner timing is not a scientific/model promotion threshold. The RSS observation also does not imply source-size-independent resident memory: full-file SHA verification faults mmap-backed pages resident on Linux.

## Qualification history

The superseded `c99d783c…` and `2269a776…` candidates were both blocked by the same reproducible Rust test-target compile failure: `Result::unwrap_err()` required the success type `WindowHandle` to implement `Debug`. A strict SHA-validator cleanup between those candidates was semantics-preserving but was not the blocking gate failure.

The final candidate `49fcca7608…` adds test-build-only debug support under `#[cfg(test)]`; release/runtime behavior is unchanged.

On this exact final head, all required Rust gates passed:

- `cargo fmt --all --check`;
- `cargo clippy --workspace --all-targets -- -D warnings`;
- `cargo test -p neuros-runtime --all-features`;
- native Python wheel build/install;
- native Arrow/provenance smoke test;
- exact-SHA provenance benchmark artifact.

The complete 9/9 exact-head repository workflow suite also passed:

1. Developer Preview Journey;
2. Rust Runtime CI;
3. Release Candidate Artifacts;
4. Reproducible Release Build;
5. Public Trust Contracts;
6. Whole Package Qualification;
7. Braindecode Compatibility;
8. Ecosystem Compatibility;
9. neurOS CI.

## Scientific boundary

This PR changes source/content identity and provenance only. It does **not** add synchronization, resampling, interpolation, preprocessing, model transforms, split authority, experiment promotion, outcome reveal, or multimodal inference semantics.

Issue #147's exact-clock multimodal synchronization contract must begin only from the post-merge, post-qualified `main` boundary created here.

## Promotion boundary

This PR implements #148, but **#148 must remain open through merge**. Promotion is complete only after the resulting squash-merge SHA is confirmed as exact `main` and the full post-merge push workflow matrix on that exact SHA reaches terminal success.

After that exact-main qualification, #148 can be closed as promoted and #147 may begin.