### PR TITLE
test(evidence): independently replay Kumar2024 synthetic fleet evidence

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-fleet-replay-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-fleet-replay-ci.yml
@@ -1,0 +1,108 @@
+name: NSQ Kumar2024 GPU fleet independent replay
+
+on:
+  pull_request:
+    paths:
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_replay.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-replay-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY.md"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_replay.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-replay-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY.md"
+
+permissions:
+  contents: read
+
+env:
+  QUALIFICATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  independent-replay:
+    name: Independent fleet replay / Python ${{ matrix.python }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.QUALIFICATION_SHA }}
+      - name: Require exact clean qualification source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SHA}"
+          test -z "$(git status --porcelain)"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python }}
+          check-latest: false
+      - name: Install pinned test harness
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
+      - name: Compile replay surfaces
+        run: |
+          python -m compileall -q \
+            scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py \
+            tests/test_kumar2024_gpu_fleet_replay.py
+      - name: Run independent replay adversarial tests
+        run: python -m pytest -q tests/test_kumar2024_gpu_fleet_replay.py
+      - name: Generate and independently replay one packet
+        run: |
+          set -euo pipefail
+          python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            --output "${RUNNER_TEMP}/packet"
+          python scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py \
+            --root "${RUNNER_TEMP}/packet" \
+            > "${RUNNER_TEMP}/independent-verification.json"
+          test -s "${RUNNER_TEMP}/independent-verification.json"
+      - name: Require verifier independence
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py")
+          text = path.read_text(encoding="utf-8")
+          tree = ast.parse(text)
+          allowed = {
+              "__future__",
+              "argparse",
+              "collections.abc",
+              "hashlib",
+              "json",
+              "os",
+              "pathlib",
+              "typing",
+          }
+          observed = set()
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  observed.update(alias.name for alias in node.names)
+              elif isinstance(node, ast.ImportFrom):
+                  observed.add(node.module or "")
+          assert observed <= allowed, sorted(observed - allowed)
+          for forbidden_import in (
+              "neuros",
+              "torch",
+              "kaggle",
+              "requests",
+              "subprocess",
+              "socket",
+              "urllib",
+              "importlib",
+          ):
+              assert forbidden_import not in observed, forbidden_import
+          for forbidden_file in ("case_result.json", "shard_result.json"):
+              assert forbidden_file not in text, forbidden_file
+          PY

