### PR TITLE
test(evidence): add provider-free Kumar2024 fleet qualification

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml
@@ -1,0 +1,112 @@
+name: NSQ Kumar2024 GPU fleet synthetic qualification
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py"
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_synthetic.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py"
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_synthetic.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md"
+
+permissions:
+  contents: read
+
+jobs:
+  synthetic-fleet:
+    name: Provider-free fleet systems qualification / Python ${{ matrix.python }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Require exact clean qualification source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha || github.sha }}"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "${{ matrix.python }}"
+
+      - name: Install pinned test harness
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
+
+      - name: Compile provider-free qualification surfaces
+        run: |
+          python -m py_compile \
+            packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py \
+            scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            tests/test_kumar2024_gpu_fleet_synthetic.py
+
+      - name: Run provider-free fleet qualification tests
+        run: python -m pytest -q tests/test_kumar2024_gpu_fleet_synthetic.py
+
+      - name: Execute and verify synthetic fleet
+        shell: bash
+        run: |
+          set -euo pipefail
+          OUT="$RUNNER_TEMP/kumar2024-fleet-synthetic"
+          python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            run --repo-root . --output "$OUT"
+          python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            verify --output "$OUT"
+
+      - name: Require dependency-light and score-blind harness
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py")
+          text = path.read_text(encoding="utf-8")
+          tree = ast.parse(text)
+          allowed = {
+              "__future__",
+              "argparse",
+              "hashlib",
+              "importlib",
+              "json",
+              "pathlib",
+              "sys",
+              "types",
+              "typing",
+          }
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  names = [alias.name.split(".", 1)[0] for alias in node.names]
+              elif isinstance(node, ast.ImportFrom):
+                  names = [(node.module or "").split(".", 1)[0]]
+              else:
+                  continue
+              for name in names:
+                  assert name in allowed, (name, node.lineno)
+
+          # The fixed scientific method identifier is allowed as inert lease metadata.
+          assert "braindecode-eegnet" in text
+          for forbidden in (
+              "case_result.json",
+              "shard_result.json",
+              "balanced_accuracy",
+              "torch",
+              "moabb",
+          ):
+              assert forbidden not in text, forbidden
+          PY

