### PR TITLE
feat(evidence): add owner-only Kumar2024 T4 preflight bridge

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml
@@ -8,6 +8,7 @@ on:
       - "tests/test_kumar2024_gpu_cloud.py"
       - ".github/workflows/nsq-kumar2024-gpu-cloud-ci.yml"
       - ".github/workflows/nsq-kumar2024-kaggle-preflight.yml"
+      - ".github/workflows/nsq-kumar2024-owner-preflight-bridge.yml"
       - "docs/NSQ_KUMAR2024_KAGGLE_GPU.md"
   push:
     branches: [main]
@@ -17,6 +18,7 @@ on:
       - "tests/test_kumar2024_gpu_cloud.py"
       - ".github/workflows/nsq-kumar2024-gpu-cloud-ci.yml"
       - ".github/workflows/nsq-kumar2024-kaggle-preflight.yml"
+      - ".github/workflows/nsq-kumar2024-owner-preflight-bridge.yml"
       - "docs/NSQ_KUMAR2024_KAGGLE_GPU.md"
 
 permissions:
@@ -83,4 +85,52 @@ jobs:
           assert "KAGGLE_GPU_REMAINING_HOURS" in preflight
           assert "kaggle_gpu_quota_snapshot_sha256" in preflight
           assert "kaggle_gpu_remaining_hours_at_gate" in preflight
+          PY
+      - name: Assert owner-only command bridge cannot choose scientific inputs
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          bridge = Path(
+              ".github/workflows/nsq-kumar2024-owner-preflight-bridge.yml"
+          ).read_text()
+          target = Path(
+              ".github/workflows/nsq-kumar2024-kaggle-preflight.yml"
+          ).read_text()
+
+          assert "issue_comment:" in bridge
+          assert "types: [created]" in bridge
+          assert "actions: write" in bridge
+          assert "contents: read" in bridge
+          assert "github.event.issue.number == 167" in bridge
+          assert "github.event.issue.pull_request != null" in bridge
+          assert "github.actor == github.repository_owner" in bridge
+          assert "github.event.comment.user.login == github.repository_owner" in bridge
+          assert "github.event.comment.author_association == 'OWNER'" in bridge
+          assert "github.event.comment.body == '/nsq-kumar2024-t4-preflight'" in bridge
+          assert "nsq-kumar2024-kaggle-preflight.yml" in bridge
+          assert "event=workflow_dispatch" in bridge
+          assert 'printf \'%s\\n\' \'{"ref":"main"}\'' in bridge
+          assert "workflow_run_id" in bridge
+          assert 'observed["head_sha"] != expected_sha' in bridge
+          assert "/cancel" in bridge
+          assert "status != \"completed\"" in bridge
+          assert 'conclusion == "success"' in bridge
+          assert "cancel-in-progress: false" in bridge
+
+          for secret_name in ("KAGGLE_USERNAME", "KAGGLE_KEY"):
+              assert secret_name not in bridge, secret_name
+          for scientific_choice in (
+              "target_session",
+              "split_seed",
+              "method_id",
+              "model_seed",
+              "budgets_per_class",
+              "balanced_accuracy",
+              "scientific_score",
+          ):
+              assert scientific_choice not in bridge, scientific_choice
+
+          assert "workflow_dispatch:" in target
+          assert "subject: `1`" not in bridge
           PY

