### PR TITLE
fix(runtime): harden exact alignment acquisition authority

### DIFF
--- a/rust/neuros-runtime/src/manifest.rs
+++ b/rust/neuros-runtime/src/manifest.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -68,6 +68,7 @@ impl DatasetManifest {
         }
 
         let mut ids = HashSet::with_capacity(self.records.len());
+        let mut sync_group_subjects = HashMap::new();
         for record in &self.records {
             record.validate()?;
             if !ids.insert(record.id.as_str()) {
@@ -75,6 +76,20 @@ impl DatasetManifest {
                     "duplicate record id {:?}",
                     record.id
                 )));
+            }
+            if let Some(sync_group) = record.sync_group.as_deref() {
+                match sync_group_subjects.get(sync_group) {
+                    Some(subject) if *subject != record.subject.as_str() => {
+                        return Err(RuntimeError::Validation(format!(
+                            "sync_group {sync_group:?} crosses subjects {:?} and {:?}; acquisition groups must be subject-local",
+                            subject, record.subject
+                        )));
+                    }
+                    Some(_) => {}
+                    None => {
+                        sync_group_subjects.insert(sync_group, record.subject.as_str());
+                    }
+                }
             }
         }
         Ok(())
@@ -244,6 +259,27 @@ mod tests {
         assert!(candidate.validate().is_err());
         candidate.sync_group = Some("sub-01/run-01 ".into());
         assert!(candidate.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_cross_subject_sync_group() {
+        let mut first = record();
+        first.id = "fmri-01".into();
+        first.sync_group = Some("run-01".into());
+
+        let mut second = record();
+        second.id = "behavior-01".into();
+        second.subject = "sub-02".into();
+        second.modality = "behavior".into();
+        second.sync_group = Some("run-01".into());
+
+        let manifest = DatasetManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            dataset_id: "cross-subject".into(),
+            records: vec![first, second],
+        };
+        let error = manifest.validate().unwrap_err();
+        assert!(error.to_string().contains("crosses subjects"));
     }
 
     #[test]

--- a/rust/neuros-runtime/src/sync.rs
+++ b/rust/neuros-runtime/src/sync.rs
@@ -134,10 +134,9 @@ fn plan_exact_alignment_from_manifest(
     spec: ExactAlignmentSpec,
 ) -> Result<ExactAlignmentPlan> {
     manifest.validate()?;
-    let sync_group = sync_group.trim();
-    if sync_group.is_empty() {
+    if sync_group.is_empty() || sync_group != sync_group.trim() {
         return Err(RuntimeError::Alignment(
-            "sync_group must be non-empty".into(),
+            "sync_group must be a non-empty canonical identifier with no surrounding whitespace".into(),
         ));
     }
     if modalities.len() < 2 {
@@ -148,15 +147,15 @@ fn plan_exact_alignment_from_manifest(
 
     let mut requested = HashSet::with_capacity(modalities.len());
     for modality in modalities {
-        let normalized = modality.trim();
-        if normalized.is_empty() {
+        if modality.is_empty() || modality != modality.trim() {
             return Err(RuntimeError::Alignment(
-                "requested modalities must be non-empty".into(),
+                "requested modalities must be non-empty canonical identifiers with no surrounding whitespace"
+                    .into(),
             ));
         }
-        if !requested.insert(normalized) {
+        if !requested.insert(modality.as_str()) {
             return Err(RuntimeError::Alignment(format!(
-                "requested modality {normalized:?} is duplicated"
+                "requested modality {modality:?} is duplicated"
             )));
         }
     }
@@ -561,6 +560,34 @@ mod tests {
         assert_eq!(plan.start_ns, 2_000_000_000);
         assert_eq!(plan.overlap_end_ns, 20_000_000_000);
         assert_eq!(plan.window_count, 8);
+    }
+
+    #[test]
+    fn noncanonical_request_identifiers_reject() {
+        let manifest = manifest(vec![
+            record("fmri", "fmri", 10, 0, 2_000_000_000),
+            record("behavior", "behavior", 40, 0, 500_000_000),
+        ]);
+        let spec = ExactAlignmentSpec::new(4_000_000_000, 2_000_000_000).unwrap();
+
+        assert!(plan_exact_alignment_from_manifest(
+            &manifest,
+            &"4".repeat(64),
+            &"d".repeat(64),
+            " sub-01/run-01",
+            &["fmri".into(), "behavior".into()],
+            spec,
+        )
+        .is_err());
+        assert!(plan_exact_alignment_from_manifest(
+            &manifest,
+            &"4".repeat(64),
+            &"d".repeat(64),
+            "sub-01/run-01",
+            &[" fmri".into(), "behavior".into()],
+            spec,
+        )
+        .is_err());
     }
 
     #[test]

--- a/rust/neuros-runtime/src/sync.rs
+++ b/rust/neuros-runtime/src/sync.rs
@@ -136,7 +136,8 @@ fn plan_exact_alignment_from_manifest(
     manifest.validate()?;
     if sync_group.is_empty() || sync_group != sync_group.trim() {
         return Err(RuntimeError::Alignment(
-            "sync_group must be a non-empty canonical identifier with no surrounding whitespace".into(),
+            "sync_group must be a non-empty canonical identifier with no surrounding whitespace"
+                .into(),
         ));
     }
     if modalities.len() < 2 {
@@ -570,24 +571,28 @@ mod tests {
         ]);
         let spec = ExactAlignmentSpec::new(4_000_000_000, 2_000_000_000).unwrap();
 
-        assert!(plan_exact_alignment_from_manifest(
-            &manifest,
-            &"4".repeat(64),
-            &"d".repeat(64),
-            " sub-01/run-01",
-            &["fmri".into(), "behavior".into()],
-            spec,
-        )
-        .is_err());
-        assert!(plan_exact_alignment_from_manifest(
-            &manifest,
-            &"4".repeat(64),
-            &"d".repeat(64),
-            "sub-01/run-01",
-            &[" fmri".into(), "behavior".into()],
-            spec,
-        )
-        .is_err());
+        assert!(
+            plan_exact_alignment_from_manifest(
+                &manifest,
+                &"4".repeat(64),
+                &"d".repeat(64),
+                " sub-01/run-01",
+                &["fmri".into(), "behavior".into()],
+                spec,
+            )
+            .is_err()
+        );
+        assert!(
+            plan_exact_alignment_from_manifest(
+                &manifest,
+                &"4".repeat(64),
+                &"d".repeat(64),
+                "sub-01/run-01",
+                &[" fmri".into(), "behavior".into()],
+                spec,
+            )
+            .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Tighten two acquisition-identity invariants discovered in the post-merge audit of #153 before issue #147 advances from exact planning into aligned execution.

Frozen base authority: independently post-merge-qualified `main@6bb6aaa6ad84d678402cd151c49a39e8e4f089be`.

Current exact candidate: `72c802c3a2073bf8024f78b2ceb650d93f6f31c4`.

The initial semantic hardening commit `217e535b23491c3c762f39932063a03f408cf838` passed the native wheel/provenance/exact-clock smoke and umbrella CI but failed `cargo fmt --all --check` on mechanical formatting only. Canonical rustfmt formatting was then applied. No qualification evidence from superseded SHAs is inherited; promotion requires fresh success on the current exact head.

This is intentionally a two-file hardening tranche. It does **not** alter the generalized CRT solver, exact window arithmetic, plan schema, source/content hashing, PyO3 surface, Python API, zero-copy streaming path, or ORION lineage boundary.

## 1. Canonical native selector semantics

The public Python facade already rejects `sync_group` and modality selectors with surrounding whitespace. The native planner previously trimmed those strings internally, meaning PyO3/Rust callers could silently map a noncanonical request such as `" fmri"` onto canonical manifest identity `"fmri"`.

The native planner now requires non-empty exact `sync_group` and modality identifiers with no surrounding whitespace and performs no selector normalization.

## 2. `sync_group` is globally subject-local

#153 rejected selected plans whose chosen records crossed subjects, but that check occurred after modality filtering. A malformed manifest could reuse one `sync_group` across multiple subjects and still produce a plan for a subject-local subset.

This change makes `DatasetManifest::validate()` enforce that every occurrence of a non-null `sync_group` belongs to exactly one subject. The planner retains its selected-record subject check as defense in depth.

## Adversarial coverage

Native tests reject:

- noncanonical native `sync_group` requests;
- noncanonical native modality requests;
- a manifest that reuses one `sync_group` across two subjects.

Existing exact-clock, provenance, content-mutation, overflow, serialization, zero-copy, packaging and compatibility tests remain authoritative and must stay green.

## Scientific boundary

This PR does **not** authorize `stream_aligned(plan, ...)` or any multimodal array execution. It does not add interpolation, resampling, nearest-neighbor tolerance, drift estimation, phase repair, HRF modeling, modality preprocessing, or stronger lineage claims.

Aligned execution remains blocked until this exact hardening head is qualified, guarded-merged, and the resulting `main` SHA independently passes push qualification.

## Promotion policy

Require on one exact head:

- `cargo fmt --all --check`;
- `cargo clippy --workspace --all-targets -- -D warnings`;
- `cargo test -p neuros-runtime --all-features`;
- Rust Runtime CI exact-source gate;
- complete applicable repository workflow matrix;
- final base/head/mergeability anti-race check;
- guarded squash merge using the exact qualified head SHA;
- independent post-merge `main` qualification.

No #153 or superseded #154 qualification result is inherited.