### PR TITLE
feat(evidence): gate Kumar2024 T4 launch on free GPU quota

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml
@@ -57,3 +57,30 @@ jobs:
           for forbidden in ("case_result.json", "shard_result.json", "balanced_accuracy"):
               assert forbidden not in text, forbidden
           PY
+      - name: Assert free-quota gate is isolated from scientific binding
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          text = Path(".github/workflows/nsq-kumar2024-kaggle-preflight.yml").read_text()
+          assert "  quota-gate:" in text
+          assert "  kaggle-t4-preflight:" in text
+          quota = text.split("  quota-gate:", 1)[1].split("  kaggle-t4-preflight:", 1)[0]
+          preflight = text.split("  kaggle-t4-preflight:", 1)[1]
+          binding_prefix = preflight.split(
+              "      - name: Build CUDA-bound no-model authority", 1
+          )[0]
+
+          assert "kaggle quota --csv" in quota
+          assert '"kaggle==${KAGGLE_CLI_VERSION}"' in quota
+          assert "MIN_FREE_GPU_HOURS" in text
+          assert "scientific_result_used" in quota
+          assert "neuros.evidence.kumar2024_gpu_cloud bind" not in quota
+          assert "needs: quota-gate" in preflight
+          assert "kaggle quota" not in binding_prefix
+          assert '"kaggle==${KAGGLE_CLI_VERSION}"' not in binding_prefix
+          assert "KAGGLE_GPU_QUOTA_SHA256" in preflight
+          assert "KAGGLE_GPU_REMAINING_HOURS" in preflight
+          assert "kaggle_gpu_quota_snapshot_sha256" in preflight
+          assert "kaggle_gpu_remaining_hours_at_gate" in preflight
+          PY

--- a/.github/workflows/nsq-kumar2024-kaggle-preflight.yml
+++ b/.github/workflows/nsq-kumar2024-kaggle-preflight.yml
@@ -9,16 +9,127 @@ permissions:
 env:
   PROMOTED_CONSTRAINTS: requirements/nsq-kumar2024-promoted-py311.constraints.txt
   KAGGLE_CLI_VERSION: "2.2.4"
+  MIN_FREE_GPU_HOURS: "1.0"
 
 jobs:
