### PR TITLE
test(evidence): qualify Kumar2024 GPU fleet transport without a provider

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml
@@ -1,0 +1,107 @@
+name: NSQ Kumar2024 GPU fleet synthetic transport
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py"
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_synthetic.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py"
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_synthetic.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md"
+
+permissions:
+  contents: read
+
+env:
+  QUALIFICATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  synthetic-fleet:
+    name: Synthetic fleet transport / Python ${{ matrix.python }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.QUALIFICATION_SHA }}
+      - name: Require exact clean qualification source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SHA}"
+          test -z "$(git status --porcelain)"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python }}
+          check-latest: false
+      - name: Install pinned test harness
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
+      - name: Compile synthetic transport surfaces
+        run: |
+          python -m compileall -q \
+            packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py \
+            scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            tests/test_kumar2024_gpu_fleet_synthetic.py
+      - name: Run provider-free synthetic fleet tests
+        run: python -m pytest -q tests/test_kumar2024_gpu_fleet_synthetic.py
+      - name: Exercise standalone synthetic qualification
+        run: |
+          set -euo pipefail
+          python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            --output "${RUNNER_TEMP}/synthetic-fleet"
+          test -s "${RUNNER_TEMP}/synthetic-fleet/synthetic-qualification.json"
+      - name: Require provider-free and score-blind surface
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py")
+          text = path.read_text(encoding="utf-8")
+          tree = ast.parse(text)
+          allowed = {
+              "__future__",
+              "argparse",
+              "collections.abc",
+              "hashlib",
+              "importlib.util",
+              "json",
+              "os",
+              "pathlib",
+              "sys",
+              "typing",
+          }
+          observed = set()
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  observed.update(alias.name for alias in node.names)
+              elif isinstance(node, ast.ImportFrom):
+                  observed.add(node.module or "")
+          assert observed <= allowed, sorted(observed - allowed)
+          for forbidden in (
+              "case_result.json",
+              "shard_result.json",
+              "balanced_accuracy",
+              "scientific_score",
+              "requests",
+              "kaggle",
+              "torch",
+              "subprocess",
+              "urllib",
+              "socket",
+          ):
+              assert forbidden not in text, forbidden
+          PY