--- a/docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md
+++ b/docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md
@@ -1,0 +1,116 @@
+# NSQ Kumar2024 GPU fleet provider-free qualification
+
+Status: **systems-emulation qualification only. This is not live provider evidence and does not authorize GPU fan-out.**
+
+This tranche exercises the promoted Kumar2024 GPU fleet control plane without Kaggle credentials, neural data, model execution, GPU access, or scientific result inspection.
+
+## Purpose
+
+The real fleet will eventually schedule 810 preregistered EEGNet shards across a provider transport. Before any external provider is allowed to become part of that evidence chain, the controller should prove its state machine works end to end in a deterministic, provider-free environment.
+
+The qualification deliberately tests the control plane rather than the neural model.
+
+## Fixed synthetic scenario
+
+The runner creates three synthetic EEGNet leases under a synthetic T4-shaped `PreflightAdmission`:
+
+1. lease 0 succeeds on attempt 1;
+2. lease 1 receives a trusted `provider_preemption` infrastructure failure, then succeeds on the only authorized retry;
+3. lease 2 succeeds on attempt 1.
+
+That produces:
+
+- 3 expected leases;
+- 4 total claims/attempts;
+- 1 trusted infrastructure failure;
+- 3 accepted terminal artifacts;
+- 0 pending leases;
+- one deterministic complete `SettlementLedger`.
+
+Every accepted synthetic artifact carries the exact fleet environment authority, worker receipt identity, worker bundle identity, learned-state identity, provider receipt identity, accelerator identity, and lease/shard/attempt identities.
+
+## What this proves
+
+The qualification exercises:
+
+- deterministic fleet and lease identity construction;
+- persisted lease-before-claim ordering;
+- claim-before-attempt namespace creation;
+- create-once attempt directories;
+- retry only after an admitted infrastructure failure;
+- environment-bound artifact settlement;
+- accepted-artifact finality;
+- deterministic full-fleet reconstruction;
+- score-blind completion semantics;
+- a path-independent outer qualification receipt.
+
+Running the same qualification in two different output directories must produce byte-identical receipts and the same qualification SHA-256.
+
+## What this does not prove
+
+It does **not** prove:
+
+- Kaggle authentication;
+- T4 availability;
+- cloud scheduling or preemption behavior;
+- CUDA determinism on real hardware;
+- MOABB data access;
+- EEGNet execution;
+- model quality;
+- external-floor validity;
+- participant-level inference;
+- ORION comparison readiness.
+
+Those remain separately gated by issue #165 and the live preflight/transport sequence.
+
+## Claim boundary
+
+The synthetic receipt permanently records:
+
+- `model_execution_performed=false`;
+- `neural_data_accessed=false`;
+- `scientific_outcomes_inspected=false`;
+- `numerical_result_interpretable=false`;
+- `external_floor_claim_generated=false`;
+- `orion_comparison_permitted=false`.
+
+Synthetic hashes are test identities only. They must never be substituted for a real GPU binding, provider receipt, worker artifact, learned state, or external scientific result.
+
+## Qualification command
+
+From repository root:
+
+```bash
+python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+  run \
+  --repo-root . \
+  --output /tmp/kumar2024-fleet-synthetic
+
+python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+  verify \
+  --output /tmp/kumar2024-fleet-synthetic
+```
+
+The output directory is write-once. Reusing an existing path fails closed.
+
+## Relationship to live execution
+
+The intended sequence is:
+
+```text
+promoted score-blind fleet software authority
+        |
+        v
+provider-free synthetic qualification
+        |
+        v
+fixed real T4 systems preflight
+        |
+        v
+tiny live multi-shard transport qualification
+        |
+        v
+explicit 810-shard fleet authorization
+```
+
+The synthetic layer removes controller-state-machine uncertainty before cloud credentials or GPU quota enter the picture. It does not replace the live T4 or live multi-shard gates.