+  quota-gate:
+    name: Verify free Kaggle GPU quota before binding
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: github.ref == 'refs/heads/main'
+    env:
+      KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+      KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+    outputs:
+      gpu_remaining_hours: ${{ steps.quota.outputs.gpu_remaining_hours }}
+      quota_snapshot_sha256: ${{ steps.quota.outputs.quota_snapshot_sha256 }}
+      quota_refresh_at: ${{ steps.quota.outputs.quota_refresh_at }}
+    steps:
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11.16"
+      - name: Require Kaggle credentials before expensive binding
+        run: |
+          set -euo pipefail
+          test -n "${KAGGLE_USERNAME:-}" || { echo "Missing repository secret KAGGLE_USERNAME" >&2; exit 2; }
+          test -n "${KAGGLE_KEY:-}" || { echo "Missing repository secret KAGGLE_KEY" >&2; exit 2; }
+      - name: Install pinned Kaggle quota client
+        run: python -m pip install --disable-pip-version-check "kaggle==${KAGGLE_CLI_VERSION}"
+      - name: Capture and require free weekly GPU quota
+        id: quota
+        run: |
+          set -euo pipefail
+          QUOTA_CSV="${RUNNER_TEMP}/kaggle_accelerator_quota.csv"
+          QUOTA_JSON="${RUNNER_TEMP}/kaggle_accelerator_quota.json"
+          kaggle quota --csv > "${QUOTA_CSV}"
+          QUOTA_CSV="${QUOTA_CSV}" QUOTA_JSON="${QUOTA_JSON}" python - <<'PY'
+          import csv
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          csv_path = Path(os.environ["QUOTA_CSV"])
+          rows = list(csv.DictReader(csv_path.read_text(encoding="utf-8").splitlines()))
+          gpu_rows = [row for row in rows if str(row.get("resource", "")).upper() == "GPU"]
+          if len(gpu_rows) != 1:
+              raise SystemExit("Kaggle quota must expose exactly one GPU row")
+          row = gpu_rows[0]
+
+          def hours(name: str) -> float:
+              text = str(row.get(name, "")).strip()
+              if not text.endswith("h"):
+                  raise SystemExit(f"Kaggle GPU quota {name} must be expressed in hours")
+              try:
+                  value = float(text[:-1])
+              except ValueError as exc:
+                  raise SystemExit(f"Kaggle GPU quota {name} is not numeric") from exc
+              if value < 0:
+                  raise SystemExit(f"Kaggle GPU quota {name} cannot be negative")
+              return value
+
+          used = hours("used")
+          remaining = hours("remaining")
+          total = hours("total")
+          minimum = float(os.environ["MIN_FREE_GPU_HOURS"])
+          if total <= 0:
+              raise SystemExit("Kaggle reports no positive weekly GPU allowance")
+          if remaining < minimum:
+              raise SystemExit(
+                  f"Kaggle free GPU quota is below launch floor: "
+                  f"remaining={remaining:.2f}h required={minimum:.2f}h"
+              )
+          payload = {
+              "schema_version": 1,
+              "resource": "GPU",
+              "used_hours": used,
+              "remaining_hours": remaining,
+              "total_hours": total,
+              "refresh_at": row.get("refreshAt") or None,
+              "minimum_launch_hours": minimum,
+              "source": "kaggle quota --csv",
+              "scientific_result_used": False,
+          }
+          encoded = json.dumps(
+              {"schema": "neuros.kaggle_accelerator_quota.v1", "payload": payload},
+              sort_keys=True,
+              separators=(",", ":"),
+              allow_nan=False,
+          ).encode("utf-8")
+          digest = hashlib.sha256(encoded).hexdigest()
+          receipt = {**payload, "quota_snapshot_sha256": digest}
+          Path(os.environ["QUOTA_JSON"]).write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+              stream.write(f"gpu_remaining_hours={remaining:.2f}\n")
+              stream.write(f"quota_snapshot_sha256={digest}\n")
+              stream.write(f"quota_refresh_at={row.get('refreshAt') or ''}\n")
+          print(json.dumps(receipt, sort_keys=True))
+          PY
+      - name: Upload systems-only quota receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nsq-kumar2024-kaggle-quota-${{ github.sha }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/kaggle_accelerator_quota.csv
+            ${{ runner.temp }}/kaggle_accelerator_quota.json
+          if-no-files-found: error
+          retention-days: 90
+
   kaggle-t4-preflight:
     name: Sealed binding -> private Kaggle T4 -> verified worker receipt
+    needs: quota-gate
     runs-on: ubuntu-24.04
     timeout-minutes: 360
     if: github.ref == 'refs/heads/main'
     env:
       KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
       KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+      KAGGLE_GPU_REMAINING_HOURS: ${{ needs.quota-gate.outputs.gpu_remaining_hours }}
+      KAGGLE_GPU_QUOTA_SHA256: ${{ needs.quota-gate.outputs.quota_snapshot_sha256 }}
+      KAGGLE_GPU_QUOTA_REFRESH_AT: ${{ needs.quota-gate.outputs.quota_refresh_at }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -100,7 +211,7 @@ jobs:
               "shard_spec_sha256": shard["shard_spec_sha256"],
           }, sort_keys=True))
           PY
-      - name: Require Kaggle credentials only after binding is sealed
+      - name: Reconfirm Kaggle credentials before publication
         run: |
           set -euo pipefail
           test -n "${KAGGLE_USERNAME:-}" || { echo "Missing repository secret KAGGLE_USERNAME" >&2; exit 2; }
@@ -140,6 +251,9 @@ jobs:
               "python_version": "3.11.16",
               "uv_version": "0.12.10",
               "machine_shape": "NvidiaTeslaT4",
+              "kaggle_gpu_quota_snapshot_sha256": os.environ["KAGGLE_GPU_QUOTA_SHA256"],
+              "kaggle_gpu_remaining_hours_at_gate": float(os.environ["KAGGLE_GPU_REMAINING_HOURS"]),
+              "kaggle_gpu_quota_refresh_at": os.environ.get("KAGGLE_GPU_QUOTA_REFRESH_AT") or None,
               "numerical_result_interpretable": False,
               "continuation_policy": "systems-only; scientific scores forbidden as go/no-go inputs",
           }
@@ -258,6 +372,8 @@ jobs:
               "elapsed_seconds": summary["elapsed_seconds"],
               "gpu_worker_receipt_sha256": summary["gpu_worker_receipt_sha256"],
               "worker_bundle_sha256": summary["worker_bundle_sha256"],
+              "kaggle_gpu_quota_snapshot_sha256": os.environ["KAGGLE_GPU_QUOTA_SHA256"],
+              "kaggle_gpu_remaining_hours_at_gate": float(os.environ["KAGGLE_GPU_REMAINING_HOURS"]),
               "numerical_result_interpretable": False,
           }, sort_keys=True))
           PY