--- a/docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md
+++ b/docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md
@@ -1,0 +1,168 @@
+# NSQ Kumar2024 provider-free GPU fleet qualification
+
+Status: **synthetic systems qualification only. No scientific execution is performed.**
+
+This tranche exists so the Kumar2024 GPU fleet controller can be exercised end to
+end before any Kaggle, Brev, NVIDIA, Lightning, or other external provider is
+available.
+
+It stacks on the score-blind fleet authority from #169 and does not modify the
+scientific worker, preprocessing, split authority, model implementation, model
+seeds, calibration frontier, or scientific result handling.
+
+## What it exercises
+
+The synthetic qualification runs a deterministic four-lease fleet with synthetic
+SHA-256 identities only.
+
+It proves the software path for:
+
+1. preflight admission;
+2. fleet authority construction;
+3. canonical lease ordering;
+4. persistence of immutable leases;
+5. claim-before-invocation;
+6. write-once attempt namespaces;
+7. multiple provider identities;
+8. one deliberately injected provider-preemption failure;
+9. retry only after the trusted infrastructure-failure record;
+10. accepted artifact settlement with learned-state, environment, worker, provider,
+    and accelerator identities;
+11. deterministic full-fleet settlement reconstruction;
+12. a path-independent synthetic qualification receipt.
+
+The test fleet contains four synthetic leases. One lease is deliberately attempted
+twice, so the complete qualification contains:
+
+- 4 leases;
+- 5 claims;
+- 5 attempt namespaces;
+- 1 infrastructure failure;
+- 4 accepted artifacts;
+- 0 pending leases.
+
+Two synthetic provider names are used to exercise provider/run identity semantics.
+No external provider API is called.
+
+## Determinism contract
+
+The same synthetic fleet is executed under two different filesystem roots. The
+resulting qualification receipt and settlement-ledger identity must be identical.
+
+Filesystem paths, wall-clock timestamps, temporary-directory names, process IDs,
+and runner identities are deliberately excluded from the scientific/control-plane
+identity.
+
+## Score blindness
+
+The synthetic runner contains no neural data and performs no model execution.
+
+It does not import:
+
+- PyTorch;
+- the Kumar2024 scientific worker;
+- the GPU cloud worker;
+- Kaggle;
+- requests/network clients;
+- subprocess/provider launch code.
+
+It does not read or write:
+
+- `case_result.json`;
+- `shard_result.json`;
+- balanced accuracy;
+- accuracy/loss fields;
+- predictions/probabilities;
+- method rankings;
+- final-assessment metrics.
+
+The emitted receipt explicitly preserves:
+
+- `scientific_execution_performed=false`;
+- `scientific_outcomes_inspected=false`;
+- `numerical_result_interpretable=false`;
+- `external_floor_claim_generated=false`;
+- `orion_comparison_permitted=false`.
+
+A green synthetic qualification means only that the fleet state machine behaves as
+intended under deterministic fake infrastructure events.
+
+## Why this matters before live cloud execution
+
+A GPU fleet can fail scientifically even when every model process is correct if the
+control plane permits duplicate claims, score-driven retries, stale environment
+identity, mutable attempt namespaces, provider-run reuse, or partial fleet
+completion to masquerade as complete execution.
+
+The synthetic lane attacks those orchestration semantics without spending GPU quota
+or opening scientific outcomes.
+
+That lets the eventual live transport test answer a narrower question:
+
+> Does the real provider preserve the already-qualified lease/claim/artifact
+> semantics under actual scheduling, preemption, upload, and accelerator behavior?
+
+It does not need to simultaneously debug the underlying state machine.
+
+## Qualification command
+
+```bash
+python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+  --output /tmp/kumar2024-synthetic-fleet
+```
+
+The output directory must not already exist. This preserves write-once execution
+semantics for the qualification packet.
+
+The final receipt is:
+
+```text
+/tmp/kumar2024-synthetic-fleet/synthetic-qualification.json
+```
+
+## CI contract
+
+`NSQ Kumar2024 GPU fleet synthetic transport` runs the qualification on Python
+3.10, 3.11, and 3.12 from the literal pull-request head SHA.
+
+Each lane requires:
+
+- a clean exact checkout;
+- Python compilation;
+- provider-free synthetic adversarial tests;
+- one standalone qualification execution;
+- an AST/import firewall proving the runner remains standard-library-only and does
+  not gain cloud/scientific dependencies.
+
+## Promotion boundary
+
+This synthetic tranche can be software-qualified independently of Kaggle
+credentials. It **must not** be interpreted as a substitute for the real fixed T4
+preflight or the later tiny live multi-shard transport qualification.
+
+The intended sequence remains:
+
+```text
+fleet authority software qualification
+        |
+        v
+provider-free synthetic state-machine qualification
+        |
+        v
+real fixed T4 systems preflight
+        |
+        v
+small live provider transport qualification
+        |
+        v
+freeze production 810-shard EEGNet fleet
+        |
+        v
+full execution completeness
+        |
+        v
+participant-level scientific analysis
+```
+
+No stage in this document grants efficacy, external-floor, or ORION comparison
+authority.