--- a/scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py
+++ b/scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Provider-free systems qualification for the Kumar2024 GPU fleet control plane.
+
+This script executes no neural model and reads no scientific result. It exercises
+only lease, claim, retry, write-once namespace, artifact-settlement, environment
+binding, and deterministic ledger semantics using synthetic identities.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Mapping, Sequence
+
+QUALIFICATION_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_synthetic_qualification.v1"
+
+
+def _canonical(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode()
+
+
+def _identity(schema: str, payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical({"schema": schema, "payload": payload})).hexdigest()
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _load_fleet(repo_root: Path) -> ModuleType:
+    module_path = (
+        repo_root
+        / "packages"
+        / "neuros"
+        / "src"
+        / "neuros"
+        / "evidence"
+        / "kumar2024_gpu_fleet.py"
+    )
+    if not module_path.is_file():
+        raise FileNotFoundError(f"fleet authority module not found: {module_path}")
+    spec = importlib.util.spec_from_file_location(
+        "neuros_kumar2024_gpu_fleet_synthetic_target",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load fleet authority module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synthetic_shards() -> list[dict[str, Any]]:
+    seeds = (
+        (1, "5", 2026, 31415, "synthetic-shard-a"),
+        (2, "4", 3407, 384165836, "synthetic-shard-b"),
+        (3, "3", 9109, 3991196546, "synthetic-shard-c"),
+    )
+    return [
+        {
+            "subject": subject,
+            "target_session": session,
+            "split_seed": split_seed,
+            "method_id": "braindecode-eegnet",
+            "model_seed": model_seed,
+            "budgets_per_class": [0, 1, 2, 5, 10],
+            "shard_spec_sha256": _digest(label),
+        }
+        for subject, session, split_seed, model_seed, label in seeds
+    ]
+
+
+def _write_receipt(path: Path, payload: Mapping[str, Any]) -> None:
+    encoded = json.dumps(payload, sort_keys=True, indent=2, allow_nan=False) + "\n"
+    path.write_text(encoded, encoding="utf-8")
+
+
+def run(repo_root: Path, output: Path) -> dict[str, Any]:
+    """Run a deterministic provider-free fleet systems qualification."""
+    if output.exists():
+        raise FileExistsError(f"refusing to reuse qualification output: {output}")
+    output.mkdir(parents=True)
+    store = output / "store"
+
+    fleet = _load_fleet(repo_root)
+    preflight = fleet.PreflightAdmission(
+        gpu_execution_authority_revision=fleet.PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        gpu_binding_sha256=_digest("synthetic-gpu-binding"),
+        execution_plan_sha256=_digest("synthetic-execution-plan"),
+        environment_authority_sha256=_digest("synthetic-environment"),
+        gpu_worker_receipt_sha256=_digest("synthetic-preflight-worker"),
+        accelerator_name="Synthetic Tesla T4 systems probe",
+        elapsed_seconds=1.0,
+    )
+    authority = fleet.FleetAuthority.from_preflight(
+        preflight,
+        expected_shard_count=3,
+        max_attempts_per_lease=2,
+    )
+    leases = fleet.build_leases(authority, _synthetic_shards())
+    if len(leases) != 3:
+        raise RuntimeError("synthetic qualification expected exactly three leases")
+
+    for lease in leases:
+        fleet.persist_lease(store, lease)
+
+    claims = []
+    outcomes = []
+
+    lease = leases[0]
+    claim = fleet.ClaimEvent(
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=1,
+        worker_id="synthetic-worker-0",
+        provider="synthetic",
+        provider_run_id="synthetic-run-0001",
+    )
+    fleet.persist_claim(store, lease, claim)
+    fleet.prepare_attempt_namespace(store, claim)
+    outcome = fleet.ArtifactSettlementEvent(
+        claim_sha256=claim.sha256,
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=1,
+        gpu_worker_receipt_sha256=_digest("synthetic-worker-receipt-0"),
+        worker_bundle_sha256=_digest("synthetic-worker-bundle-0"),
+        learned_state_sha256=_digest("synthetic-learned-state-0"),
+        environment_authority_sha256=authority.environment_authority_sha256,
+        provider_receipt_sha256=_digest("synthetic-provider-receipt-0"),
+        accelerator_name="Synthetic Tesla T4 systems probe",
+    )
+    fleet.persist_outcome(store, outcome)
+    claims.append(claim)
+    outcomes.append(outcome)
+
+    lease = leases[1]
+    first = fleet.ClaimEvent(
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=1,
+        worker_id="synthetic-worker-1a",
+        provider="synthetic",
+        provider_run_id="synthetic-run-0002",
+    )
+    fleet.persist_claim(store, lease, first)
+    fleet.prepare_attempt_namespace(store, first)
+    failure = fleet.InfrastructureFailureEvent(
+        claim_sha256=first.sha256,
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=1,
+        failure_kind="provider_preemption",
+        failure_evidence_sha256=_digest("synthetic-preemption-evidence"),
+    )
+    fleet.persist_outcome(store, failure)
+
+    second = fleet.ClaimEvent(
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=2,
+        worker_id="synthetic-worker-1b",
+        provider="synthetic",
+        provider_run_id="synthetic-run-0003",
+    )
+    fleet.persist_claim(store, lease, second)
+    fleet.prepare_attempt_namespace(store, second)
+    recovered = fleet.ArtifactSettlementEvent(
+        claim_sha256=second.sha256,
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=2,
+        gpu_worker_receipt_sha256=_digest("synthetic-worker-receipt-1"),
+        worker_bundle_sha256=_digest("synthetic-worker-bundle-1"),
+        learned_state_sha256=_digest("synthetic-learned-state-1"),
+        environment_authority_sha256=authority.environment_authority_sha256,
+        provider_receipt_sha256=_digest("synthetic-provider-receipt-1"),
+        accelerator_name="Synthetic Tesla T4 systems probe",
+    )
+    fleet.persist_outcome(store, recovered)
+    claims.extend((first, second))
+    outcomes.extend((failure, recovered))
+
+    lease = leases[2]
+    claim = fleet.ClaimEvent(
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=1,
+        worker_id="synthetic-worker-2",
+        provider="synthetic",
+        provider_run_id="synthetic-run-0004",
+    )
+    fleet.persist_claim(store, lease, claim)
+    fleet.prepare_attempt_namespace(store, claim)
+    outcome = fleet.ArtifactSettlementEvent(
+        claim_sha256=claim.sha256,
+        lease_sha256=lease.sha256,
+        shard_spec_sha256=lease.shard_spec_sha256,
+        attempt_number=1,
+        gpu_worker_receipt_sha256=_digest("synthetic-worker-receipt-2"),
+        worker_bundle_sha256=_digest("synthetic-worker-bundle-2"),
+        learned_state_sha256=_digest("synthetic-learned-state-2"),
+        environment_authority_sha256=authority.environment_authority_sha256,
+        provider_receipt_sha256=_digest("synthetic-provider-receipt-2"),
+        accelerator_name="Synthetic Tesla T4 systems probe",
+    )
+    fleet.persist_outcome(store, outcome)
+    claims.append(claim)
+    outcomes.append(outcome)
+
+    ledger = fleet.reconstruct_settlement(authority, leases, claims, outcomes)
+    if ledger["complete"] is not True:
+        raise RuntimeError("synthetic fleet did not settle completely")
+    if ledger["accepted_artifact_count"] != 3:
+        raise RuntimeError("synthetic fleet accepted-artifact count drifted")
+    if ledger["infrastructure_failure_count"] != 1:
+        raise RuntimeError("synthetic retry path was not exercised exactly once")
+    if ledger["pending_lease_count"] != 0:
+        raise RuntimeError("synthetic fleet retained a pending lease")
+    if ledger["scientific_outcomes_inspected"] is not False:
+        raise RuntimeError("synthetic fleet crossed the scientific-outcome boundary")
+    if ledger["numerical_result_interpretable"] is not False:
+        raise RuntimeError("synthetic fleet promoted numerical interpretation")
+    if ledger["orion_comparison_permitted"] is not False:
+        raise RuntimeError("synthetic fleet incorrectly permitted ORION comparison")
+
+    receipt_payload = {
+        "schema_version": 1,
+        "artifact_kind": "provider_free_gpu_fleet_systems_qualification",
+        "promoted_gpu_execution_authority_revision": (
+            fleet.PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION
+        ),
+        "preflight_admission_sha256": preflight.sha256,
+        "fleet_authority_sha256": authority.sha256,
+        "environment_authority_sha256": authority.environment_authority_sha256,
+        "lease_sha256s": [lease.sha256 for lease in leases],
+        "settlement_ledger_sha256": ledger["settlement_ledger_sha256"],
+        "expected_lease_count": 3,
+        "accepted_artifact_count": 3,
+        "infrastructure_failure_count": 1,
+        "attempt_count": 4,
+        "provider": "synthetic",
+        "model_execution_performed": False,
+        "neural_data_accessed": False,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "claim_boundary": (
+            "provider-free control-plane systems qualification only; synthetic "
+            "identities are not scientific or provider execution evidence"
+        ),
+    }
+    fleet.reject_scientific_fields(receipt_payload)
+    qualification_sha256 = _identity(QUALIFICATION_SCHEMA, receipt_payload)
+    receipt = {
+        **receipt_payload,
+        "synthetic_qualification_sha256": qualification_sha256,
+    }
+    _write_receipt(output / "synthetic_qualification_receipt.json", receipt)
+    return receipt
+
+
+def verify(output: Path) -> dict[str, Any]:
+    """Verify the deterministic outer receipt without rerunning the simulation."""
+    path = output / "synthetic_qualification_receipt.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("synthetic qualification receipt must be a JSON object")
+    declared = raw.get("synthetic_qualification_sha256")
+    if not isinstance(declared, str):
+        raise ValueError("synthetic qualification receipt lacks its identity")
+    payload = dict(raw)
+    payload.pop("synthetic_qualification_sha256", None)
+    expected = _identity(QUALIFICATION_SCHEMA, payload)
+    if declared != expected:
+        raise ValueError("synthetic qualification receipt identity mismatch")
+    for field in (
+        "model_execution_performed",
+        "neural_data_accessed",
+        "scientific_outcomes_inspected",
+        "numerical_result_interpretable",
+        "external_floor_claim_generated",
+        "orion_comparison_permitted",
+    ):
+        if payload.get(field) is not False:
+            raise ValueError(f"synthetic qualification requires {field}=false")
+    if payload.get("accepted_artifact_count") != payload.get("expected_lease_count"):
+        raise ValueError("synthetic qualification does not show complete settlement")
+    return {
+        "verified": True,
+        "synthetic_qualification_sha256": expected,
+        "settlement_ledger_sha256": payload["settlement_ledger_sha256"],
+        "model_execution_performed": False,
+        "scientific_outcomes_inspected": False,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    run_parser = sub.add_parser("run")
+    run_parser.add_argument("--repo-root", default=".")
+    run_parser.add_argument("--output", required=True)
+    verify_parser = sub.add_parser("verify")
+    verify_parser.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "run":
+        result = run(Path(args.repo_root).resolve(), Path(args.output).resolve())
+    else:
+        result = verify(Path(args.output).resolve())
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kumar2024_gpu_fleet_synthetic.py
+++ b/tests/test_kumar2024_gpu_fleet_synthetic.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "scripts"
+    / "evidence"
+    / "qualify_kumar2024_gpu_fleet_synthetic.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "kumar2024_gpu_fleet_synthetic_qualification",
+    SCRIPT_PATH,
+)
+assert SPEC is not None and SPEC.loader is not None
+qualification = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = qualification
+SPEC.loader.exec_module(qualification)
+
+
+def test_provider_free_qualification_is_complete_and_deterministic(tmp_path: Path):
+    repo_root = Path(__file__).parents[1]
+    first = qualification.run(repo_root, tmp_path / "first")
+    second = qualification.run(repo_root, tmp_path / "second")
+
+    assert first["synthetic_qualification_sha256"] == second[
+        "synthetic_qualification_sha256"
+    ]
+    assert first["settlement_ledger_sha256"] == second["settlement_ledger_sha256"]
+    assert first["accepted_artifact_count"] == 3
+    assert first["infrastructure_failure_count"] == 1
+    assert first["attempt_count"] == 4
+    assert first["model_execution_performed"] is False
+    assert first["neural_data_accessed"] is False
+    assert first["scientific_outcomes_inspected"] is False
+    assert first["orion_comparison_permitted"] is False
+
+    first_bytes = (
+        tmp_path / "first" / "synthetic_qualification_receipt.json"
+    ).read_bytes()
+    second_bytes = (
+        tmp_path / "second" / "synthetic_qualification_receipt.json"
+    ).read_bytes()
+    assert first_bytes == second_bytes
+
+
+def test_verifier_rejects_resealed_false_scientific_claim(tmp_path: Path):
+    repo_root = Path(__file__).parents[1]
+    output = tmp_path / "qualification"
+    qualification.run(repo_root, output)
+
+    receipt_path = output / "synthetic_qualification_receipt.json"
+    receipt = json.loads(receipt_path.read_text())
+    receipt["scientific_outcomes_inspected"] = True
+    payload = dict(receipt)
+    payload.pop("synthetic_qualification_sha256")
+    receipt["synthetic_qualification_sha256"] = qualification._identity(
+        qualification.QUALIFICATION_SCHEMA,
+        payload,
+    )
+    receipt_path.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n")
+
+    with pytest.raises(ValueError, match="scientific_outcomes_inspected=false"):
+        qualification.verify(output)
+
+
+def test_runner_refuses_output_reuse(tmp_path: Path):
+    repo_root = Path(__file__).parents[1]
+    output = tmp_path / "qualification"
+    qualification.run(repo_root, output)
+    with pytest.raises(FileExistsError, match="refusing to reuse"):
+        qualification.run(repo_root, output)


### PR DESCRIPTION
## Purpose

Add a deterministic provider-free systems qualification for the already-promoted Kumar2024 GPU fleet control plane.

This tranche executes **no neural model**, accesses **no neural data**, launches **no GPU/provider job**, and reads **no scientific result**. It removes controller-state-machine uncertainty before Kaggle credentials or cloud quota enter the evidence chain.

## Exact candidate

- base: `main@f7a870ff173f5f07e0fd5c129e5a02207cfdeb6e`
- head: `44ceeff92f789c870a3316b18a193db7dace0dbc`
- ancestry: exactly one commit over that base
- changed files: exactly four

Files:
1. `scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py`
2. `tests/test_kumar2024_gpu_fleet_synthetic.py`
3. `.github/workflows/nsq-kumar2024-gpu-fleet-synthetic-ci.yml`
4. `docs/NSQ_KUMAR2024_GPU_FLEET_SYNTHETIC.md`

No scientific worker, model, preprocessing, binding, GPU adapter, split, seed, budget, or score-handling implementation is changed.

## Fixed synthetic scenario

Three synthetic EEGNet leases are exercised under a synthetic T4-shaped systems admission:
- lease 0 succeeds on attempt 1;
- lease 1 terminates with trusted `provider_preemption` on attempt 1, then succeeds on attempt 2;
- lease 2 succeeds on attempt 1.

Expected terminal state: 3 leases, 4 attempts, 1 trusted infrastructure failure, 3 accepted terminal artifacts, 0 pending leases, deterministic `complete=true` settlement.

Every accepted synthetic artifact binds fleet environment authority plus worker-receipt, worker-bundle, learned-state, provider-receipt, accelerator, lease, shard, and attempt identities.

## Systems properties exercised

`PreflightAdmission -> FleetAuthority -> build_leases -> persist_lease -> ClaimEvent -> persist_claim -> prepare_attempt_namespace -> terminal outcome -> reconstruct_settlement`

The qualification tests deterministic fleet/lease identity, lease-before-claim ordering, claim-before-attempt ordering, create-once namespaces, infrastructure-only retry authorization, environment-bound settlement, learned-state identity carriage, accepted-artifact finality, deterministic reconstruction, and score-blind completion.

Two independent output roots must yield byte-identical receipts and identical qualification/ledger SHA-256 values.

## Adversarial tests

- deterministic byte-identical receipts across independent roots;
- rejection of a **resealed** false `scientific_outcomes_inspected=true` receipt;
- write-once output-root enforcement.

The dedicated workflow AST-audits the runner as standard-library only. The inert fixed method identifier `braindecode-eegnet` is explicitly allowed as lease metadata; importing Braindecode is still impossible under the import allowlist. Scientific result-file names, balanced accuracy, torch, and MOABB remain forbidden from the runner.

## Superseded candidates

`97ffdc12...` failed before tests because default pull-request checkout resolved to GitHub's merge ref rather than the literal head. `6a6e652f...` fixed exact checkout and then successfully passed tests plus the actual synthetic execution, producing qualification SHA `1e35e04e2bf49085b15e837d32c5abc1cee52b1f26ac872353f9089598a68df1` and ledger SHA `293184148318914f332b3c4fe9c6658ca7a0acabadc79d3e46d63239291ec3d5`, but its final static string gate incorrectly rejected the required inert string `braindecode-eegnet`.

Current head `44ceeff9...` changes only that over-broad static check. No scientific/runtime semantics changed, and no qualification evidence from either superseded SHA is inherited.

## Claim boundary

The receipt permanently records:
- `model_execution_performed=false`
- `neural_data_accessed=false`
- `scientific_outcomes_inspected=false`
- `numerical_result_interpretable=false`
- `external_floor_claim_generated=false`
- `orion_comparison_permitted=false`

Synthetic identities are systems-test identities only.

## Relationship to live execution

`promoted fleet software authority -> provider-free synthetic qualification -> fixed real T4 systems preflight -> tiny live multi-shard transport qualification -> explicit 810-shard fleet authorization`

Passing this PR does **not** satisfy the live T4, CUDA, MOABB, EEGNet, external-floor, participant-level, or ORION gates.

Refs #165, #169, #164, #175.