--- a/.github/workflows/nsq-kumar2024-owner-preflight-bridge.yml
+++ b/.github/workflows/nsq-kumar2024-owner-preflight-bridge.yml
@@ -1,0 +1,177 @@
+name: NSQ Kumar2024 owner preflight bridge
+
+run-name: NSQ Kumar2024 owner preflight bridge / ${{ github.sha }}
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: nsq-kumar2024-owner-preflight-bridge
+  cancel-in-progress: false
+
+env:
+  TARGET_WORKFLOW: nsq-kumar2024-kaggle-preflight.yml
+
+jobs:
+  dispatch:
+    name: Authorize owner command and dispatch fixed T4 preflight
+    if: >-
+      github.event.issue.number == 167 &&
+      github.event.issue.pull_request != null &&
+      github.actor == github.repository_owner &&
+      github.event.comment.user.login == github.repository_owner &&
+      github.event.comment.author_association == 'OWNER' &&
+      github.event.comment.body == '/nsq-kumar2024-t4-preflight'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Reconfirm exact default-branch authority
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF}" = "refs/heads/main"
+          MAIN_SHA="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/${GITHUB_REPOSITORY}/branches/main" \
+            --jq '.commit.sha')"
+          if [[ "${MAIN_SHA}" != "${GITHUB_SHA}" ]]; then
+            echo "Default branch moved before command authorization: event=${GITHUB_SHA} main=${MAIN_SHA}" >&2
+            exit 1
+          fi
+          echo "Authorized exact main source: ${GITHUB_SHA}"
+
+      - name: Reject duplicate or concurrent T4 preflight
+        run: |
+          set -euo pipefail
+          RUNS_JSON="${RUNNER_TEMP}/target_workflow_runs.json"
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW}/runs?branch=main&event=workflow_dispatch&per_page=100" \
+            > "${RUNS_JSON}"
+          RUNS_JSON="${RUNS_JSON}" SOURCE_SHA="${GITHUB_SHA}" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["RUNS_JSON"]).read_text(encoding="utf-8"))
+          source_sha = os.environ["SOURCE_SHA"]
+          active = []
+          successful_same_sha = []
+          for run in payload.get("workflow_runs", []):
+              status = str(run.get("status") or "")
+              conclusion = str(run.get("conclusion") or "")
+              run_id = run.get("id")
+              head_sha = str(run.get("head_sha") or "")
+              if status != "completed":
+                  active.append((run_id, status, head_sha))
+              if head_sha == source_sha and conclusion == "success":
+                  successful_same_sha.append(run_id)
+
+          if active:
+              raise SystemExit(f"A T4 preflight is already active: {active}")
+          if successful_same_sha:
+              raise SystemExit(
+                  "A successful T4 preflight already exists for this exact source SHA: "
+                  f"{successful_same_sha}"
+              )
+          print("No active preflight and no successful same-SHA preflight found")
+          PY
+
+      - name: Dispatch fixed systems-only T4 preflight
+        id: dispatch
+        run: |
+          set -euo pipefail
+          PAYLOAD="${RUNNER_TEMP}/dispatch.json"
+          RESPONSE="${RUNNER_TEMP}/dispatch_response.json"
+          printf '%s\n' '{"ref":"main"}' > "${PAYLOAD}"
+          gh api --method POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/${TARGET_WORKFLOW}/dispatches" \
+            --input "${PAYLOAD}" > "${RESPONSE}"
+          RUN_ID="$(RESPONSE="${RESPONSE}" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["RESPONSE"]).read_text(encoding="utf-8"))
+          run_id = payload.get("workflow_run_id")
+          if not isinstance(run_id, int) or run_id <= 0:
+              raise SystemExit("Workflow dispatch response did not include workflow_run_id")
+          print(run_id)
+          PY
+          )"
+          echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
+          echo "Dispatched workflow run ${RUN_ID}"
+
+      - name: Verify dispatched run resolved to captured main SHA
+        env:
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          RUN_JSON="${RUNNER_TEMP}/dispatched_run.json"
+          fetched=0
+          for _ in $(seq 1 10); do
+            if gh api \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" > "${RUN_JSON}"; then
+              fetched=1
+              break
+            fi
+            sleep 1
+          done
+          if [[ "${fetched}" != "1" ]]; then
+            echo "Could not read dispatched workflow run ${RUN_ID}" >&2
+            exit 1
+          fi
+
+          if ! RUN_JSON="${RUN_JSON}" SOURCE_SHA="${GITHUB_SHA}" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          run = json.loads(Path(os.environ["RUN_JSON"]).read_text(encoding="utf-8"))
+          expected_sha = os.environ["SOURCE_SHA"]
+          observed = {
+              "id": run.get("id"),
+              "event": run.get("event"),
+              "head_branch": run.get("head_branch"),
+              "head_sha": run.get("head_sha"),
+          }
+          if observed["event"] != "workflow_dispatch":
+              raise SystemExit(f"Unexpected dispatched event: {observed}")
+          if observed["head_branch"] != "main":
+              raise SystemExit(f"Unexpected dispatched branch: {observed}")
+          if observed["head_sha"] != expected_sha:
+              raise SystemExit(
+                  "Dispatch/main race detected: "
+                  f"expected={expected_sha} observed={observed['head_sha']}"
+              )
+          print(json.dumps(observed, sort_keys=True))
+          PY
+          then
+            gh api --method POST \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1 || true
+            echo "Cancelled mismatched dispatched run ${RUN_ID}" >&2
+            exit 1
+          fi
+
+          {
+            echo "### Kumar2024 T4 preflight dispatched"
+            echo ""
+            echo "- command source: PR #167 owner comment"
+            echo "- exact source SHA: \`${GITHUB_SHA}\`"
+            echo "- target workflow run: \`${RUN_ID}\`"
+            echo "- scientific launch inputs: none"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/NSQ_KUMAR2024_KAGGLE_GPU.md
+++ b/docs/NSQ_KUMAR2024_KAGGLE_GPU.md
@@ -147,7 +147,7 @@ completeness rules are satisfied.
 
 ## Orchestration
 
-The manual workflow is:
+The execution workflow is:
 
 `.github/workflows/nsq-kumar2024-kaggle-preflight.yml`
 
@@ -175,16 +175,62 @@ It performs the following in one provenance chain:
 The Kaggle kernel itself is
 `scripts/evidence/kaggle_kumar2024_gpu_runner.py`.
 
+## Owner-only command bridge
+
+The repository also contains a deliberately narrow orchestration bridge:
+
+`.github/workflows/nsq-kumar2024-owner-preflight-bridge.yml`
+
+It exists so an authorized repository-owner comment can trigger the already
+fixed systems preflight without exposing workflow-dispatch controls or any
+scientific parameter surface. The bridge listens only for a newly created
+comment on merged control PR `#167`, and the complete comment body must be
+exactly:
+
+```text
+/nsq-kumar2024-t4-preflight
+```
+
+Authorization is redundant by design. The comment actor, comment author and
+repository owner must all be the same account, and GitHub must report the
+comment author's association as `OWNER`. The event must refer to PR `#167`, not
+an arbitrary issue.
+
+The bridge has no Kaggle credentials and contains no subject, session, split,
+method, model-seed, budget or score inputs. Its `GITHUB_TOKEN` is limited to
+`actions: write` and `contents: read`, which are used only to inspect the current
+`main` authority, inspect existing target-workflow runs, dispatch the fixed
+preflight, verify the resulting workflow run, and cancel that run if GitHub
+resolved the dispatch to a different source SHA.
+
+The `issue_comment` event captures the latest default-branch SHA. Before
+launch, the bridge independently reads `main` and requires that SHA to remain
+identical. It then rejects:
+
+- any already queued or running T4 preflight;
+- any second successful T4 preflight for the same exact source SHA.
+
+Bridge command handling is serialized. After dispatch, the returned workflow
+run ID is read back and must report all three of:
+
+- event `workflow_dispatch`;
+- branch `main`;
+- `head_sha` exactly equal to the SHA captured by the owner-comment event.
+
+A mismatch is treated as a dispatch/main race: the bridge attempts to cancel
+the target run and fails closed. This makes the comment a control-plane action,
+not a mechanism for choosing science.
+
 ## One-time account boundary
 
-The workflow needs these GitHub Actions repository secrets:
+The execution workflow needs these GitHub Actions repository secrets:
 
 - `KAGGLE_USERNAME`
 - `KAGGLE_KEY`
 
 They are account credentials and must not be committed or pasted into issue/PR
 text. Once present, the workflow uses Kaggle's official CLI; no browser-session
-automation is needed.
+automation is needed. The owner-command bridge does not read either secret.
 
 ## Expansion gate
 
@@ -215,4 +261,5 @@ This tranche does not:
 - permit ORION comparison;
 - automatically inspect a preflight score;
 - claim CUDA numerical identity with CPU execution;
-- treat quota availability as scientific evidence.
+- treat quota availability as scientific evidence;
+- allow issue/PR comments to choose scientific execution parameters.


### PR DESCRIPTION
## Purpose

Close the remaining ChatGPT/GitHub orchestration gap for the already-promoted Kumar2024 Kaggle T4 systems preflight without adding any scientific launch controls.

Qualified base:
`main@f54a0f01d26d81c70b69910266ed653f27051228`

Exact qualified candidate:
`8d57c25cef4ca97cac927a8a161c01095ebf6e05`

This is one commit directly over the promoted base. It changes only:
- `.github/workflows/nsq-kumar2024-owner-preflight-bridge.yml` (new)
- `.github/workflows/nsq-kumar2024-gpu-cloud-ci.yml`
- `docs/NSQ_KUMAR2024_KAGGLE_GPU.md`

No scientific implementation, promoted CPU authority, CUDA binding code, worker code, preprocessing, subject/session choice, split/model seed, budget frontier, score handling, or quota semantics change.

## Owner-only command surface

The bridge listens only for a newly created comment on merged control PR #167 whose complete body is exactly:

`/nsq-kumar2024-t4-preflight`

It additionally requires:
- `github.actor == github.repository_owner`
- comment user login == repository owner
- comment author association == `OWNER`
- the event target is PR #167

Non-matching comments produce no dispatch job.

The connected GitHub action surface was independently checked against an existing connector-authored comment on PR #167; those comments are attributed to repository owner `sidhulyalkar`, so the owner guard is compatible with the intended ChatGPT-triggered path without relaxing authorization.

## No scientific inputs

The bridge contains no Kaggle credentials and no subject, session, split, method, model seed, budget, score, ranking, final-assessment, or ORION controls. It dispatches only `.github/workflows/nsq-kumar2024-kaggle-preflight.yml` with fixed `ref=main` and no workflow inputs.

## Race and duplicate protection

Before dispatch the bridge:
1. requires the issue-comment event SHA to still equal current `main`;
2. rejects any queued/running target preflight;
3. rejects a second successful target preflight for the same exact source SHA;
4. serializes bridge command handling.

After dispatch, it reads the returned workflow run and requires:
- event = `workflow_dispatch`
- branch = `main`
- `head_sha` = the exact SHA captured by the owner-comment event

If GitHub resolves the dispatch to another SHA, the bridge attempts cancellation and fails closed.

## Token boundary

The bridge uses only `actions: write` and `contents: read` on its ephemeral `GITHUB_TOKEN`. It does not receive `KAGGLE_USERNAME` or `KAGGLE_KEY`. GitHub currently documents `workflow_dispatch` as an allowed downstream workflow trigger when initiated with `GITHUB_TOKEN`.

## Exact-head qualification

Exact PR head `8d57c25cef4ca97cac927a8a161c01095ebf6e05` passed all three applicable PR workflows:

1. `NSQ Kumar2024 GPU cloud contracts` — success
2. `Public Trust Contracts` — success
3. `neurOS CI` — success

The GPU-cloud lane specifically passed:
- GPU authority tests;
- cloud-surface compilation;
- scientific score-artifact quarantine;
- free-quota/scientific-binding isolation;
- the new owner-only bridge contract proving the bridge cannot choose scientific inputs.

The complete 14-job neurOS CI matrix also succeeded, including kernel contracts on Python 3.10/3.11/3.12, source reliability on Python 3.10/3.11/3.12, model/mech-int contracts, scientific/latency gates, foundation and recording interoperability, ORION contracts/tokenization, BCI smoke, workspace wheel builds, and repository hygiene.

Pre-merge qualification guard:
- head = `8d57c25cef4ca97cac927a8a161c01095ebf6e05`
- base/current main = `f54a0f01d26d81c70b69910266ed653f27051228`
- mergeable = true
- review threads = 0
- submitted reviews = 0
- exact-head workflows = 3/3 success

## Promotion policy

Use a guarded squash merge only while the above state remains unchanged. PR evidence expires at merge: the resulting exact `main` SHA must independently pass every fresh push-triggered workflow observed for that SHA before the bridge is considered promoted or used to launch the real Kaggle T4 preflight.