### PR TITLE
feat(evidence): add score-blind Kumar2024 external admission

### DIFF
--- a/.github/workflows/nsq-kumar2024-external-admission-ci.yml
+++ b/.github/workflows/nsq-kumar2024-external-admission-ci.yml
@@ -1,0 +1,88 @@
+name: NSQ Kumar2024 external admission contracts
+
+on:
+  pull_request:
+    paths:
+      - "scripts/evidence/verify_kumar2024_external_qualification.py"
+      - "scripts/evidence/admit_kumar2024_external_qualification.py"
+      - "tests/test_kumar2024_external_qualification_admission.py"
+      - ".github/workflows/nsq-kumar2024-external-admission-ci.yml"
+      - "docs/NSQ_KUMAR2024_EXTERNAL_ADMISSION.md"
+
+permissions:
+  contents: read
+
+jobs:
+  admission-contracts:
+    name: External admission contracts / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    env:
+      QUALIFICATION_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.QUALIFICATION_SHA }}
+          persist-credentials: false
+      - name: Require exact clean qualification source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SHA}"
+          test -z "$(git status --porcelain)"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pinned test harness
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check \
+            "pytest==9.1.1" "pytest-asyncio==1.4.0"
+      - name: Compile verifier and admission surfaces
+        run: |
+          python -m compileall -q \
+            scripts/evidence/verify_kumar2024_external_qualification.py \
+            scripts/evidence/admit_kumar2024_external_qualification.py \
+            tests/test_kumar2024_external_qualification_admission.py
+      - name: Run score-blind admission adversarial tests
+        run: python -m pytest -q tests/test_kumar2024_external_qualification_admission.py
+      - name: Enforce admission dependency and scientific-result firewall
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("scripts/evidence/admit_kumar2024_external_qualification.py")
+          text = path.read_text(encoding="utf-8")
+          tree = ast.parse(text)
+          allowed = {
+              "__future__",
+              "argparse",
+              "collections.abc",
+              "hashlib",
+              "importlib.util",
+              "json",
+              "os",
+              "pathlib",
+              "sys",
+              "typing",
+          }
+          observed = set()
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  observed.update(alias.name for alias in node.names)
+              elif isinstance(node, ast.ImportFrom):
+                  observed.add(node.module or "")
+          assert observed <= allowed, sorted(observed - allowed)
+          for forbidden in (
+              "case_result.json",
+              "shard_result.json",
+              "balanced_accuracy",
+              "scientific_score",
+              "final_assessment_metric",
+              "torch",
+          ):
+              assert forbidden not in text, forbidden
+          PY