--- a/docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY.md
+++ b/docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY.md
@@ -1,0 +1,200 @@
+# NSQ Kumar2024 GPU fleet independent replay v1
+
+Status: **independent synthetic-evidence audit only. No scientific execution or cloud admission.**
+
+This tranche stacks above the provider-free synthetic fleet qualification in #170.
+Its purpose is to prove that a top-level `complete=true` receipt is not trusted merely
+because the same code that generated it says it is complete.
+
+The verifier is deliberately implemented as a separate standard-library-only program
+that imports neither neurOS nor the fleet/synthetic modules.
+
+## Independent authority model
+
+The verifier knows the frozen synthetic protocol, but it does not call the generator
+to derive identities. It independently reconstructs:
+
+- synthetic preflight payload and SHA-256;
+- synthetic fleet-authority payload and SHA-256;
+- all four canonical leases and lease SHA-256 identities;
+- all five claims and claim SHA-256 identities;
+- the one infrastructure-failure outcome;
+- all four artifact-settlement outcomes;
+- provider/run invocation identities;
+- settlement-ledger identity;
+- final synthetic qualification receipt identity.
+
+All identities use the same explicit domain-separated schemas as the authority layer,
+but the implementation is independent.
+
+## Closed evidence packet
+
+The synthetic evidence root is treated as a closed packet rather than an open working
+directory.
+
+Verification requires the exact expected file **and directory** topology:
+
+```text
+leases/
+claims/
+attempts/
+outcomes/
+synthetic-qualification.json
+```
+
+Each expected lease, claim, attempt invocation, and outcome path must exist exactly
+once. Any missing file, unexpected shadow file, unexpected empty directory, or
+symlink causes rejection.
+
+This means an operator cannot delete an inconvenient terminal artifact, add a shadow
+retry, or smuggle a second receipt into the packet while retaining the original
+`complete=true` envelope.
+
+## JSON and cryptographic hygiene
+
+Every JSON object is parsed with:
+
+- duplicate-key rejection;
+- non-finite-number rejection;
+- UTF-8 decoding;
+- recursive scientific-field firewalling.
+
+For each sealed lease, claim, infrastructure failure, and artifact settlement, the
+verifier removes the declared identity field and recomputes the domain-separated
+SHA-256 from the remaining canonical payload.
+
+The declared identity must match both:
+
+1. the recomputed object contents; and
+2. the independently derived frozen synthetic protocol.
+
+Changing a persisted body while leaving its old SHA field in place therefore fails.
+Freshly resealing a different synthetic event also fails because it is not part of
+the independently preregistered packet.
+
+## Independent retry replay
+
+The verifier does not infer success from file counts alone. It independently replays
+the lease/claim/outcome graph and requires:
+
+- attempts contiguous from 1;
+- no attempt after an accepted artifact;
+- the second attempt only after the exact first-attempt infrastructure failure;
+- `valid_worker_artifact_exists=false` for retry authority;
+- every accepted artifact bound to the expected claim;
+- every lease to terminate with one accepted artifact;
+- no pending lease.
+
+Only then is the settlement-ledger SHA reconstructed.
+
+## Final receipt verification
+
+After the store independently earns complete settlement, the verifier reconstructs
+the expected top-level receipt from the replayed evidence and requires exact equality
+with `synthetic-qualification.json`.
+
+It then recomputes `synthetic_qualification_sha256` independently.
+
+A receipt that says four artifacts were accepted when the packet contains three, or
+that names another fleet/ledger/environment identity, is rejected.
+
+## Scientific firewall
+
+The independent verifier has no imports from:
+
+- neurOS;
+- PyTorch;
+- Kaggle;
+- cloud/provider SDKs;
+- networking clients;
+- subprocess launchers;
+- model/scientific result code.
+
+It never reads:
+
+- `case_result.json`;
+- `shard_result.json`;
+- predictions;
+- probabilities;
+- accuracy or balanced accuracy;
+- loss;
+- scientific rankings.
+
+Its successful output preserves only systems identities/counts and:
+
+- `scientific_execution_performed=false`;
+- `scientific_outcomes_inspected=false`;
+- `numerical_result_interpretable=false`;
+- `orion_comparison_permitted=false`.
+
+## Adversarial qualification
+
+The replay tests require rejection of:
+
+1. a mutated persisted claim;
+2. a mutated learned-state identity in an accepted artifact;
+3. a missing outcome;
+4. an extra shadow file;
+5. a modified top-level receipt;
+6. duplicate JSON object keys;
+7. symlink injection.
+
+The positive path must independently reproduce the exact generator receipt and
+settlement-ledger SHA.
+
+## Usage
+
+Generate the provider-free packet:
+
+```bash
+python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+  --output /tmp/kumar2024-synthetic-fleet
+```
+
+Then verify it with the independent program:
+
+```bash
+python scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py \
+  --root /tmp/kumar2024-synthetic-fleet
+```
+
+## What this does not prove
+
+Independent synthetic replay does not prove:
+
+- Kaggle credentials or quota are available;
+- a real T4 worker launches;
+- provider artifact upload is reliable;
+- a real learned state matches a scientific worker bundle;
+- 810 EEGNet shards can complete economically;
+- any model is accurate;
+- any external baseline is established;
+- ORION comparison is permitted.
+
+It removes one narrower risk: the same orchestration code cannot generate a packet and
+then self-certify an inconsistent packet without an independent deterministic replay
+catching the inconsistency.
+
+## Gate sequence
+
+```text
+#169 fleet authority software qualification
+        |
+        v
+#170 provider-free synthetic state-machine qualification
+        |
+        v
+independent synthetic packet replay (this tranche)
+        |
+        v
+real fixed T4 preflight
+        |
+        v
+small live multi-shard provider transport
+        |
+        v
+production EEGNet fleet freeze/execution
+```
+
+This stage is systems/software evidence only and does not raise the scientific claim
+ceiling.

