### PR TITLE
feat(evidence): add Kumar2024 Merkle fleet roster authority

### DIFF
--- a/.github/workflows/nsq-kumar2024-gpu-fleet-roster-ci.yml
+++ b/.github/workflows/nsq-kumar2024-gpu-fleet-roster-ci.yml
@@ -1,0 +1,103 @@
+name: NSQ Kumar2024 GPU fleet Merkle roster
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py"
+      - "tests/test_kumar2024_gpu_roster.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-roster-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_ROSTER.md"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py"
+      - "tests/test_kumar2024_gpu_roster.py"
+      - ".github/workflows/nsq-kumar2024-gpu-fleet-roster-ci.yml"
+      - "docs/NSQ_KUMAR2024_GPU_FLEET_ROSTER.md"
+
+permissions:
+  contents: read
+
+env:
+  QUALIFICATION_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  merkle-roster:
+    name: Merkle roster / Python ${{ matrix.python }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ env.QUALIFICATION_SHA }}
+
+      - name: Require exact clean qualification source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${QUALIFICATION_SHA}"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python }}
+          check-latest: false
+
+      - name: Install pinned test harness
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
+
+      - name: Compile roster surfaces
+        run: |
+          python -m py_compile \
+            packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py \
+            tests/test_kumar2024_gpu_roster.py
+
+      - name: Run Merkle roster adversarial qualification
+        run: python -m pytest -q tests/test_kumar2024_gpu_roster.py
+
+      - name: Require standalone distribution-integrity boundary
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py")
+          text = path.read_text(encoding="utf-8")
+          tree = ast.parse(text)
+          allowed = {
+              "__future__",
+              "collections.abc",
+              "dataclasses",
+              "hashlib",
+              "json",
+              "types",
+              "typing",
+          }
+          observed = set()
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  observed.update(alias.name for alias in node.names)
+              elif isinstance(node, ast.ImportFrom):
+                  observed.add(node.module or "")
+          assert observed <= allowed, sorted(observed - allowed)
+          for forbidden_import in (
+              "neuros",
+              "torch",
+              "moabb",
+              "kaggle",
+              "requests",
+              "subprocess",
+              "socket",
+              "urllib",
+              "importlib",
+          ):
+              assert forbidden_import not in observed, forbidden_import
+          for forbidden_file in ("case_result.json", "shard_result.json"):
+              assert forbidden_file not in text, forbidden_file
+          PY

--- a/docs/NSQ_KUMAR2024_GPU_FLEET_ROSTER.md
+++ b/docs/NSQ_KUMAR2024_GPU_FLEET_ROSTER.md
@@ -1,0 +1,134 @@
+# NSQ Kumar2024 GPU fleet Merkle roster authority
+
+Status: **distribution-integrity software only. This does not authorize a provider, GPU execution, scientific interpretation, or the production fleet.**
+
+This tranche adds a compact cryptographic inclusion layer above the promoted Kumar2024 GPU fleet lease authority. A provider worker can verify that one exact `LeaseSpec` belongs to the preregistered fleet without trusting mutable scheduler state or receiving the entire 810-lease manifest.
+
+## Authority boundary
+
+The implementation is deliberately additive. It does not modify `kumar2024_gpu_fleet.py`, the scientific execution graph, model code, seeds, calibration frontier, provider choice, retry semantics, settlement semantics, or score-handling boundary.
+
+`FleetRosterAuthority` binds:
+
+- fleet-authority SHA-256;
+- exact expected lease count;
+- ordered-leaf commitment SHA-256;
+- Merkle algorithm and odd-node policy;
+- Merkle root SHA-256;
+- GPU binding SHA-256;
+- execution-plan SHA-256;
+- environment-authority SHA-256;
+- fleet retry ceiling;
+- fixed EEGNet method identifier;
+- fixed `(0,1,2,5,10)` calibration frontier;
+- explicit negative claim semantics for execution, efficacy, completeness, and ORION readiness.
+
+The ordered-leaf commitment hashes the complete sequence of domain-separated leaf hashes. Each leaf is derived from the exact canonical `LeaseSpec` SHA-256, not from a reduced `(subject, session, seed)` tuple or provider metadata.
+
+## Frozen Merkle v1
+
+The algorithm is named:
+
+`sha256-canonical-json-domain-separated-duplicate-last-v1`
+
+Rules:
+
+1. SHA-256 only.
+2. Canonical JSON uses sorted keys, compact separators, ASCII escaping, and rejects NaN/Infinity.
+3. Lease identity uses the already-promoted `neuros.nsq_kumar2024_gpu_fleet_lease.v1` domain.
+4. Leaf identity uses `neuros.nsq_kumar2024_gpu_fleet_roster_leaf.v1`.
+5. Internal nodes use `neuros.nsq_kumar2024_gpu_fleet_roster_node.v1` and commit ordered `left_sha256` / `right_sha256` children.
+6. Leaves are ordered only by the existing canonical lease ordinal.
+7. Odd levels duplicate the final unpaired node.
+8. The empty tree is invalid.
+9. A singleton root equals its one domain-separated leaf hash.
+10. Proof verification never sorts nodes. It checks the explicit leaf index, expected sibling side at every level, proof depth, and duplicate-last behavior.
+
+This removes implementation-dependent Merkle conventions from the evidence surface.
+
+## Proof-carrying lease
+
+`build_fleet_roster(...)` consumes complete canonical `LeaseSpec.to_dict()` records plus the independently supplied frozen fleet bindings. It returns one small roster authority and one `ProofCarryingLease` per canonical ordinal.
+
+A dispatch package contains only:
+
+- the canonical lease record;
+- its lease SHA-256;
+- roster-authority SHA-256;
+- leaf index;
+- ordered authentication path.
+
+The roster authority is a small content-addressed header. A worker that resolves that header by SHA can call `verify_proof_carrying_lease(...)` before provider/model invocation. Verification independently performs:
+
+`LeaseSpec payload -> lease SHA -> leaf SHA -> ordered authentication path -> roster root`
+
+It also checks fleet authority, GPU binding, execution plan, environment authority, retry ceiling, method, and calibration frontier against the roster header.
+
+## Adversarial qualification
+
+The test tranche rejects:
+
+- altered lease payload with unchanged proof;
+- altered lease ordinal;
+- swapped proof order;
+- flipped sibling side;
+- foreign sibling hash;
+- proof from another roster;
+- wrong environment authority;
+- wrong execution plan;
+- wrong GPU binding;
+- wrong retry ceiling;
+- duplicate lease identity;
+- duplicate shard identity;
+- missing/extra leaves;
+- non-contiguous ordinals;
+- scientific-result contamination;
+- a proof that could only work after implicit reordering;
+- invalid duplicate-last behavior.
+
+It also requires differently ordered input iterables to produce byte-identical canonical authority and proof packages.
+
+A synthetic production-shaped qualification constructs all **810** expected axis combinations using the frozen shape only:
+
+- 18 subjects;
+- sessions `1` through `5`;
+- split seeds `2026`, `3407`, `9109`;
+- EEGNet model seeds `31415`, `384165836`, `3991196546`;
+- complete `(0,1,2,5,10)` frontier per lease.
+
+The shard hashes used by that test are synthetic test identities. The test does not materialize neural data, execute EEGNet, or claim a production roster root.
+
+Pre-publication local construction evidence: **23/23 tests passed**. CI must independently requalify the exact PR head on Python 3.10, 3.11, and 3.12; local evidence is not promotion evidence.
+
+## Scientific firewall
+
+The roster implementation is standard-library only and imports neither the fleet scheduler nor any neural/provider stack. CI AST-audits the import boundary.
+
+Scientific outcome keys are rejected recursively at the roster boundary. Membership means only:
+
+> this exact immutable assignment is one leaf committed by this exact roster root.
+
+It does **not** mean the provider ran, an artifact exists, the fleet settled completely, the model worked well, an external floor is valid, or ORION comparison is permitted.
+
+## Gate sequence
+
+```text
+promoted provider-free fleet + independent replay
+        |
+        v
+Merkle roster authority + proof-carrying leases (this tranche)
+        |
+        v
+real fixed T4 systems preflight
+        |
+        v
+systems-only preflight admission
+        |
+        v
+tiny live provider transport qualification
+        |
+        v
+complete settlement + explicit production fleet authorization
+```
+
+Issue #165 remains the live-execution authority boundary. Issue #175 owns this distribution-integrity tranche.