--- a/docs/NSQ_KUMAR2024_EXTERNAL_ADMISSION.md
+++ b/docs/NSQ_KUMAR2024_EXTERNAL_ADMISSION.md
@@ -1,0 +1,126 @@
+# NSQ Kumar2024 external systems admission
+
+Status: **score-blind admission contract. No efficacy, fleet, or ORION claim.**
+
+This layer sits after the independent verifier from PR #163. It exists so a successful real external classical-worker qualification can be accepted mechanically without a human or controller opening score-bearing worker files.
+
+## Authority flow
+
+```text
+frozen binding + archived source + one authorized CSP shard
+                     |
+                     v
+         provider-neutral external runner
+                     |
+                     v
+          sealed qualification bundle
+                     |
+                     v
+       independent stdlib verifier
+                     |
+        narrow score-free return value
+                     |
+                     v
+             admission adapter
+                     |
+                     v
+      immutable systems-admission receipt
+```
+
+The adapter never reads `case_result.json`, never reads a model metric, and never imports neurOS scientific code. It calls the already-independent verifier and consumes only its narrow return mapping.
+
+## Exact verifier output contract
+
+The admission adapter requires the verifier to return exactly:
+
+- `verified`
+- `transport_provider`
+- `binding_input_mode`
+- `transport_source_revision`
+- `transport_script_sha256`
+- `external_bundle_sha256`
+- `qualification_sha256`
+- `worker_bundle_sha256`
+- `shard_result_sha256`
+- `numerical_result_interpretable`
+- `global_analysis_performed`
+- `external_floor_claim_generated`
+- `orion_comparison_permitted`
+
+Unexpected keys fail closed. This prevents a future verifier from silently widening the admission surface to include scientific values.
+
+The four claim flags must remain `false`.
+
+## Admission receipt
+
+A successful admission binds:
+
+- frozen scientific source revision;
+- binding run/artifact/ZIP/bundle identity;
+- exact EnvironmentAuthority;
+- raw and study materialization identities;
+- execution-plan and authorized shard identities;
+- transport provider and binding-input mode;
+- transport source revision;
+- transport-script SHA-256;
+- external bundle SHA-256;
+- qualification SHA-256;
+- worker bundle SHA-256;
+- promoted shard-result SHA-256;
+- independent verifier-script SHA-256.
+
+It positively states only:
+
+```text
+transport_structurally_qualified = true
+```
+
+and preserves:
+
+```text
+scientific_outcomes_inspected = false
+numerical_result_interpretable = false
+global_analysis_performed = false
+external_floor_claim_generated = false
+production_fleet_authorized = false
+orion_comparison_permitted = false
+```
+
+The receipt is domain-separated and content-addressed by `admission_sha256`.
+
+## Verifier version binding
+
+The admission records the exact SHA-256 of `verify_kumar2024_external_qualification.py`.
+
+By default `verify-admission` requires that identity to equal the verifier bytes in the current checkout. Historical admission receipts may be inspected with an explicit `--allow-historical-verifier` flag, but that is an audit convenience, not permission to reinterpret or upgrade the historical claim.
+
+## Write-once admission
+
+The `admit` command creates the requested admission path with create-if-absent semantics. Existing admission files are never overwritten.
+
+Example after a real external qualification:
+
+```bash
+python3 scripts/evidence/admit_kumar2024_external_qualification.py admit \
+  /path/to/qualification \
+  --transport-script scripts/evidence/run_kumar2024_external_qualification.sh \
+  --expected-transport-revision <EXACT_PR163_TRANSPORT_SHA> \
+  --output /new/write-once/path/external_systems_admission.json
+```
+
+Then independently check the receipt itself:
+
+```bash
+python3 scripts/evidence/admit_kumar2024_external_qualification.py verify-admission \
+  /path/to/external_systems_admission.json
+```
+
+Neither command should be used to inspect the numerical contents of the worker artifact.
+
+## Acceptance boundary for issue #166
+
+A future issue #166 success can be recorded from the immutable admission receipt plus the underlying independently verified sealed bundle. No human score review is required for the transport go/no-go.
+
+A structurally admitted one-shard CSP execution proves only that the frozen worker can execute outside GitHub Actions while preserving the authority graph.
+
+It does not authorize the 1,350-shard comparison, does not create an external scientific floor, and does not permit ORION comparison.

