### PR TITLE
test(evidence): independently replay promoted Kumar2024 fleet packet

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-fleet-replay-v2-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-fleet-replay-v2-ci.yml
@@ -1,0 +1,130 @@
+name: NSQ Kumar2024 GPU fleet independent replay
+
+on:
+  pull_request:
+    paths:
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_replay_v2.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-replay-v2-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY_V2.md"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py"
+      - "scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py"
+      - "tests/test_kumar2024_gpu_fleet_replay_v2.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-replay-v2-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY_V2.md"
+
+permissions:
+  contents: read
+
+env:
+  QUALIFICATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  independent-replay:
+    name: Independent three-lease replay / Python ${{ matrix.python }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.QUALIFICATION_SHA }}
+      - name: Require exact clean qualification source
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SHA}"
+          test -z "$(git status --porcelain)"
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python }}
+          check-latest: false
+      - name: Install pinned test harness
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
+      - name: Compile replay surfaces
+        run: |
+          python -m compileall -q \
+            packages/neuros/src/neuros/evidence/kumar2024_gpu_fleet.py \
+            scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py \
+            scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py \
+            tests/test_kumar2024_gpu_fleet_replay_v2.py
+      - name: Run independent replay adversarial tests
+        run: python -m pytest -q tests/test_kumar2024_gpu_fleet_replay_v2.py
+      - name: Generate and independently replay one exact packet
+        run: |
+          set -euo pipefail
+          python scripts/evidence/qualify_kumar2024_gpu_fleet_synthetic.py run \
+            --output "${RUNNER_TEMP}/packet" > "${RUNNER_TEMP}/generated.json"
+          python scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py \
+            --root "${RUNNER_TEMP}/packet" > "${RUNNER_TEMP}/verified.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"])
+          generated = json.loads((root / "generated.json").read_text())
+          verified = json.loads((root / "verified.json").read_text())
+          expected_qualification = (
+              "1e35e04e2bf49085b15e837d32c5abc1cee52b1f26ac872353f9089598a68df1"
+          )
+          expected_ledger = (
+              "293184148318914f332b3c4fe9c6658ca7a0acabadc79d3e46d63239291ec3d5"
+          )
+          assert generated["synthetic_qualification_sha256"] == expected_qualification
+          assert verified["synthetic_qualification_sha256"] == expected_qualification
+          assert generated["settlement_ledger_sha256"] == expected_ledger
+          assert verified["settlement_ledger_sha256"] == expected_ledger
+          assert verified["complete"] is True
+          assert verified["scientific_outcomes_inspected"] is False
+          assert verified["numerical_result_interpretable"] is False
+          assert verified["orion_comparison_permitted"] is False
+          PY
+      - name: Require verifier independence
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py")
+          text = path.read_text(encoding="utf-8")
+          tree = ast.parse(text)
+          allowed = {
+              "__future__",
+              "argparse",
+              "collections.abc",
+              "hashlib",
+              "json",
+              "os",
+              "pathlib",
+              "typing",
+          }
+          observed = set()
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  observed.update(alias.name for alias in node.names)
+              elif isinstance(node, ast.ImportFrom):
+                  observed.add(node.module or "")
+          assert observed <= allowed, sorted(observed - allowed)
+          for forbidden_import in (
+              "neuros",
+              "torch",
+              "kaggle",
+              "requests",
+              "subprocess",
+              "socket",
+              "urllib",
+              "importlib",
+          ):
+              assert forbidden_import not in observed, forbidden_import
+          for forbidden_file in ("case_result.json", "shard_result.json"):
+              assert forbidden_file not in text, forbidden_file
+          PY