--- a/packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py
+++ b/packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py
@@ -1,0 +1,548 @@
+"""Merkle roster authority for proof-carrying Kumar2024 GPU fleet leases.
+
+This module is a distribution-integrity layer only. It independently validates
+canonical LeaseSpec records, commits their exact ordered identities into a
+versioned Merkle tree, and verifies compact inclusion proofs before a provider
+or model invocation is allowed to begin.
+
+It intentionally does not import the fleet scheduler, model code, provider
+SDKs, or scientific-result code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+ROSTER_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_roster_authority.v1"
+ORDERED_LEAVES_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_roster_ordered_leaves.v1"
+LEAF_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_roster_leaf.v1"
+NODE_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_roster_node.v1"
+LEASE_SCHEMA = "neuros.nsq_kumar2024_gpu_fleet_lease.v1"
+MERKLE_ALGORITHM = "sha256-canonical-json-domain-separated-duplicate-last-v1"
+ODD_NODE_POLICY = "duplicate_last"
+EEGNET_METHOD_ID = "braindecode-eegnet"
+CALIBRATION_FRONTIER = (0, 1, 2, 5, 10)
+
+LEASE_PAYLOAD_KEYS = frozenset(
+    {
+        "schema_version",
+        "fleet_authority_sha256",
+        "gpu_binding_sha256",
+        "execution_plan_sha256",
+        "environment_authority_sha256",
+        "shard_spec_sha256",
+        "ordinal",
+        "subject",
+        "target_session",
+        "split_seed",
+        "method_id",
+        "model_seed",
+        "budgets_per_class",
+        "max_attempts",
+    }
+)
+LEASE_RECORD_KEYS = LEASE_PAYLOAD_KEYS | {"lease_sha256"}
+FORBIDDEN_CONTROL_KEYS = frozenset(
+    {
+        "accuracy",
+        "balanced_accuracy",
+        "auc",
+        "auroc",
+        "f1",
+        "loss",
+        "logits",
+        "method_ranking",
+        "predictions",
+        "probabilities",
+        "scientific_score",
+        "final_assessment_metric",
+    }
+)
+
+
+def _canonical(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _identity(schema: str, payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical({"schema": schema, "payload": payload})).hexdigest()
+
+
+def _sha(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a canonical lowercase SHA-256")
+    if (
+        value != value.strip()
+        or value != value.lower()
+        or len(value) != 64
+        or any(char not in "0123456789abcdef" for char in value)
+    ):
+        raise ValueError(f"{name} must be a canonical lowercase SHA-256")
+    return value
+
+
+def _positive_int(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _nonnegative_int(name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _identifier(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError(f"{name} must be a non-empty canonical string")
+    return value
+
+
+def _frontier(value: Any) -> tuple[int, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError("budgets_per_class must be the frozen calibration frontier")
+    result = tuple(value)
+    if result != CALIBRATION_FRONTIER or any(
+        isinstance(item, bool) or not isinstance(item, int) for item in result
+    ):
+        raise ValueError(f"budgets_per_class must equal {CALIBRATION_FRONTIER}")
+    return result
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _thaw(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+def reject_scientific_fields(value: Any, path: str = "$") -> None:
+    """Fail closed if a scientific outcome enters the roster boundary."""
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"non-string roster key at {path}")
+            if key.lower() in FORBIDDEN_CONTROL_KEYS:
+                raise ValueError(f"scientific field {key!r} is forbidden at {path}")
+            reject_scientific_fields(item, f"{path}.{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            reject_scientific_fields(item, f"{path}[{index}]")
+
+
+def _normalized_lease(record: Mapping[str, Any]) -> dict[str, Any]:
+    reject_scientific_fields(record)
+    if set(record) != LEASE_RECORD_KEYS:
+        raise ValueError(
+            "lease record keys differ: "
+            f"missing={sorted(LEASE_RECORD_KEYS - set(record))}, "
+            f"extra={sorted(set(record) - LEASE_RECORD_KEYS)}"
+        )
+    if record["schema_version"] != 1 or isinstance(record["schema_version"], bool):
+        raise ValueError("lease schema_version must be 1")
+    normalized = {
+        "schema_version": 1,
+        "fleet_authority_sha256": _sha(
+            "fleet_authority_sha256", record["fleet_authority_sha256"]
+        ),
+        "gpu_binding_sha256": _sha("gpu_binding_sha256", record["gpu_binding_sha256"]),
+        "execution_plan_sha256": _sha(
+            "execution_plan_sha256", record["execution_plan_sha256"]
+        ),
+        "environment_authority_sha256": _sha(
+            "environment_authority_sha256", record["environment_authority_sha256"]
+        ),
+        "shard_spec_sha256": _sha("shard_spec_sha256", record["shard_spec_sha256"]),
+        "ordinal": _nonnegative_int("ordinal", record["ordinal"]),
+        "subject": _positive_int("subject", record["subject"]),
+        "target_session": _identifier("target_session", record["target_session"]),
+        "split_seed": _nonnegative_int("split_seed", record["split_seed"]),
+        "method_id": _identifier("method_id", record["method_id"]),
+        "model_seed": _nonnegative_int("model_seed", record["model_seed"]),
+        "budgets_per_class": list(_frontier(record["budgets_per_class"])),
+        "max_attempts": _positive_int("max_attempts", record["max_attempts"]),
+    }
+    if normalized["method_id"] != EEGNET_METHOD_ID:
+        raise ValueError("roster lease is not EEGNet")
+    expected_sha = _identity(LEASE_SCHEMA, normalized)
+    provided_sha = _sha("lease_sha256", record["lease_sha256"])
+    if provided_sha != expected_sha:
+        raise ValueError("lease_sha256 does not match canonical LeaseSpec payload")
+    return {**normalized, "lease_sha256": provided_sha}
+
+
+def _leaf_hash(lease_sha256: str) -> str:
+    return _identity(LEAF_SCHEMA, {"lease_sha256": _sha("lease_sha256", lease_sha256)})
+
+
+def _node_hash(left_sha256: str, right_sha256: str) -> str:
+    return _identity(
+        NODE_SCHEMA,
+        {
+            "left_sha256": _sha("left_sha256", left_sha256),
+            "right_sha256": _sha("right_sha256", right_sha256),
+        },
+    )
+
+
+def _merkle_root(leaf_hashes: Sequence[str]) -> str:
+    """Compute the v1 root. Empty trees are invalid; singleton root is its leaf."""
+    level = tuple(_sha("leaf_sha256", item) for item in leaf_hashes)
+    if not level:
+        raise ValueError("roster cannot be empty")
+    while len(level) > 1:
+        next_level = []
+        for index in range(0, len(level), 2):
+            left = level[index]
+            right = level[index + 1] if index + 1 < len(level) else left
+            next_level.append(_node_hash(left, right))
+        level = tuple(next_level)
+    return level[0]
+
+
+@dataclass(frozen=True)
+class MerkleProofEntry:
+    side: str
+    sibling_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.side not in {"left", "right"}:
+            raise ValueError("Merkle proof side must be 'left' or 'right'")
+        object.__setattr__(
+            self,
+            "sibling_sha256",
+            _sha("sibling_sha256", self.sibling_sha256),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {"side": self.side, "sibling_sha256": self.sibling_sha256}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "MerkleProofEntry":
+        if set(value) != {"side", "sibling_sha256"}:
+            raise ValueError("Merkle proof entry has unexpected keys")
+        return cls(value["side"], value["sibling_sha256"])
+
+
+@dataclass(frozen=True)
+class FleetRosterAuthority:
+    fleet_authority_sha256: str
+    expected_lease_count: int
+    ordered_leaf_commitment_sha256: str
+    merkle_root_sha256: str
+    gpu_binding_sha256: str
+    execution_plan_sha256: str
+    environment_authority_sha256: str
+    max_attempts_per_lease: int
+    merkle_algorithm: str = MERKLE_ALGORITHM
+    odd_node_policy: str = ODD_NODE_POLICY
+    lease_schema: str = LEASE_SCHEMA
+    method_id: str = EEGNET_METHOD_ID
+    budgets_per_class: tuple[int, ...] = CALIBRATION_FRONTIER
+
+    def __post_init__(self) -> None:
+        for field in (
+            "fleet_authority_sha256",
+            "ordered_leaf_commitment_sha256",
+            "merkle_root_sha256",
+            "gpu_binding_sha256",
+            "execution_plan_sha256",
+            "environment_authority_sha256",
+        ):
+            object.__setattr__(self, field, _sha(field, getattr(self, field)))
+        object.__setattr__(
+            self,
+            "expected_lease_count",
+            _positive_int("expected_lease_count", self.expected_lease_count),
+        )
+        object.__setattr__(
+            self,
+            "max_attempts_per_lease",
+            _positive_int("max_attempts_per_lease", self.max_attempts_per_lease),
+        )
+        if self.merkle_algorithm != MERKLE_ALGORITHM:
+            raise ValueError("unsupported Merkle algorithm")
+        if self.odd_node_policy != ODD_NODE_POLICY:
+            raise ValueError("unsupported odd-node policy")
+        if self.lease_schema != LEASE_SCHEMA:
+            raise ValueError("roster must commit the canonical LeaseSpec v1 schema")
+        if self.method_id != EEGNET_METHOD_ID:
+            raise ValueError("roster v1 is fixed to EEGNet")
+        object.__setattr__(self, "budgets_per_class", _frontier(self.budgets_per_class))
+
+    def payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "artifact_kind": "kumar2024_gpu_fleet_merkle_roster_authority",
+            "fleet_authority_sha256": self.fleet_authority_sha256,
+            "expected_lease_count": self.expected_lease_count,
+            "ordered_leaf_commitment_sha256": self.ordered_leaf_commitment_sha256,
+            "merkle_algorithm": self.merkle_algorithm,
+            "odd_node_policy": self.odd_node_policy,
+            "leaf_domain": LEAF_SCHEMA,
+            "node_domain": NODE_SCHEMA,
+            "lease_schema": self.lease_schema,
+            "merkle_root_sha256": self.merkle_root_sha256,
+            "gpu_binding_sha256": self.gpu_binding_sha256,
+            "execution_plan_sha256": self.execution_plan_sha256,
+            "environment_authority_sha256": self.environment_authority_sha256,
+            "max_attempts_per_lease": self.max_attempts_per_lease,
+            "method_id": self.method_id,
+            "budgets_per_class": list(self.budgets_per_class),
+            "empty_tree_policy": "reject",
+            "singleton_tree_policy": "root_equals_leaf",
+            "proof_ordering": "leaf_index_and_explicit_sibling_side_no_sorting",
+            "membership_implies_execution": False,
+            "membership_implies_numerical_efficacy": False,
+            "membership_implies_fleet_completeness": False,
+            "orion_comparison_permitted": False,
+        }
+
+    @property
+    def sha256(self) -> str:
+        return _identity(ROSTER_SCHEMA, self.payload())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**self.payload(), "roster_authority_sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class ProofCarryingLease:
+    lease: Mapping[str, Any]
+    lease_sha256: str
+    roster_authority_sha256: str
+    leaf_index: int
+    authentication_path: tuple[MerkleProofEntry, ...]
+
+    def __post_init__(self) -> None:
+        normalized = _normalized_lease(self.lease)
+        lease_sha = _sha("lease_sha256", self.lease_sha256)
+        if normalized["lease_sha256"] != lease_sha:
+            raise ValueError("proof package lease_sha256 differs from LeaseSpec")
+        object.__setattr__(self, "lease", _freeze(normalized))
+        object.__setattr__(self, "lease_sha256", lease_sha)
+        object.__setattr__(
+            self,
+            "roster_authority_sha256",
+            _sha("roster_authority_sha256", self.roster_authority_sha256),
+        )
+        object.__setattr__(self, "leaf_index", _nonnegative_int("leaf_index", self.leaf_index))
+        path = tuple(self.authentication_path)
+        if any(not isinstance(item, MerkleProofEntry) for item in path):
+            raise TypeError("authentication_path must contain MerkleProofEntry values")
+        object.__setattr__(self, "authentication_path", path)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "lease": _thaw(self.lease),
+            "lease_sha256": self.lease_sha256,
+            "roster_authority_sha256": self.roster_authority_sha256,
+            "leaf_index": self.leaf_index,
+            "authentication_path": [item.to_dict() for item in self.authentication_path],
+        }
+
+
+def _proof_for_index(leaf_hashes: Sequence[str], leaf_index: int) -> tuple[MerkleProofEntry, ...]:
+    count = len(leaf_hashes)
+    if count == 0:
+        raise ValueError("roster cannot be empty")
+    if leaf_index < 0 or leaf_index >= count:
+        raise ValueError("leaf_index outside roster")
+    level = tuple(_sha("leaf_sha256", item) for item in leaf_hashes)
+    index = leaf_index
+    proof: list[MerkleProofEntry] = []
+    while len(level) > 1:
+        if index % 2:
+            proof.append(MerkleProofEntry("left", level[index - 1]))
+        else:
+            sibling = level[index + 1] if index + 1 < len(level) else level[index]
+            proof.append(MerkleProofEntry("right", sibling))
+        next_level = []
+        for offset in range(0, len(level), 2):
+            left = level[offset]
+            right = level[offset + 1] if offset + 1 < len(level) else left
+            next_level.append(_node_hash(left, right))
+        index //= 2
+        level = tuple(next_level)
+    return tuple(proof)
+
+
+def build_fleet_roster(
+    leases: Iterable[Mapping[str, Any]],
+    *,
+    fleet_authority_sha256: str,
+    expected_lease_count: int,
+    gpu_binding_sha256: str,
+    execution_plan_sha256: str,
+    environment_authority_sha256: str,
+    max_attempts_per_lease: int,
+) -> tuple[FleetRosterAuthority, tuple[ProofCarryingLease, ...]]:
+    """Build one deterministic roster and one compact proof per canonical lease."""
+    expected_fleet = _sha("fleet_authority_sha256", fleet_authority_sha256)
+    expected_count = _positive_int("expected_lease_count", expected_lease_count)
+    expected_binding = _sha("gpu_binding_sha256", gpu_binding_sha256)
+    expected_plan = _sha("execution_plan_sha256", execution_plan_sha256)
+    expected_environment = _sha(
+        "environment_authority_sha256", environment_authority_sha256
+    )
+    expected_max_attempts = _positive_int(
+        "max_attempts_per_lease", max_attempts_per_lease
+    )
+    normalized = [_normalized_lease(item) for item in leases]
+    if len(normalized) != expected_count:
+        raise ValueError("roster lease count differs from frozen fleet authority")
+    if len({item["lease_sha256"] for item in normalized}) != len(normalized):
+        raise ValueError("roster contains duplicate lease identities")
+    if len({item["shard_spec_sha256"] for item in normalized}) != len(normalized):
+        raise ValueError("roster contains duplicate shard identities")
+    by_ordinal: dict[int, dict[str, Any]] = {}
+    for lease in normalized:
+        if lease["ordinal"] in by_ordinal:
+            raise ValueError("roster contains duplicate lease ordinals")
+        if lease["fleet_authority_sha256"] != expected_fleet:
+            raise ValueError("lease names a foreign fleet authority")
+        if lease["gpu_binding_sha256"] != expected_binding:
+            raise ValueError("lease names a foreign GPU binding")
+        if lease["execution_plan_sha256"] != expected_plan:
+            raise ValueError("lease names a foreign execution plan")
+        if lease["environment_authority_sha256"] != expected_environment:
+            raise ValueError("lease names a foreign environment authority")
+        if lease["max_attempts"] != expected_max_attempts:
+            raise ValueError("lease retry ceiling differs from fleet authority")
+        by_ordinal[lease["ordinal"]] = lease
+    if set(by_ordinal) != set(range(expected_count)):
+        raise ValueError("roster lease ordinals must be contiguous from zero")
+    ordered = tuple(by_ordinal[index] for index in range(expected_count))
+    lease_ids = tuple(item["lease_sha256"] for item in ordered)
+    leaf_hashes = tuple(_leaf_hash(item) for item in lease_ids)
+    ordered_commitment = _identity(
+        ORDERED_LEAVES_SCHEMA,
+        {
+            "expected_lease_count": expected_count,
+            "leaf_sha256s": list(leaf_hashes),
+        },
+    )
+    authority = FleetRosterAuthority(
+        expected_fleet,
+        expected_count,
+        ordered_commitment,
+        _merkle_root(leaf_hashes),
+        expected_binding,
+        expected_plan,
+        expected_environment,
+        expected_max_attempts,
+    )
+    packages = tuple(
+        ProofCarryingLease(
+            lease,
+            lease["lease_sha256"],
+            authority.sha256,
+            index,
+            _proof_for_index(leaf_hashes, index),
+        )
+        for index, lease in enumerate(ordered)
+    )
+    return authority, packages
+
+
+def verify_proof_carrying_lease(
+    package: ProofCarryingLease,
+    authority: FleetRosterAuthority,
+) -> str:
+    """Verify one roster inclusion proof without consulting scheduler state."""
+    if not isinstance(package, ProofCarryingLease):
+        raise TypeError("package must be ProofCarryingLease")
+    if not isinstance(authority, FleetRosterAuthority):
+        raise TypeError("authority must be FleetRosterAuthority")
+    if package.roster_authority_sha256 != authority.sha256:
+        raise ValueError("proof package names a foreign roster authority")
+    lease = _normalized_lease(_thaw(package.lease))
+    if package.lease_sha256 != lease["lease_sha256"]:
+        raise ValueError("proof package lease identity mismatch")
+    if lease["ordinal"] != package.leaf_index:
+        raise ValueError("lease ordinal differs from Merkle leaf index")
+    if package.leaf_index >= authority.expected_lease_count:
+        raise ValueError("Merkle leaf index outside roster authority")
+    if lease["fleet_authority_sha256"] != authority.fleet_authority_sha256:
+        raise ValueError("lease names a foreign fleet authority")
+    if lease["gpu_binding_sha256"] != authority.gpu_binding_sha256:
+        raise ValueError("lease names a foreign GPU binding")
+    if lease["execution_plan_sha256"] != authority.execution_plan_sha256:
+        raise ValueError("lease names a foreign execution plan")
+    if lease["environment_authority_sha256"] != authority.environment_authority_sha256:
+        raise ValueError("lease names a foreign environment authority")
+    if lease["max_attempts"] != authority.max_attempts_per_lease:
+        raise ValueError("lease retry ceiling differs from roster authority")
+    if lease["method_id"] != authority.method_id:
+        raise ValueError("lease method differs from roster policy")
+    if tuple(lease["budgets_per_class"]) != authority.budgets_per_class:
+        raise ValueError("lease calibration frontier differs from roster policy")
+
+    current = _leaf_hash(package.lease_sha256)
+    index = package.leaf_index
+    width = authority.expected_lease_count
+    path = package.authentication_path
+    expected_depth = 0
+    probe_width = width
+    while probe_width > 1:
+        expected_depth += 1
+        probe_width = (probe_width + 1) // 2
+    if len(path) != expected_depth:
+        raise ValueError("Merkle authentication path has the wrong depth")
+
+    for entry in path:
+        expected_side = "left" if index % 2 else "right"
+        if entry.side != expected_side:
+            raise ValueError("Merkle proof side contradicts the explicit leaf index")
+        if index % 2 == 0 and index + 1 >= width:
+            if entry.sibling_sha256 != current:
+                raise ValueError("duplicate-last proof must duplicate the unpaired node")
+        if entry.side == "left":
+            current = _node_hash(entry.sibling_sha256, current)
+        else:
+            current = _node_hash(current, entry.sibling_sha256)
+        index //= 2
+        width = (width + 1) // 2
+    if index != 0 or width != 1:
+        raise ValueError("Merkle proof did not terminate at the roster root")
+    if current != authority.merkle_root_sha256:
+        raise ValueError("Merkle proof does not reconstruct the roster root")
+    return package.lease_sha256
+
+
+def serialize_roster_authority(authority: FleetRosterAuthority) -> bytes:
+    """Return the canonical byte representation used for distribution and hashing."""
+    if not isinstance(authority, FleetRosterAuthority):
+        raise TypeError("authority must be FleetRosterAuthority")
+    return _canonical(authority.to_dict())
+
+
+def serialize_proof_carrying_lease(package: ProofCarryingLease) -> bytes:
+    """Return a canonical provider-dispatch package without scheduler state."""
+    if not isinstance(package, ProofCarryingLease):
+        raise TypeError("package must be ProofCarryingLease")
+    return _canonical(package.to_dict())

--- a/tests/test_kumar2024_gpu_roster.py
+++ b/tests/test_kumar2024_gpu_roster.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "packages" / "neuros" / "src" / "neuros" / "evidence" / "kumar2024_gpu_roster.py"
+)
+if not MODULE_PATH.is_file():
+    MODULE_PATH = Path(__file__).with_name("kumar2024_gpu_roster.py")
+spec = importlib.util.spec_from_file_location("roster_target", MODULE_PATH)
+assert spec and spec.loader
+roster = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = roster
+spec.loader.exec_module(roster)
+
+
+def digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+FLEET = digest("fleet")
+BINDING = digest("binding")
+PLAN = digest("plan")
+ENV = digest("environment")
+
+
+def lease(ordinal: int, *, subject: int | None = None, session: str = "1") -> dict:
+    payload = {
+        "schema_version": 1,
+        "fleet_authority_sha256": FLEET,
+        "gpu_binding_sha256": BINDING,
+        "execution_plan_sha256": PLAN,
+        "environment_authority_sha256": ENV,
+        "shard_spec_sha256": digest(f"shard-{ordinal}"),
+        "ordinal": ordinal,
+        "subject": subject if subject is not None else ordinal + 1,
+        "target_session": session,
+        "split_seed": 2026 + ordinal,
+        "method_id": roster.EEGNET_METHOD_ID,
+        "model_seed": 31415 + ordinal,
+        "budgets_per_class": list(roster.CALIBRATION_FRONTIER),
+        "max_attempts": 3,
+    }
+    return {**payload, "lease_sha256": roster._identity(roster.LEASE_SCHEMA, payload)}
+
+
+def build(items):
+    return roster.build_fleet_roster(
+        items,
+        fleet_authority_sha256=FLEET,
+        expected_lease_count=len(items),
+        gpu_binding_sha256=BINDING,
+        execution_plan_sha256=PLAN,
+        environment_authority_sha256=ENV,
+        max_attempts_per_lease=3,
+    )
+
+
+def test_build_is_input_order_independent_and_all_proofs_verify():
+    leases = [lease(i) for i in range(9)]
+    authority_a, packages_a = build(leases)
+    shuffled = leases[:]
+    random.Random(2026).shuffle(shuffled)
+    authority_b, packages_b = build(shuffled)
+    assert authority_a.to_dict() == authority_b.to_dict()
+    assert [item.to_dict() for item in packages_a] == [item.to_dict() for item in packages_b]
+    assert authority_a.merkle_algorithm == roster.MERKLE_ALGORITHM
+    assert authority_a.odd_node_policy == "duplicate_last"
+    assert all(
+        roster.verify_proof_carrying_lease(package, authority_a) == package.lease_sha256
+        for package in packages_a
+    )
+
+
+def test_singleton_is_explicit_and_empty_rejects():
+    authority, packages = build([lease(0)])
+    assert authority.merkle_root_sha256 == roster._leaf_hash(packages[0].lease_sha256)
+    assert packages[0].authentication_path == ()
+    roster.verify_proof_carrying_lease(packages[0], authority)
+    with pytest.raises(ValueError, match="positive integer"):
+        roster.build_fleet_roster(
+            [],
+            fleet_authority_sha256=FLEET,
+            expected_lease_count=0,
+            gpu_binding_sha256=BINDING,
+            execution_plan_sha256=PLAN,
+            environment_authority_sha256=ENV,
+            max_attempts_per_lease=3,
+        )
+
+
+def test_altered_lease_payload_with_unchanged_proof_rejects():
+    authority, packages = build([lease(i) for i in range(5)])
+    raw = packages[2].to_dict()
+    raw["lease"]["subject"] = 18
+    with pytest.raises(ValueError, match="lease_sha256"):
+        roster.ProofCarryingLease(
+            raw["lease"], raw["lease_sha256"], raw["roster_authority_sha256"],
+            raw["leaf_index"], packages[2].authentication_path,
+        )
+
+
+def test_altered_ordinal_rejects_before_path_verification():
+    authority, packages = build([lease(i) for i in range(5)])
+    payload = dict(packages[2].lease)
+    payload["ordinal"] = 3
+    payload_without_sha = {k: v for k, v in payload.items() if k != "lease_sha256"}
+    payload["lease_sha256"] = roster._identity(roster.LEASE_SCHEMA, payload_without_sha)
+    package = roster.ProofCarryingLease(
+        payload, payload["lease_sha256"], authority.sha256, 2, packages[2].authentication_path
+    )
+    with pytest.raises(ValueError, match="ordinal"):
+        roster.verify_proof_carrying_lease(package, authority)
+
+
+def test_swapped_proof_order_rejects():
+    authority, packages = build([lease(i) for i in range(9)])
+    path = list(packages[4].authentication_path)
+    path[0], path[1] = path[1], path[0]
+    package = roster.ProofCarryingLease(
+        packages[4].lease, packages[4].lease_sha256, authority.sha256, 4, tuple(path)
+    )
+    with pytest.raises(ValueError):
+        roster.verify_proof_carrying_lease(package, authority)
+
+
+def test_flipped_sibling_side_rejects():
+    authority, packages = build([lease(i) for i in range(5)])
+    path = list(packages[1].authentication_path)
+    first = path[0]
+    path[0] = roster.MerkleProofEntry("right" if first.side == "left" else "left", first.sibling_sha256)
+    package = roster.ProofCarryingLease(
+        packages[1].lease, packages[1].lease_sha256, authority.sha256, 1, tuple(path)
+    )
+    with pytest.raises(ValueError, match="side"):
+        roster.verify_proof_carrying_lease(package, authority)
+
+
+def test_foreign_sibling_hash_rejects():
+    authority, packages = build([lease(i) for i in range(5)])
+    path = list(packages[1].authentication_path)
+    path[0] = roster.MerkleProofEntry(path[0].side, digest("foreign"))
+    package = roster.ProofCarryingLease(
+        packages[1].lease, packages[1].lease_sha256, authority.sha256, 1, tuple(path)
+    )
+    with pytest.raises(ValueError, match="root"):
+        roster.verify_proof_carrying_lease(package, authority)
+
+
+def test_proof_from_different_roster_rejects():
+    authority_a, packages_a = build([lease(i) for i in range(5)])
+    foreign = [lease(i) for i in range(5)]
+    foreign[4] = lease(4, subject=18)
+    # reseal changed LeaseSpec
+    p = {k: v for k, v in foreign[4].items() if k != "lease_sha256"}
+    foreign[4]["lease_sha256"] = roster._identity(roster.LEASE_SCHEMA, p)
+    authority_b, _ = build(foreign)
+    with pytest.raises(ValueError, match="foreign roster"):
+        roster.verify_proof_carrying_lease(packages_a[2], authority_b)
+    assert authority_a.sha256 != authority_b.sha256
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("environment_authority_sha256", "environment"),
+        ("execution_plan_sha256", "execution plan"),
+    ],
+)
+def test_wrong_bound_authority_rejects_during_build(field, message):
+    item = lease(0)
+    item[field] = digest("wrong")
+    payload = {k: v for k, v in item.items() if k != "lease_sha256"}
+    item["lease_sha256"] = roster._identity(roster.LEASE_SCHEMA, payload)
+    with pytest.raises(ValueError, match=message):
+        build([item])
+
+
+def test_duplicate_lease_identity_rejects():
+    item = lease(0)
+    with pytest.raises(ValueError, match="duplicate lease"):
+        roster.build_fleet_roster(
+            [item, copy.deepcopy(item)], fleet_authority_sha256=FLEET,
+            expected_lease_count=2, gpu_binding_sha256=BINDING,
+            execution_plan_sha256=PLAN, environment_authority_sha256=ENV,
+            max_attempts_per_lease=3,
+        )
+
+
+def test_duplicate_shard_identity_rejects_even_when_lease_is_resealed():
+    items = [lease(0), lease(1)]
+    items[1]["shard_spec_sha256"] = items[0]["shard_spec_sha256"]
+    p = {k: v for k, v in items[1].items() if k != "lease_sha256"}
+    items[1]["lease_sha256"] = roster._identity(roster.LEASE_SCHEMA, p)
+    with pytest.raises(ValueError, match="duplicate shard"):
+        build(items)
+
+
+@pytest.mark.parametrize("ordinals", [[0, 2], [1, 2], [0, 1, 3]])
+def test_missing_or_noncontiguous_ordinal_rejects(ordinals):
+    items = [lease(value) for value in ordinals]
+    with pytest.raises(ValueError, match="contiguous"):
+        roster.build_fleet_roster(
+            items,
+            fleet_authority_sha256=FLEET,
+            expected_lease_count=len(items),
+            gpu_binding_sha256=BINDING,
+            execution_plan_sha256=PLAN,
+            environment_authority_sha256=ENV,
+            max_attempts_per_lease=3,
+        )
+
+
+def test_missing_or_extra_leaf_rejects_against_frozen_count():
+    items = [lease(i) for i in range(4)]
+    with pytest.raises(ValueError, match="count"):
+        roster.build_fleet_roster(
+            items[:-1], fleet_authority_sha256=FLEET, expected_lease_count=4,
+            gpu_binding_sha256=BINDING, execution_plan_sha256=PLAN, environment_authority_sha256=ENV,
+            max_attempts_per_lease=3,
+        )
+    with pytest.raises(ValueError, match="count"):
+        roster.build_fleet_roster(
+            [*items, lease(4)], fleet_authority_sha256=FLEET, expected_lease_count=4,
+            gpu_binding_sha256=BINDING, execution_plan_sha256=PLAN, environment_authority_sha256=ENV,
+            max_attempts_per_lease=3,
+        )
+
+
+def test_scientifically_contaminated_payload_rejects():
+    item = lease(0)
+    item["balanced_accuracy"] = 0.99
+    with pytest.raises(ValueError, match="scientific field"):
+        build([item])
+
+
+def test_verifier_never_sorts_proof_nodes():
+    authority, packages = build([lease(i) for i in range(6)])
+    package = packages[3]
+    reversed_path = tuple(reversed(package.authentication_path))
+    contaminated = roster.ProofCarryingLease(
+        package.lease, package.lease_sha256, authority.sha256, package.leaf_index, reversed_path
+    )
+    with pytest.raises(ValueError):
+        roster.verify_proof_carrying_lease(contaminated, authority)
+
+
+def test_duplicate_last_policy_is_explicitly_verified():
+    authority, packages = build([lease(i) for i in range(5)])
+    package = packages[-1]
+    assert package.authentication_path[0].side == "right"
+    assert package.authentication_path[0].sibling_sha256 == roster._leaf_hash(package.lease_sha256)
+    path = list(package.authentication_path)
+    path[0] = roster.MerkleProofEntry("right", digest("not-self"))
+    contaminated = roster.ProofCarryingLease(
+        package.lease, package.lease_sha256, authority.sha256, package.leaf_index, tuple(path)
+    )
+    with pytest.raises(ValueError, match="duplicate-last"):
+        roster.verify_proof_carrying_lease(contaminated, authority)
+
+
+def test_wrong_gpu_binding_rejects_even_when_lease_is_resealed():
+    item = lease(0)
+    item["gpu_binding_sha256"] = digest("foreign-binding")
+    payload = {k: v for k, v in item.items() if k != "lease_sha256"}
+    item["lease_sha256"] = roster._identity(roster.LEASE_SCHEMA, payload)
+    with pytest.raises(ValueError, match="GPU binding"):
+        build([item])
+
+
+def test_wrong_retry_ceiling_rejects_even_when_lease_is_resealed():
+    item = lease(0)
+    item["max_attempts"] = 4
+    payload = {k: v for k, v in item.items() if k != "lease_sha256"}
+    item["lease_sha256"] = roster._identity(roster.LEASE_SCHEMA, payload)
+    with pytest.raises(ValueError, match="retry ceiling"):
+        build([item])
+
+
+def test_canonical_authority_and_proof_bytes_are_input_order_independent():
+    items = [lease(i) for i in range(7)]
+    authority_a, packages_a = build(items)
+    authority_b, packages_b = build(list(reversed(items)))
+    assert roster.serialize_roster_authority(authority_a) == roster.serialize_roster_authority(authority_b)
+    assert [roster.serialize_proof_carrying_lease(x) for x in packages_a] == [
+        roster.serialize_proof_carrying_lease(x) for x in packages_b
+    ]
+
+
+def test_production_shape_810_synthetic_identities_are_deterministic():
+    split_seeds = (2026, 3407, 9109)
+    model_seeds = (31415, 384165836, 3991196546)
+    items = []
+    ordinal = 0
+    for subject in range(1, 19):
+        for session in ("1", "2", "3", "4", "5"):
+            for split_seed in split_seeds:
+                for model_seed in model_seeds:
+                    payload = {
+                        "schema_version": 1,
+                        "fleet_authority_sha256": FLEET,
+                        "gpu_binding_sha256": BINDING,
+                        "execution_plan_sha256": PLAN,
+                        "environment_authority_sha256": ENV,
+                        "shard_spec_sha256": digest(f"synthetic-shard-{ordinal}"),
+                        "ordinal": ordinal,
+                        "subject": subject,
+                        "target_session": session,
+                        "split_seed": split_seed,
+                        "method_id": roster.EEGNET_METHOD_ID,
+                        "model_seed": model_seed,
+                        "budgets_per_class": list(roster.CALIBRATION_FRONTIER),
+                        "max_attempts": 3,
+                    }
+                    items.append({**payload, "lease_sha256": roster._identity(roster.LEASE_SCHEMA, payload)})
+                    ordinal += 1
+    assert len(items) == 810
+    authority_a, packages_a = roster.build_fleet_roster(
+        items, fleet_authority_sha256=FLEET, expected_lease_count=810,
+        gpu_binding_sha256=BINDING, execution_plan_sha256=PLAN, environment_authority_sha256=ENV,
+        max_attempts_per_lease=3,
+    )
+    authority_b, packages_b = roster.build_fleet_roster(
+        reversed(items), fleet_authority_sha256=FLEET, expected_lease_count=810,
+        gpu_binding_sha256=BINDING, execution_plan_sha256=PLAN, environment_authority_sha256=ENV,
+        max_attempts_per_lease=3,
+    )
+    assert authority_a.to_dict() == authority_b.to_dict()
+    assert packages_a[0].to_dict() == packages_b[0].to_dict()
+    assert packages_a[-1].to_dict() == packages_b[-1].to_dict()
+    for index in (0, 1, 404, 809):
+        roster.verify_proof_carrying_lease(packages_a[index], authority_a)


### PR DESCRIPTION
## Purpose

Add the #175 distribution-integrity layer above the promoted Kumar2024 provider-free fleet substrate. This tranche lets one provider worker verify that its exact immutable `LeaseSpec` belongs to the frozen fleet without trusting mutable scheduler state or receiving the entire manifest.

This does **not** authorize live provider execution or the production 810-shard fleet.

## Exact composition

- base: `main@a4286ebcf09f0f5ff6d5b1658c958798d27a7219`
- authoritative candidate head: `c2834225e9f2a424bdfd95ffa7a2616890b77096`
- ancestry: exactly one commit over the promoted base
- changed files: exactly four, all additive

Files:

1. `packages/neuros/src/neuros/evidence/kumar2024_gpu_roster.py`
2. `tests/test_kumar2024_gpu_roster.py`
3. `.github/workflows/nsq-kumar2024-gpu-fleet-roster-ci.yml`
4. `docs/NSQ_KUMAR2024_GPU_FLEET_ROSTER.md`

`kumar2024_gpu_fleet.py` is intentionally unchanged.

The previous candidate `e7b5db5cc79cd9a5cb14458d2f1d69264d3aa25d` is explicitly superseded. Its new roster lane reached exact clean checkout and compilation, then discovered that the workflow omitted the repo-required `pytest-asyncio` plugin; no tests ran. The replacement was rebuilt directly from the same promoted base rather than stacking a repair commit, and differs only by pinning `pytest-asyncio==1.4.0` in the test harness. No green evidence from the superseded SHA counts toward this candidate.

## Frozen roster authority

`FleetRosterAuthority` binds:

- exact fleet-authority SHA-256;
- exact expected lease count;
- ordered-leaf commitment;
- versioned Merkle algorithm/domain;
- Merkle root;
- GPU-binding SHA-256;
- execution-plan SHA-256;
- environment-authority SHA-256;
- fleet retry ceiling;
- fixed EEGNet method;
- complete `(0,1,2,5,10)` calibration frontier.

Leaves are derived from the complete canonical `LeaseSpec` identity, never a reduced scientific tuple or provider metadata.

## Merkle v1

Algorithm: `sha256-canonical-json-domain-separated-duplicate-last-v1`

- SHA-256 only;
- separate lease, leaf, node, ordered-leaf, and roster domains;
- canonical JSON serialization;
- canonical order from existing lease ordinal;
- no implicit sorting during proof verification;
- explicit sibling side;
- duplicate-last for odd levels;
- empty tree rejects;
- singleton root equals its one domain-separated leaf hash.

## Proof-carrying leases

A dispatch package carries only the exact canonical lease, lease SHA, roster-authority SHA, leaf index, and authentication path. Worker-side verification independently reconstructs:

`LeaseSpec -> lease SHA -> leaf SHA -> authentication path -> roster root`

It also rejects mismatched fleet authority, GPU binding, execution plan, environment authority, retry ceiling, method, or calibration frontier before provider/model invocation.

## Adversarial construction evidence

Local construction suite: **23/23 passed**.

Coverage includes altered payloads and ordinals, swapped proof order, flipped side, foreign sibling, foreign roster, wrong environment/plan/GPU binding/retry ceiling, duplicate lease/shard identities, missing/extra leaves, non-contiguous ordinals, scientific contamination, no-sort verification, and explicit duplicate-last enforcement.

The suite also constructs the full **810-lease production-shaped axis topology** from 18 subjects × 5 sessions × 3 split seeds × 3 EEGNet model seeds and proves input-order-independent authority/proof bytes. Those shard hashes are synthetic test identities; no production roster root is claimed.

Local evidence is construction evidence only. The exact authoritative candidate head must independently pass GitHub CI on Python 3.10, 3.11, and 3.12 before promotion.

## Scientific firewall

The new implementation is standard-library only and imports neither the fleet scheduler nor neural/provider code. It reads no neural data, runs no model, inspects no score, performs no provider selection, and makes no scientific claim.

Roster membership proves assignment inclusion only. It does not prove execution, artifact existence, fleet completeness, efficacy, external-floor validity, or ORION readiness.

## Promotion boundary

After exact-head qualification, guarded merge, and fresh-main requalification, the next live gate remains the fixed T4 systems preflight under #165, followed by systems-only admission and a tiny real provider transport qualification. The 810 EEGNet workers remain unauthorized until those gates and explicit fleet authorization complete.

Refs #175, #165.