### PR TITLE
feat(evidence): add sealed Kaggle T4 Kumar2024 preflight

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml
@@ -1,0 +1,59 @@
+name: NSQ Kumar2024 GPU cloud contracts
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_cloud.py"
+      - "scripts/evidence/kaggle_kumar2024_gpu_runner.py"
+      - "tests/test_kumar2024_gpu_cloud.py"
+      - ".github/workflows/nsq-kumar2024-gpu-cloud-ci.yml"
+      - ".github/workflows/nsq-kumar2024-kaggle-preflight.yml"
+      - "docs/NSQ_KUMAR2024_KAGGLE_GPU.md"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_cloud.py"
+      - "scripts/evidence/kaggle_kumar2024_gpu_runner.py"
+      - "tests/test_kumar2024_gpu_cloud.py"
+      - ".github/workflows/nsq-kumar2024-gpu-cloud-ci.yml"
+      - ".github/workflows/nsq-kumar2024-kaggle-preflight.yml"
+      - "docs/NSQ_KUMAR2024_KAGGLE_GPU.md"
+
+permissions:
+  contents: read
+
+jobs:
+  gpu-cloud-contracts:
+    name: GPU cloud authority contracts / Python 3.11
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11.16"
+          cache: pip
+      - name: Install authority stack
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/neuros-core
+          python -m pip install -e packages/neuros-drivers
+          python -m pip install -e packages/neuros-models
+          python -m pip install -e packages/neuros-foundation
+          python -m pip install -e packages/orion
+          python -m pip install -e packages/neuros pytest pytest-asyncio
+      - name: Run GPU cloud authority tests
+        run: pytest -q tests/test_kumar2024_gpu_cloud.py
+      - name: Compile cloud execution surfaces
+        run: |
+          python -m compileall -q \
+            packages/neuros/src/neuros/evidence/kumar2024_gpu_cloud.py \
+            scripts/evidence/kaggle_kumar2024_gpu_runner.py
+      - name: Assert cloud runner never reads scientific score artifacts
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          text = Path("scripts/evidence/kaggle_kumar2024_gpu_runner.py").read_text()
+          for forbidden in ("case_result.json", "shard_result.json", "balanced_accuracy"):
+              assert forbidden not in text, forbidden
+          PY