--- a/scripts/evidence/admit_kumar2024_external_qualification.py
+++ b/scripts/evidence/admit_kumar2024_external_qualification.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Score-blind admission for one verified Kumar2024 external systems artifact.
+
+This layer consumes only the narrow return value of the independent external
+qualification verifier. It never opens a worker result file and never receives a
+scientific metric. Its sole positive claim is that one exact sealed external
+transport artifact passed the frozen structural verifier.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+ADMISSION_SCHEMA = "neuros.nsq_kumar2024_external_systems_admission.v1"
+VERIFIER_PATH = Path(__file__).resolve().with_name(
+    "verify_kumar2024_external_qualification.py"
+)
+
+_SPEC = importlib.util.spec_from_file_location(
+    "neuros_kumar2024_external_qualification_verifier_for_admission",
+    VERIFIER_PATH,
+)
+if _SPEC is None or _SPEC.loader is None:  # pragma: no cover - repository corruption
+    raise RuntimeError("cannot load external qualification verifier")
+verifier = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = verifier
+_SPEC.loader.exec_module(verifier)
+
+_VERIFIED_KEYS = frozenset(
+    {
+        "verified",
+        "transport_provider",
+        "binding_input_mode",
+        "transport_source_revision",
+        "transport_script_sha256",
+        "external_bundle_sha256",
+        "qualification_sha256",
+        "worker_bundle_sha256",
+        "shard_result_sha256",
+        "numerical_result_interpretable",
+        "global_analysis_performed",
+        "external_floor_claim_generated",
+        "orion_comparison_permitted",
+    }
+)
+_FALSE_CLAIM_KEYS = (
+    "numerical_result_interpretable",
+    "global_analysis_performed",
+    "external_floor_claim_generated",
+    "orion_comparison_permitted",
+)
+
+
+def _canonical(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _identity(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        _canonical({"schema": ADMISSION_SCHEMA, "payload": payload})
+    ).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _hex(name: str, value: Any, length: int) -> str:
+    if not isinstance(value, str) or len(value) != length:
+        raise ValueError(f"{name} must be a {length}-character lowercase hexadecimal string")
+    if value != value.lower() or any(char not in "0123456789abcdef" for char in value):
+        raise ValueError(f"{name} must be lowercase hexadecimal")
+    return value
+
+
+def _canonical_string(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError(f"{name} must be a non-empty canonical string")
+    return value
+
+
+def _write_once(path: Path, payload: Mapping[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as stream:
+            fd = -1
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    return path
+
+
+def build_admission(
+    verified: Mapping[str, Any],
+    *,
+    verifier_script_sha256: str,
+) -> dict[str, Any]:
+    """Bind the exact independent-verifier output into a systems-only admission."""
+    if set(verified) != _VERIFIED_KEYS:
+        raise ValueError(
+            "independent verifier output contract drifted: "
+            f"missing={sorted(_VERIFIED_KEYS - set(verified))}, "
+            f"extra={sorted(set(verified) - _VERIFIED_KEYS)}"
+        )
+    if verified.get("verified") is not True:
+        raise ValueError("external qualification is not independently verified")
+    for key in _FALSE_CLAIM_KEYS:
+        if verified.get(key) is not False:
+            raise ValueError(f"external qualification requires {key}=false")
+
+    provider = _canonical_string("transport_provider", verified["transport_provider"])
+    if provider not in verifier.ALLOWED_PROVIDERS:
+        raise ValueError("transport provider is outside the frozen verifier contract")
+    input_mode = _canonical_string("binding_input_mode", verified["binding_input_mode"])
+    if input_mode not in verifier.ALLOWED_BINDING_INPUT_MODES:
+        raise ValueError("binding input mode is outside the frozen verifier contract")
+
+    transport_revision = _hex(
+        "transport_source_revision", verified["transport_source_revision"], 40
+    )
+    digest_fields = {
+        key: _hex(key, verified[key], 64)
+        for key in (
+            "transport_script_sha256",
+            "external_bundle_sha256",
+            "qualification_sha256",
+            "worker_bundle_sha256",
+            "shard_result_sha256",
+        )
+    }
+    verifier_sha = _hex("verifier_script_sha256", verifier_script_sha256, 64)
+
+    payload = {
+        "schema_version": 1,
+        "artifact_kind": "verified_external_classical_worker_systems_admission",
+        "source_revision": verifier.SOURCE_REVISION,
+        "binding_run_id": verifier.BINDING_RUN_ID,
+        "binding_artifact_id": verifier.BINDING_ARTIFACT_ID,
+        "binding_artifact_sha256": verifier.BINDING_ARTIFACT_SHA256,
+        "binding_bundle_sha256": verifier.BINDING_BUNDLE_SHA256,
+        "environment_authority_sha256": verifier.ENVIRONMENT_AUTHORITY_SHA256,
+        "raw_materialization_sha256": verifier.RAW_MATERIALIZATION_SHA256,
+        "study_materialization_sha256": verifier.STUDY_MATERIALIZATION_SHA256,
+        "execution_plan_sha256": verifier.EXECUTION_PLAN_SHA256,
+        "shard_spec_sha256": verifier.SHARD_SPEC_SHA256,
+        "transport_provider": provider,
+        "binding_input_mode": input_mode,
+        "transport_source_revision": transport_revision,
+        **digest_fields,
+        "verifier_script_sha256": verifier_sha,
+        "transport_structurally_qualified": True,
+        "admission_basis": [
+            "independent_outer_bundle_verification",
+            "independent_worker_bundle_verification",
+            "frozen_source_and_environment_identity",
+            "frozen_execution_and_shard_identity",
+            "score_blind_claim_boundary",
+        ],
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "production_fleet_authorized": False,
+        "orion_comparison_permitted": False,
+    }
+    return {**payload, "admission_sha256": _identity(payload)}
+
+
+def verify_admission(
+    path: str | Path,
+    *,
+    require_current_verifier: bool = True,
+) -> dict[str, Any]:
+    admission_path = Path(path).expanduser().resolve()
+    payload = json.loads(admission_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("admission must contain a JSON object")
+    declared = payload.pop("admission_sha256", None)
+    if not isinstance(declared, str):
+        raise ValueError("admission is missing admission_sha256")
+    expected = _identity(payload)
+    if declared != expected:
+        raise ValueError("admission identity mismatch")
+
+    fixed = {
+        "schema_version": 1,
+        "artifact_kind": "verified_external_classical_worker_systems_admission",
+        "source_revision": verifier.SOURCE_REVISION,
+        "binding_run_id": verifier.BINDING_RUN_ID,
+        "binding_artifact_id": verifier.BINDING_ARTIFACT_ID,
+        "binding_artifact_sha256": verifier.BINDING_ARTIFACT_SHA256,
+        "binding_bundle_sha256": verifier.BINDING_BUNDLE_SHA256,
+        "environment_authority_sha256": verifier.ENVIRONMENT_AUTHORITY_SHA256,
+        "raw_materialization_sha256": verifier.RAW_MATERIALIZATION_SHA256,
+        "study_materialization_sha256": verifier.STUDY_MATERIALIZATION_SHA256,
+        "execution_plan_sha256": verifier.EXECUTION_PLAN_SHA256,
+        "shard_spec_sha256": verifier.SHARD_SPEC_SHA256,
+        "transport_structurally_qualified": True,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "production_fleet_authorized": False,
+        "orion_comparison_permitted": False,
+    }
+    for key, value in fixed.items():
+        if payload.get(key) != value:
+            raise ValueError(f"admission {key} mismatch")
+    if payload.get("transport_provider") not in verifier.ALLOWED_PROVIDERS:
+        raise ValueError("admission transport provider is not frozen")
+    if payload.get("binding_input_mode") not in verifier.ALLOWED_BINDING_INPUT_MODES:
+        raise ValueError("admission binding input mode is not frozen")
+    _hex("transport_source_revision", payload.get("transport_source_revision"), 40)
+    for key in (
+        "transport_script_sha256",
+        "external_bundle_sha256",
+        "qualification_sha256",
+        "worker_bundle_sha256",
+        "shard_result_sha256",
+        "verifier_script_sha256",
+    ):
+        _hex(key, payload.get(key), 64)
+    if require_current_verifier and payload["verifier_script_sha256"] != _file_sha256(VERIFIER_PATH):
+        raise ValueError("admission was produced by a different verifier byte identity")
+    payload["admission_sha256"] = declared
+    return payload
+
+
+def admit(
+    qualification_root: str | Path,
+    *,
+    transport_script: str | Path,
+    expected_transport_revision: str,
+    output: str | Path,
+) -> dict[str, Any]:
+    transport_revision = _hex(
+        "expected_transport_revision", expected_transport_revision, 40
+    )
+    verified = verifier.verify(
+        qualification_root,
+        transport_script=transport_script,
+        expected_transport_revision=transport_revision,
+    )
+    receipt = build_admission(
+        verified,
+        verifier_script_sha256=_file_sha256(VERIFIER_PATH),
+    )
+    _write_once(Path(output).expanduser().resolve(), receipt)
+    return receipt
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Admit or verify one score-blind Kumar2024 external systems receipt."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("admit")
+    create.add_argument("qualification_root")
+    create.add_argument("--transport-script", required=True)
+    create.add_argument("--expected-transport-revision", required=True)
+    create.add_argument("--output", required=True)
+
+    verify = subparsers.add_parser("verify-admission")
+    verify.add_argument("admission")
+    verify.add_argument("--allow-historical-verifier", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "admit":
+        result = admit(
+            args.qualification_root,
+            transport_script=args.transport_script,
+            expected_transport_revision=args.expected_transport_revision,
+            output=args.output,
+        )
+    else:
+        result = verify_admission(
+            args.admission,
+            require_current_verifier=not args.allow_historical_verifier,
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_kumar2024_external_qualification_admission.py
+++ b/tests/test_kumar2024_external_qualification_admission.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "scripts"
+    / "evidence"
+    / "admit_kumar2024_external_qualification.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "neuros_kumar2024_external_admission_test",
+    SCRIPT_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+admission = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = admission
+SPEC.loader.exec_module(admission)
+
+
+def sha(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def verified(**overrides):
+    values = {
+        "verified": True,
+        "transport_provider": "local-linux",
+        "binding_input_mode": "verified_archive",
+        "transport_source_revision": "a" * 40,
+        "transport_script_sha256": sha("transport-script"),
+        "external_bundle_sha256": sha("outer-bundle"),
+        "qualification_sha256": sha("qualification"),
+        "worker_bundle_sha256": sha("worker-bundle"),
+        "shard_result_sha256": sha("shard-result"),
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+    }
+    values.update(overrides)
+    return values
+
+
+def test_admission_is_deterministic_score_blind_and_frozen():
+    first = admission.build_admission(
+        verified(), verifier_script_sha256=sha("verifier")
+    )
+    second = admission.build_admission(
+        verified(), verifier_script_sha256=sha("verifier")
+    )
+    assert first == second
+    assert first["admission_sha256"] == second["admission_sha256"]
+    assert first["source_revision"] == admission.verifier.SOURCE_REVISION
+    assert (
+        first["environment_authority_sha256"]
+        == admission.verifier.ENVIRONMENT_AUTHORITY_SHA256
+    )
+    assert first["shard_spec_sha256"] == admission.verifier.SHARD_SPEC_SHA256
+    assert first["transport_structurally_qualified"] is True
+    assert first["scientific_outcomes_inspected"] is False
+    assert first["numerical_result_interpretable"] is False
+    assert first["external_floor_claim_generated"] is False
+    assert first["production_fleet_authorized"] is False
+    assert first["orion_comparison_permitted"] is False
+
+
+def test_admission_rejects_verifier_contract_widening_or_claim_promotion():
+    widened = verified()
+    widened["accuracy"] = 0.99
+    with pytest.raises(ValueError, match="output contract drifted"):
+        admission.build_admission(widened, verifier_script_sha256=sha("verifier"))
+
+    with pytest.raises(ValueError, match="numerical_result_interpretable=false"):
+        admission.build_admission(
+            verified(numerical_result_interpretable=True),
+            verifier_script_sha256=sha("verifier"),
+        )
+
+
+def test_admission_rejects_unverified_or_malformed_transport_identity():
+    with pytest.raises(ValueError, match="not independently verified"):
+        admission.build_admission(
+            verified(verified=False), verifier_script_sha256=sha("verifier")
+        )
+    with pytest.raises(ValueError, match="40-character"):
+        admission.build_admission(
+            verified(transport_source_revision="not-a-revision"),
+            verifier_script_sha256=sha("verifier"),
+        )
+
+
+def test_admit_calls_independent_verifier_and_writes_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    transport = tmp_path / "transport.sh"
+    transport.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    transport_sha = hashlib.sha256(transport.read_bytes()).hexdigest()
+    expected_revision = "b" * 40
+    expected = verified(
+        transport_source_revision=expected_revision,
+        transport_script_sha256=transport_sha,
+    )
+    observed: dict[str, object] = {}
+
+    def fake_verify(root, *, transport_script, expected_transport_revision):
+        observed["root"] = Path(root)
+        observed["transport_script"] = Path(transport_script)
+        observed["revision"] = expected_transport_revision
+        return expected
+
+    monkeypatch.setattr(admission.verifier, "verify", fake_verify)
+    output = tmp_path / "admission.json"
+    receipt = admission.admit(
+        tmp_path / "qualification",
+        transport_script=transport,
+        expected_transport_revision=expected_revision,
+        output=output,
+    )
+    assert output.is_file()
+    assert observed["transport_script"] == transport
+    assert observed["revision"] == expected_revision
+    assert receipt["transport_script_sha256"] == transport_sha
+
+    with pytest.raises(FileExistsError):
+        admission.admit(
+            tmp_path / "qualification",
+            transport_script=transport,
+            expected_transport_revision=expected_revision,
+            output=output,
+        )
+
+
+def test_verify_admission_recomputes_identity_and_binds_current_verifier(tmp_path: Path):
+    receipt = admission.build_admission(
+        verified(),
+        verifier_script_sha256=admission._file_sha256(admission.VERIFIER_PATH),
+    )
+    path = tmp_path / "admission.json"
+    path.write_text(json.dumps(receipt, sort_keys=True), encoding="utf-8")
+    checked = admission.verify_admission(path)
+    assert checked["admission_sha256"] == receipt["admission_sha256"]
+
+    tampered = dict(receipt)
+    tampered["transport_provider"] = "nvidia-brev"
+    path.write_text(json.dumps(tampered, sort_keys=True), encoding="utf-8")
+    with pytest.raises(ValueError, match="identity mismatch"):
+        admission.verify_admission(path)
+
+
+def test_historical_verifier_requires_explicit_opt_out(tmp_path: Path):
+    receipt = admission.build_admission(
+        verified(), verifier_script_sha256=sha("historical-verifier")
+    )
+    path = tmp_path / "historical.json"
+    path.write_text(json.dumps(receipt, sort_keys=True), encoding="utf-8")
+    with pytest.raises(ValueError, match="different verifier byte identity"):
+        admission.verify_admission(path)
+    assert (
+        admission.verify_admission(path, require_current_verifier=False)[
+            "admission_sha256"
+        ]
+        == receipt["admission_sha256"]
+    )


### PR DESCRIPTION
## Purpose

Add a mechanical, score-blind systems-admission layer after the independent external qualification verifier from #163.

A successful real external worker should be admitted from the verifier's narrow structural output, not by a human or controller opening score-bearing worker files.

## Exact candidate

- base: `feat/kumar2024-external-execution-transport-v1@61293f39806afb702c90834a8325f7924823a3c3`
- head: `0a7d380b8a5433afdfab8ddf74e9dbfad8ac1a4f`
- ancestry: exactly one commit over #163's current-main transport candidate
- changed files: exactly four

Files:

1. `scripts/evidence/admit_kumar2024_external_qualification.py`
2. `tests/test_kumar2024_external_qualification_admission.py`
3. `.github/workflows/nsq-kumar2024-external-admission-ci.yml`
4. `docs/NSQ_KUMAR2024_EXTERNAL_ADMISSION.md`

## Admission boundary

The adapter calls only the already-independent stdlib verifier and requires its return mapping to contain exactly the frozen score-free contract. Unexpected keys fail closed.

It never opens `case_result.json`, never reads a model metric, never imports torch, and never imports the scientific worker.

A successful receipt binds:

- frozen scientific source revision;
- binding run/artifact/ZIP/bundle identity;
- exact EnvironmentAuthority;
- raw/study materialization identities;
- execution-plan and authorized shard identities;
- transport provider and binding-input mode;
- exact transport source revision and transport-script SHA;
- external bundle, qualification, worker bundle and promoted shard-result identities;
- exact independent verifier-script SHA-256.

Its sole positive claim is:

`transport_structurally_qualified=true`

It preserves:

- `scientific_outcomes_inspected=false`
- `numerical_result_interpretable=false`
- `global_analysis_performed=false`
- `external_floor_claim_generated=false`
- `production_fleet_authorized=false`
- `orion_comparison_permitted=false`

## Verifier-version authority

The admission binds the exact byte digest of `verify_kumar2024_external_qualification.py`. By default, admission verification requires that digest to match the verifier in the current checkout. Historical verifier receipts require an explicit audit-only opt-out and are never silently upgraded.

## Write-once semantics

`admit` writes the admission JSON with create-if-absent semantics. Existing admission paths cannot be overwritten.

`verify-admission` independently recomputes the domain-separated admission identity and all frozen constants/claim flags.

## Qualification

Dedicated `NSQ Kumar2024 external admission contracts` CI runs on literal PR head SHA across Python 3.10 / 3.11 / 3.12 and:

- requires exact clean checkout;
- compiles verifier/admission/test surfaces;
- runs adversarial admission tests;
- AST-audits the admission adapter for stdlib-only dependencies;
- forbids score-bearing result-file names/metric controls in the admission source.

## Execution boundary

This PR is systems-admission infrastructure only. It does not make #166 complete without a real external CPU worker, does not authorize the 1,350-shard study, does not create an external scientific floor, and does not permit ORION comparison.

Refs #163, #166, #82.