--- a/scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py
+++ b/scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py
@@ -1,0 +1,265 @@
+"""Provider-free end-to-end qualification for Kumar2024 GPU fleet control semantics.
+
+No neural data, model execution, predictions, scores, or external provider API is
+used. The script exercises the fleet authority as a deterministic systems state
+machine with synthetic identities only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+SYNTHETIC_RECEIPT_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_synthetic_qualification.v1"
+SYNTHETIC_PROVIDER_A = "synthetic-provider-a"
+SYNTHETIC_PROVIDER_B = "synthetic-provider-b"
+SYNTHETIC_LEASE_COUNT = 4
+
+
+def _load_fleet():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "packages"
+        / "neuros"
+        / "src"
+        / "neuros"
+        / "evidence"
+        / "kumar2024_gpu_fleet.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "neuros_kumar2024_gpu_fleet_synthetic_contract",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load Kumar2024 GPU fleet authority")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fleet = _load_fleet()
+
+
+def _sha(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identity(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        {"schema": SYNTHETIC_RECEIPT_SCHEMA, "payload": payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _write_once(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, sort_keys=True, indent=2, allow_nan=False) + "\n"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as stream:
+            fd = -1
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _synthetic_roster() -> list[dict[str, Any]]:
+    return [
+        {
+            "subject": subject,
+            "target_session": "5",
+            "split_seed": 2026,
+            "method_id": fleet.EEGNET_METHOD_ID,
+            "model_seed": 31415 + subject - 1,
+            "budgets_per_class": list(fleet.CALIBRATION_FRONTIER),
+            "shard_spec_sha256": _sha(f"synthetic-shard-{subject}"),
+        }
+        for subject in range(1, SYNTHETIC_LEASE_COUNT + 1)
+    ]
+
+
+def _accepted(claim, *, ordinal: int):
+    return fleet.ArtifactSettlementEvent(
+        claim_sha256=claim.sha256,
+        lease_sha256=claim.lease_sha256,
+        shard_spec_sha256=claim.shard_spec_sha256,
+        attempt_number=claim.attempt_number,
+        gpu_worker_receipt_sha256=_sha(
+            f"synthetic-worker-receipt-{ordinal}-{claim.attempt_number}"
+        ),
+        worker_bundle_sha256=_sha(
+            f"synthetic-worker-bundle-{ordinal}-{claim.attempt_number}"
+        ),
+        learned_state_sha256=_sha(
+            f"synthetic-learned-state-{ordinal}-{claim.attempt_number}"
+        ),
+        environment_authority_sha256=_sha("synthetic-environment-authority"),
+        provider_receipt_sha256=_sha(
+            f"synthetic-provider-receipt-{ordinal}-{claim.attempt_number}"
+        ),
+        accelerator_name="Tesla T4 (synthetic)",
+    )
+
+
+def _claim(lease, *, attempt: int, provider: str):
+    return fleet.ClaimEvent(
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=attempt,
+        worker_id=f"synthetic-worker-{lease.ordinal}-{attempt}",
+        provider=provider,
+        provider_run_id=f"synthetic-run-{lease.ordinal}-{attempt}",
+    )
+
+
+def run_synthetic_qualification(output: str | Path) -> dict[str, Any]:
+    root = Path(output).resolve()
+    root.mkdir(parents=True, exist_ok=False)
+
+    preflight = fleet.PreflightAdmission(
+        gpu_execution_authority_revision=fleet.PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        gpu_binding_sha256=_sha("synthetic-gpu-binding"),
+        execution_plan_sha256=_sha("synthetic-execution-plan"),
+        environment_authority_sha256=_sha("synthetic-environment-authority"),
+        gpu_worker_receipt_sha256=_sha("synthetic-preflight-worker-receipt"),
+        accelerator_name="Tesla T4 (synthetic)",
+        elapsed_seconds=1.0,
+    )
+    authority = fleet.FleetAuthority.from_preflight(
+        preflight,
+        expected_shard_count=SYNTHETIC_LEASE_COUNT,
+        max_attempts_per_lease=3,
+    )
+    leases = fleet.build_leases(authority, reversed(_synthetic_roster()))
+
+    for lease in leases:
+        fleet.persist_lease(root, lease)
+
+    claims = []
+    outcomes = []
+    providers = set()
+
+    for lease in leases:
+        first_provider = (
+            SYNTHETIC_PROVIDER_A if lease.ordinal % 2 == 0 else SYNTHETIC_PROVIDER_B
+        )
+        first = _claim(lease, attempt=1, provider=first_provider)
+        providers.add(first.provider)
+        fleet.persist_claim(root, lease, first)
+        attempt_root = fleet.prepare_attempt_namespace(root, first)
+        _write_once(
+            attempt_root / "provider-invocation.json",
+            {
+                "schema_version": 1,
+                "provider": first.provider,
+                "provider_run_id": first.provider_run_id,
+                "scientific_execution_performed": False,
+            },
+        )
+        claims.append(first)
+
+        if lease.ordinal == 1:
+            failure = fleet.InfrastructureFailureEvent(
+                claim_sha256=first.sha256,
+                lease_sha256=lease.sha256,
+                shard_spec_sha256=lease.shard_spec_sha256,
+                attempt_number=1,
+                failure_kind="provider_preemption",
+                failure_evidence_sha256=_sha("synthetic-provider-preemption"),
+            )
+            fleet.persist_outcome(root, failure)
+            outcomes.append(failure)
+
+            second = _claim(lease, attempt=2, provider=SYNTHETIC_PROVIDER_A)
+            providers.add(second.provider)
+            fleet.persist_claim(root, lease, second)
+            second_root = fleet.prepare_attempt_namespace(root, second)
+            _write_once(
+                second_root / "provider-invocation.json",
+                {
+                    "schema_version": 1,
+                    "provider": second.provider,
+                    "provider_run_id": second.provider_run_id,
+                    "scientific_execution_performed": False,
+                },
+            )
+            claims.append(second)
+            settlement = _accepted(second, ordinal=lease.ordinal)
+        else:
+            settlement = _accepted(first, ordinal=lease.ordinal)
+
+        fleet.persist_outcome(root, settlement)
+        outcomes.append(settlement)
+
+    ledger = fleet.reconstruct_settlement(authority, leases, claims, outcomes)
+    if not ledger["complete"]:
+        raise RuntimeError("synthetic fleet did not reach complete deterministic settlement")
+
+    payload = {
+        "schema_version": 1,
+        "artifact_kind": "provider_free_gpu_fleet_transport_qualification",
+        "fleet_authority_sha256": authority.sha256,
+        "environment_authority_sha256": authority.environment_authority_sha256,
+        "settlement_ledger_sha256": ledger["settlement_ledger_sha256"],
+        "lease_count": len(leases),
+        "claim_count": len(claims),
+        "accepted_artifact_count": ledger["accepted_artifact_count"],
+        "infrastructure_failure_count": ledger["infrastructure_failure_count"],
+        "pending_lease_count": ledger["pending_lease_count"],
+        "providers": sorted(providers),
+        "complete": True,
+        "scientific_execution_performed": False,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "claim_boundary": (
+            "synthetic systems qualification of lease/claim/retry/artifact settlement only; "
+            "no neural data, model execution, prediction, score, efficacy, or ORION evidence"
+        ),
+    }
+    receipt = {
+        **payload,
+        "synthetic_qualification_sha256": _identity(payload),
+    }
+    _write_once(root / "synthetic-qualification.json", receipt)
+    return receipt
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run provider-free Kumar2024 GPU fleet systems qualification"
+    )
+    parser.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    print(
+        json.dumps(
+            run_synthetic_qualification(args.output),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kumar2024_gpu_fleet_synthetic.py
+++ b/tests/test_kumar2024_gpu_fleet_synthetic.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "scripts"
+    / "evidence"
+    / "qualify_kumar2024_gpu_fleet_synthetic.py"
+)
+SPEC = importlib.util.spec_from_file_location("synthetic_fleet_qualification", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+qual = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = qual
+SPEC.loader.exec_module(qual)
+
+
+def test_synthetic_fleet_completes_with_one_infrastructure_retry(tmp_path: Path):
+    receipt = qual.run_synthetic_qualification(tmp_path / "run")
+    assert receipt["complete"] is True
+    assert receipt["lease_count"] == 4
+    assert receipt["claim_count"] == 5
+    assert receipt["accepted_artifact_count"] == 4
+    assert receipt["infrastructure_failure_count"] == 1
+    assert receipt["pending_lease_count"] == 0
+    assert receipt["scientific_execution_performed"] is False
+    assert receipt["scientific_outcomes_inspected"] is False
+    assert receipt["numerical_result_interpretable"] is False
+    assert receipt["orion_comparison_permitted"] is False
+
+
+def test_synthetic_receipt_is_path_and_iteration_order_independent(tmp_path: Path):
+    first = qual.run_synthetic_qualification(tmp_path / "first")
+    second = qual.run_synthetic_qualification(tmp_path / "second")
+    assert first == second
+
+
+def test_synthetic_store_has_write_once_attempt_topology_and_no_scores(tmp_path: Path):
+    root = tmp_path / "run"
+    qual.run_synthetic_qualification(root)
+
+    claims = sorted(root.glob("claims/*/attempt-*.json"))
+    attempts = sorted(root.glob("attempts/*/attempt-*"))
+    outcomes = sorted(root.glob("outcomes/*/attempt-*.json"))
+    assert len(claims) == 5
+    assert len(attempts) == 5
+    assert len(outcomes) == 5
+
+    for path in [*claims, *outcomes, root / "synthetic-qualification.json"]:
+        payload = json.loads(path.read_text())
+        text = json.dumps(payload, sort_keys=True).lower()
+        for forbidden in (
+            "balanced_accuracy",
+            '"accuracy"',
+            '"loss"',
+            "predictions",
+            "probabilities",
+            "scientific_score",
+        ):
+            assert forbidden not in text


### PR DESCRIPTION
## Purpose

Exercise the #169 score-blind GPU fleet authority end to end **without Kaggle credentials, GPU quota, neural data, model execution, or external provider APIs**.

This is a stacked software/systems qualification tranche. It exists so the state machine is tested independently before live-cloud behavior is introduced.

## Exact composition

- base: `feat/kumar2024-gpu-fleet-authority-v1@316b5b6bb6bfae332b032e665f1c9f9ecf845ff5`
- exact head: `5fa83691fd9b523756b5ecc48f4c65a2f72315d8`
- ancestry: exactly one commit over the hardened #169 head
- changed files: exactly four

Files:

1. `scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py`
2. `tests/test_kumar2024_gpu_fleet_synthetic.py`
3. `.github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml`
4. `docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md`

No fleet-authority implementation, scientific worker, GPU worker, preprocessing, model, split, seed, budget, or score-handling file changes in this stacked tranche.

## Synthetic execution graph

The qualification deterministically constructs:

- 4 synthetic EEGNet leases;
- 2 synthetic provider identities;
- 5 claims / attempt namespaces;
- 1 deliberately injected `provider_preemption` failure;
- exactly 1 retry admitted through the trusted infrastructure-failure path;
- 4 terminal accepted artifacts;
- 0 pending leases;
- one complete deterministic settlement ledger.

All identities are synthetic SHA-256 values. No scientific source bytes are opened.

## What is proven

The tranche exercises:

- preflight -> fleet authority construction;
- canonical lease ordering;
- environment authority propagation inherited from #169;
- write-once lease and claim persistence;
- claim-before-invocation;
- write-once attempt namespaces;
- provider/run identity separation;
- infrastructure-only retry admission;
- artifact-first settlement with worker/bundle/learned-state/environment/provider identities;
- complete deterministic settlement reconstruction;
- path-independent qualification receipt identity.

The same synthetic fleet is executed in two different filesystem roots and must produce an identical receipt.

## Scientific firewall

The runner imports no PyTorch, Kumar2024 worker, GPU cloud worker, Kaggle SDK, requests/network client, subprocess launcher, socket, or provider adapter.

It does not read/write `case_result.json`, `shard_result.json`, balanced accuracy, accuracy/loss, predictions, probabilities, rankings, or scientific scores.

The final receipt requires:

- `scientific_execution_performed=false`;
- `scientific_outcomes_inspected=false`;
- `numerical_result_interpretable=false`;
- `external_floor_claim_generated=false`;
- `orion_comparison_permitted=false`.

## Construction evidence

Before publication, the exact script/test payload passed Python compilation and **3/3 provider-free end-to-end tests** locally.

This is construction evidence only.

## Exact-head CI

`NSQ Kumar2024 GPU fleet synthetic transport` runs on Python 3.10 / 3.11 / 3.12 and requires:

- literal PR-head checkout and clean-tree guard;
- pinned pytest harness;
- compilation of #169 fleet authority + synthetic runner/tests;
- synthetic end-to-end tests;
- one standalone synthetic qualification execution;
- AST/import firewall preventing cloud/scientific dependencies.

## Promotion boundary

A green synthetic lane does **not** replace:

1. the real fixed Kaggle T4 preflight;
2. independent preflight receipt admission;
3. a tiny live multi-shard provider transport test;
4. production 810-shard fleet authorization.

It only proves that the provider-neutral orchestration state machine behaves correctly before provider-specific uncertainty is introduced.

Refs #165, #169.