--- a/docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY_V2.md
+++ b/docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY_V2.md
@@ -1,0 +1,124 @@
+# NSQ Kumar2024 GPU fleet independent replay v2
+
+Status: **software/systems verification only. No live provider or scientific execution.**
+
+This tranche independently audits the provider-free three-lease Kumar2024 fleet packet
+promoted by `main@7ff39990361038e5c578d1100c61b3c7e7dac826`.
+
+It exists because a synthetic generator must not be allowed to certify its own
+`complete=true` output through the same implementation that produced it.
+
+## Independence boundary
+
+`scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py` is standard-library only.
+It imports neither neurOS nor the synthetic generator. It independently reconstructs:
+
+- the fixed synthetic preflight payload and SHA-256;
+- the fleet authority and environment binding;
+- all three canonical `LeaseSpec` identities;
+- all four `ClaimEvent` identities;
+- the one trusted `provider_preemption` failure;
+- all three artifact settlements;
+- retry legality and fleet completeness;
+- the settlement-ledger SHA-256;
+- the top-level synthetic qualification receipt SHA-256.
+
+The verifier's independent derivation reproduces the already-observed promoted
+identities:
+
+- settlement ledger:
+  `293184148318914f332b3c4fe9c6658ca7a0acabadc79d3e46d63239291ec3d5`
+- synthetic qualification:
+  `1e35e04e2bf49085b15e837d32c5abc1cee52b1f26ac872353f9089598a68df1`
+
+## Closed packet topology
+
+The promoted generator writes:
+
+```text
+synthetic_qualification_receipt.json
+store/
+  leases/
+  claims/
+  attempts/
+  outcomes/
+```
+
+Every expected lease, claim, outcome, lease-specific directory, and immutable attempt
+directory is derived independently from the frozen three-lease protocol. Attempt
+directories are intentionally empty: provider/run identity is already sealed into
+the claim, so this protocol does not invent a redundant invocation record.
+
+Verification rejects missing or shadow files, unexpected directories, symlinks,
+duplicate JSON keys, and non-finite JSON values.
+
+## Cryptographic replay
+
+Each lease, claim, infrastructure failure, and artifact settlement is checked twice:
+
+1. its declared domain-separated identity is recomputed from its own contents;
+2. the entire record must equal the independently preregistered protocol record.
+
+Simply recomputing a SHA after changing a learned-state or environment identity does
+not make that change acceptable.
+
+The retry graph is independently replayed. The second attempt exists only for the
+predeclared lease and only after the exact trusted `provider_preemption` outcome with
+`valid_worker_artifact_exists=false`. Any attempt after an accepted artifact rejects.
+Every accepted artifact must carry the exact frozen environment authority.
+
+## Adversarial suite
+
+The exact-head tests require rejection of mutated claims, freshly resealed
+learned-state substitutions, freshly resealed environment substitutions, missing
+terminal outcomes, shadow files, unexpected empty directories, freshly resealed false
+top-level scientific claims, duplicate JSON keys, symlink injection, and a symlinked
+evidence root.
+
+The positive path generates a packet with the promoted generator, then verifies it
+with the independent implementation and requires the two known SHA-256 identities
+above.
+
+## Claim boundary
+
+Successful replay proves only that the provider-free systems packet is internally
+consistent with the preregistered synthetic state machine.
+
+It permanently preserves:
+
+- `model_execution_performed=false`;
+- `neural_data_accessed=false`;
+- `scientific_outcomes_inspected=false`;
+- `numerical_result_interpretable=false`;
+- `orion_comparison_permitted=false`.
+
+It does not prove Kaggle credentials, T4 execution, provider upload reliability,
+scientific efficacy, external-floor validity, complete production execution, or
+ORION readiness.
+
+## Gate sequence
+
+```text
+promoted fleet authority
+        |
+        v
+promoted provider-free synthetic qualification
+        |
+        v
+independent three-lease replay (this tranche)
+        |
+        v
+real fixed T4 systems preflight
+        |
+        v
+systems-only preflight admission
+        |
+        v
+tiny live multi-shard provider transport
+        |
+        v
+explicit production fleet authorization
+```
+
+The production 810-shard EEGNet fleet remains blocked until the live gates are
+satisfied.

