### PR TITLE
feat(evidence): add ScientificClaimSpec v1 horizon facade

### DIFF
--- a/.github/workflows/nsq-kumar2024-ci.yml
+++ b/.github/workflows/nsq-kumar2024-ci.yml
@@ -13,6 +13,7 @@ on:
       - "packages/neuros/src/neuros/evidence/**"
       - "packages/neuros/pyproject.toml"
       - "tests/test_moabb_epoch_evidence.py"
+      - "tests/test_scientific_claim_spec.py"
       - "tests/test_kumar2024_nsq_study.py"
       - "tests/test_kumar2024_comparison_authority.py"
       - "tests/test_kumar2024_promoted_execution_authority.py"
@@ -37,6 +38,7 @@ on:
       - "packages/neuros/src/neuros/evidence/**"
       - "packages/neuros/pyproject.toml"
       - "tests/test_moabb_epoch_evidence.py"
+      - "tests/test_scientific_claim_spec.py"
       - "tests/test_kumar2024_nsq_study.py"
       - "tests/test_kumar2024_comparison_authority.py"
       - "tests/test_kumar2024_promoted_execution_authority.py"
@@ -87,6 +89,7 @@ jobs:
             tests/test_moabb_materialization_authority.py \
             tests/test_kumar2024_materialization_roles.py \
             tests/test_kumar2024_bundle_v2.py \
+            tests/test_scientific_claim_spec.py \
             tests/test_kumar2024_nsq_study.py \
             tests/test_kumar2024_comparison_authority.py \
             tests/test_kumar2024_promoted_execution_authority.py \
@@ -100,6 +103,7 @@ jobs:
             packages/neuros-foundation/src/neuros/foundation_models/moabb_epochs.py \
             packages/neuros-foundation/src/neuros/foundation_models/materialization_authority.py \
             packages/neuros-foundation/src/neuros/foundation_models/moabb_materialization.py \
+            packages/neuros/src/neuros/evidence/claims.py \
             packages/neuros/src/neuros/evidence/kumar2024.py \
             packages/neuros/src/neuros/evidence/kumar2024_materialization.py \
             packages/neuros/src/neuros/evidence/kumar2024_materialized_study.py \