--- a/.github/workflows/nsq-kumar2024-kaggle-preflight.yml
+++ b/.github/workflows/nsq-kumar2024-kaggle-preflight.yml
@@ -1,0 +1,274 @@
+name: NSQ Kumar2024 Kaggle T4 systems preflight
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PROMOTED_CONSTRAINTS: requirements/nsq-kumar2024-promoted-py311.constraints.txt
+  KAGGLE_CLI_VERSION: "2.2.4"
+
+jobs:
+  kaggle-t4-preflight:
+    name: Sealed binding -> private Kaggle T4 -> verified worker receipt
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    if: github.ref == 'refs/heads/main'
+    env:
+      KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+      KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Require exact clean main source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test "${GITHUB_REF}" = "refs/heads/main"
+          git diff --quiet HEAD --
+          git diff --cached --quiet HEAD --
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11.16"
+          cache: pip
+          cache-dependency-path: ${{ env.PROMOTED_CONSTRAINTS }}
+      - name: Install exact promoted binding environment
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -c "${PROMOTED_CONSTRAINTS}" \
+            "pip==26.2.1" "setuptools==79.0.1" "wheel==0.48.0"
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros-core
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros-drivers
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros-models
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e "packages/neuros-foundation[evidence,braindecode-evidence]"
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/orion
+          python -m pip install --disable-pip-version-check --no-build-isolation \
+            -c "${PROMOTED_CONSTRAINTS}" -e packages/neuros
+          python scripts/evidence/validate_promoted_environment.py --constraints "${PROMOTED_CONSTRAINTS}"
+      - name: Build CUDA-bound no-model authority
+        id: binding
+        run: |
+          set -euo pipefail
+          ROOT="${RUNNER_TEMP}/kumar2024-gpu-binding"
+          python -P -s -m neuros.evidence.kumar2024_gpu_cloud bind --output "${ROOT}"
+          python -P -s -m neuros.evidence.kumar2024_gpu_cloud verify-binding --output "${ROOT}"
+          ROOT="${ROOT}" python - <<'PY'
+          import json, os
+          from pathlib import Path
+          root = Path(os.environ["ROOT"])
+          authority = json.loads((root / "gpu_authority.json").read_text())
+          inner = json.loads((root / "binding" / "artifact_hashes.json").read_text())
+          assert authority["model_execution_performed"] is False
+          assert authority["final_assessment_metrics_generated"] is False
+          assert authority["cuda_policy"]["requested_device"] == "cuda"
+          assert authority["cloud_execution"]["machine_shape"] == "NvidiaTeslaT4"
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as stream:
+              stream.write(f"gpu_binding_sha256={authority['gpu_binding_sha256']}\n")
+              stream.write(f"binding_bundle_sha256={inner['bundle_sha256']}\n")
+          PY
+      - name: Select fixed non-adaptive systems-preflight shard
+        id: shard
+        run: |
+          set -euo pipefail
+          ROOT="${RUNNER_TEMP}/kumar2024-gpu-binding"
+          ROOT="${ROOT}" python - <<'PY'
+          import json, os
+          from pathlib import Path
+          from neuros.evidence.kumar2024_gpu_cloud import select_preflight_shard
+          shard = select_preflight_shard(os.environ["ROOT"])
+          Path(os.environ["RUNNER_TEMP"], "preflight_shard.json").write_text(
+              json.dumps(shard, indent=2, sort_keys=True) + "\n"
+          )
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as stream:
+              stream.write(f"shard_spec_sha256={shard['shard_spec_sha256']}\n")
+          print(json.dumps({
+              "subject": shard["subject"],
+              "target_session": shard["target_session"],
+              "split_seed": shard["split_seed"],
+              "method_id": shard["method_id"],
+              "model_seed": shard["model_seed"],
+              "budgets_per_class": shard["budgets_per_class"],
+              "shard_spec_sha256": shard["shard_spec_sha256"],
+          }, sort_keys=True))
+          PY
+      - name: Require Kaggle credentials only after binding is sealed
+        run: |
+          set -euo pipefail
+          test -n "${KAGGLE_USERNAME:-}" || { echo "Missing repository secret KAGGLE_USERNAME" >&2; exit 2; }
+          test -n "${KAGGLE_KEY:-}" || { echo "Missing repository secret KAGGLE_KEY" >&2; exit 2; }
+      - name: Prepare private Kaggle launch pack
+        id: kaggle
+        env:
+          GPU_BINDING_SHA256: ${{ steps.binding.outputs.gpu_binding_sha256 }}
+          BINDING_BUNDLE_SHA256: ${{ steps.binding.outputs.binding_bundle_sha256 }}
+          SHARD_SPEC_SHA256: ${{ steps.shard.outputs.shard_spec_sha256 }}
+        run: |
+          set -euo pipefail
+          DATASET_SLUG="neuros-kumar2024-gpu-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          KERNEL_SLUG="neuros-kumar2024-t4-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          DATASET_ID="${KAGGLE_USERNAME}/${DATASET_SLUG}"
+          KERNEL_ID="${KAGGLE_USERNAME}/${KERNEL_SLUG}"
+          PACK="${RUNNER_TEMP}/launch-pack"
+          DATASET="${RUNNER_TEMP}/kaggle-dataset"
+          KERNEL="${RUNNER_TEMP}/kaggle-kernel"
+          mkdir -p "${PACK}" "${DATASET}" "${KERNEL}"
+          cp -a "${RUNNER_TEMP}/kumar2024-gpu-binding" "${PACK}/gpu-binding"
+          CONSTRAINTS_SHA256="$(sha256sum "${PROMOTED_CONSTRAINTS}" | awk '{print $1}')"
+          PACK="${PACK}" GPU_BINDING_SHA256="${GPU_BINDING_SHA256}" \
+          BINDING_BUNDLE_SHA256="${BINDING_BUNDLE_SHA256}" SHARD_SPEC_SHA256="${SHARD_SPEC_SHA256}" \
+          CONSTRAINTS_SHA256="${CONSTRAINTS_SHA256}" python - <<'PY'
+          import json, os, platform
+          from pathlib import Path
+          assert platform.python_version() == "3.11.16"
+          payload = {
+              "schema_version": 1,
+              "phase": "systems-preflight",
+              "source_revision": os.environ["GITHUB_SHA"],
+              "gpu_binding_sha256": os.environ["GPU_BINDING_SHA256"],
+              "binding_bundle_sha256": os.environ["BINDING_BUNDLE_SHA256"],
+              "shard_spec_sha256": os.environ["SHARD_SPEC_SHA256"],
+              "constraints_sha256": os.environ["CONSTRAINTS_SHA256"],
+              "python_version": "3.11.16",
+              "uv_version": "0.12.10",
+              "machine_shape": "NvidiaTeslaT4",
+              "numerical_result_interpretable": False,
+              "continuation_policy": "systems-only; scientific scores forbidden as go/no-go inputs",
+          }
+          Path(os.environ["PACK"], "launch_manifest.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n"
+          )
+          PY
+          (cd "${PACK}" && zip -qr "${DATASET}/gpu_launch_pack.zip" gpu-binding launch_manifest.json)
+          DATASET="${DATASET}" DATASET_ID="${DATASET_ID}" python - <<'PY'
+          import json, os
+          from pathlib import Path
+          payload = {
+              "title": f"neurOS Kumar2024 GPU authority {os.environ['GITHUB_RUN_ID']}",
+              "id": os.environ["DATASET_ID"],
+              "licenses": [{"name": "other"}],
+              "description": (
+                  "Private systems-qualification launch pack containing content-addressed neurOS "
+                  "authority metadata only. It contains no redistributed Kumar2024 raw data."
+              ),
+          }
+          Path(os.environ["DATASET"], "dataset-metadata.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n"
+          )
+          PY
+          cp scripts/evidence/kaggle_kumar2024_gpu_runner.py "${KERNEL}/kaggle_kumar2024_gpu_runner.py"
+          KERNEL="${KERNEL}" KERNEL_ID="${KERNEL_ID}" DATASET_ID="${DATASET_ID}" python - <<'PY'
+          import json, os
+          from pathlib import Path
+          payload = {
+              "id": os.environ["KERNEL_ID"],
+              "title": f"neurOS Kumar2024 T4 preflight {os.environ['GITHUB_RUN_ID']}",
+              "code_file": "kaggle_kumar2024_gpu_runner.py",
+              "language": "python",
+              "kernel_type": "script",
+              "is_private": True,
+              "enable_gpu": True,
+              "enable_internet": True,
+              "machine_shape": "NvidiaTeslaT4",
+              "dataset_sources": [os.environ["DATASET_ID"]],
+              "competition_sources": [],
+              "kernel_sources": [],
+              "model_sources": [],
+          }
+          Path(os.environ["KERNEL"], "kernel-metadata.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n"
+          )
+          PY
+          {
+            echo "dataset_id=${DATASET_ID}"
+            echo "kernel_id=${KERNEL_ID}"
+            echo "dataset_dir=${DATASET}"
+            echo "kernel_dir=${KERNEL}"
+          } >> "${GITHUB_OUTPUT}"
+      - name: Install pinned Kaggle control-plane CLI
+        run: python -m pip install --disable-pip-version-check "kaggle==${KAGGLE_CLI_VERSION}"
+      - name: Publish private launch dataset and run T4 kernel
+        env:
+          DATASET_DIR: ${{ steps.kaggle.outputs.dataset_dir }}
+          KERNEL_DIR: ${{ steps.kaggle.outputs.kernel_dir }}
+        run: |
+          set -euo pipefail
+          kaggle datasets create -p "${DATASET_DIR}" -q
+          kaggle kernels push -p "${KERNEL_DIR}" --accelerator NvidiaTeslaT4 --timeout 18000
+      - name: Poll Kaggle preflight to terminal state
+        env:
+          KERNEL_ID: ${{ steps.kaggle.outputs.kernel_id }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 19800))
+          while (( SECONDS < deadline )); do
+            status="$(kaggle kernels status "${KERNEL_ID}" 2>&1 || true)"
+            printf '%s\n' "${status}"
+            normalized="$(printf '%s' "${status}" | tr '[:upper:]' '[:lower:]')"
+            if grep -Eq 'complete|completed' <<<"${normalized}"; then exit 0; fi
+            if grep -Eq 'error|failed|failure|cancelled|canceled' <<<"${normalized}"; then
+              echo "Kaggle preflight reached failure state" >&2
+              exit 1
+            fi
+            sleep 60
+          done
+          echo "Kaggle preflight did not reach terminal state within GitHub polling horizon" >&2
+          exit 1
+      - name: Download Kaggle systems output
+        env:
+          KERNEL_ID: ${{ steps.kaggle.outputs.kernel_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/kaggle-output"
+          kaggle kernels output "${KERNEL_ID}" -p "${RUNNER_TEMP}/kaggle-output" -o -q
+          test -f "${RUNNER_TEMP}/kaggle-output/neuros_kumar2024_gpu_preflight.zip"
+          test -f "${RUNNER_TEMP}/kaggle-output/kaggle_run_summary.json"
+          unzip -q "${RUNNER_TEMP}/kaggle-output/neuros_kumar2024_gpu_preflight.zip" \
+            -d "${RUNNER_TEMP}/verified-kaggle-output"
+      - name: Verify returned worker bundle without reading score fields
+        env:
+          GPU_BINDING_ROOT: ${{ runner.temp }}/kumar2024-gpu-binding
+          WORKER_ROOT: ${{ runner.temp }}/verified-kaggle-output/gpu-worker
+          SUMMARY: ${{ runner.temp }}/kaggle-output/kaggle_run_summary.json
+        run: |
+          set -euo pipefail
+          python -P -s -m neuros.evidence.kumar2024_gpu_cloud verify-worker \
+            --binding "${GPU_BINDING_ROOT}" --output "${WORKER_ROOT}" \
+            | tee "${RUNNER_TEMP}/verified_gpu_worker.json"
+          SUMMARY="${SUMMARY}" python - <<'PY'
+          import json, os
+          from pathlib import Path
+          summary = json.loads(Path(os.environ["SUMMARY"]).read_text())
+          assert summary["numerical_result_interpretable"] is False
+          assert summary["score_fields_read_by_bootstrap"] is False
+          assert "T4" in summary["device_name"].upper()
+          assert "balanced_accuracy" not in summary
+          assert "scientific_score" not in summary
+          print(json.dumps({
+              "verified": True,
+              "device_name": summary["device_name"],
+              "elapsed_seconds": summary["elapsed_seconds"],
+              "gpu_worker_receipt_sha256": summary["gpu_worker_receipt_sha256"],
+              "worker_bundle_sha256": summary["worker_bundle_sha256"],
+              "numerical_result_interpretable": False,
+          }, sort_keys=True))
+          PY
+      - name: Upload sealed GPU binding and quarantined systems result
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nsq-kumar2024-kaggle-t4-preflight-${{ github.sha }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/kumar2024-gpu-binding
+            ${{ runner.temp }}/kaggle-output/kaggle_run_summary.json
+            ${{ runner.temp }}/kaggle-output/neuros_kumar2024_gpu_preflight.zip
+            ${{ runner.temp }}/verified_gpu_worker.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/NSQ_KUMAR2024_KAGGLE_GPU.md
+++ b/docs/NSQ_KUMAR2024_KAGGLE_GPU.md
@@ -1,0 +1,170 @@
+# Kumar2024 Kaggle T4 execution authority
+
+Status: **cloud execution tranche; systems preflight before scientific fan-out**.
+
+This design accelerates the preregistered Kumar2024 promoted execution without
+silently changing the already-qualified CPU authority. The existing promoted
+CPU binding and classical worker paths remain unchanged.
+
+## Why Kaggle T4
+
+The cloud worker is intentionally pinned to Kaggle's `NvidiaTeslaT4` machine
+shape. Kaggle currently exposes T4 selection through the official CLI and kernel
+metadata. P100 is not used because the current Kaggle documentation warns that
+the default PyTorch image does not include Pascal `sm_60` kernels.
+
+The runner does not trust the Kaggle base Python environment. It creates an
+isolated CPython 3.11.16 environment, installs the exact promoted constraints,
+checks out the binding-owned neurOS Git SHA, and recomputes the promoted
+environment authority before model execution.
+
+## Authority layering
+
+```text
+qualified neurOS source revision
+        |
+        v
+canonical promoted comparison plan
+        |
+        v
+CUDA-bound no-model promoted binding
+        |
+        +-- exact raw/processed/case authority
+        +-- exact method specs with device="cuda"
+        +-- exact environment authority
+        +-- deterministic CUDA policy
+        |
+        v
+private Kaggle launch pack
+        |
+        v
+NvidiaTeslaT4 worker
+        |
+        v
+canonical promoted atomic worker bundle
+        |
+        v
+GPU systems receipt
+```
+
+The CUDA adapter is deliberately separate from the canonical CPU path. Its
+compatibility scope temporarily projects `promoted_materialization_config()` to
+`device="cuda"` only within one sequential binder/worker process, then restores
+the original functions. This keeps old CPU semantics unchanged while the GPU
+path is qualified independently.
+
+## Determinism policy
+
+Before binding and before GPU execution, neurOS requires:
+
+- `CUBLAS_WORKSPACE_CONFIG=:4096:8`;
+- `torch.use_deterministic_algorithms(True)`;
+- `torch.backends.cudnn.deterministic = True`;
+- `torch.backends.cudnn.benchmark = False`;
+- CUDA matmul TF32 disabled;
+- cuDNN TF32 disabled.
+
+The normal environment authority independently binds the requested device,
+Torch/CUDA/cuDNN runtime and the deterministic-algorithm/cuDNN flags. The outer
+GPU authority additionally seals the cuBLAS and TF32 policy.
+
+Actual accelerator identity is observed at worker time. The first tranche fails
+closed unless the device name is T4-class.
+
+## Systems-preflight shard
+
+The first cloud run is fixed before execution:
+
+- subject: `1`;
+- target session: `5`;
+- split seed: `2026`;
+- method: `braindecode-eegnet`;
+- model seed: `31415`;
+- budgets per class: `[0, 1, 2, 5, 10]`.
+
+Selection is content-addressed through the archived `shard_spec_sha256`. The
+scheduler cannot choose a different participant, session, model seed or budget
+frontier at launch time.
+
+### Preflight claim boundary
+
+The preflight executes a real atomic worker, but it is **systems evidence only**.
+The GitHub/Kaggle orchestration may use only:
+
+- worker-bundle verification;
+- elapsed wall-clock time;
+- accelerator identity;
+- environment identity.
+
+It may not use balanced accuracy, scientific score, method ranking, final
+assessment metrics, external-floor status or ORION comparison as a go/no-go
+input. The bootstrap never reads `case_result.json` or `shard_result.json`; those
+remain quarantined inside the sealed worker archive.
+
+No scientific interpretation is permitted until the preregistered execution
+completeness rules are satisfied.
+
+## Orchestration
+
+The manual workflow is:
+
+`.github/workflows/nsq-kumar2024-kaggle-preflight.yml`
+
+It performs the following in one provenance chain:
+
+1. requires an exact clean `main` checkout;
+2. creates the CUDA-bound no-model binding in the pinned Python environment;
+3. selects the fixed preflight shard;
+4. creates a unique private Kaggle Dataset containing only the sealed launch
+   pack, not redistributed Kumar2024 raw data;
+5. creates a unique private Kaggle script kernel with T4 + internet enabled;
+6. polls the official Kaggle CLI to terminal state;
+7. downloads the zipped systems output;
+8. structurally verifies the returned worker bundle on GitHub without reading
+   score fields;
+9. uploads the binding, systems summary, quarantined worker ZIP and verification
+   record as a 90-day GitHub Actions artifact.
+
+The Kaggle kernel itself is
+`scripts/evidence/kaggle_kumar2024_gpu_runner.py`.
+
+## One-time account boundary
+
+The workflow needs these GitHub Actions repository secrets:
+
+- `KAGGLE_USERNAME`
+- `KAGGLE_KEY`
+
+They are account credentials and must not be committed or pasted into issue/PR
+text. Once present, the workflow uses Kaggle's official CLI; no browser-session
+automation is needed.
+
+## Expansion gate
+
+Do not fan out all promoted EEGNet shards after code qualification alone.
+
+The sequence is:
+
+1. one fixed T4 systems preflight;
+2. verify environment + bundle + wall-clock;
+3. use systems-only timing to estimate full GPU-hours;
+4. if feasible, define a deterministic 9-shard timing grid before execution;
+5. only then freeze a chunking schedule for the full 810 EEGNet shards / 4,050
+   fit attempts.
+
+Chunking should group work to amortize raw-data downloads and must be fixed from
+the execution plan rather than adapted to observed scientific scores.
+
+## Non-goals
+
+This tranche does not:
+
+- change the promoted comparison plan;
+- change preprocessing, case authority, budgets or model seeds;
+- reinterpret existing CPU evidence as GPU evidence;
+- compare CPU and GPU efficacy;
+- run global analysis;
+- generate an external-floor claim;
+- permit ORION comparison;
+- automatically inspect a preflight score;
+- claim CUDA numerical identity with CPU execution.

--- a/packages/neuros/src/neuros/evidence/kumar2024_gpu_cloud.py
+++ b/packages/neuros/src/neuros/evidence/kumar2024_gpu_cloud.py
@@ -1,0 +1,535 @@
+"""CUDA/Kaggle execution authority for the promoted Kumar2024 study.
+
+This adapter leaves the canonical CPU promoted path unchanged.  It derives a
+separate CUDA-bound no-model authority, executes only archived EEGNet shards,
+and wraps every GPU result in a systems receipt.  The compatibility scope is
+process-local and sequential: it temporarily projects the canonical promoted
+configuration onto ``device='cuda'`` while calling the already-qualified binder
+and worker implementations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Sequence
+
+from . import kumar2024 as base
+from . import kumar2024_promoted_binding as promoted_binding
+from . import kumar2024_promoted_worker as promoted_worker
+from .kumar2024_comparison import Kumar2024ComparisonPlan, promoted_external_floor_plan
+
+GPU_BINDING_SCHEMA = "neuros.nsq_kumar2024_gpu_binding.v1"
+GPU_WORKER_SCHEMA = "neuros.nsq_kumar2024_gpu_worker.v1"
+CUDA_DEVICE = "cuda"
+KAGGLE_MACHINE_SHAPE = "NvidiaTeslaT4"
+CUBLAS_WORKSPACE_CONFIG = ":4096:8"
+UV_VERSION = "0.12.10"
+
+
+def _require_sha256(name: str, value: Any) -> str:
+    text = str(value).strip().lower()
+    if len(text) != 64 or any(ch not in "0123456789abcdef" for ch in text):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return text
+
+
+def _cuda_config(plan: Kumar2024ComparisonPlan | None = None) -> base.Kumar2024StudyConfig:
+    plan = plan or promoted_external_floor_plan()
+    return replace(promoted_binding.promoted_materialization_config(plan), device=CUDA_DEVICE)
+
+
+@contextlib.contextmanager
+def promoted_cuda_scope() -> Iterator[None]:
+    """Project the canonical promoted config onto CUDA for one sequential process.
+
+    The canonical CPU functions remain untouched outside this context.  Both the
+    binding module and worker module hold direct references to the config helper,
+    so both references are replaced and restored together.
+    """
+
+    original_binding = promoted_binding.promoted_materialization_config
+    original_worker = promoted_worker.promoted_materialization_config
+
+    def cuda_config(plan: Kumar2024ComparisonPlan | None = None):
+        return replace(original_binding(plan), device=CUDA_DEVICE)
+
+    promoted_binding.promoted_materialization_config = cuda_config
+    promoted_worker.promoted_materialization_config = cuda_config
+    try:
+        yield
+    finally:
+        promoted_binding.promoted_materialization_config = original_binding
+        promoted_worker.promoted_materialization_config = original_worker
+
+
+def configure_cuda_determinism(*, require_available: bool) -> dict[str, Any]:
+    """Apply the CUDA determinism policy used by both binder and worker."""
+
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = CUBLAS_WORKSPACE_CONFIG
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - cloud/runtime integration
+        raise ImportError("Kumar2024 GPU authority requires torch") from exc
+
+    torch.use_deterministic_algorithms(True)
+    if hasattr(torch.backends, "cudnn"):
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        if hasattr(torch.backends.cudnn, "allow_tf32"):
+            torch.backends.cudnn.allow_tf32 = False
+    if hasattr(torch.backends, "cuda") and hasattr(torch.backends.cuda, "matmul"):
+        if hasattr(torch.backends.cuda.matmul, "allow_tf32"):
+            torch.backends.cuda.matmul.allow_tf32 = False
+
+    available = bool(torch.cuda.is_available())
+    if require_available and not available:
+        raise RuntimeError("CUDA-bound Kumar2024 worker requires torch.cuda.is_available()")
+
+    observation: dict[str, Any] = {
+        "requested_device": CUDA_DEVICE,
+        "cuda_available": available,
+        "torch_version": str(torch.__version__),
+        "cuda_runtime": str(torch.version.cuda or "none"),
+        "cudnn_runtime": str(torch.backends.cudnn.version() or "none"),
+        "cublas_workspace_config": os.environ["CUBLAS_WORKSPACE_CONFIG"],
+        "torch_deterministic_algorithms": bool(torch.are_deterministic_algorithms_enabled()),
+        "cudnn_deterministic": bool(torch.backends.cudnn.deterministic),
+        "cudnn_benchmark": bool(torch.backends.cudnn.benchmark),
+    }
+    if hasattr(torch.backends, "cuda") and hasattr(torch.backends.cuda, "matmul"):
+        observation["cuda_matmul_allow_tf32"] = bool(torch.backends.cuda.matmul.allow_tf32)
+    if hasattr(torch.backends.cudnn, "allow_tf32"):
+        observation["cudnn_allow_tf32"] = bool(torch.backends.cudnn.allow_tf32)
+    if available:
+        observation.update(
+            {
+                "device_count": int(torch.cuda.device_count()),
+                "device_name": str(torch.cuda.get_device_name(0)),
+                "compute_capability": list(torch.cuda.get_device_capability(0)),
+            }
+        )
+    return observation
+
+
+def _assert_cuda_binding_payload(binding_root: Path) -> dict[str, Any]:
+    manifest = json.loads((binding_root / "binding_manifest.json").read_text(encoding="utf-8"))
+    materialization = json.loads((binding_root / "materialization.json").read_text(encoding="utf-8"))
+    methods = json.loads((binding_root / "method_specs.json").read_text(encoding="utf-8"))
+
+    config = manifest.get("materialization_config") or {}
+    braindecode = config.get("braindecode") or {}
+    if braindecode.get("device") != CUDA_DEVICE:
+        raise ValueError("GPU binding materialization config is not CUDA-bound")
+
+    environment = materialization["authority"]["environment"]
+    accelerator = environment.get("accelerator_runtime") or {}
+    flags = environment.get("deterministic_flags") or {}
+    if accelerator.get("requested_device") != CUDA_DEVICE:
+        raise ValueError("GPU binding environment does not request CUDA")
+    expected_flags = {
+        "torch_deterministic_algorithms": "true",
+        "cudnn_deterministic": "true",
+        "cudnn_benchmark": "false",
+    }
+    drift = {
+        key: {"expected": value, "observed": flags.get(key)}
+        for key, value in expected_flags.items()
+        if flags.get(key) != value
+    }
+    if drift:
+        raise ValueError(f"GPU binding determinism flags drifted: {drift}")
+
+    eegnet = [
+        item for item in methods["method_specs"]
+        if str(item["realization_key"]).startswith("braindecode-eegnet/")
+    ]
+    if len(eegnet) != 3:
+        raise ValueError("GPU binding requires exactly three EEGNet realizations")
+    if any(item["method_spec"]["metadata"].get("device") != CUDA_DEVICE for item in eegnet):
+        raise ValueError("GPU binding EEGNet method specs are not CUDA-bound")
+    return {
+        "manifest": manifest,
+        "environment": environment,
+        "eegnet_method_specs": eegnet,
+    }
+
+
+def _gpu_binding_identity(authority_payload: Mapping[str, Any]) -> str:
+    return base._identity_sha256(GPU_BINDING_SCHEMA, authority_payload)
+
+
+def run_gpu_binding(output: str | Path, *, overwrite: bool = False) -> dict[str, Any]:
+    """Create a CUDA-bound no-model promoted binding plus GPU policy seal."""
+
+    root = Path(output).resolve()
+    if root.exists() and any(root.iterdir()) and not overwrite:
+        raise FileExistsError(f"refusing to overwrite non-empty GPU binding output: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+    binding_root = root / "binding"
+
+    binding_runtime_observation = configure_cuda_determinism(require_available=False)
+    with promoted_cuda_scope():
+        result = promoted_binding.run_promoted_binding(binding_root, overwrite=overwrite)
+        verified = promoted_binding.verify_promoted_binding_bundle(binding_root)
+
+    checked = _assert_cuda_binding_payload(binding_root)
+    source_revision = str(checked["manifest"]["source_revision"])
+    authority_payload = {
+        "schema_version": 1,
+        "artifact_kind": "cuda_no_model_promoted_binding_authority",
+        "source_revision": source_revision,
+        "binding_bundle_sha256": _require_sha256("binding bundle SHA", verified["bundle_sha256"]),
+        "comparison_plan_sha256": _require_sha256(
+            "comparison plan SHA", checked["manifest"]["comparison_plan_sha256"]
+        ),
+        "execution_plan_sha256": _require_sha256(
+            "execution plan SHA", checked["manifest"]["execution_plan_sha256"]
+        ),
+        "environment_authority_sha256": _require_sha256(
+            "environment SHA", checked["manifest"]["environment_authority_sha256"]
+        ),
+        "cuda_policy": {
+            "requested_device": CUDA_DEVICE,
+            "cublas_workspace_config": CUBLAS_WORKSPACE_CONFIG,
+            "torch_deterministic_algorithms": True,
+            "cudnn_deterministic": True,
+            "cudnn_benchmark": False,
+            "cuda_matmul_allow_tf32": False,
+            "cudnn_allow_tf32": False,
+        },
+        "binding_runtime_policy_observation": binding_runtime_observation,
+        "cloud_execution": {
+            "provider": "kaggle",
+            "machine_shape": KAGGLE_MACHINE_SHAPE,
+            "bootstrap_uv_version": UV_VERSION,
+            "python_version": checked["environment"]["python"]["version"],
+            "internet_required": True,
+        },
+        "model_execution_performed": False,
+        "final_assessment_predictions_generated": False,
+        "final_assessment_metrics_generated": False,
+        "claim_boundary": (
+            "CUDA/cloud execution authority only; this artifact contains no model result and "
+            "does not strengthen efficacy, method-ranking, or external-floor claims"
+        ),
+    }
+    gpu_binding_sha = _gpu_binding_identity(authority_payload)
+    authority = {**authority_payload, "gpu_binding_sha256": gpu_binding_sha}
+    base._json_dump(root / "gpu_authority.json", authority)
+    hashes = {
+        "schema_version": 1,
+        "binding_bundle_sha256": verified["bundle_sha256"],
+        "gpu_authority_file_sha256": base._file_sha256(root / "gpu_authority.json"),
+        "gpu_binding_sha256": gpu_binding_sha,
+    }
+    base._json_dump(root / "gpu_artifact_hashes.json", hashes)
+    return {
+        **result,
+        "gpu_binding_sha256": gpu_binding_sha,
+        "gpu_binding_root": str(root),
+        "binding_root": str(binding_root),
+    }
+
+
+def verify_gpu_binding(output: str | Path) -> dict[str, Any]:
+    root = Path(output).resolve()
+    binding_root = root / "binding"
+    with promoted_cuda_scope():
+        inner = promoted_binding.verify_promoted_binding_bundle(binding_root)
+    checked = _assert_cuda_binding_payload(binding_root)
+    authority = json.loads((root / "gpu_authority.json").read_text(encoding="utf-8"))
+    hashes = json.loads((root / "gpu_artifact_hashes.json").read_text(encoding="utf-8"))
+    payload = dict(authority)
+    declared = _require_sha256("gpu_binding_sha256", payload.pop("gpu_binding_sha256", ""))
+    expected = _gpu_binding_identity(payload)
+    if declared != expected or hashes.get("gpu_binding_sha256") != expected:
+        raise ValueError("GPU binding root identity mismatch")
+    if hashes.get("binding_bundle_sha256") != inner["bundle_sha256"]:
+        raise ValueError("GPU wrapper and inner promoted binding disagree")
+    if hashes.get("gpu_authority_file_sha256") != base._file_sha256(root / "gpu_authority.json"):
+        raise ValueError("GPU authority file hash mismatch")
+    if authority.get("source_revision") != checked["manifest"].get("source_revision"):
+        raise ValueError("GPU authority source revision differs from promoted binding")
+    if authority.get("environment_authority_sha256") != checked["manifest"].get(
+        "environment_authority_sha256"
+    ):
+        raise ValueError("GPU authority environment differs from promoted binding")
+    policy_observation = authority.get("binding_runtime_policy_observation") or {}
+    policy = authority.get("cuda_policy") or {}
+    for key in (
+        "cublas_workspace_config",
+        "torch_deterministic_algorithms",
+        "cudnn_deterministic",
+        "cudnn_benchmark",
+        "cuda_matmul_allow_tf32",
+        "cudnn_allow_tf32",
+    ):
+        if policy_observation.get(key) != policy.get(key):
+            raise ValueError(f"GPU binding runtime policy observation differs for {key}")
+    return {
+        "verified": True,
+        "gpu_binding_sha256": expected,
+        "binding_bundle_sha256": inner["bundle_sha256"],
+        "execution_plan_sha256": inner["execution_plan_sha256"],
+        "source_revision": authority["source_revision"],
+        "machine_shape": authority["cloud_execution"]["machine_shape"],
+        "binding_root": str(binding_root),
+    }
+
+
+def select_preflight_shard(gpu_binding_root: str | Path) -> dict[str, Any]:
+    """Select one fixed, non-adaptive EEGNet shard for systems preflight."""
+
+    verified = verify_gpu_binding(gpu_binding_root)
+    execution = json.loads(
+        (Path(verified["binding_root"]) / "execution_plan.json").read_text(encoding="utf-8")
+    )
+    matches = [
+        shard for shard in execution["template"]["shards"]
+        if int(shard["subject"]) == 1
+        and str(shard["target_session"]) == "5"
+        and int(shard["split_seed"]) == 2026
+        and str(shard["method_id"]) == "braindecode-eegnet"
+        and int(shard.get("model_seed")) == 31415
+    ]
+    if len(matches) != 1:
+        raise ValueError("fixed GPU systems-preflight shard is not unique in binding")
+    shard = matches[0]
+    if tuple(shard.get("budgets_per_class", ())) != (0, 1, 2, 5, 10):
+        raise ValueError("GPU preflight shard does not contain the complete budget frontier")
+    return shard
+
+
+def _gpu_worker_identity(payload: Mapping[str, Any]) -> str:
+    return base._identity_sha256(GPU_WORKER_SCHEMA, payload)
+
+
+def _require_t4(observation: Mapping[str, Any]) -> None:
+    name = str(observation.get("device_name", ""))
+    if "T4" not in name.upper():
+        raise RuntimeError(
+            f"Kaggle GPU preflight requires a T4-class device; observed {name!r}"
+        )
+
+
+def run_gpu_worker(
+    gpu_binding_root: str | Path,
+    shard_spec_sha256: str,
+    output: str | Path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Run one archived EEGNet shard under the sealed CUDA/Kaggle authority."""
+
+    gpu_binding = verify_gpu_binding(gpu_binding_root)
+    observation = configure_cuda_determinism(require_available=True)
+    _require_t4(observation)
+    root = Path(output).resolve()
+    if root.exists() and any(root.iterdir()) and not overwrite:
+        raise FileExistsError(f"refusing to overwrite non-empty GPU worker output: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+    inner_root = root / "worker"
+
+    with promoted_cuda_scope():
+        assignment = promoted_worker.load_promoted_worker_assignment(
+            gpu_binding["binding_root"], shard_spec_sha256
+        )
+        if assignment.shard.method_id != "braindecode-eegnet":
+            raise ValueError("GPU cloud worker accepts only archived EEGNet shards")
+        started = time.monotonic()
+        result = promoted_worker.run_promoted_worker(
+            gpu_binding["binding_root"],
+            shard_spec_sha256,
+            inner_root,
+            overwrite=overwrite,
+        )
+        elapsed = time.monotonic() - started
+        inner_verified = promoted_worker.verify_promoted_worker_bundle(
+            inner_root, binding_root=gpu_binding["binding_root"]
+        )
+
+    receipt_payload = {
+        "schema_version": 1,
+        "artifact_kind": "kaggle_t4_promoted_worker_systems_receipt",
+        "gpu_binding_sha256": gpu_binding["gpu_binding_sha256"],
+        "binding_bundle_sha256": gpu_binding["binding_bundle_sha256"],
+        "source_revision": gpu_binding["source_revision"],
+        "shard_spec_sha256": _require_sha256("shard_spec_sha256", shard_spec_sha256),
+        "worker_bundle_sha256": inner_verified["worker_bundle_sha256"],
+        "shard_result_sha256": inner_verified["shard_result_sha256"],
+        "accelerator_observation": observation,
+        "elapsed_seconds": elapsed,
+        "attempted_budgets": inner_verified["attempted_budgets"],
+        "statuses": inner_verified["statuses"],
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "go_no_go_inputs": [
+            "worker_bundle_verification",
+            "wall_clock_seconds",
+            "accelerator_identity",
+            "environment_identity",
+        ],
+        "forbidden_go_no_go_inputs": [
+            "balanced_accuracy",
+            "scientific_score",
+            "method_ranking",
+            "final_assessment_metric",
+        ],
+        "claim_boundary": (
+            "systems qualification of one preregistered GPU worker frontier only; numerical "
+            "results remain quarantined and cannot guide continuation, efficacy, ranking, "
+            "external-floor, or ORION decisions"
+        ),
+    }
+    receipt_sha = _gpu_worker_identity(receipt_payload)
+    receipt = {**receipt_payload, "gpu_worker_receipt_sha256": receipt_sha}
+    base._json_dump(root / "gpu_receipt.json", receipt)
+    hashes = {
+        "schema_version": 1,
+        "gpu_worker_receipt_sha256": receipt_sha,
+        "gpu_receipt_file_sha256": base._file_sha256(root / "gpu_receipt.json"),
+        "worker_bundle_sha256": inner_verified["worker_bundle_sha256"],
+    }
+    base._json_dump(root / "gpu_artifact_hashes.json", hashes)
+    return {
+        "verified": True,
+        "gpu_worker_receipt_sha256": receipt_sha,
+        "worker_bundle_sha256": inner_verified["worker_bundle_sha256"],
+        "gpu_binding_sha256": gpu_binding["gpu_binding_sha256"],
+        "shard_spec_sha256": shard_spec_sha256,
+        "elapsed_seconds": elapsed,
+        "device_name": observation["device_name"],
+        "numerical_result_interpretable": False,
+        "output": str(root),
+        **{key: result[key] for key in ("attempted_budgets", "statuses")},
+    }
+
+
+def verify_gpu_worker(
+    output: str | Path,
+    *,
+    gpu_binding_root: str | Path,
+) -> dict[str, Any]:
+    root = Path(output).resolve()
+    gpu_binding = verify_gpu_binding(gpu_binding_root)
+    receipt = json.loads((root / "gpu_receipt.json").read_text(encoding="utf-8"))
+    hashes = json.loads((root / "gpu_artifact_hashes.json").read_text(encoding="utf-8"))
+    payload = dict(receipt)
+    declared = _require_sha256(
+        "gpu_worker_receipt_sha256", payload.pop("gpu_worker_receipt_sha256", "")
+    )
+    expected = _gpu_worker_identity(payload)
+    if declared != expected or hashes.get("gpu_worker_receipt_sha256") != expected:
+        raise ValueError("GPU worker receipt root identity mismatch")
+    with promoted_cuda_scope():
+        inner = promoted_worker.verify_promoted_worker_bundle(
+            root / "worker", binding_root=gpu_binding["binding_root"]
+        )
+    if hashes.get("worker_bundle_sha256") != inner["worker_bundle_sha256"]:
+        raise ValueError("GPU receipt and inner worker bundle disagree")
+    if receipt.get("gpu_binding_sha256") != gpu_binding["gpu_binding_sha256"]:
+        raise ValueError("GPU worker names a different GPU binding")
+    if receipt.get("numerical_result_interpretable") is not False:
+        raise ValueError("GPU systems preflight may not promote numerical interpretation")
+    observation = receipt.get("accelerator_observation") or {}
+    _require_t4(observation)
+    authority = json.loads(
+        (Path(gpu_binding_root).resolve() / "gpu_authority.json").read_text(encoding="utf-8")
+    )
+    policy = authority.get("cuda_policy") or {}
+    for key in (
+        "cublas_workspace_config",
+        "torch_deterministic_algorithms",
+        "cudnn_deterministic",
+        "cudnn_benchmark",
+        "cuda_matmul_allow_tf32",
+        "cudnn_allow_tf32",
+    ):
+        if observation.get(key) != policy.get(key):
+            raise ValueError(f"GPU worker runtime policy differs for {key}")
+    return {
+        "verified": True,
+        "gpu_worker_receipt_sha256": expected,
+        "worker_bundle_sha256": inner["worker_bundle_sha256"],
+        "shard_spec_sha256": inner["shard_spec_sha256"],
+        "elapsed_seconds": float(receipt["elapsed_seconds"]),
+        "device_name": receipt["accelerator_observation"]["device_name"],
+        "numerical_result_interpretable": False,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Kumar2024 CUDA/Kaggle authority adapter")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bind = sub.add_parser("bind")
+    bind.add_argument("--output", required=True)
+    bind.add_argument("--overwrite", action="store_true")
+
+    verify_binding = sub.add_parser("verify-binding")
+    verify_binding.add_argument("--output", required=True)
+
+    select = sub.add_parser("select-preflight")
+    select.add_argument("--binding", required=True)
+
+    worker = sub.add_parser("run-worker")
+    worker.add_argument("--binding", required=True)
+    worker.add_argument("--shard-spec-sha256", required=True)
+    worker.add_argument("--output", required=True)
+    worker.add_argument("--overwrite", action="store_true")
+
+    verify_worker = sub.add_parser("verify-worker")
+    verify_worker.add_argument("--binding", required=True)
+    verify_worker.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "bind":
+        result = run_gpu_binding(args.output, overwrite=args.overwrite)
+    elif args.command == "verify-binding":
+        result = verify_gpu_binding(args.output)
+    elif args.command == "select-preflight":
+        result = select_preflight_shard(args.binding)
+    elif args.command == "run-worker":
+        result = run_gpu_worker(
+            args.binding,
+            args.shard_spec_sha256,
+            args.output,
+            overwrite=args.overwrite,
+        )
+    else:
+        result = verify_gpu_worker(args.output, gpu_binding_root=args.binding)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CUBLAS_WORKSPACE_CONFIG",
+    "CUDA_DEVICE",
+    "GPU_BINDING_SCHEMA",
+    "GPU_WORKER_SCHEMA",
+    "KAGGLE_MACHINE_SHAPE",
+    "UV_VERSION",
+    "configure_cuda_determinism",
+    "main",
+    "promoted_cuda_scope",
+    "run_gpu_binding",
+    "run_gpu_worker",
+    "select_preflight_shard",
+    "verify_gpu_binding",
+    "verify_gpu_worker",
+]

--- a/scripts/evidence/kaggle_kumar2024_gpu_runner.py
+++ b/scripts/evidence/kaggle_kumar2024_gpu_runner.py
@@ -1,0 +1,274 @@
+"""Kaggle bootstrap for one sealed Kumar2024 T4 systems-preflight worker.
+
+This script is intentionally standalone: Kaggle runs it with the base image,
+then it creates an isolated CPython environment, checks out the binding-owned
+neurOS revision, reproduces the pinned promoted environment, and invokes the
+GPU authority adapter. It never reads or prints scientific scores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import zipfile
+
+INPUT_ROOT = Path("/kaggle/input")
+WORK_ROOT = Path("/kaggle/working/neuros-kumar2024-gpu")
+OUTPUT_ROOT = Path("/kaggle/working/neuros-kumar2024-gpu-output")
+REPO_URL = "https://github.com/sidhulyalkar/neurOS-v1.git"
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _run(args: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    print("+", " ".join(args))
+    subprocess.run(args, cwd=cwd, env=env, check=True)
+
+
+def _one_launch_pack() -> Path:
+    matches = sorted(INPUT_ROOT.rglob("gpu_launch_pack.zip"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected exactly one gpu_launch_pack.zip, found {len(matches)}")
+    return matches[0]
+
+
+def _load_manifest(root: Path) -> dict:
+    path = root / "launch_manifest.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    required = {
+        "schema_version",
+        "phase",
+        "source_revision",
+        "gpu_binding_sha256",
+        "binding_bundle_sha256",
+        "shard_spec_sha256",
+        "constraints_sha256",
+        "python_version",
+        "uv_version",
+        "machine_shape",
+    }
+    if set(payload) < required:
+        raise ValueError(f"launch manifest missing keys: {sorted(required - set(payload))}")
+    if payload["schema_version"] != 1 or payload["phase"] != "systems-preflight":
+        raise ValueError("Kaggle runner accepts only schema-v1 systems-preflight launches")
+    for key, length in (
+        ("source_revision", 40),
+        ("gpu_binding_sha256", 64),
+        ("binding_bundle_sha256", 64),
+        ("shard_spec_sha256", 64),
+        ("constraints_sha256", 64),
+    ):
+        value = str(payload[key])
+        if len(value) != length or any(ch not in "0123456789abcdef" for ch in value):
+            raise ValueError(f"launch manifest {key} is malformed")
+    if payload["machine_shape"] != "NvidiaTeslaT4":
+        raise ValueError("systems preflight is frozen to Kaggle NvidiaTeslaT4")
+    if payload.get("numerical_result_interpretable") is not False:
+        raise ValueError("systems preflight must explicitly forbid numerical interpretation")
+    return payload
+
+
+def _find_uv() -> str:
+    candidates = [shutil.which("uv"), str(Path.home() / ".local/bin/uv")]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return candidate
+    raise RuntimeError("uv installation completed but executable was not found")
+
+
+def main() -> int:
+    if WORK_ROOT.exists():
+        shutil.rmtree(WORK_ROOT)
+    if OUTPUT_ROOT.exists():
+        shutil.rmtree(OUTPUT_ROOT)
+    WORK_ROOT.mkdir(parents=True)
+    OUTPUT_ROOT.mkdir(parents=True)
+
+    launch_pack = _one_launch_pack()
+    pack_root = WORK_ROOT / "launch-pack"
+    pack_root.mkdir()
+    with zipfile.ZipFile(launch_pack) as archive:
+        archive.extractall(pack_root)
+    manifest = _load_manifest(pack_root)
+
+    gpu_binding_root = pack_root / "gpu-binding"
+    if not (gpu_binding_root / "gpu_artifact_hashes.json").is_file():
+        raise FileNotFoundError("launch pack is missing the sealed GPU binding")
+
+    uv_version = str(manifest["uv_version"])
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            f"uv=={uv_version}",
+        ]
+    )
+    uv = _find_uv()
+    python_version = str(manifest["python_version"])
+    _run([uv, "python", "install", python_version])
+
+    venv = WORK_ROOT / "venv"
+    _run([uv, "venv", "--python", python_version, str(venv)])
+    py = venv / "bin/python"
+    if not py.is_file():
+        raise RuntimeError("isolated Python environment was not created")
+
+    repo = WORK_ROOT / "repo"
+    _run(["git", "clone", "--filter=blob:none", "--no-checkout", REPO_URL, str(repo)])
+    _run(["git", "checkout", "--detach", str(manifest["source_revision"])], cwd=repo)
+    observed_revision = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+    if observed_revision != manifest["source_revision"]:
+        raise RuntimeError("Kaggle checkout differs from binding-owned source revision")
+    if subprocess.check_output(["git", "status", "--porcelain"], cwd=repo, text=True).strip():
+        raise RuntimeError("Kaggle source checkout is not clean")
+
+    constraints = repo / "requirements/nsq-kumar2024-promoted-py311.constraints.txt"
+    if _sha256(constraints) != manifest["constraints_sha256"]:
+        raise RuntimeError("promoted constraints file differs from launch manifest")
+
+    pip_base = [
+        uv,
+        "pip",
+        "install",
+        "--python",
+        str(py),
+        "--constraint",
+        str(constraints),
+    ]
+    _run([*pip_base, "pip==26.2.1", "setuptools==79.0.1", "wheel==0.48.0"])
+    editable = [
+        uv,
+        "pip",
+        "install",
+        "--python",
+        str(py),
+        "--no-build-isolation",
+        "--constraint",
+        str(constraints),
+    ]
+    for package in (
+        "packages/neuros-core",
+        "packages/neuros-drivers",
+        "packages/neuros-models",
+        "packages/neuros-foundation[evidence,braindecode-evidence]",
+        "packages/orion",
+        "packages/neuros",
+    ):
+        _run([*editable, "-e", package], cwd=repo)
+
+    _run(
+        [
+            str(py),
+            "scripts/evidence/validate_promoted_environment.py",
+            "--constraints",
+            str(constraints),
+        ],
+        cwd=repo,
+    )
+
+    run_env = dict(os.environ)
+    run_env["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+    _run(
+        [
+            str(py),
+            "-P",
+            "-s",
+            "-m",
+            "neuros.evidence.kumar2024_gpu_cloud",
+            "verify-binding",
+            "--output",
+            str(gpu_binding_root),
+        ],
+        cwd=repo,
+        env=run_env,
+    )
+
+    worker_root = OUTPUT_ROOT / "gpu-worker"
+    _run(
+        [
+            str(py),
+            "-P",
+            "-s",
+            "-m",
+            "neuros.evidence.kumar2024_gpu_cloud",
+            "run-worker",
+            "--binding",
+            str(gpu_binding_root),
+            "--shard-spec-sha256",
+            str(manifest["shard_spec_sha256"]),
+            "--output",
+            str(worker_root),
+        ],
+        cwd=repo,
+        env=run_env,
+    )
+    _run(
+        [
+            str(py),
+            "-P",
+            "-s",
+            "-m",
+            "neuros.evidence.kumar2024_gpu_cloud",
+            "verify-worker",
+            "--binding",
+            str(gpu_binding_root),
+            "--output",
+            str(worker_root),
+        ],
+        cwd=repo,
+        env=run_env,
+    )
+
+    receipt = json.loads((worker_root / "gpu_receipt.json").read_text(encoding="utf-8"))
+    summary = {
+        "schema_version": 1,
+        "phase": "systems-preflight",
+        "source_revision": manifest["source_revision"],
+        "gpu_binding_sha256": manifest["gpu_binding_sha256"],
+        "binding_bundle_sha256": manifest["binding_bundle_sha256"],
+        "shard_spec_sha256": manifest["shard_spec_sha256"],
+        "gpu_worker_receipt_sha256": receipt["gpu_worker_receipt_sha256"],
+        "worker_bundle_sha256": receipt["worker_bundle_sha256"],
+        "device_name": receipt["accelerator_observation"]["device_name"],
+        "compute_capability": receipt["accelerator_observation"]["compute_capability"],
+        "elapsed_seconds": receipt["elapsed_seconds"],
+        "statuses": receipt["statuses"],
+        "numerical_result_interpretable": False,
+        "score_fields_read_by_bootstrap": False,
+        "go_no_go_inputs": receipt["go_no_go_inputs"],
+        "forbidden_go_no_go_inputs": receipt["forbidden_go_no_go_inputs"],
+    }
+    (OUTPUT_ROOT / "kaggle_run_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    shutil.make_archive(
+        "/kaggle/working/neuros_kumar2024_gpu_preflight",
+        "zip",
+        root_dir=OUTPUT_ROOT,
+    )
+    shutil.copy2(
+        OUTPUT_ROOT / "kaggle_run_summary.json",
+        "/kaggle/working/kaggle_run_summary.json",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kumar2024_gpu_cloud.py
+++ b/tests/test_kumar2024_gpu_cloud.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neuros.evidence import kumar2024_gpu_cloud as gpu
+from neuros.evidence import kumar2024_promoted_binding as binding
+from neuros.evidence import kumar2024_promoted_worker as worker
+
+
+def test_cuda_config_is_explicit_without_mutating_cpu_default():
+    cpu = binding.promoted_materialization_config()
+    cuda = gpu._cuda_config()
+    assert cpu.device == "cpu"
+    assert cuda.device == "cuda"
+    assert cpu.to_dict()["braindecode"]["device"] == "cpu"
+    assert cuda.to_dict()["braindecode"]["device"] == "cuda"
+    assert cpu.sha256 != cuda.sha256
+
+
+def test_cuda_scope_updates_binder_and_worker_and_restores_on_error():
+    original_binding = binding.promoted_materialization_config
+    original_worker = worker.promoted_materialization_config
+    with pytest.raises(RuntimeError, match="probe"):
+        with gpu.promoted_cuda_scope():
+            assert binding.promoted_materialization_config().device == "cuda"
+            assert worker.promoted_materialization_config().device == "cuda"
+            raise RuntimeError("probe")
+    assert binding.promoted_materialization_config is original_binding
+    assert worker.promoted_materialization_config is original_worker
+
+
+def test_fixed_preflight_selection_is_non_adaptive(tmp_path: Path, monkeypatch):
+    binding_root = tmp_path / "binding"
+    binding_root.mkdir()
+    target = {
+        "subject": 1,
+        "target_session": "5",
+        "split_seed": 2026,
+        "method_id": "braindecode-eegnet",
+        "model_seed": 31415,
+        "budgets_per_class": [0, 1, 2, 5, 10],
+        "shard_spec_sha256": "a" * 64,
+    }
+    decoy = {**target, "subject": 10, "shard_spec_sha256": "b" * 64}
+    (binding_root / "execution_plan.json").write_text(
+        json.dumps({"template": {"shards": [decoy, target]}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        gpu,
+        "verify_gpu_binding",
+        lambda _: {"binding_root": str(binding_root)},
+    )
+    assert gpu.select_preflight_shard(tmp_path) == target
+
+
+def test_preflight_selection_rejects_ambiguous_match(tmp_path: Path, monkeypatch):
+    binding_root = tmp_path / "binding"
+    binding_root.mkdir()
+    target = {
+        "subject": 1,
+        "target_session": "5",
+        "split_seed": 2026,
+        "method_id": "braindecode-eegnet",
+        "model_seed": 31415,
+        "budgets_per_class": [0, 1, 2, 5, 10],
+        "shard_spec_sha256": "a" * 64,
+    }
+    (binding_root / "execution_plan.json").write_text(
+        json.dumps({"template": {"shards": [target, target]}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        gpu,
+        "verify_gpu_binding",
+        lambda _: {"binding_root": str(binding_root)},
+    )
+    with pytest.raises(ValueError, match="not unique"):
+        gpu.select_preflight_shard(tmp_path)
+
+
+def test_t4_policy_rejects_other_accelerators():
+    gpu._require_t4({"device_name": "Tesla T4"})
+    with pytest.raises(RuntimeError, match="T4-class"):
+        gpu._require_t4({"device_name": "NVIDIA A100-SXM4-40GB"})
+
+
+def test_gpu_worker_receipt_identity_is_order_independent_for_mappings():
+    first = {"b": 2, "a": 1}
+    second = {"a": 1, "b": 2}
+    assert gpu._gpu_worker_identity(first) == gpu._gpu_worker_identity(second)


### PR DESCRIPTION
## Purpose

Add a free-cloud GPU execution path for the promoted Kumar2024 EEGNet work without silently changing the already-qualified CPU study.

Frozen qualified base:
`main@52c9bd1fc14a684181181a8ebd16d0a39827b0ab`

Exact qualified candidate:
`60d36906e7ae7d17f3361cbe61408fca5aca3145`

The candidate is one commit directly over the frozen base and adds six files only. Existing promoted binding/worker/runtime/model files are unchanged.

## Provider decision

Use **Kaggle T4** as the first free GPU executor. The official Kaggle CLI supports private datasets, script kernels, `NvidiaTeslaT4`, status polling and output retrieval. We deliberately avoid P100 because current Kaggle documentation warns the default PyTorch image lacks Pascal `sm_60` kernels.

Colab remains a fallback but its free accelerator availability/runtime is dynamic and non-guaranteed. Lightning starter credits are useful but are not the same stable recurring free quota.

## Architecture

```text
qualified main SHA
   |
   v
canonical promoted comparison plan
   |
   v
CUDA-bound no-model binding
   |  device=cuda in archived method/config identity
   |  deterministic CUDA policy sealed
   v
private Kaggle launch dataset
   |
   v
private NvidiaTeslaT4 script kernel
   |
   v
canonical promoted atomic EEGNet worker
   |
   v
GPU systems receipt
   |
   v
GitHub-side structural verification
```

The canonical CPU path is not edited. `kumar2024_gpu_cloud.py` uses a process-local, sequential compatibility scope to project the existing promoted config to `device="cuda"` only while invoking the canonical binder/worker, then restores the original functions.

## Determinism

GPU binding and execution require:

- `CUBLAS_WORKSPACE_CONFIG=:4096:8`
- `torch.use_deterministic_algorithms(True)`
- cuDNN deterministic on
- cuDNN benchmark off
- CUDA matmul TF32 off
- cuDNN TF32 off

The normal environment authority binds requested device, Torch/CUDA/cuDNN runtime and its existing deterministic flags. The outer GPU authority additionally seals the cuBLAS/TF32 policy and records the binding-time policy observation.

The actual worker fails closed unless CUDA is available and device 0 is T4-class.

## Fixed systems preflight

The first cloud shard is selected non-adaptively from the sealed execution plan:

- subject 1
- target session 5
- split seed 2026
- EEGNet
- model seed 31415
- complete budget frontier `[0,1,2,5,10]`

The scheduler supplies only the resulting archived `shard_spec_sha256`; it cannot pick a different participant/session/model seed/budget at launch time.

### Scientific boundary

The preflight is **systems evidence only**.

Allowed go/no-go inputs:
- bundle verification
- wall-clock time
- accelerator identity
- environment identity

Forbidden go/no-go inputs:
- balanced accuracy
- scientific score
- method ranking
- final-assessment metric

The standalone Kaggle bootstrap never reads `case_result.json`, `shard_result.json`, or balanced-accuracy fields. The numerical worker result remains inside the sealed/quarantined bundle and is explicitly `numerical_result_interpretable=false` until preregistered execution completeness is satisfied.

No global analysis, external-floor claim, or ORION comparison is permitted here.

## Kaggle orchestration

Manual workflow:
`.github/workflows/nsq-kumar2024-kaggle-preflight.yml`

It:
1. requires exact clean `main`;
2. installs the pinned promoted environment on CPython 3.11.16;
3. creates the CUDA no-model authority;
4. creates a unique private Kaggle Dataset with the launch pack only (no redistributed Kumar raw data);
5. creates a unique private T4 script kernel;
6. polls the official Kaggle CLI;
7. downloads a zipped systems result;
8. re-verifies the worker bundle on GitHub without score inspection;
9. saves binding + summary + quarantined worker ZIP as GitHub artifacts.

The Kaggle script distrusts the base image: it pins `uv==0.12.10`, installs CPython 3.11.16 into an isolated venv, checks out the binding-owned exact git SHA, installs the existing promoted constraints, validates the promoted environment, then runs the sealed worker.

## Exact-head qualification

Exact PR head `60d36906e7ae7d17f3361cbe61408fca5aca3145` passed all 11 applicable PR workflows:

1. Developer Preview Journey
2. Reproducible Release Build
3. Ecosystem Compatibility
4. Public Trust Contracts
5. NSQ Kumar2024 v1
6. neurOS real-world evidence
7. Whole Package Qualification
8. Braindecode Compatibility
9. neurOS CI
10. NSQ Kumar2024 GPU cloud contracts
11. Release Candidate Artifacts

The GPU cloud contract lane independently succeeded in:
- installing the authority stack;
- running `tests/test_kumar2024_gpu_cloud.py`;
- compiling both cloud execution surfaces;
- asserting the standalone runner does not read `case_result.json`, `shard_result.json`, or `balanced_accuracy`.

A prior superseded head failed before test collection because its CI lane omitted `pytest-asyncio`; that evidence is intentionally not reused. The dependency ownership error was repaired and the branch was reconstructed as this one-commit exact candidate before fresh qualification.

Pre-merge guard at qualification time:
- PR head = `60d36906e7ae7d17f3361cbe61408fca5aca3145`
- base/main = `52c9bd1fc14a684181181a8ebd16d0a39827b0ab`
- review threads = 0
- submitted reviews = 0
- exact-head workflows = 11/11 success

## Account boundary

Actual Kaggle execution requires these repository secrets:
- `KAGGLE_USERNAME`
- `KAGGLE_KEY`

They are not available to this chat and must not be pasted into PR/issue text. Once stored as GitHub Actions secrets, no browser automation is required.

## Expansion gate

Do **not** fan out the 810 EEGNet shards / 4,050 fit attempts yet.

First:
1. merge + exact-main qualification;
2. one T4 systems preflight;
3. use only systems timing to project full GPU-hours;
4. if feasible, freeze a deterministic 9-shard timing grid;
5. only then define full subject-grouped chunking.

This prevents free GPU quota from becoming outcome-adaptive model search.