--- a/scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py
+++ b/scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Independent verifier for the promoted three-lease Kumar2024 synthetic fleet packet.
+
+This verifier is intentionally standard-library only and imports neither neurOS nor
+the synthetic generator. It independently derives the fixed synthetic protocol,
+checks the complete on-disk packet topology, recomputes every domain-separated
+identity, replays retry legality, and reconstructs the final receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+FLEET_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_authority.v1"
+PREFLIGHT_SCHEMA = "neuros.nsq_kumar2024_gpu_preflight_admission.v1"
+LEASE_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_lease.v1"
+CLAIM_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_claim.v1"
+FAILURE_SCHEMA = "neuros.nsq_kumar2024_gpu_infrastructure_failure.v1"
+SETTLEMENT_SCHEMA = "neuros.nsq_kumar2024_gpu_artifact_settlement.v1"
+LEDGER_SCHEMA = "neuros.nsq_kumar2024_gpu_settlement_ledger.v1"
+QUALIFICATION_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_synthetic_qualification.v1"
+
+PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION = "07a6c5fa5f212d54aae408237f14bb56f2f6eee9"
+EEGNET_METHOD_ID = "braindecode-eegnet"
+CALIBRATION_FRONTIER = [0, 1, 2, 5, 10]
+MAX_ATTEMPTS = 2
+LEASE_COUNT = 3
+PROVIDER = "synthetic"
+ACCELERATOR = "Synthetic Tesla T4 systems probe"
+ALLOWED_INFRASTRUCTURE_FAILURES = [
+    "provider_preemption",
+    "provider_timeout",
+    "node_loss",
+    "bootstrap_failure",
+    "environment_mismatch",
+    "artifact_upload_failure",
+]
+PROVIDER_SELECTION_BASIS = [
+    "wall_clock_seconds",
+    "provider_cost",
+    "provider_availability",
+    "accelerator_identity",
+    "environment_identity",
+]
+FORBIDDEN_SCIENTIFIC_KEYS = frozenset(
+    {
+        "accuracy",
+        "balanced_accuracy",
+        "auc",
+        "auroc",
+        "f1",
+        "loss",
+        "logits",
+        "method_ranking",
+        "predictions",
+        "probabilities",
+        "scientific_score",
+        "final_assessment_metric",
+    }
+)
+CLAIM_BOUNDARY = (
+    "provider-free control-plane systems qualification only; synthetic identities "
+    "are not scientific or provider execution evidence"
+)
+
+
+def _canonical(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _identity(schema: str, payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical({"schema": schema, "payload": payload})).hexdigest()
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _bad_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number is forbidden: {value}")
+
+
+def _reject_scientific_fields(value: Any, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"non-string key at {path}")
+            if key.lower() in FORBIDDEN_SCIENTIFIC_KEYS:
+                raise ValueError(f"scientific field {key!r} is forbidden at {path}")
+            _reject_scientific_fields(item, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            _reject_scientific_fields(item, f"{path}[{index}]")
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        raise ValueError(f"symlink evidence file is forbidden: {path}")
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_object_pairs,
+            parse_constant=_bad_constant,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot decode JSON evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"evidence must be a JSON object: {path}")
+    _reject_scientific_fields(value)
+    return value
+
+
+def _preflight_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "gpu_execution_authority_revision": PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        "gpu_binding_sha256": _digest("synthetic-gpu-binding"),
+        "execution_plan_sha256": _digest("synthetic-execution-plan"),
+        "environment_authority_sha256": _digest("synthetic-environment"),
+        "gpu_worker_receipt_sha256": _digest("synthetic-preflight-worker"),
+        "accelerator_name": ACCELERATOR,
+        "elapsed_seconds": 1.0,
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "admission_inputs": list(PROVIDER_SELECTION_BASIS),
+    }
+
+
+def _fleet_payload() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "artifact_kind": "score_blind_gpu_fleet_execution_authority",
+        "preflight_admission_sha256": _identity(PREFLIGHT_SCHEMA, _preflight_payload()),
+        "gpu_execution_authority_revision": PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        "gpu_binding_sha256": _digest("synthetic-gpu-binding"),
+        "execution_plan_sha256": _digest("synthetic-execution-plan"),
+        "environment_authority_sha256": _digest("synthetic-environment"),
+        "expected_shard_count": LEASE_COUNT,
+        "max_attempts_per_lease": MAX_ATTEMPTS,
+        "method_id": EEGNET_METHOD_ID,
+        "budgets_per_class": list(CALIBRATION_FRONTIER),
+        "allowed_infrastructure_failures": list(ALLOWED_INFRASTRUCTURE_FAILURES),
+        "provider_selection_basis": list(PROVIDER_SELECTION_BASIS),
+        "scientific_outcome_may_control_retry": False,
+        "scientific_outcome_may_control_provider_selection": False,
+        "orion_comparison_permitted": False,
+    }
+
+
+def _shard_rows() -> list[tuple[int, str, int, int, str]]:
+    return [
+        (1, "5", 2026, 31415, "synthetic-shard-a"),
+        (2, "4", 3407, 384165836, "synthetic-shard-b"),
+        (3, "3", 9109, 3991196546, "synthetic-shard-c"),
+    ]
+
+
+def _expected_leases() -> list[dict[str, Any]]:
+    fleet_sha = _identity(FLEET_SCHEMA, _fleet_payload())
+    rows = sorted(
+        (
+            subject,
+            session,
+            split_seed,
+            model_seed,
+            _digest(label),
+        )
+        for subject, session, split_seed, model_seed, label in _shard_rows()
+    )
+    result = []
+    for ordinal, (subject, session, split_seed, model_seed, shard_sha) in enumerate(rows):
+        payload = {
+            "schema_version": 1,
+            "fleet_authority_sha256": fleet_sha,
+            "gpu_binding_sha256": _digest("synthetic-gpu-binding"),
+            "execution_plan_sha256": _digest("synthetic-execution-plan"),
+            "environment_authority_sha256": _digest("synthetic-environment"),
+            "shard_spec_sha256": shard_sha,
+            "ordinal": ordinal,
+            "subject": subject,
+            "target_session": session,
+            "split_seed": split_seed,
+            "method_id": EEGNET_METHOD_ID,
+            "model_seed": model_seed,
+            "budgets_per_class": list(CALIBRATION_FRONTIER),
+            "max_attempts": MAX_ATTEMPTS,
+        }
+        result.append({**payload, "lease_sha256": _identity(LEASE_SCHEMA, payload)})
+    return result
+
+
+def _claim(
+    lease: Mapping[str, Any],
+    attempt: int,
+    worker_id: str,
+    provider_run_id: str,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": 1,
+        "event_type": "claim",
+        "lease_sha256": lease["lease_sha256"],
+        "shard_spec_sha256": lease["shard_spec_sha256"],
+        "attempt_number": attempt,
+        "worker_id": worker_id,
+        "provider": PROVIDER,
+        "provider_run_id": provider_run_id,
+    }
+    return {**payload, "claim_sha256": _identity(CLAIM_SCHEMA, payload)}
+
+
+def _expected_claims(leases: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        _claim(leases[0], 1, "synthetic-worker-0", "synthetic-run-0001"),
+        _claim(leases[1], 1, "synthetic-worker-1a", "synthetic-run-0002"),
+        _claim(leases[1], 2, "synthetic-worker-1b", "synthetic-run-0003"),
+        _claim(leases[2], 1, "synthetic-worker-2", "synthetic-run-0004"),
+    ]
+
+
+def _failure(claim: Mapping[str, Any]) -> dict[str, Any]:
+    payload = {
+        "schema_version": 1,
+        "event_type": "infrastructure_failure",
+        "claim_sha256": claim["claim_sha256"],
+        "lease_sha256": claim["lease_sha256"],
+        "shard_spec_sha256": claim["shard_spec_sha256"],
+        "attempt_number": 1,
+        "failure_kind": "provider_preemption",
+        "failure_evidence_sha256": _digest("synthetic-preemption-evidence"),
+        "valid_worker_artifact_exists": False,
+    }
+    return {**payload, "outcome_sha256": _identity(FAILURE_SCHEMA, payload)}
+
+
+def _settlement(claim: Mapping[str, Any], label_index: int) -> dict[str, Any]:
+    payload = {
+        "schema_version": 1,
+        "event_type": "artifact_settlement",
+        "claim_sha256": claim["claim_sha256"],
+        "lease_sha256": claim["lease_sha256"],
+        "shard_spec_sha256": claim["shard_spec_sha256"],
+        "attempt_number": claim["attempt_number"],
+        "gpu_worker_receipt_sha256": _digest(f"synthetic-worker-receipt-{label_index}"),
+        "worker_bundle_sha256": _digest(f"synthetic-worker-bundle-{label_index}"),
+        "learned_state_sha256": _digest(f"synthetic-learned-state-{label_index}"),
+        "environment_authority_sha256": _digest("synthetic-environment"),
+        "provider_receipt_sha256": _digest(f"synthetic-provider-receipt-{label_index}"),
+        "accelerator_name": ACCELERATOR,
+        "numerical_result_interpretable": False,
+        "global_analysis_performed": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+    }
+    return {**payload, "outcome_sha256": _identity(SETTLEMENT_SCHEMA, payload)}
+
+
+def _expected_outcomes(
+    leases: Sequence[dict[str, Any]],
+    claims: Sequence[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    del leases
+    return [
+        _settlement(claims[0], 0),
+        _failure(claims[1]),
+        _settlement(claims[2], 1),
+        _settlement(claims[3], 2),
+    ]
+
+
+def _expected_topology(
+    leases: Sequence[dict[str, Any]],
+    claims: Sequence[dict[str, Any]],
+) -> tuple[set[str], set[str]]:
+    files = {"synthetic_qualification_receipt.json"}
+    directories = {"store", "store/leases", "store/claims", "store/outcomes", "store/attempts"}
+    for lease in leases:
+        lease_sha = lease["lease_sha256"]
+        files.add(f"store/leases/{lease_sha}.json")
+        for prefix in ("claims", "outcomes", "attempts"):
+            directories.add(f"store/{prefix}/{lease_sha}")
+    for claim in claims:
+        lease_sha = claim["lease_sha256"]
+        attempt = claim["attempt_number"]
+        files.add(f"store/claims/{lease_sha}/attempt-{attempt:04d}.json")
+        files.add(f"store/outcomes/{lease_sha}/attempt-{attempt:04d}.json")
+        directories.add(
+            f"store/attempts/{lease_sha}/"
+            f"attempt-{attempt:04d}-{claim['claim_sha256'][:16]}"
+        )
+    return files, directories
+
+
+def _walk_topology(root: Path) -> tuple[set[str], set[str]]:
+    files: set[str] = set()
+    directories: set[str] = set()
+    for current, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        for name in list(dirnames):
+            path = current_path / name
+            if path.is_symlink():
+                raise ValueError(f"symlink directory is forbidden: {path}")
+            directories.add(path.relative_to(root).as_posix())
+        for name in filenames:
+            path = current_path / name
+            if path.is_symlink():
+                raise ValueError(f"symlink file is forbidden: {path}")
+            files.add(path.relative_to(root).as_posix())
+    return files, directories
+
+
+def _require_exact_record(
+    path: Path,
+    expected: Mapping[str, Any],
+    identity_field: str,
+    schema: str,
+) -> dict[str, Any]:
+    observed = _load_json(path)
+    if observed != expected:
+        raise ValueError(f"evidence differs from frozen synthetic protocol: {path}")
+    declared = observed.get(identity_field)
+    payload = dict(observed)
+    payload.pop(identity_field, None)
+    if declared != _identity(schema, payload):
+        raise ValueError(f"{identity_field} does not match record contents: {path}")
+    return observed
+
+
+def _replay_ledger(
+    leases: Sequence[dict[str, Any]],
+    claims: Sequence[dict[str, Any]],
+    outcomes: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    claim_by_slot: dict[tuple[str, int], dict[str, Any]] = {}
+    provider_runs: set[tuple[str, str]] = set()
+    for claim in claims:
+        slot = (claim["lease_sha256"], claim["attempt_number"])
+        provider_slot = (claim["provider"], claim["provider_run_id"])
+        if slot in claim_by_slot or provider_slot in provider_runs:
+            raise ValueError("duplicate claim slot or provider run")
+        claim_by_slot[slot] = claim
+        provider_runs.add(provider_slot)
+
+    outcome_by_claim: dict[str, dict[str, Any]] = {}
+    for outcome in outcomes:
+        if outcome["claim_sha256"] in outcome_by_claim:
+            raise ValueError("claim has multiple terminal outcomes")
+        outcome_by_claim[outcome["claim_sha256"]] = outcome
+
+    accepted = []
+    failures = []
+    pending: set[str] = set()
+    for lease in sorted(leases, key=lambda item: item["ordinal"]):
+        lease_claims = sorted(
+            (
+                claim
+                for (lease_sha, _), claim in claim_by_slot.items()
+                if lease_sha == lease["lease_sha256"]
+            ),
+            key=lambda item: item["attempt_number"],
+        )
+        attempts = [claim["attempt_number"] for claim in lease_claims]
+        if attempts != list(range(1, len(attempts) + 1)):
+            raise ValueError("lease attempts are not contiguous from 1")
+        if not lease_claims:
+            pending.add(lease["lease_sha256"])
+            continue
+
+        artifact_seen = False
+        for index, claim in enumerate(lease_claims):
+            if claim["shard_spec_sha256"] != lease["shard_spec_sha256"]:
+                raise ValueError("claim shard does not match lease")
+            if artifact_seen:
+                raise ValueError("attempt exists after accepted artifact")
+            if index:
+                prior = outcome_by_claim.get(lease_claims[index - 1]["claim_sha256"])
+                if prior is None or prior.get("event_type") != "infrastructure_failure":
+                    raise ValueError("retry lacks trusted infrastructure failure")
+                if prior.get("valid_worker_artifact_exists") is not False:
+                    raise ValueError("retry follows a valid worker artifact")
+            outcome = outcome_by_claim.get(claim["claim_sha256"])
+            if outcome is None:
+                if index != len(lease_claims) - 1:
+                    raise ValueError("only the latest claim may be unsettled")
+                pending.add(lease["lease_sha256"])
+                continue
+            if (
+                outcome["lease_sha256"] != claim["lease_sha256"]
+                or outcome["shard_spec_sha256"] != claim["shard_spec_sha256"]
+                or outcome["attempt_number"] != claim["attempt_number"]
+            ):
+                raise ValueError("outcome binding differs from claim")
+            if outcome["event_type"] == "infrastructure_failure":
+                failures.append(outcome)
+            elif outcome["event_type"] == "artifact_settlement":
+                if outcome["environment_authority_sha256"] != lease["environment_authority_sha256"]:
+                    raise ValueError("artifact environment authority differs from lease")
+                accepted.append(outcome)
+                artifact_seen = True
+            else:
+                raise ValueError("unknown terminal outcome type")
+
+        if not artifact_seen and lease_claims[-1]["claim_sha256"] in outcome_by_claim:
+            pending.add(lease["lease_sha256"])
+
+    complete = len(accepted) == LEASE_COUNT and not pending
+    payload = {
+        "schema_version": 1,
+        "fleet_authority_sha256": _identity(FLEET_SCHEMA, _fleet_payload()),
+        "environment_authority_sha256": _digest("synthetic-environment"),
+        "expected_lease_count": LEASE_COUNT,
+        "lease_sha256s": [
+            item["lease_sha256"] for item in sorted(leases, key=lambda item: item["ordinal"])
+        ],
+        "claim_sha256s": sorted(item["claim_sha256"] for item in claims),
+        "outcome_sha256s": sorted(item["outcome_sha256"] for item in outcomes),
+        "accepted_artifact_count": len(accepted),
+        "infrastructure_failure_count": len(failures),
+        "pending_lease_count": len(pending),
+        "complete": complete,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "orion_comparison_permitted": False,
+    }
+    return {**payload, "settlement_ledger_sha256": _identity(LEDGER_SCHEMA, payload)}
+
+
+def verify_synthetic_packet(root: str | Path) -> dict[str, Any]:
+    supplied = Path(root)
+    if supplied.is_symlink():
+        raise ValueError("synthetic evidence root may not be a symlink")
+    root_path = supplied.resolve()
+    if not root_path.is_dir():
+        raise FileNotFoundError(f"synthetic evidence root is not a directory: {root_path}")
+
+    leases = _expected_leases()
+    claims = _expected_claims(leases)
+    outcomes = _expected_outcomes(leases, claims)
+
+    expected_files, expected_dirs = _expected_topology(leases, claims)
+    files, dirs = _walk_topology(root_path)
+    if files != expected_files:
+        raise ValueError(
+            "synthetic evidence file topology differs: "
+            f"missing={sorted(expected_files - files)}, extra={sorted(files - expected_files)}"
+        )
+    if dirs != expected_dirs:
+        raise ValueError(
+            "synthetic evidence directory topology differs: "
+            f"missing={sorted(expected_dirs - dirs)}, extra={sorted(dirs - expected_dirs)}"
+        )
+
+    for lease in leases:
+        _require_exact_record(
+            root_path / "store" / "leases" / f"{lease['lease_sha256']}.json",
+            lease,
+            "lease_sha256",
+            LEASE_SCHEMA,
+        )
+
+    for claim in claims:
+        _require_exact_record(
+            root_path
+            / "store"
+            / "claims"
+            / claim["lease_sha256"]
+            / f"attempt-{claim['attempt_number']:04d}.json",
+            claim,
+            "claim_sha256",
+            CLAIM_SCHEMA,
+        )
+
+    outcomes_by_slot = {
+        (item["lease_sha256"], item["attempt_number"]): item for item in outcomes
+    }
+    for claim in claims:
+        expected = outcomes_by_slot[(claim["lease_sha256"], claim["attempt_number"])]
+        schema = (
+            FAILURE_SCHEMA
+            if expected["event_type"] == "infrastructure_failure"
+            else SETTLEMENT_SCHEMA
+        )
+        _require_exact_record(
+            root_path
+            / "store"
+            / "outcomes"
+            / claim["lease_sha256"]
+            / f"attempt-{claim['attempt_number']:04d}.json",
+            expected,
+            "outcome_sha256",
+            schema,
+        )
+
+    ledger = _replay_ledger(leases, claims, outcomes)
+    if ledger["complete"] is not True:
+        raise ValueError("persisted synthetic packet does not earn complete settlement")
+
+    receipt_payload = {
+        "schema_version": 1,
+        "artifact_kind": "provider_free_gpu_fleet_systems_qualification",
+        "promoted_gpu_execution_authority_revision": PROMOTED_GPU_EXECUTION_AUTHORITY_REVISION,
+        "preflight_admission_sha256": _identity(PREFLIGHT_SCHEMA, _preflight_payload()),
+        "fleet_authority_sha256": _identity(FLEET_SCHEMA, _fleet_payload()),
+        "environment_authority_sha256": _digest("synthetic-environment"),
+        "lease_sha256s": [lease["lease_sha256"] for lease in leases],
+        "settlement_ledger_sha256": ledger["settlement_ledger_sha256"],
+        "expected_lease_count": 3,
+        "accepted_artifact_count": 3,
+        "infrastructure_failure_count": 1,
+        "attempt_count": 4,
+        "provider": PROVIDER,
+        "model_execution_performed": False,
+        "neural_data_accessed": False,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "external_floor_claim_generated": False,
+        "orion_comparison_permitted": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    expected_receipt = {
+        **receipt_payload,
+        "synthetic_qualification_sha256": _identity(QUALIFICATION_SCHEMA, receipt_payload),
+    }
+    receipt_path = root_path / "synthetic_qualification_receipt.json"
+    observed_receipt = _load_json(receipt_path)
+    if observed_receipt != expected_receipt:
+        raise ValueError("synthetic qualification receipt differs from independent replay")
+    payload = dict(observed_receipt)
+    declared = payload.pop("synthetic_qualification_sha256")
+    if declared != _identity(QUALIFICATION_SCHEMA, payload):
+        raise ValueError("synthetic qualification receipt identity mismatch")
+
+    return {
+        "verified": True,
+        "synthetic_qualification_sha256": declared,
+        "fleet_authority_sha256": receipt_payload["fleet_authority_sha256"],
+        "environment_authority_sha256": receipt_payload["environment_authority_sha256"],
+        "settlement_ledger_sha256": ledger["settlement_ledger_sha256"],
+        "lease_count": 3,
+        "claim_count": 4,
+        "accepted_artifact_count": 3,
+        "infrastructure_failure_count": 1,
+        "complete": True,
+        "model_execution_performed": False,
+        "neural_data_accessed": False,
+        "scientific_outcomes_inspected": False,
+        "numerical_result_interpretable": False,
+        "orion_comparison_permitted": False,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Independently verify the promoted Kumar2024 synthetic fleet packet"
+    )
+    parser.add_argument("--root", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    print(json.dumps(verify_synthetic_packet(args.root), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kumar2024_gpu_fleet_replay_v2.py
+++ b/tests/test_kumar2024_gpu_fleet_replay_v2.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[1]
+GENERATOR_PATH = REPO_ROOT / "scripts" / "evidence" / "qualify_kumar2024_gpu_fleet_synthetic.py"
+VERIFIER_PATH = REPO_ROOT / "scripts" / "evidence" / "verify_kumar2024_gpu_fleet_synthetic.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+generator = _load("kumar2024_synthetic_generator_for_replay", GENERATOR_PATH)
+verifier = _load("kumar2024_synthetic_independent_replay", VERIFIER_PATH)
+
+
+def _packet(tmp_path: Path) -> Path:
+    root = tmp_path / "packet"
+    generator.run(REPO_ROOT, root)
+    return root
+
+
+def _first_json(root: Path, bucket: str) -> Path:
+    return sorted((root / "store" / bucket).rglob("*.json"))[0]
+
+
+def test_independent_replay_matches_promoted_known_identities(tmp_path: Path):
+    result = verifier.verify_synthetic_packet(_packet(tmp_path))
+    assert result["verified"] is True
+    assert result["complete"] is True
+    assert result["settlement_ledger_sha256"] == (
+        "293184148318914f332b3c4fe9c6658ca7a0acabadc79d3e46d63239291ec3d5"
+    )
+    assert result["synthetic_qualification_sha256"] == (
+        "1e35e04e2bf49085b15e837d32c5abc1cee52b1f26ac872353f9089598a68df1"
+    )
+    assert result["lease_count"] == 3
+    assert result["claim_count"] == 4
+    assert result["accepted_artifact_count"] == 3
+    assert result["infrastructure_failure_count"] == 1
+    assert result["model_execution_performed"] is False
+    assert result["neural_data_accessed"] is False
+    assert result["scientific_outcomes_inspected"] is False
+    assert result["orion_comparison_permitted"] is False
+
+
+def test_mutated_persisted_claim_rejects(tmp_path: Path):
+    root = _packet(tmp_path)
+    path = _first_json(root, "claims")
+    payload = json.loads(path.read_text())
+    payload["worker_id"] = "tampered-worker"
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    with pytest.raises(ValueError, match="frozen synthetic protocol"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_resealed_learned_state_substitution_rejects(tmp_path: Path):
+    root = _packet(tmp_path)
+    paths = sorted((root / "store" / "outcomes").rglob("*.json"))
+    path = next(
+        p for p in paths if json.loads(p.read_text()).get("event_type") == "artifact_settlement"
+    )
+    payload = json.loads(path.read_text())
+    payload["learned_state_sha256"] = "a" * 64
+    body = dict(payload)
+    body.pop("outcome_sha256")
+    payload["outcome_sha256"] = verifier._identity(verifier.SETTLEMENT_SCHEMA, body)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    with pytest.raises(ValueError, match="frozen synthetic protocol"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_resealed_environment_substitution_rejects(tmp_path: Path):
+    root = _packet(tmp_path)
+    paths = sorted((root / "store" / "outcomes").rglob("*.json"))
+    path = next(
+        p for p in paths if json.loads(p.read_text()).get("event_type") == "artifact_settlement"
+    )
+    payload = json.loads(path.read_text())
+    payload["environment_authority_sha256"] = "b" * 64
+    body = dict(payload)
+    body.pop("outcome_sha256")
+    payload["outcome_sha256"] = verifier._identity(verifier.SETTLEMENT_SCHEMA, body)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    with pytest.raises(ValueError, match="frozen synthetic protocol"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_missing_outcome_rejects_closed_packet(tmp_path: Path):
+    root = _packet(tmp_path)
+    _first_json(root, "outcomes").unlink()
+    with pytest.raises(ValueError, match="file topology differs"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_shadow_file_and_empty_directory_reject(tmp_path: Path):
+    root = _packet(tmp_path)
+    shadow = root / "store" / "claims" / "shadow.json"
+    shadow.write_text("{}\n")
+    with pytest.raises(ValueError, match="file topology differs"):
+        verifier.verify_synthetic_packet(root)
+
+    shadow.unlink()
+    (root / "store" / "attempts" / "unexpected-empty-dir").mkdir()
+    with pytest.raises(ValueError, match="directory topology differs"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_resealed_false_top_level_claim_rejects(tmp_path: Path):
+    root = _packet(tmp_path)
+    path = root / "synthetic_qualification_receipt.json"
+    payload = json.loads(path.read_text())
+    payload["scientific_outcomes_inspected"] = True
+    body = dict(payload)
+    body.pop("synthetic_qualification_sha256")
+    payload["synthetic_qualification_sha256"] = verifier._identity(
+        verifier.QUALIFICATION_SCHEMA, body
+    )
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n")
+    with pytest.raises(ValueError, match="independent replay|scientific"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_duplicate_json_key_rejects(tmp_path: Path):
+    root = _packet(tmp_path)
+    path = _first_json(root, "claims")
+    text = path.read_text()
+    insert = text.rfind("}")
+    text = text[:insert] + ',\n  "worker_id": "duplicate"\n' + text[insert:]
+    path.write_text(text)
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        verifier.verify_synthetic_packet(root)
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable")
+def test_symlink_injection_rejects(tmp_path: Path):
+    root = _packet(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text("{}\n")
+    link = root / "store" / "claims" / "injected.json"
+    os.symlink(target, link)
+    with pytest.raises(ValueError, match="symlink"):
+        verifier.verify_synthetic_packet(root)
+
+
+def test_root_symlink_rejects(tmp_path: Path):
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks unavailable")
+    root = _packet(tmp_path)
+    alias = tmp_path / "alias"
+    os.symlink(root, alias, target_is_directory=True)
+    with pytest.raises(ValueError, match="root may not be a symlink"):
+        verifier.verify_synthetic_packet(alias)


### PR DESCRIPTION
## Purpose

Add an independent, standard-library-only replay verifier for the provider-free three-lease Kumar2024 fleet packet already promoted at `main@7ff39990361038e5c578d1100c61b3c7e7dac826`.

The generator must not be allowed to self-certify its own `complete=true` receipt through the same implementation that produced it.

## Exact candidate

- base: `main@7ff39990361038e5c578d1100c61b3c7e7dac826`
- current head: `1397723886d16f99d4cc50de1f1e3c1a8d7b75b6`
- ancestry: exactly one commit over the promoted synthetic qualification
- changed files: exactly four

Superseded candidate `535a674514cef573e121aa71afc352937355ea13` is historical evidence only. Its 10-test adversarial suite passed on Python 3.10/3.11/3.12, but the standalone positive step used the generator CLI without its required `run` subcommand and failed before replay. No result from that SHA counts toward promotion.

Files:
1. `scripts/evidence/verify_kumar2024_gpu_fleet_synthetic.py`
2. `tests/test_kumar2024_gpu_fleet_replay_v2.py`
3. `.github/workflows/nsq-kumar2024-gpu-fleet-replay-v2-ci.yml`
4. `docs/NSQ_KUMAR2024_GPU_FLEET_REPLAY_V2.md`

No scientific worker, model, split, seed, budget, GPU binding, fleet authority, or generator code is modified.

## Independent reconstruction

The verifier imports neither neurOS nor the generator. It independently reconstructs the exact current protocol:

- 3 canonical synthetic EEGNet leases;
- 4 claims;
- one `provider_preemption` failure proving `valid_worker_artifact_exists=false`;
- 3 accepted artifact settlements;
- exact environment authority on leases and accepted artifacts;
- retry legality;
- deterministic settlement ledger;
- final top-level qualification receipt.

The independently derived identities reproduce the already-observed promoted values:

- settlement ledger: `293184148318914f332b3c4fe9c6658ca7a0acabadc79d3e46d63239291ec3d5`
- synthetic qualification: `1e35e04e2bf49085b15e837d32c5abc1cee52b1f26ac872353f9089598a68df1`

## Closed-packet verification

The verifier requires the exact current file and directory topology under `store/{leases,claims,attempts,outcomes}` plus `synthetic_qualification_receipt.json`.

It rejects missing files, shadow files, unexpected directories, symlinks, duplicate JSON keys, non-finite JSON numbers, mutated persisted claims, freshly resealed learned-state substitutions, freshly resealed environment substitutions, missing outcomes, and freshly resealed false top-level claims.

Every sealed record must both recompute its own domain-separated SHA and exactly equal the independently preregistered record. Resealing a different record therefore does not make it admissible.

## Qualification

The exact-source three-version workflow runs Python 3.10/3.11/3.12, compiles the replay surfaces, executes the adversarial suite, generates a packet with the promoted generator, verifies it independently, requires the two known SHA-256 identities above, and AST-audits the verifier to ensure it has no neurOS, torch, Kaggle, provider SDK, subprocess, network, or scientific-result dependency.

The current head fixes only the standalone invocation to use the generator's canonical CLI: `qualify_kumar2024_gpu_fleet_synthetic.py run --output ...`.

Construction evidence before publication: the verifier compiled and its independent identity derivation reproduced both known promoted hashes. This is construction evidence only; promotion requires fresh exact-head CI on `1397723886d16f99d4cc50de1f1e3c1a8d7b75b6`.

## Claim boundary

This tranche is systems/software evidence only. It executes no neural model, accesses no neural data, inspects no score, and does not authorize a provider or the production 810-shard EEGNet fleet. The real fixed T4 preflight, systems-only admission, tiny live provider transport, complete fleet settlement, participant-level inference, external-floor construction, and ORION comparison remain separately gated.

Refs #165, #174, #175. Supersedes the obsolete four-lease replay topology in #171.