--- a/docs/SCIENTIFIC_CLAIM_HORIZON.md
+++ b/docs/SCIENTIFIC_CLAIM_HORIZON.md
@@ -1,0 +1,327 @@
+# Scientific Claim Horizon
+
+## North star
+
+neurOS should make a resulting scientific claim auditable.
+
+The long-term object is not a paper, model, notebook, or workflow. It is a
+machine-readable scientific proposition bound to the protocol, authority,
+execution, evidence, failures, and attestations that determine what the
+proposition is allowed to mean.
+
+```text
+human / AI agent / autonomous lab
+              |
+              v
+      ScientificClaimSpec
+              |
+       protocol authority
+              |
+              v
+ existing Scientific Authority / NSQ
+              |
+              v
+     immutable evidence
+              |
+              v
+       claim qualification
+              |
+              +--> paper / report
+              +--> reviewer
+              +--> external reproducer
+              +--> future machine auditor
+```
+
+This document is a horizon architecture, not permission to expand the active
+implementation surface. The current scientific priority remains the first
+frozen real-data NSQ result in #82.
+
+## Why the abstraction changes
+
+Traditional scientific software organizes around datasets, models, runs, and
+metrics. Those remain implementation objects. The durable public object should
+instead answer:
+
+- what proposition is being evaluated?
+- what is its intended population/scope and inferential unit?
+- what authority must exist before the evidence can support it?
+- what evidence objects support, contradict, replicate, or contextualize it?
+- what evidence tier was actually earned?
+- what remains unknown?
+- which protocol and study identities produced the cited evidence?
+
+As AI systems perform larger portions of hypothesis generation, code writing,
+experiment search, analysis, and reporting, reproducibility of the final run is
+not enough. Selection history, outcome access, adaptation budgets, and
+prospective decisions increasingly determine whether a result is interpretable.
+
+## v1 implemented surface
+
+`neuros.evidence` defines a dependency-light proposition facade:
+
+### `ScientificClaimSpec`
+
+Content-addresses:
+
+- `claim_id`;
+- natural-language `statement`;
+- namespaced/freeform `domain`;
+- declared `scope`;
+- independent `inference_unit`;
+- the **target** evidence tier the future protocol intends to earn;
+- explicit `EvidenceRequirement` objects;
+- deterministic metadata.
+
+`target_evidence_tier` is an intention, not a qualification. A real-data claim
+spec does not become real-data evidence merely because it requests that tier.
+
+### `EvidenceRequirement`
+
+Declares one requirement in terms of:
+
+- a stable requirement ID;
+- an authority type such as `LongitudinalCaseAuthority`,
+  `FailurePreservingResultSet`, `DatasetLineage`, or future authority types;
+- a human-readable description;
+- the evidence tier at which the requirement applies;
+- whether the requirement is mandatory.
+
+The v1 facade does not instantiate or validate those external authority objects.
+Existing Scientific Authority / NSQ remains the enforcement system.
+
+### `ClaimEvidenceRef`
+
+Binds one content-addressed evidence object to the claim with a relation:
+
+- `supports`;
+- `contradicts`;
+- `replicates`;
+- `context`.
+
+Each reference carries its evidence tier explicitly. The claim layer does not
+infer a stronger tier from the presence of evidence.
+
+### `ScientificClaimBundle`
+
+Binds:
+
+- the exact claim identity;
+- one or more exact evidence identities;
+- an optional protocol SHA-256;
+- zero or more scientific-study SHA-256 identities.
+
+It deliberately has no `truth`, `confidence`, or inferred
+`achieved_evidence_tier` field.
+
+## Relationship to existing ORION Scientific Authority
+
+This layer must not duplicate the already-qualified Scientific Authority.
+
+```text
+ScientificClaimSpec
+       |
+       | proposition + requirements
+       v
+ScientificStudyAuthority
+       |
+       | executes and validates lineage / roles / metrics / failures
+       v
+EvidenceClaim
+       |
+       | earned qualification inside the study
+       v
+ClaimEvidenceRef
+       |
+       v
+ScientificClaimBundle
+```
+
+ORION's existing `EvidenceClaim` remains the authority for study-local
+qualification. `ScientificClaimSpec` is the public proposition above it.
+
+A future bridge may compile or validate a `ScientificClaimSpec` against a
+`ScientificStudyAuthority`, but it must reuse the existing authority objects and
+recompute their identities rather than accepting manually asserted verdicts.
+
+## Evidence tiers
+
+The public claim layer uses the same maturity language already used by neurOS:
+
+```text
+software_contract
+        |
+integration
+        |
+replay_or_synthetic
+        |
+real_data
+        |
+physical_hardware
+        |
+closed_loop
+        |
+clinical
+```
+
+The Python enum intentionally does **not** implement ordering or automatic
+promotion. Tier transitions must be earned by explicit qualification policy.
+
+## Horizon plan
+
+### 0-1 year: claims become first-class
+
+Primary proof remains #82.
+
+After the Kumar2024 baseline is frozen:
+
+1. emit a `ScientificClaimSpec` for the flagship calibration-frontier question;
+2. bind the exact NSQ study/result identities into a `ScientificClaimBundle`;
+3. export the bundle beside the existing study artifact;
+4. make a reviewer able to answer "what exactly is this result evidence for?"
+   without reading implementation code;
+5. add machine-readable mappings from requirements to the authority objects that
+   satisfied or failed them.
+
+Do not add another benchmark runner or model framework for this phase.
+
+### 1-3 years: prospective and agentic science
+
+Add only after a real study exposes the need:
+
+#### `ProtocolSeal`
+
+A content-addressed declaration that exists before protected outcomes are
+available. Candidate fields include:
+
+- hypotheses/claims;
+- observation-role policy;
+- inclusion/exclusion rules;
+- metrics;
+- calibration/adaptation budgets;
+- model-selection/search policy;
+- stopping rules;
+- permitted outcome access;
+- protocol creation/seal time and issuer identity.
+
+The key property is temporal authority, not secrecy.
+
+#### `OutcomeRevealReceipt`
+
+Records the transition at which protected final outcomes became accessible to
+the research process.
+
+#### `ExplorationLedger`
+
+Captures externally observable scientific decisions made during large
+human/agent search:
+
+- hypothesis/experiment proposals;
+- tool executions;
+- parameter/config identities;
+- outcomes made available to the agent;
+- selection/rejection decisions;
+- promotion/stopping events;
+- human approvals where required.
+
+It must capture actions and decision provenance, not private model
+chain-of-thought.
+
+### 3-5 years: evidence becomes federated and graph-shaped
+
+Add cross-site and cross-study objects only once there are independent
+reproducers/labs.
+
+Candidate primitives:
+
+- `SiteEvidenceReceipt`;
+- `ReproductionReceipt`;
+- `EvidenceGraphEdge`;
+- `ClaimRelation` such as supports/contradicts/replicates/refines;
+- external signatures/attestations over immutable evidence identities.
+
+Prefer interoperability mappings to PROV, RO-Crate, NWB/BIDS, DANDI, and
+external registries over a neurOS-specific replacement ontology.
+
+The goal is to answer questions such as:
+
+- which independent studies support this claim?
+- which apparently independent studies share dataset or pretraining lineage?
+- which replication changed population, device, or preprocessing authority?
+- which evidence is unavailable because a site failed rather than because the
+  row disappeared from an aggregate?
+
+### 5-10 years: autonomous experimental systems
+
+When software can choose consequential physical actions, extend authority rather
+than replacing it.
+
+Candidate objects:
+
+- `AgentIdentity`;
+- `ActionAuthority`;
+- `AgentActionReceipt`;
+- `DeviceAuthority`;
+- `SafetyEnvelope`;
+- `EmergencyStopReceipt`;
+- `ClosedLoopSessionAuthority`.
+
+The scientific system should be able to prove what an autonomous agent was
+allowed to modify and whether every action remained inside the predeclared
+experimental/safety envelope.
+
+This future work is downstream of physical-device and closed-loop qualification.
+Software contracts alone must never self-promote into safety or clinical claims.
+
+## Design invariants
+
+1. **Claims outrank workflows.** New subsystems must identify which claim
+   property they protect.
+2. **Unknown is first-class.** Missing lineage or failed execution never becomes
+   implied cleanliness.
+3. **Failures are evidence.** Failure rows remain present in bundles and graphs.
+4. **Authority precedes protected observation.** Outcome-sensitive decisions
+   should be sealable before outcome reveal where scientifically required.
+5. **Capture actions, not hidden reasoning.** Agent auditability is based on
+   observable proposals, tool calls, data access, decisions, and approvals.
+6. **Standards at the boundary.** Integrate existing research/provenance formats
+   rather than creating another universal data format.
+7. **No truth oracle.** neurOS qualifies support under declared conditions. It
+   does not pronounce a proposition universally true.
+8. **No automatic evidence promotion.** A higher-tier claim target and a
+   lower-tier cited artifact remain visibly different.
+9. **No new package without earned need.** Horizon primitives should begin in
+   the public `neuros.evidence` facade and split only if external use proves a
+   separate distribution is necessary.
+10. **The runtime stays boring.** Claim evolution is not a reason to reopen the
+    exact-clock/data-plane layer absent an external execution requirement.
+
+## Immediate implementation sequence
+
+1. Land `ScientificClaimSpec v1` as a dependency-light public evidence contract.
+2. Keep #82 as the dominant scientific workstream.
+3. Once #82 has a frozen result, make Kumar2024 the first real claim bundle.
+4. Recruit an external reproducer and preserve their failures as evidence.
+5. Design `ProtocolSeal` only after the first real claim bundle shows which
+   prospective fields are actually needed.
+6. Design `ExplorationLedger` against one concrete agent-driven study, not an
+   abstract agent framework.
+
+## Non-goals
+
+Do not use this horizon to justify:
+
+- a generic autonomous-scientist framework;
+- a new notebook/runtime platform;
+- a competing provenance ontology;
+- a new data archive or file format;
+- a model zoo;
+- an agent chain-of-thought recorder;
+- a blockchain;
+- automatic scientific truth scoring;
+- UI/cloud expansion before the claim/evidence contract has external users.
+
+The strategic bet is narrower:
+
+> As generating experiments becomes cheaper, trustworthy scientific evidence
+> becomes more scarce. neurOS should make the boundary between result and claim
+> explicit, executable, and independently auditable.