--- a/scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py
+++ b/scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py
@@ -1,0 +1,579 @@
+"""Independent verifier for the provider-free Kumar2024 GPU fleet packet.
+
+This verifier intentionally does not import neurOS, the fleet authority module,
+the synthetic runner, model code, provider SDKs, or scientific-result code.
+It derives the frozen synthetic protocol independently and verifies the complete
+on-disk evidence graph before accepting the top-level receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+FLEET_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_authority.v1"
+PREFLIGHT_SCHEMA = "neuros.nsq_kumar2024_gpu_preflight_admission.v1"
+LEASE_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_lease.v1"
+CLAIM_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_claim.v1"
+FAILURE_SCHEMA = "neuros.nsq_kumar2024_gpu_infrastructure_failure.v1"
+SETTLEMENT_SCHEMA = "neuros.nsq_kumar2024_gpu_artifact_settlement.v1"
+LEDGER_SCHEMA = "neuros.nsq_kumar2024_gpu_settlement_ledger.v1"
+SYNTHETIC_RECEIPT_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_synthetic_qualification.v1"
+
+PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION = "07a6c5fa5f212d54aae408237f14bb56f2f6eee9"
+EEGNET_METHOD_ID = "braindecode-eegnet"
+CALIBRATION_FRONTIER = [0, 1, 2, 5, 10]
+MAX_ATTEMPTS = 3
+LEASE_COUNT = 4
+PROVIDER_A = "synthetic-provider-a"
+PROVIDER_B = "synthetic-provider-b"
+ALLOWED_INFRASTRUCTURE_FAILURES = [
+    "provider_preemption",
+    "provider_timeout",
+    "node_loss",
+    "bootstrap_failure",
+    "environment_mismatch",
+    "artifact_upload_failure",
+]
+PROVIDER_SELECTION_BASIS = [
+    "wall_clock_seconds",
+    "provider_cost",
+    "provider_availability",
+    "accelerator_identity",
+    "environment_identity",
+]
+FORBIDDEN_SCIENTIFIC_KEYS = frozenset(
+    {
+        "accuracy",
+        "balanced_accuracy",
+        "auc",
+        "auroc",
+        "f1",
+        "loss",
+        "logits",
+        "method_ranking",
+        "predictions",
+        "probabilities",
+        "scientific_score",
+        "final_assessment_metric",
+    }
+)
+CLAIM_BOUNDARY = (
+    "synthetic systems qualification of lease/claim/retry/artifact settlement only; "
+    "no neural data, model execution, prediction, score, efficacy, or ORION evidence"
+)
+
+
+def _canonical(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _identity(schema: str, payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical({"schema": schema, "payload": payload})).hexdigest()
+
+
+def _label_sha(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _bad_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number is forbidden: {value}")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_object_pairs,
+            parse_constant=_bad_constant,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot decode JSON evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"evidence must be a JSON object: {path}")
+    _reject_scientific_fields(value)
+    return value
+
+
+def _reject_scientific_fields(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"non-string key at {path}")
+            if key.lower() in FORBIDDEN_SCIENTIFIC_KEYS:
+                raise ValueError(f"scientific field {key!r} is forbidden at {path}")
+            _reject_scientific_fields(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_scientific_fields(item, f"{path}[{index}]")
+
+
+def _preflight_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "gpu_execution_authority_revision": PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        "gpu_binding_sha256": _label_sha("synthetic-gpu-binding"),
+        "execution_plan_sha256": _label_sha("synthetic-execution-plan"),
+        "environment_authority_sha256": _label_sha("synthetic-environment-authority"),
+        "gpu_worker_receipt_sha256": _label_sha("synthetic-preflight-worker-receipt"),
+        "accelerator_name": "Tesla T4 (synthetic)",
+        "elapsed_seconds": 1.0,
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "admission_inputs": list(PROVIDER_SELECTION_BASIS),
+    }
+
+
+def _fleet_payload() -> dict[str, Any]:
+    preflight_sha = _identity(PREFLIGHT_SCHEMA, _preflight_payload())
+    return {
+        "schema_version": 1,
+        "artifact_kind": "score_blind_gpu_fleet_execution_authority",
+        "preflight_admission_sha256": preflight_sha,
+        "gpu_execution_authority_revision": PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        "gpu_binding_sha256": _label_sha("synthetic-gpu-binding"),
+        "execution_plan_sha256": _label_sha("synthetic-execution-plan"),
+        "environment_authority_sha256": _label_sha("synthetic-environment-authority"),
+        "expected_shard_count": LEASE_COUNT,
+        "max_attempts_per_lease": MAX_ATTEMPTS,
+        "method_id": EEGNET_METHOD_ID,
+        "budgets_per_class": list(CALIBRATION_FRONTIER),
+        "allowed_infrastructure_failures": list(ALLOWED_INFRASTRUCTURE_FAILURES),
+        "provider_selection_basis": list(PROVIDER_SELECTION_BASIS),
+        "scientific_outcome_may_control_retry": False,
+        "scientific_outcome_may_control_provider_selection": False,
+        "orion_comparison_permitted": False,
+    }
+
+
+def _expected_leases() -> list[dict[str, Any]]:
+    fleet_sha = _identity(FLEET_SCHEMA, _fleet_payload())
+    result = []
+    for ordinal, subject in enumerate(range(1, LEASE_COUNT + 1)):
+        payload = {
+            "schema_version": 1,
+            "fleet_authority_sha256": fleet_sha,
+            "gpu_binding_sha256": _label_sha("synthetic-gpu-binding"),
+            "execution_plan_sha256": _label_sha("synthetic-execution-plan"),
+            "environment_authority_sha256": _label_sha("synthetic-environment-authority"),
+            "shard_spec_sha256": _label_sha(f"synthetic-shard-{subject}"),
+            "ordinal": ordinal,
+            "subject": subject,
+            "target_session": "5",
+            "split_seed": 2026,
+            "method_id": EEGNET_METHOD_ID,
+            "model_seed": 31415 + subject - 1,
+            "budgets_per_class": list(CALIBRATION_FRONTIER),
+            "max_attempts": MAX_ATTEMPTS,
+        }
+        result.append({**payload, "lease_sha256": _identity(LEASE_SCHEMA, payload)})
+    return result
+
+
+def _claim_payload(lease: dict[str, Any], attempt: int, provider: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "event_type": "claim",
+        "lease_sha256": lease["lease_sha256"],
+        "shard_spec_sha256": lease["shard_spec_sha256"],
+        "attempt_number": attempt,
+        "worker_id": f"synthetic-worker-{lease['ordinal']}-{attempt}",
+        "provider": provider,
+        "provider_run_id": f"synthetic-run-{lease['ordinal']}-{attempt}",
+    }
+
+
+def _expected_claims(leases: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    result = []
+    for lease in leases:
+        provider = PROVIDER_A if lease["ordinal"] % 2 == 0 else PROVIDER_B
+        payload = _claim_payload(lease, 1, provider)
+        result.append({**payload, "claim_sha256": _identity(CLAIM_SCHEMA, payload)})
+        if lease["ordinal"] == 1:
+            payload = _claim_payload(lease, 2, PROVIDER_A)
+            result.append({**payload, "claim_sha256": _identity(CLAIM_SCHEMA, payload)})
+    return result
+
+
+def _failure_payload(claim: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "event_type": "infrastructure_failure",
+        "claim_sha256": claim["claim_sha256"],
+        "lease_sha256": claim["lease_sha256"],
+        "shard_spec_sha256": claim["shard_spec_sha256"],
+        "attempt_number": 1,
+        "failure_kind": "provider_preemption",
+        "failure_evidence_sha256": _label_sha("synthetic-provider-preemption"),
+        "valid_worker_artifact_exists": False,
+    }
+
+
+def _settlement_payload(claim: dict[str, Any], ordinal: int) -> dict[str, Any]:
+    attempt = claim["attempt_number"]
+    return {
+        "schema_version": 1,
+        "event_type": "artifact_settlement",
+        "claim_sha256": claim["claim_sha256"],
+        "lease_sha256": claim["lease_sha256"],
+        "shard_spec_sha256": claim["shard_spec_sha256"],
+        "attempt_number": attempt,
+        "gpu_worker_receipt_sha256": _label_sha(
+            f"synthetic-worker-receipt-{ordinal}-{attempt}"
+        ),
+        "worker_bundle_sha256": _label_sha(
+            f"synthetic-worker-bundle-{ordinal}-{attempt}"
+        ),
+        "learned_state_sha256": _label_sha(
+            f"synthetic-learned-state-{ordinal}-{attempt}"
+        ),
+        "environment_authority_sha256": _label_sha("synthetic-environment-authority"),
+        "provider_receipt_sha256": _label_sha(
+            f"synthetic-provider-receipt-{ordinal}-{attempt}"
+        ),
+        "accelerator_name": "Tesla T4 (synthetic)",
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+    }
+
+
+def _expected_outcomes(
+    leases: Sequence[dict[str, Any]], claims: Sequence[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    claims_by_slot = {
+        (claim["lease_sha256"], claim["attempt_number"]): claim for claim in claims
+    }
+    result = []
+    for lease in leases:
+        if lease["ordinal"] == 1:
+            first = claims_by_slot[(lease["lease_sha256"], 1)]
+            failure = _failure_payload(first)
+            result.append(
+                {**failure, "outcome_sha256": _identity(FAILURE_SCHEMA, failure)}
+            )
+            terminal = claims_by_slot[(lease["lease_sha256"], 2)]
+        else:
+            terminal = claims_by_slot[(lease["lease_sha256"], 1)]
+        settlement = _settlement_payload(terminal, lease["ordinal"])
+        result.append(
+            {**settlement, "outcome_sha256": _identity(SETTLEMENT_SCHEMA, settlement)}
+        )
+    return result
+
+
+def _expected_invocation(claim: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "provider": claim["provider"],
+        "provider_run_id": claim["provider_run_id"],
+        "scientific_execution_performed": False,
+    }
+
+
+def _managed_topology(
+    leases: Sequence[dict[str, Any]],
+    claims: Sequence[dict[str, Any]],
+) -> tuple[set[str], set[str]]:
+    files = {"synthetic-qualification.json"}
+    directories = {"leases", "claims", "outcomes", "attempts"}
+    for lease in leases:
+        lease_sha = lease["lease_sha256"]
+        files.add(f"leases/{lease_sha}.json")
+        for prefix in ("claims", "outcomes", "attempts"):
+            directories.add(f"{prefix}/{lease_sha}")
+    for claim in claims:
+        lease_sha = claim["lease_sha256"]
+        attempt = claim["attempt_number"]
+        files.add(f"claims/{lease_sha}/attempt-{attempt:04d}.json")
+        files.add(f"outcomes/{lease_sha}/attempt-{attempt:04d}.json")
+        attempt_dir = (
+            f"attempts/{lease_sha}/"
+            f"attempt-{attempt:04d}-{claim['claim_sha256'][:16]}"
+        )
+        directories.add(attempt_dir)
+        files.add(f"{attempt_dir}/provider-invocation.json")
+    return files, directories
+
+
+def _walk_topology(root: Path) -> tuple[set[str], set[str]]:
+    files: set[str] = set()
+    directories: set[str] = set()
+    for current, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        for name in list(dirnames):
+            path = current_path / name
+            if path.is_symlink():
+                raise ValueError(f"symlink directory is forbidden: {path}")
+            directories.add(path.relative_to(root).as_posix())
+        for name in filenames:
+            path = current_path / name
+            if path.is_symlink():
+                raise ValueError(f"symlink file is forbidden: {path}")
+            files.add(path.relative_to(root).as_posix())
+    return files, directories
+
+
+def _require_exact(
+    path: Path,
+    expected: dict[str, Any],
+    identity_field: str,
+    schema: str,
+) -> None:
+    observed = _load_json(path)
+    if observed != expected:
+        raise ValueError(f"evidence differs from frozen protocol: {path}")
+    declared = observed.get(identity_field)
+    payload = dict(observed)
+    payload.pop(identity_field, None)
+    recomputed = _identity(schema, payload)
+    if declared != recomputed:
+        raise ValueError(f"{identity_field} does not match record contents: {path}")
+
+
+def _reconstruct_ledger(
+    leases: Sequence[dict[str, Any]],
+    claims: Sequence[dict[str, Any]],
+    outcomes: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    accepted = [item for item in outcomes if item["event_type"] == "artifact_settlement"]
+    failures = [item for item in outcomes if item["event_type"] == "infrastructure_failure"]
+    claim_by_slot = {
+        (item["lease_sha256"], item["attempt_number"]): item for item in claims
+    }
+    outcome_by_claim = {item["claim_sha256"]: item for item in outcomes}
+
+    pending: set[str] = set()
+    for lease in leases:
+        lease_claims = sorted(
+            (
+                claim
+                for (lease_sha, _), claim in claim_by_slot.items()
+                if lease_sha == lease["lease_sha256"]
+            ),
+            key=lambda item: item["attempt_number"],
+        )
+        attempts = [item["attempt_number"] for item in lease_claims]
+        if attempts != list(range(1, len(attempts) + 1)):
+            raise ValueError("attempts are not contiguous")
+        artifact_seen = False
+        for index, claim in enumerate(lease_claims):
+            if artifact_seen:
+                raise ValueError("attempt exists after accepted artifact")
+            if index:
+                prior = outcome_by_claim.get(lease_claims[index - 1]["claim_sha256"])
+                if prior is None or prior["event_type"] != "infrastructure_failure":
+                    raise ValueError("retry lacks trusted infrastructure failure")
+                if prior.get("valid_worker_artifact_exists") is not False:
+                    raise ValueError("retry follows a valid worker artifact")
+            outcome = outcome_by_claim.get(claim["claim_sha256"])
+            if outcome is None:
+                pending.add(lease["lease_sha256"])
+            elif outcome["event_type"] == "artifact_settlement":
+                artifact_seen = True
+        if not artifact_seen:
+            pending.add(lease["lease_sha256"])
+
+    complete = len(accepted) == LEASE_COUNT and not pending
+    payload = {
+        "schema_version": 1,
+        "fleet_authority_sha256": _identity(FLEET_SCHEMA, _fleet_payload()),
+        "environment_authority_sha256": _label_sha("synthetic-environment-authority"),
+        "expected_lease_count": LEASE_COUNT,
+        "lease_sha256s": [item["lease_sha256"] for item in leases],
+        "claim_sha256s": sorted(item["claim_sha256"] for item in claims),
+        "outcome_sha256s": sorted(item["outcome_sha256"] for item in outcomes),
+        "accepted_artifact_count": len(accepted),
+        "infrastructure_failure_count": len(failures),
+        "pending_lease_count": len(pending),
+        "complete": complete,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "orion_comparison_permitted": False,
+    }
+    return {**payload, "settlement_ledger_sha256": _identity(LEDGER_SCHEMA, payload)}
+
+
+def verify_synthetic_store(root: str | Path) -> dict[str, Any]:
+    supplied = Path(root)
+    if supplied.is_symlink():
+        raise ValueError("synthetic evidence root may not be a symlink")
+    root_path = supplied.resolve()
+    if not root_path.is_dir():
+        raise FileNotFoundError(f"synthetic evidence root is not a directory: {root_path}")
+
+    leases = _expected_leases()
+    claims = _expected_claims(leases)
+    outcomes = _expected_outcomes(leases, claims)
+    expected_files, expected_directories = _managed_topology(leases, claims)
+    files, directories = _walk_topology(root_path)
+    if files != expected_files:
+        raise ValueError(
+            f"synthetic evidence file topology differs: "
+            f"missing={sorted(expected_files - files)}, extra={sorted(files - expected_files)}"
+        )
+    if directories != expected_directories:
+        raise ValueError(
+            f"synthetic evidence directory topology differs: "
+            f"missing={sorted(expected_directories - directories)}, "
+            f"extra={sorted(directories - expected_directories)}"
+        )
+
+    for lease in leases:
+        _require_exact(
+            root_path / "leases" / f"{lease['lease_sha256']}.json",
+            lease,
+            "lease_sha256",
+            LEASE_SCHEMA,
+        )
+
+    claims_by_slot = {}
+    for claim in claims:
+        claims_by_slot[(claim["lease_sha256"], claim["attempt_number"])] = claim
+        _require_exact(
+            root_path
+            / "claims"
+            / claim["lease_sha256"]
+            / f"attempt-{claim['attempt_number']:04d}.json",
+            claim,
+            "claim_sha256",
+            CLAIM_SCHEMA,
+        )
+        invocation_path = (
+            root_path
+            / "attempts"
+            / claim["lease_sha256"]
+            / (
+                f"attempt-{claim['attempt_number']:04d}-"
+                f"{claim['claim_sha256'][:16]}"
+            )
+            / "provider-invocation.json"
+        )
+        if _load_json(invocation_path) != _expected_invocation(claim):
+            raise ValueError(f"provider invocation differs from claim: {invocation_path}")
+
+    outcomes_by_slot = {
+        (item["lease_sha256"], item["attempt_number"]): item for item in outcomes
+    }
+    for slot, claim in claims_by_slot.items():
+        outcome = outcomes_by_slot.get(slot)
+        if outcome is None:
+            raise ValueError(f"missing terminal outcome for claim slot {slot}")
+        schema = (
+            FAILURE_SCHEMA
+            if outcome["event_type"] == "infrastructure_failure"
+            else SETTLEMENT_SCHEMA
+        )
+        _require_exact(
+            root_path
+            / "outcomes"
+            / outcome["lease_sha256"]
+            / f"attempt-{outcome['attempt_number']:04d}.json",
+            outcome,
+            "outcome_sha256",
+            schema,
+        )
+        if outcome["claim_sha256"] != claim["claim_sha256"]:
+            raise ValueError("outcome does not bind exact claim identity")
+
+    ledger = _reconstruct_ledger(leases, claims, outcomes)
+    if not ledger["complete"]:
+        raise ValueError("persisted synthetic evidence does not earn complete settlement")
+
+    receipt_payload = {
+        "schema_version": 1,
+        "artifact_kind": "provider_free_gpu_fleet_transport_qualification",
+        "fleet_authority_sha256": _identity(FLEET_SCHEMA, _fleet_payload()),
+        "environment_authority_sha256": _label_sha("synthetic-environment-authority"),
+        "settlement_ledger_sha256": ledger["settlement_ledger_sha256"],
+        "lease_count": LEASE_COUNT,
+        "claim_count": len(claims),
+        "accepted_artifact_count": ledger["accepted_artifact_count"],
+        "infrastructure_failure_count": ledger["infrastructure_failure_count"],
+        "pending_lease_count": ledger["pending_lease_count"],
+        "providers": sorted({item["provider"] for item in claims}),
+        "complete": True,
+        "scientific_execution_performed": False,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    expected_receipt = {
+        **receipt_payload,
+        "synthetic_qualification_sha256": _identity(
+            SYNTHETIC_RECEIPT_SCHEMA, receipt_payload
+        ),
+    }
+    receipt_path = root_path / "synthetic-qualification.json"
+    observed_receipt = _load_json(receipt_path)
+    if observed_receipt != expected_receipt:
+        raise ValueError(
+            "synthetic qualification receipt differs from independently replayed store"
+        )
+    payload = dict(observed_receipt)
+    declared = payload.pop("synthetic_qualification_sha256")
+    if _identity(SYNTHETIC_RECEIPT_SCHEMA, payload) != declared:
+        raise ValueError("synthetic qualification receipt SHA does not match contents")
+
+    return {
+        "verified": True,
+        "synthetic_qualification_sha256": declared,
+        "fleet_authority_sha256": receipt_payload["fleet_authority_sha256"],
+        "settlement_ledger_sha256": ledger["settlement_ledger_sha256"],
+        "lease_count": LEASE_COUNT,
+        "claim_count": len(claims),
+        "accepted_artifact_count": len(
+            [item for item in outcomes if item["event_type"] == "artifact_settlement"]
+        ),
+        "infrastructure_failure_count": len(
+            [item for item in outcomes if item["event_type"] == "infrastructure_failure"]
+        ),
+        "complete": True,
+        "scientific_execution_performed": False,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "orion_comparison_permitted": False,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Independently verify provider-free Kumar2024 GPU fleet evidence"
+    )
+    parser.add_argument("--root", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    print(json.dumps(verify_synthetic_store(args.root), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kumar2024_gpu_fleet_replay.py
+++ b/tests/test_kumar2024_gpu_fleet_replay.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+RUNNER_PATH = ROOT / "scripts" / "evidence" / "qualify_kumar2024_gpu_fleet_synthetic.py"
+VERIFIER_PATH = ROOT / "scripts" / "evidence" / "verify_kumar2024_gpu_fleet_synthetic.py"
+
+
+def load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runner = load("synthetic_fleet_runner_for_verifier", RUNNER_PATH)
+verifier = load("synthetic_fleet_independent_verifier", VERIFIER_PATH)
+
+
+def make_store(tmp_path: Path) -> tuple[Path, dict]:
+    root = tmp_path / "packet"
+    receipt = runner.run_synthetic_qualification(root)
+    return root, receipt
+
+
+def test_independent_verifier_replays_complete_store(tmp_path: Path):
+    root, receipt = make_store(tmp_path)
+    checked = verifier.verify_synthetic_store(root)
+    assert checked["verified"] is True
+    assert checked["complete"] is True
+    assert checked["synthetic_qualification_sha256"] == receipt[
+        "synthetic_qualification_sha256"
+    ]
+    assert checked["settlement_ledger_sha256"] == receipt["settlement_ledger_sha256"]
+    assert checked["lease_count"] == 4
+    assert checked["claim_count"] == 5
+    assert checked["accepted_artifact_count"] == 4
+    assert checked["infrastructure_failure_count"] == 1
+    assert checked["scientific_outcomes_inspected"] is False
+    assert checked["orion_comparison_permitted"] is False
+
+
+def test_independent_verifier_rejects_tampered_claim(tmp_path: Path):
+    root, _ = make_store(tmp_path)
+    path = sorted(root.glob("claims/*/attempt-*.json"))[0]
+    payload = json.loads(path.read_text())
+    payload["provider_run_id"] = "shadow-provider-run"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="frozen protocol"):
+        verifier.verify_synthetic_store(root)
+
+
+def test_independent_verifier_rejects_tampered_artifact(tmp_path: Path):
+    root, _ = make_store(tmp_path)
+    for path in sorted(root.glob("outcomes/*/attempt-*.json")):
+        payload = json.loads(path.read_text())
+        if payload["event_type"] == "artifact_settlement":
+            payload["learned_state_sha256"] = "0" * 64
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            break
+    else:
+        raise AssertionError("expected artifact settlement")
+    with pytest.raises(ValueError, match="frozen protocol"):
+        verifier.verify_synthetic_store(root)
+
+
+def test_independent_verifier_rejects_missing_and_extra_records(tmp_path: Path):
+    root, _ = make_store(tmp_path)
+    outcome = sorted(root.glob("outcomes/*/attempt-*.json"))[0]
+    outcome.unlink()
+    with pytest.raises(ValueError, match="file topology differs"):
+        verifier.verify_synthetic_store(root)
+
+    root2, _ = make_store(tmp_path / "second")
+    extra = root2 / "outcomes" / "shadow.json"
+    extra.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError, match="file topology differs"):
+        verifier.verify_synthetic_store(root2)
+
+
+def test_independent_verifier_rejects_receipt_tamper(tmp_path: Path):
+    root, _ = make_store(tmp_path)
+    path = root / "synthetic-qualification.json"
+    payload = json.loads(path.read_text())
+    payload["accepted_artifact_count"] = 3
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="independently replayed store"):
+        verifier.verify_synthetic_store(root)
+
+
+def test_independent_verifier_rejects_duplicate_json_keys(tmp_path: Path):
+    root, _ = make_store(tmp_path)
+    path = sorted(root.glob("attempts/*/attempt-*/provider-invocation.json"))[0]
+    original = json.loads(path.read_text())
+    path.write_text(
+        "{"
+        '"schema_version":1,'
+        f'"provider":{json.dumps(original["provider"])},'
+        f'"provider":{json.dumps(original["provider"])},'
+        f'"provider_run_id":{json.dumps(original["provider_run_id"])},'
+        '"scientific_execution_performed":false'
+        "}",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        verifier.verify_synthetic_store(root)
+
+
+def test_independent_verifier_rejects_symlink_injection(tmp_path: Path):
+    root, _ = make_store(tmp_path)
+    target = root / "synthetic-qualification.json"
+    link = root / "shadow-link.json"
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+    with pytest.raises(ValueError, match="symlink file is forbidden"):
+        verifier.verify_synthetic_store(root)


### PR DESCRIPTION
## Purpose

Independently audit the complete provider-free Kumar2024 GPU fleet evidence packet produced by #170 without importing neurOS, the fleet authority module, the synthetic runner, model code, provider SDKs, or scientific-result code.

This is a stacked verification tranche. It does not modify #169 fleet semantics or #170 generation semantics.

## Exact composition

- base: `test/kumar2024-gpu-fleet-synthetic-v1@5fa83691fd9b523756b5ecc48f4c65a2f72315d8`
- exact head: `1e6f78e70e5908e4575f833a8e2f495213aae417`
- ancestry: exactly one commit over the fully green #170 head
- changed files: exactly four

Files:

1. `scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py`
2. `tests/test_kumar2024_gpu_fleet_replay.py`
3. `.github/workflows/nsq-kumar2024-gpu-fleet-replay-ci.yml`
4. `docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY.md`

## Independent derivation

The verifier hard-codes only the frozen synthetic protocol vocabulary/identities and independently derives:

- preflight payload and SHA;
- fleet authority payload and SHA;
- all four canonical lease payloads/SHAs;
- all five claim payloads/SHAs;
- the one infrastructure failure;
- all four artifact settlements;
- provider invocation envelopes;
- deterministic settlement-ledger SHA;
- final synthetic qualification receipt SHA.

It does not call generator/fleet functions to obtain expected identities.

## Closed packet topology

The evidence root is treated as a closed packet. Verification requires the exact expected files **and directories** under:

- `leases/`
- `claims/`
- `attempts/`
- `outcomes/`
- `synthetic-qualification.json`

Missing records, shadow files, unexpected empty directories, and symlinks reject.

## Cryptographic replay

JSON parsing rejects duplicate keys and non-finite numbers. Every sealed lease/claim/outcome has its domain-separated SHA recomputed from contents and is also compared with the independently derived protocol object.

The verifier independently replays retry legality and fleet completeness before reconstructing the settlement ledger. Only after the persisted packet independently earns complete settlement is the top-level receipt reconstructed and checked.

## Adversarial coverage

Tests require rejection of:

1. mutated persisted claim;
2. mutated learned-state identity in an accepted artifact;
3. missing outcome;
4. extra shadow record;
5. top-level receipt tamper;
6. duplicate JSON keys;
7. symlink injection.

Positive replay must reproduce the generator's exact synthetic qualification SHA and settlement-ledger SHA.

## Independence firewall

The verifier is standard-library only. CI AST-audits its imports and forbids neurOS, PyTorch, Kaggle, requests, subprocess, socket, urllib, importlib, and scientific result-file coupling.

It never reads predictions, probabilities, balanced accuracy, accuracy/loss, rankings, or scientific scores.

Successful verification remains systems evidence only:

- `scientific_execution_performed=false`
- `scientific_outcomes_inspected=false`
- `numerical_result_interpretable=false`
- `orion_comparison_permitted=false`

## Exact-head qualification

New `NSQ Kumar2024 GPU fleet independent replay` runs on Python 3.10 / 3.11 / 3.12 with exact clean-source checkout, compilation, adversarial replay tests, one standalone generation+independent-verification cycle, and the independence firewall.

No evidence from a superseded SHA is inherited.

## Promotion boundary

This independent replay does not replace the real fixed T4 preflight, its systems-only admission, or the later tiny live provider transport qualification. It only proves that an inconsistent synthetic packet cannot self-certify through the same implementation that generated it.

Refs #165, #169, #170.