--- a/docs/NSQ_KUMAR2024_KAGGLE_GPU.md
+++ b/docs/NSQ_KUMAR2024_KAGGLE_GPU.md
@@ -23,6 +23,11 @@ environment authority before model execution.
 ```text
 qualified neurOS source revision
         |
+        +--> isolated Kaggle quota gate
+        |      +-- credentials present
+        |      +-- >= 1.0 free GPU-hour
+        |      +-- content-addressed systems receipt
+        |
         v
 canonical promoted comparison plan
         |
@@ -46,6 +51,11 @@ canonical promoted atomic worker bundle
         v
 GPU systems receipt
 ```
+
+The quota gate and scientific binding execute in separate GitHub Actions jobs.
+This separation is deliberate: the Kaggle CLI needed to inspect account quota
+must never become an installed distribution inside the environment captured by
+the promoted scientific `EnvironmentAuthority`.
 
 The CUDA adapter is deliberately separate from the canonical CPU path. Its
 compatibility scope temporarily projects `promoted_materialization_config()` to
@@ -71,6 +81,36 @@ GPU authority additionally seals the cuBLAS and TF32 policy.
 Actual accelerator identity is observed at worker time. The first tranche fails
 closed unless the device name is T4-class.
 
+## Free-GPU quota gate
+
+Before the 18-participant binding is materialized, a separate control-plane job
+uses the pinned Kaggle CLI to query the account's current weekly accelerator
+quota. The workflow requires exactly one GPU quota row and a predeclared launch
+floor of at least `1.0` remaining GPU-hour.
+
+The gate records only systems metadata:
+
+- used GPU hours;
+- remaining GPU hours;
+- total weekly GPU hours;
+- quota refresh time when supplied by Kaggle;
+- the fixed minimum launch threshold;
+- a domain-separated SHA-256 of the normalized quota snapshot.
+
+It explicitly records `scientific_result_used=false`. No dataset values, worker
+predictions, scores, rankings, or method results are available to this job.
+
+The raw CSV and normalized quota receipt are retained as a separate GitHub
+Actions artifact. Only the quota-receipt SHA, remaining-hours value and refresh
+time cross into the later launch manifest. This makes the claim "the preflight
+was started with free GPU quota available" auditable without allowing quota
+inspection to alter scientific authority.
+
+A quota failure stops the workflow before the expensive binding. This includes
+missing Kaggle credentials, a missing/ambiguous GPU quota row, malformed quota
+units, zero weekly allowance, or less than the predeclared one-hour launch
+floor.
+
 ## Systems-preflight shard
 
 The first cloud run is fixed before execution:
@@ -94,7 +134,8 @@ The GitHub/Kaggle orchestration may use only:
 - worker-bundle verification;
 - elapsed wall-clock time;
 - accelerator identity;
-- environment identity.
+- environment identity;
+- accelerator quota availability and refresh metadata.
 
 It may not use balanced accuracy, scientific score, method ranking, final
 assessment metrics, external-floor status or ORION comparison as a go/no-go
@@ -112,18 +153,24 @@ The manual workflow is:
 
 It performs the following in one provenance chain:
 
-1. requires an exact clean `main` checkout;
-2. creates the CUDA-bound no-model binding in the pinned Python environment;
-3. selects the fixed preflight shard;
-4. creates a unique private Kaggle Dataset containing only the sealed launch
+1. in an isolated control-plane job, requires Kaggle credentials and queries the
+   current weekly GPU quota;
+2. requires at least `1.0` remaining free GPU-hour and seals the quota receipt;
+3. in a fresh job, requires an exact clean `main` checkout;
+4. installs only the exact promoted scientific environment and creates the
+   CUDA-bound no-model binding;
+5. selects the fixed preflight shard;
+6. binds the quota-receipt SHA and safe quota metadata into the systems launch
+   manifest;
+7. creates a unique private Kaggle Dataset containing only the sealed launch
    pack, not redistributed Kumar2024 raw data;