--- a/packages/neuros/src/neuros/evidence/__init__.py
+++ b/packages/neuros/src/neuros/evidence/__init__.py
@@ -8,4 +8,20 @@ Study modules must keep heavyweight scientific imports local to execution paths
 so the base neurOS runtime remains dependency-light.
 """
 
-__all__: list[str] = []
+from .claims import (
+    ClaimEvidenceRef,
+    EvidenceRelation,
+    EvidenceRequirement,
+    EvidenceTier,
+    ScientificClaimBundle,
+    ScientificClaimSpec,
+)
+
+__all__ = [
+    "ClaimEvidenceRef",
+    "EvidenceRelation",
+    "EvidenceRequirement",
+    "EvidenceTier",
+    "ScientificClaimBundle",
+    "ScientificClaimSpec",
+]

--- a/packages/neuros/src/neuros/evidence/claims.py
+++ b/packages/neuros/src/neuros/evidence/claims.py
@@ -1,0 +1,350 @@
+"""Machine-readable scientific claim manifests for the public neurOS evidence layer.
+
+This module is intentionally dependency-light. It defines the proposition and
+evidence-reference layer above Scientific Authority / NSQ without duplicating
+their qualification logic. A claim manifest can say what evidence would be
+required and which immutable artifacts are being cited; it cannot promote
+itself to a stronger scientific evidence tier.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _nonempty(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    return normalized
+
+
+def _require_sha256(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a SHA-256 string")
+    normalized = value.strip().lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError(f"{name} must be a 64-character lowercase SHA-256 digest")
+    return normalized
+
+
+def _canonical_json(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("claim manifests cannot contain NaN or infinity")
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in sorted(value.items(), key=lambda pair: str(pair[0])):
+            normalized_key = str(key)
+            if not normalized_key.strip():
+                raise ValueError("claim manifest mapping keys must be non-empty")
+            if normalized_key in normalized:
+                raise ValueError(
+                    "claim manifest mapping keys collide after string normalization: "
+                    f"{normalized_key!r}"
+                )
+            normalized[normalized_key] = _canonical_json(item)
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_canonical_json(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        raise TypeError("unordered sets are not valid claim manifest values")
+    raise TypeError(
+        "claim manifest values must be deterministic JSON-compatible primitives, "
+        f"mappings, lists, or tuples; got {type(value).__name__}"
+    )
+
+
+def _freeze_json(value: Any) -> Any:
+    normalized = _canonical_json(value)
+    if isinstance(normalized, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in normalized.items()})
+    if isinstance(normalized, list):
+        return tuple(_freeze_json(item) for item in normalized)
+    return normalized
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _canonical_sha256(value: Any) -> str:
+    raw = json.dumps(
+        _canonical_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+class EvidenceTier(str, Enum):
+    """Evidence strata. They are labels, not automatically comparable scores."""
+
+    SOFTWARE_CONTRACT = "software_contract"
+    INTEGRATION = "integration"
+    REPLAY_OR_SYNTHETIC = "replay_or_synthetic"
+    REAL_DATA = "real_data"
+    PHYSICAL_HARDWARE = "physical_hardware"
+    CLOSED_LOOP = "closed_loop"
+    CLINICAL = "clinical"
+
+
+class EvidenceRelation(str, Enum):
+    """How one cited evidence object relates to a claim."""
+
+    SUPPORTS = "supports"
+    CONTRADICTS = "contradicts"
+    REPLICATES = "replicates"
+    CONTEXT = "context"
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRequirement:
+    """One predeclared requirement for evaluating a scientific claim."""
+
+    requirement_id: str
+    authority_type: str
+    description: str
+    required_tier: EvidenceTier
+    required: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("EvidenceRequirement schema_version must be 1")
+        if not isinstance(self.required_tier, EvidenceTier):
+            raise TypeError("required_tier must be EvidenceTier")
+        if not isinstance(self.required, bool):
+            raise TypeError("required must be boolean")
+        object.__setattr__(self, "requirement_id", _nonempty("requirement_id", self.requirement_id))
+        object.__setattr__(self, "authority_type", _nonempty("authority_type", self.authority_type))
+        object.__setattr__(self, "description", _nonempty("description", self.description))
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "requirement_id": self.requirement_id,
+            "authority_type": self.authority_type,
+            "description": self.description,
+            "required_tier": self.required_tier.value,
+            "required": self.required,
+            "metadata": _thaw_json(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScientificClaimSpec:
+    """Canonical proposition-level contract.
+
+    This is intentionally upstream of Scientific Authority / NSQ qualification.
+    ``target_evidence_tier`` describes the level of evidence the protocol intends
+    to earn. It never implies that the claim has earned that tier.
+    """
+
+    claim_id: str
+    statement: str
+    domain: str
+    scope: str
+    inference_unit: str
+    target_evidence_tier: EvidenceTier
+    requirements: tuple[EvidenceRequirement, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("ScientificClaimSpec schema_version must be 1")
+        if not isinstance(self.target_evidence_tier, EvidenceTier):
+            raise TypeError("target_evidence_tier must be EvidenceTier")
+        object.__setattr__(self, "claim_id", _nonempty("claim_id", self.claim_id))
+        object.__setattr__(self, "statement", _nonempty("statement", self.statement))
+        object.__setattr__(self, "domain", _nonempty("domain", self.domain))
+        object.__setattr__(self, "scope", _nonempty("scope", self.scope))
+        object.__setattr__(self, "inference_unit", _nonempty("inference_unit", self.inference_unit))
+
+        requirements = tuple(self.requirements)
+        if not requirements:
+            raise ValueError("requirements must contain at least one EvidenceRequirement")
+        if any(not isinstance(item, EvidenceRequirement) for item in requirements):
+            raise TypeError("requirements must contain only EvidenceRequirement objects")
+        ids = [item.requirement_id for item in requirements]
+        if len(set(ids)) != len(ids):
+            raise ValueError("requirements cannot contain duplicate requirement_id values")
+        object.__setattr__(self, "requirements", requirements)
+
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def claim_sha256(self) -> str:
+        return _canonical_sha256(self.to_dict(include_identity=False))
+
+    @property
+    def display_fingerprint(self) -> str:
+        return self.claim_sha256[:16]
+
+    def to_dict(self, *, include_identity: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema": "neuros.scientific_claim.v1",
+            "schema_version": self.schema_version,
+            "claim_id": self.claim_id,
+            "statement": self.statement,
+            "domain": self.domain,
+            "scope": self.scope,
+            "inference_unit": self.inference_unit,
+            "target_evidence_tier": self.target_evidence_tier.value,
+            "requirements": [item.to_dict() for item in self.requirements],
+            "metadata": _thaw_json(self.metadata),
+        }
+        if include_identity:
+            payload["claim_sha256"] = self.claim_sha256
+            payload["display_fingerprint"] = self.display_fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimEvidenceRef:
+    """Immutable reference from a claim to one content-addressed evidence object."""
+
+    evidence_sha256: str
+    relation: EvidenceRelation
+    evidence_tier: EvidenceTier
+    source_kind: str
+    source_id: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("ClaimEvidenceRef schema_version must be 1")
+        if not isinstance(self.relation, EvidenceRelation):
+            raise TypeError("relation must be EvidenceRelation")
+        if not isinstance(self.evidence_tier, EvidenceTier):
+            raise TypeError("evidence_tier must be EvidenceTier")
+        object.__setattr__(
+            self, "evidence_sha256", _require_sha256("evidence_sha256", self.evidence_sha256)
+        )
+        object.__setattr__(self, "source_kind", _nonempty("source_kind", self.source_kind))
+        object.__setattr__(self, "source_id", _nonempty("source_id", self.source_id))
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def reference_sha256(self) -> str:
+        return _canonical_sha256(self.to_dict(include_identity=False))
+
+    def to_dict(self, *, include_identity: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema_version": self.schema_version,
+            "evidence_sha256": self.evidence_sha256,
+            "relation": self.relation.value,
+            "evidence_tier": self.evidence_tier.value,
+            "source_kind": self.source_kind,
+            "source_id": self.source_id,
+            "metadata": _thaw_json(self.metadata),
+        }
+        if include_identity:
+            payload["reference_sha256"] = self.reference_sha256
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ScientificClaimBundle:
+    """Portable manifest binding one claim spec to cited evidence.
+
+    The bundle records evidence labels exactly as supplied. It deliberately does
+    not infer an achieved tier, resolve contradictions, or convert cited support
+    into truth. Scientific Authority / NSQ remain responsible for qualification.
+    """
+
+    claim: ScientificClaimSpec
+    evidence: tuple[ClaimEvidenceRef, ...]
+    protocol_sha256: str | None = None
+    study_sha256s: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("ScientificClaimBundle schema_version must be 1")
+        if not isinstance(self.claim, ScientificClaimSpec):
+            raise TypeError("claim must be ScientificClaimSpec")
+
+        evidence = tuple(self.evidence)
+        if not evidence:
+            raise ValueError("evidence must contain at least one ClaimEvidenceRef")
+        if any(not isinstance(item, ClaimEvidenceRef) for item in evidence):
+            raise TypeError("evidence must contain only ClaimEvidenceRef objects")
+        ref_ids = [item.reference_sha256 for item in evidence]
+        if len(set(ref_ids)) != len(ref_ids):
+            raise ValueError("evidence cannot contain duplicate references")
+        object.__setattr__(self, "evidence", evidence)
+
+        if self.protocol_sha256 is not None:
+            object.__setattr__(
+                self,
+                "protocol_sha256",
+                _require_sha256("protocol_sha256", self.protocol_sha256),
+            )
+        study_sha256s = tuple(
+            _require_sha256("study_sha256", value) for value in self.study_sha256s
+        )
+        if len(set(study_sha256s)) != len(study_sha256s):
+            raise ValueError("study_sha256s cannot contain duplicates")
+        object.__setattr__(self, "study_sha256s", study_sha256s)
+
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def bundle_sha256(self) -> str:
+        return _canonical_sha256(self.to_dict(include_identity=False))
+
+    @property
+    def display_fingerprint(self) -> str:
+        return self.bundle_sha256[:16]
+
+    def to_dict(self, *, include_identity: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema": "neuros.scientific_claim_bundle.v1",
+            "schema_version": self.schema_version,
+            "claim": self.claim.to_dict(),
+            "evidence": [item.to_dict() for item in self.evidence],
+            "protocol_sha256": self.protocol_sha256,
+            "study_sha256s": list(self.study_sha256s),
+            "metadata": _thaw_json(self.metadata),
+        }
+        if include_identity:
+            payload["bundle_sha256"] = self.bundle_sha256
+            payload["display_fingerprint"] = self.display_fingerprint
+        return payload

--- a/tests/test_scientific_claim_spec.py
+++ b/tests/test_scientific_claim_spec.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from neuros.evidence import (
+    ClaimEvidenceRef,
+    EvidenceRelation,
+    EvidenceRequirement,
+    EvidenceTier,
+    ScientificClaimBundle,
+    ScientificClaimSpec,
+)
+
+
+def _claim(**metadata):
+    return ScientificClaimSpec(
+        claim_id="kumar2024-calibration-frontier",
+        statement=(
+            "EEGNet requires less participant-specific labeled calibration than "
+            "CSP+LDA under the frozen longitudinal Kumar2024 protocol."
+        ),
+        domain="task_utility",
+        scope="MOABB Kumar2024 bar-feedback subset; prospective prior-session history",
+        inference_unit="participant",
+        target_evidence_tier=EvidenceTier.REAL_DATA,
+        requirements=(
+            EvidenceRequirement(
+                requirement_id="prospective-authority",
+                authority_type="LongitudinalCaseAuthority",
+                description="Final-assessment observations remain untouched.",
+                required_tier=EvidenceTier.REAL_DATA,
+            ),
+            EvidenceRequirement(
+                requirement_id="failure-preserving-results",
+                authority_type="FailurePreservingResultSet",
+                description="All declared participant/session/budget cases remain visible.",
+                required_tier=EvidenceTier.REAL_DATA,
+            ),
+        ),
+        metadata=metadata,
+    )
+
+
+def test_claim_identity_is_stable_across_mapping_order():
+    first = _claim(beta=2, alpha={"y": 2, "x": 1})
+    second = _claim(alpha={"x": 1, "y": 2}, beta=2)
+    assert first.claim_sha256 == second.claim_sha256
+    assert first.to_dict()["schema"] == "neuros.scientific_claim.v1"
+
+
+def test_claim_rejects_duplicate_requirement_ids():
+    requirement = EvidenceRequirement(
+        requirement_id="same",
+        authority_type="Authority",
+        description="first",
+        required_tier=EvidenceTier.SOFTWARE_CONTRACT,
+    )
+    with pytest.raises(ValueError, match="duplicate requirement_id"):
+        ScientificClaimSpec(
+            claim_id="claim",
+            statement="statement",
+            domain="task_utility",
+            scope="scope",
+            inference_unit="participant",
+            target_evidence_tier=EvidenceTier.REAL_DATA,
+            requirements=(requirement, requirement),
+        )
+
+
+def test_claim_metadata_is_immutable_and_rejects_unordered_sets():
+    claim = _claim(nested={"items": [1, 2]})
+    with pytest.raises(TypeError):
+        claim.metadata["new"] = "value"
+    with pytest.raises(TypeError, match="unordered sets"):
+        _claim(bad={"x", "y"})
+
+
+def test_evidence_ref_requires_content_identity():
+    with pytest.raises(ValueError, match="64-character"):
+        ClaimEvidenceRef(
+            evidence_sha256="abc",
+            relation=EvidenceRelation.SUPPORTS,
+            evidence_tier=EvidenceTier.REAL_DATA,
+            source_kind="orion.failure_preserving_result_set",
+            source_id="result-set-1",
+        )
+
+
+def test_bundle_binds_claim_without_promoting_evidence():
+    claim = _claim()
+    evidence = ClaimEvidenceRef(
+        evidence_sha256="a" * 64,
+        relation=EvidenceRelation.SUPPORTS,
+        evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
+        source_kind="orion.failure_preserving_result_set",
+        source_id="result-set-1",
+    )
+    bundle = ScientificClaimBundle(
+        claim=claim,
+        evidence=(evidence,),
+        protocol_sha256="b" * 64,
+        study_sha256s=("c" * 64,),
+    )
+
+    payload = bundle.to_dict()
+    assert payload["claim"]["target_evidence_tier"] == EvidenceTier.REAL_DATA.value
+    assert payload["evidence"][0]["evidence_tier"] == EvidenceTier.SOFTWARE_CONTRACT.value
+    assert "achieved_evidence_tier" not in payload
+    assert len(bundle.bundle_sha256) == 64
+
+
+def test_bundle_rejects_duplicate_evidence_reference():
+    claim = _claim()
+    evidence = ClaimEvidenceRef(
+        evidence_sha256="d" * 64,
+        relation=EvidenceRelation.CONTEXT,
+        evidence_tier=EvidenceTier.REAL_DATA,
+        source_kind="orion.scientific_authority.v2",
+        source_id="study",
+    )
+    with pytest.raises(ValueError, match="duplicate references"):
+        ScientificClaimBundle(claim=claim, evidence=(evidence, evidence))


### PR DESCRIPTION
## Purpose

Establish the first long-horizon public abstraction above Scientific Authority / NSQ without reopening the qualified runtime or duplicating ORION qualification logic.

Tracks #160.

Frozen base authority:
`main@c7b7ac174840bdab73e9438ad7d9fd1bf5782105`

That base independently passed **14/14** post-merge push workflows and includes the promoted runtime → research authority bridge from #159.

Exact candidate:
`56e1f8f9febcbd6e1b46fc9b47dccab4041fef92`

The candidate is one commit directly over the frozen base. Earlier construction heads are superseded and provide no promotion evidence.

## Architecture

```text
runtime provenance
       |
       v
research authority
       |
       v
ScientificClaimSpec
       |
       | proposition + evidence requirements
       v
existing ScientificStudyAuthority / NSQ
       |
       | earned qualification
       v
existing EvidenceClaim
       |
       v
ClaimEvidenceRef
       |
       v
ScientificClaimBundle
```

The new layer is intentionally dependency-light and lives in the public `neuros.evidence` facade. It does not require ORION at import time.

## New contracts

- `EvidenceTier`
- `EvidenceRelation`
- `EvidenceRequirement`
- `ScientificClaimSpec`
- `ClaimEvidenceRef`
- `ScientificClaimBundle`

All manifests are immutable and content-addressed through deterministic JSON-compatible SHA-256 identities. Mapping insertion order is normalized; ordered sequences remain manifest content, matching existing Scientific Authority conventions.

## Critical scientific boundary

`target_evidence_tier` is an intention, not an achieved qualification.

A claim targeting `real_data` may cite only `software_contract` evidence and remains visibly so. `ScientificClaimBundle` deliberately has no truth field, confidence field, or automatically inferred `achieved_evidence_tier`.

Existing ORION `EvidenceClaim` remains the study-local earned qualification authority.

## Tests and CI ownership

A dependency-light construction probe passed 6/6 focused tests covering:

- deterministic identity independent of mapping insertion order;
- duplicate requirement rejection;
- immutable metadata / unordered-set rejection;
- malformed evidence identity rejection;
- preservation of target-tier vs cited-tier distinction;
- duplicate evidence-reference rejection.

The existing **NSQ Kumar2024 v1** evidence lane is extended to own this public contract rather than adding a new workflow:

- `tests/test_scientific_claim_spec.py` is an explicit path trigger;
- it runs in the authority-contract matrix on Python 3.10/3.11/3.12;
- `claims.py` is included in the evidence compile step.

Repository CI on the exact GitHub head remains the promotion authority; local probe evidence is construction evidence only.

## Horizon document

Adds `docs/SCIENTIFIC_CLAIM_HORIZON.md` covering:

- 0-1y: claims become first class, with Kumar2024 as first real consumer after #82 freezes;
- 1-3y: `ProtocolSeal`, `OutcomeRevealReceipt`, and action-level `ExplorationLedger` for agentic science;
- 3-5y: reproduction/site receipts and graph-shaped/federated evidence;
- 5-10y: action/device/safety authority for autonomous physical experiments.

The document explicitly keeps #82 as the dominant near-term scientific workstream and rejects using the horizon to justify a generic agent framework, new provenance ontology, blockchain, truth scoring, or premature UI/cloud expansion.

## Scope

Changed surfaces only:

- `packages/neuros/src/neuros/evidence/claims.py`
- `packages/neuros/src/neuros/evidence/__init__.py`
- `tests/test_scientific_claim_spec.py`
- `docs/SCIENTIFIC_CLAIM_HORIZON.md`
- `.github/workflows/nsq-kumar2024-ci.yml` (test ownership only)

No Rust, runtime, ORION authority, NSQ runner, model, driver, package dependency, or study execution semantics change.