-5. creates a unique private Kaggle script kernel with T4 + internet enabled;
-6. polls the official Kaggle CLI to terminal state;
-7. downloads the zipped systems output;
-8. structurally verifies the returned worker bundle on GitHub without reading
-   score fields;
-9. uploads the binding, systems summary, quarantined worker ZIP and verification
-   record as a 90-day GitHub Actions artifact.
+8. creates a unique private Kaggle script kernel with T4 + internet enabled;
+9. polls the official Kaggle CLI to terminal state;
+10. downloads the zipped systems output;
+11. structurally verifies the returned worker bundle on GitHub without reading
+    score fields;
+12. uploads the binding, systems summary, quarantined worker ZIP and verification
+    record as a 90-day GitHub Actions artifact.
 
 The Kaggle kernel itself is
 `scripts/evidence/kaggle_kumar2024_gpu_runner.py`.
@@ -167,4 +214,5 @@ This tranche does not:
 - generate an external-floor claim;
 - permit ORION comparison;
 - automatically inspect a preflight score;
-- claim CUDA numerical identity with CPU execution.
+- claim CUDA numerical identity with CPU execution;
+- treat quota availability as scientific evidence.


### PR DESCRIPTION
## Purpose

Harden the already-promoted Kumar2024 Kaggle T4 systems-preflight control plane so a launch proves that free GPU quota is actually available before spending CPU time materializing the 18-participant binding.

Qualified base:
`main@07a6c5fa5f212d54aae408237f14bb56f2f6eee9`

Exact qualified candidate:
`abcae91ba3342b101fea8285cea5c2b97b89824c`

The candidate is one commit directly over the fully qualified base. It changes only:
- `.github/workflows/nsq-kumar2024-kaggle-preflight.yml`
- `.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml`
- `docs/NSQ_KUMAR2024_KAGGLE_GPU.md`

No scientific implementation, promoted CPU authority, preprocessing, case authority, worker, model seed, budget, or score-handling code changes.

## Isolated quota gate

A new `quota-gate` job runs before the scientific binding job. It:

1. requires Kaggle credentials;
2. installs pinned `kaggle==2.2.4` in its own GitHub job;
3. calls the official `kaggle quota --csv` accelerator-quota endpoint;
4. requires exactly one GPU row;
5. parses used/remaining/total hours fail-closed;
6. requires a predeclared `1.0` free GPU-hour launch floor;
7. seals a domain-separated systems-only quota snapshot;
8. retains raw CSV + normalized receipt as a 90-day artifact.

The scientific T4 job has `needs: quota-gate`.

## Authority separation

The Kaggle quota CLI is intentionally **not installed before the CUDA binding** in the scientific job. GitHub jobs are isolated, so the quota client cannot appear in the complete Python distribution set captured by promoted `EnvironmentAuthority`.

Only these safe systems fields cross the boundary:
- quota snapshot SHA-256;
- remaining GPU hours at gate time;
- quota refresh timestamp when supplied.

They enter the systems launch manifest, not the scientific method/config identity.

## Claim boundary

Quota availability is systems evidence only. The quota job has no access to dataset values, predictions, model scores, rankings, final-assessment metrics, external-floor state, or ORION comparison state. Its normalized receipt explicitly records `scientific_result_used=false`.

The existing fixed preflight shard and score-quarantine policy are unchanged.

## Exact-head qualification

Exact PR head `abcae91ba3342b101fea8285cea5c2b97b89824c` passed all three applicable PR workflows:

1. `NSQ Kumar2024 GPU cloud contracts`
2. `Public Trust Contracts`
3. `neurOS CI`

The GPU-cloud lane independently passed:
- existing GPU authority tests;
- cloud surface compilation;
- scientific score-artifact quarantine;
- the new quota-client/scientific-binding isolation contract.

The complete neurOS CI job matrix also succeeded, including Python 3.10/3.11/3.12 kernel and source-reliability lanes, scientific/latency gates, model/mech-int contracts, foundation interoperability, recording interoperability, repository hygiene, wheel builds, and BCI smoke.

Pre-merge guard at qualification time:
- PR head = `abcae91ba3342b101fea8285cea5c2b97b89824c`
- base/main = `07a6c5fa5f212d54aae408237f14bb56f2f6eee9`
- review threads = 0
- submitted reviews = 0
- applicable workflows = 3/3 success

## Why now

The promoted cloud path is ready for one real T4 systems preflight, but account quota is an external runtime dependency. This gate prevents two avoidable failure classes before launch:
- missing/invalid Kaggle account credentials;
- exhausted or nearly exhausted free GPU quota.

It also makes the statement “this run started with free accelerator quota available” auditable.

## Promotion policy

Use a guarded squash merge only if head/base/review state remains unchanged. PR evidence is not sufficient for promotion: the resulting exact `main` SHA must independently pass every fresh push-triggered workflow applicable to these files before the quota gate is considered promoted or any real Kaggle preflight is launched.