### PR TITLE
feat(research): add neurOS scientific-engineering swarm council

### DIFF
--- a/.github/workflows/neuros-scientific-engineering-swarm.yml
+++ b/.github/workflows/neuros-scientific-engineering-swarm.yml
@@ -1,0 +1,89 @@
+name: neurOS scientific-engineering swarm
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-research/src/neuros/research/swarm.py"
+      - "packages/neuros-research/src/neuros/research/nim_swarm.py"
+      - "packages/neuros-research/tests/test_swarm.py"
+      - "packages/neuros-research/tests/test_nim_swarm.py"
+      - "docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md"
+      - ".github/workflows/neuros-scientific-engineering-swarm.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros-research/src/neuros/research/swarm.py"
+      - "packages/neuros-research/src/neuros/research/nim_swarm.py"
+      - "packages/neuros-research/tests/test_swarm.py"
+      - "packages/neuros-research/tests/test_nim_swarm.py"
+      - "docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md"
+      - ".github/workflows/neuros-scientific-engineering-swarm.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  offline-contract:
+    name: offline council contract / py${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install deterministic test harness
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0"
+
+      - name: Compile swarm modules
+        run: |
+          python -m py_compile \
+            packages/neuros-research/src/neuros/research/swarm.py \
+            packages/neuros-research/src/neuros/research/nim_swarm.py
+
+      - name: Run offline adversarial tests
+        env:
+          PYTHONPATH: packages/neuros-research/src
+        run: |
+          python -m pytest -q \
+            packages/neuros-research/tests/test_swarm.py \
+            packages/neuros-research/tests/test_nim_swarm.py
+
+      - name: Audit provider-neutral core boundary
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          path = Path("packages/neuros-research/src/neuros/research/swarm.py")
+          tree = ast.parse(path.read_text(encoding="utf-8"))
+          forbidden = {
+              "requests", "httpx", "urllib", "socket", "subprocess",
+              "github", "torch", "braindecode", "moabb", "kaggle",
+          }
+          imports = set()
+          for node in ast.walk(tree):
+              if isinstance(node, ast.Import):
+                  imports.update(alias.name.split(".")[0] for alias in node.names)
+              elif isinstance(node, ast.ImportFrom) and node.module:
+                  imports.add(node.module.split(".")[0])
+          unexpected = sorted(imports & forbidden)
+          if unexpected:
+              raise SystemExit(f"provider-neutral core imported forbidden modules: {unexpected}")
+
+          text = path.read_text(encoding="utf-8").lower()
+          for token in ("nvidia_api_key", "kaggle_key", "authorization: bearer"):
+              if token in text:
+                  raise SystemExit(f"credential token leaked into provider-neutral core: {token}")
+          PY

--- a/docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md
+++ b/docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md
@@ -1,0 +1,125 @@
+# neurOS scientific-engineering swarm
+
+This layer turns the existing qualified NVIDIA NIM research transport into a parallel,
+dissent-preserving engineering council. It is intentionally outside neurOS scientific evidence
+and execution authority.
+
+## Why this exists
+
+The existing NIM tournament is a strong serial pipeline for proposal generation, adversarial
+critique, and synthesis. The council adds a different capability: multiple independent reviewers
+receive the same sealed task before any cross-agent synthesis. Their job is to surface distinct
+failure modes, not to vote a claim into existence.
+
+## v0 contract
+
+`SealedSwarmTask` binds:
+
+- repository and exact source revision;
+- development objective;
+- explicit scientific claim boundary;
+- optional file allowlist;
+- relevant authority SHA-256 identities;
+- forbidden actions;
+- public-only context.
+
+The task identity is canonical and content-addressed. Public context rejects secret/private-data
+keys such as credentials, API keys, raw participant data, participant identifiers, hidden targets,
+and private leaderboard feedback.
+
+Each `CouncilMember` binds a stable member ID, role, live-qualified model ID, and role prompt hash.
+The NVIDIA adapter constructs five roles:
+
+1. architecture;
+2. scientific adversary;
+3. reproducibility/evidence;
+4. implementation;
+5. experimental design.
+
+The available models are supplied only after the existing `QualifiedNvidiaNimClient` has performed
+its bounded provider/model qualification. Roles are distributed round-robin across the qualified
+model set so heterogeneous routes are used when available.
+
+## Independent fan-out
+
+`run_council()` dispatches all members concurrently through a provider-neutral transport protocol.
+Every member receives the same exact sealed task SHA and body. A member cannot see another
+member's response through this API.
+
+The NVIDIA transport reuses `QualifiedNvidiaNimClient.chat_json()` and therefore inherits the
+existing HTTPS endpoint restriction, route qualification, call journaling, request/response
+fingerprinting, and credential handling. No NVIDIA credential is accepted by the council module.
+
+## Finding schema
+
+Every finding must contain:
+
+- stable finding ID;
+- severity;
+- category;
+- claim;
+- evidence;
+- falsification test;
+- proposed repair;
+- confidence in `[0, 1]`;
+- human-judgment flag;
+- optional exact reference.
+
+The parser rejects extra or missing finding fields. Finding IDs must be unique within one reviewer.
+
+## Dissent is data
+
+`finding_support()` records which reviewers independently emitted an exact finding ID. Minority
+findings are preserved even if four other agents are silent. Agreement is metadata only.
+
+The run manifest explicitly records:
+
+- `majority_vote_is_authority = false`;
+- `merge_authority = false`;
+- `provider_execution_authority = false`;
+- `scientific_promotion_authority = false`.
+
+No number of agreeing LLMs can change those values.
+
+## Failure behavior
+
+By default the council fails closed if any required member fails. Optional partial mode can retain
+successful reviews while preserving only bounded member/error-class identity in the council
+manifest. Provider-specific diagnostics stay with the already-qualified transport and are not
+copied into the provider-neutral manifest.
+
+## CI and credentials
+
+The council test lane is fully offline and does not require `NVIDIA_API_KEY`. It uses mock transport
+objects to prove fan-out, deterministic identities, schema enforcement, failure preservation,
+minority-finding retention, model assignment, and compatibility with the existing NIM client
+interface.
+
+A future live workflow may use the existing repository `NVIDIA_API_KEY` secret, but the live model
+outputs remain advisory proposal material.
+
+## Next qualification tranche
+
+The next step is not more orchestration. It is evaluation.
+
+Build a benchmark corpus from known neurOS defects and controlled mutations, including stale
+exact-head evidence, leakage-prone splits, duplicate identities, environment drift, malformed
+proofs, outcome-adaptive scheduling, missing dependencies, and scientific overclaiming. Compare:
+
+- one qualified model;
+- the existing serial tournament;
+- homogeneous five-member council;
+- heterogeneous five-member council.
+
+Measure validated defect recall, precision, unique valid findings, false-positive rate, latency,
+token cost, and marginal value of each additional member. The council should remain optional unless
+it demonstrates measurable value over a single strong reviewer.
+
+## Scientific boundary
+
+This layer can propose tests, repairs, controls, and experiments. Only executable tests,
+reproducible computation, bound data, and the existing neurOS evidence authorities can promote a
+result. It cannot authorize the Kumar2024 T4 preflight, the production 810-shard fleet, ORION
+comparison, or any scientific claim.
+
+Tracks #178.

--- a/packages/neuros-research/src/neuros/research/nim_swarm.py
+++ b/packages/neuros-research/src/neuros/research/nim_swarm.py
@@ -1,0 +1,164 @@
+"""NVIDIA NIM transport for the neurOS scientific-engineering council."""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from ._canonical import canonical_sha256
+from .nim_provider import QualifiedNvidiaNimClient
+from .swarm import CouncilMember, SealedSwarmTask
+
+ROLE_PROMPTS: dict[str, str] = {
+    "architecture": (
+        "Audit package boundaries, interfaces, unnecessary complexity, coupling, and long-term "
+        "maintainability. Prefer simplification when it preserves capability."
+    ),
+    "scientific_adversary": (
+        "Attack scientific validity: leakage, circularity, hidden adaptivity, confounding, "
+        "invalid units of analysis, overclaiming, and unfalsifiable reasoning."
+    ),
+    "reproducibility": (
+        "Audit provenance, determinism, exact-revision binding, replayability, stale evidence, "
+        "incomplete artifacts, environment drift, and evidence-chain attacks."
+    ),
+    "implementation": (
+        "Audit correctness, edge cases, portability, concurrency, performance, dependency "
+        "assumptions, and missing executable tests."
+    ),
+    "experimental_design": (
+        "Propose the highest-information falsification tests, controls, ablations, stopping "
+        "rules, and cheap experiments before expensive compute."
+    ),
+}
+
+_OUTPUT_SCHEMA = {
+    "findings": [
+        {
+            "finding_id": "stable-short-id",
+            "severity": "info | low | medium | high | critical",
+            "category": (
+                "architecture | scientific_validity | reproducibility | implementation | "
+                "experimental_design | security | performance"
+            ),
+            "claim": "specific defect or testable concern",
+            "evidence": "specific evidence from the sealed packet",
+            "falsification_test": "executable or inspectable test that could refute the concern",
+            "proposed_repair": "specific repair or empty string",
+            "confidence": 0.0,
+            "requires_human_judgment": False,
+            "reference": "file:symbol/line or contract reference, or empty string",
+        }
+    ]
+}
+
+
+def build_nvidia_council(
+    qualified_models: tuple[str, ...],
+) -> tuple[CouncilMember, ...]:
+    """Build five independent roles distributed across live-qualified models."""
+    models = tuple(
+        dict.fromkeys(
+            str(model).strip()
+            for model in qualified_models
+            if str(model).strip()
+        )
+    )
+    if not models:
+        raise ValueError("at least one live-qualified NVIDIA model is required")
+
+    members = []
+    for index, (role, instruction) in enumerate(ROLE_PROMPTS.items()):
+        model = models[index % len(models)]
+        system_prompt = (
+            "You are one independent neurOS scientific-engineering council member. "
+            "You are advisory only: you cannot merge code, authorize provider execution, alter "
+            "frozen scientific authority, or promote a scientific claim. Do not infer secret or "
+            "private data. Return exactly one JSON object matching the requested schema. "
+            "Do not suppress a finding because another agent may disagree. "
+            + instruction
+        )
+        members.append(
+            CouncilMember(
+                member_id=f"{role}:{index + 1}",
+                role=role,
+                model=model,
+                system_prompt=system_prompt,
+            )
+        )
+    return tuple(members)
+
+
+def _user_prompt(task: SealedSwarmTask) -> str:
+    task_json = json.dumps(
+        task.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    schema_json = json.dumps(
+        _OUTPUT_SCHEMA,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return (
+        "Audit the sealed task below independently. Report zero or more concrete findings. "
+        "Every finding must include a falsification test. Finding IDs should be stable and "
+        "derived from the defect concept, not confidence or severity. Do not request additional "
+        "private data.\n\n"
+        "SEALED_TASK_SHA256="
+        + task.sha256
+        + "\n\nSEALED_TASK="
+        + task_json
+        + "\n\nOUTPUT_SCHEMA="
+        + schema_json
+    )
+
+
+class NvidiaCouncilTransport:
+    """Concurrent council adapter over an already-qualified NVIDIA NIM client."""
+
+    def __init__(
+        self,
+        client: QualifiedNvidiaNimClient,
+        *,
+        max_tokens: int = 2800,
+    ) -> None:
+        self.client = client
+        self.max_tokens = int(max_tokens)
+        if self.max_tokens < 512 or self.max_tokens > 8192:
+            raise ValueError("max_tokens must be in [512, 8192]")
+
+    async def review(
+        self,
+        task: SealedSwarmTask,
+        member: CouncilMember,
+    ) -> dict[str, Any]:
+        user_prompt = _user_prompt(task)
+        parsed, _record = await asyncio.to_thread(
+            self.client.chat_json,
+            role=f"swarm:{member.role}",
+            model=member.model,
+            system_prompt=member.system_prompt,
+            user_prompt=user_prompt,
+            max_tokens=self.max_tokens,
+            temperature=0.1,
+        )
+        return parsed
+
+
+def council_configuration_sha256(
+    members: tuple[CouncilMember, ...],
+) -> str:
+    return canonical_sha256(
+        [
+            {
+                "member_id": member.member_id,
+                "role": member.role,
+                "model": member.model,
+                "prompt_sha256": member.prompt_sha256,
+            }
+            for member in sorted(members, key=lambda member: member.member_id)
+        ]
+    )

--- a/packages/neuros-research/src/neuros/research/swarm.py
+++ b/packages/neuros-research/src/neuros/research/swarm.py
@@ -1,0 +1,387 @@
+"""Deterministic, provider-neutral scientific-engineering council for neurOS.
+
+This module is advisory only. It can produce review findings and proposal artifacts,
+but it has no Git, provider-execution, ExperimentEvidence, or promotion authority.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+from ._canonical import canonical_sha256, require_nonempty, require_sha256
+
+Severity = Literal["info", "low", "medium", "high", "critical"]
+Category = Literal[
+    "architecture",
+    "scientific_validity",
+    "reproducibility",
+    "implementation",
+    "experimental_design",
+    "security",
+    "performance",
+]
+
+_ALLOWED_SEVERITIES = {"info", "low", "medium", "high", "critical"}
+_ALLOWED_CATEGORIES = {
+    "architecture",
+    "scientific_validity",
+    "reproducibility",
+    "implementation",
+    "experimental_design",
+    "security",
+    "performance",
+}
+_FORBIDDEN_TASK_KEYS = {
+    "credential",
+    "credentials",
+    "api_key",
+    "token",
+    "secret",
+    "password",
+    "raw_participant_data",
+    "participant_identifier",
+    "hidden_target",
+    "private_leaderboard",
+}
+
+
+def _contains_forbidden_key(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if str(key).strip().lower() in _FORBIDDEN_TASK_KEYS:
+                return True
+            if _contains_forbidden_key(item):
+                return True
+    elif isinstance(value, (list, tuple)):
+        return any(_contains_forbidden_key(item) for item in value)
+    return False
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class SealedSwarmTask:
+    repository: str
+    source_revision: str
+    objective: str
+    claim_boundary: str
+    allowed_paths: tuple[str, ...] = ()
+    authority_sha256s: tuple[str, ...] = ()
+    forbidden_actions: tuple[str, ...] = ()
+    public_context: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "repository", require_nonempty(self.repository, name="repository"))
+        object.__setattr__(
+            self,
+            "source_revision",
+            require_nonempty(self.source_revision, name="source_revision"),
+        )
+        object.__setattr__(self, "objective", require_nonempty(self.objective, name="objective"))
+        object.__setattr__(
+            self,
+            "claim_boundary",
+            require_nonempty(self.claim_boundary, name="claim_boundary"),
+        )
+        for name in ("allowed_paths", "forbidden_actions"):
+            values = tuple(require_nonempty(v, name=name) for v in getattr(self, name))
+            if len(set(values)) != len(values):
+                raise ValueError(f"{name} values must be unique")
+            object.__setattr__(self, name, values)
+        hashes = tuple(
+            require_sha256(v, name="authority_sha256") for v in self.authority_sha256s
+        )
+        if len(set(hashes)) != len(hashes):
+            raise ValueError("authority_sha256s values must be unique")
+        object.__setattr__(self, "authority_sha256s", hashes)
+        context = json.loads(_canonical_bytes(self.public_context).decode("utf-8"))
+        if _contains_forbidden_key(context):
+            raise ValueError("public_context contains a forbidden secret/private-data key")
+        object.__setattr__(self, "public_context", context)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": "neuros.scientific_engineering_swarm_task.v1",
+            "repository": self.repository,
+            "source_revision": self.source_revision,
+            "objective": self.objective,
+            "claim_boundary": self.claim_boundary,
+            "allowed_paths": list(self.allowed_paths),
+            "authority_sha256s": list(self.authority_sha256s),
+            "forbidden_actions": list(self.forbidden_actions),
+            "public_context": self.public_context,
+            "llm_output_is_authority": False,
+        }
+
+    @property
+    def sha256(self) -> str:
+        return canonical_sha256(self.to_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class CouncilMember:
+    member_id: str
+    role: str
+    model: str
+    system_prompt: str
+
+    def __post_init__(self) -> None:
+        for name in ("member_id", "role", "model", "system_prompt"):
+            object.__setattr__(
+                self,
+                name,
+                require_nonempty(getattr(self, name), name=name),
+            )
+
+    @property
+    def prompt_sha256(self) -> str:
+        return hashlib.sha256(self.system_prompt.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    finding_id: str
+    severity: Severity
+    category: Category
+    claim: str
+    evidence: str
+    falsification_test: str
+    proposed_repair: str
+    confidence: float
+    requires_human_judgment: bool
+    reference: str = ""
+
+    def __post_init__(self) -> None:
+        for name in ("finding_id", "claim", "evidence", "falsification_test"):
+            object.__setattr__(
+                self,
+                name,
+                require_nonempty(getattr(self, name), name=name),
+            )
+        if self.severity not in _ALLOWED_SEVERITIES:
+            raise ValueError(f"unsupported severity {self.severity!r}")
+        if self.category not in _ALLOWED_CATEGORIES:
+            raise ValueError(f"unsupported category {self.category!r}")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be in [0, 1]")
+        object.__setattr__(self, "confidence", float(self.confidence))
+        object.__setattr__(
+            self,
+            "requires_human_judgment",
+            bool(self.requires_human_judgment),
+        )
+        object.__setattr__(self, "reference", str(self.reference).strip())
+        object.__setattr__(self, "proposed_repair", str(self.proposed_repair).strip())
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> Finding:
+        expected = {
+            "finding_id",
+            "severity",
+            "category",
+            "claim",
+            "evidence",
+            "falsification_test",
+            "proposed_repair",
+            "confidence",
+            "requires_human_judgment",
+            "reference",
+        }
+        if set(payload) != expected:
+            raise ValueError("finding fields must match the v1 schema exactly")
+        return cls(**payload)  # type: ignore[arg-type]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "severity": self.severity,
+            "category": self.category,
+            "claim": self.claim,
+            "evidence": self.evidence,
+            "falsification_test": self.falsification_test,
+            "proposed_repair": self.proposed_repair,
+            "confidence": self.confidence,
+            "requires_human_judgment": self.requires_human_judgment,
+            "reference": self.reference,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AgentReview:
+    task_sha256: str
+    member_id: str
+    role: str
+    model: str
+    prompt_sha256: str
+    response_sha256: str
+    findings: tuple[Finding, ...]
+
+    def __post_init__(self) -> None:
+        for name in ("task_sha256", "prompt_sha256", "response_sha256"):
+            object.__setattr__(
+                self,
+                name,
+                require_sha256(getattr(self, name), name=name),
+            )
+        for name in ("member_id", "role", "model"):
+            object.__setattr__(
+                self,
+                name,
+                require_nonempty(getattr(self, name), name=name),
+            )
+        ids = [finding.finding_id for finding in self.findings]
+        if len(ids) != len(set(ids)):
+            raise ValueError("finding IDs must be unique within one review")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_sha256": self.task_sha256,
+            "member_id": self.member_id,
+            "role": self.role,
+            "model": self.model,
+            "prompt_sha256": self.prompt_sha256,
+            "response_sha256": self.response_sha256,
+            "findings": [finding.to_dict() for finding in self.findings],
+        }
+
+
+class CouncilTransport(Protocol):
+    async def review(
+        self,
+        task: SealedSwarmTask,
+        member: CouncilMember,
+    ) -> dict[str, Any]: ...
+
+
+def parse_review_payload(
+    payload: dict[str, Any],
+    *,
+    task: SealedSwarmTask,
+    member: CouncilMember,
+) -> AgentReview:
+    if set(payload) != {"findings"} or not isinstance(payload["findings"], list):
+        raise ValueError("review response must contain exactly one findings list")
+    findings = tuple(
+        Finding.from_dict(row) for row in payload["findings"] if isinstance(row, dict)
+    )
+    if len(findings) != len(payload["findings"]):
+        raise ValueError("every finding must be a JSON object")
+    return AgentReview(
+        task_sha256=task.sha256,
+        member_id=member.member_id,
+        role=member.role,
+        model=member.model,
+        prompt_sha256=member.prompt_sha256,
+        response_sha256=canonical_sha256(payload),
+        findings=findings,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CouncilRun:
+    task_sha256: str
+    reviews: tuple[AgentReview, ...]
+    failed_members: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "task_sha256",
+            require_sha256(self.task_sha256, name="task_sha256"),
+        )
+        members = [review.member_id for review in self.reviews]
+        if len(members) != len(set(members)):
+            raise ValueError("council reviews must have unique member IDs")
+        if any(review.task_sha256 != self.task_sha256 for review in self.reviews):
+            raise ValueError("all reviews must bind the same sealed task")
+        failed = tuple(
+            require_nonempty(value, name="failed_member") for value in self.failed_members
+        )
+        if len(set(failed)) != len(failed) or set(failed) & set(members):
+            raise ValueError(
+                "failed_members must be unique and disjoint from successful reviews"
+            )
+        object.__setattr__(self, "failed_members", failed)
+
+    def to_dict(self) -> dict[str, Any]:
+        ordered = sorted(self.reviews, key=lambda review: review.member_id)
+        payload = {
+            "schema": "neuros.scientific_engineering_swarm_run.v1",
+            "task_sha256": self.task_sha256,
+            "reviews": [review.to_dict() for review in ordered],
+            "failed_members": sorted(self.failed_members),
+            "majority_vote_is_authority": False,
+            "merge_authority": False,
+            "provider_execution_authority": False,
+            "scientific_promotion_authority": False,
+        }
+        payload["run_sha256"] = canonical_sha256(payload)
+        return payload
+
+    @property
+    def sha256(self) -> str:
+        return self.to_dict()["run_sha256"]
+
+    @property
+    def findings(self) -> tuple[Finding, ...]:
+        return tuple(
+            finding for review in self.reviews for finding in review.findings
+        )
+
+
+async def run_council(
+    task: SealedSwarmTask,
+    members: tuple[CouncilMember, ...],
+    transport: CouncilTransport,
+    *,
+    require_all: bool = True,
+) -> CouncilRun:
+    if not members:
+        raise ValueError("council must contain at least one member")
+    ids = [member.member_id for member in members]
+    if len(ids) != len(set(ids)):
+        raise ValueError("council member IDs must be unique")
+
+    async def one(member: CouncilMember):
+        try:
+            payload = await transport.review(task, member)
+            return parse_review_payload(payload, task=task, member=member), None
+        except Exception as exc:
+            # Preserve only bounded failure identity here. Provider-specific diagnostics are
+            # already retained by the qualified transport and must not leak into this authority-
+            # neutral manifest.
+            return None, f"{member.member_id}:{type(exc).__name__}"
+
+    results = await asyncio.gather(*(one(member) for member in members))
+    reviews = tuple(row for row, _ in results if row is not None)
+    failures = tuple(error for _, error in results if error is not None)
+    if require_all and failures:
+        raise RuntimeError("council member failure: " + ",".join(sorted(failures)))
+    return CouncilRun(
+        task_sha256=task.sha256,
+        reviews=reviews,
+        failed_members=failures,
+    )
+
+
+def finding_support(run: CouncilRun) -> dict[str, tuple[str, ...]]:
+    """Return support by exact finding ID, preserving minority findings without voting."""
+    support: dict[str, set[str]] = {}
+    for review in run.reviews:
+        for finding in review.findings:
+            support.setdefault(finding.finding_id, set()).add(review.member_id)
+    return {
+        finding_id: tuple(sorted(member_ids))
+        for finding_id, member_ids in sorted(support.items())
+    }

--- a/packages/neuros-research/tests/test_nim_swarm.py
+++ b/packages/neuros-research/tests/test_nim_swarm.py
@@ -1,0 +1,125 @@
+import asyncio
+
+from neuros.research.nim_swarm import (
+    NvidiaCouncilTransport,
+    _user_prompt,
+    build_nvidia_council,
+    council_configuration_sha256,
+)
+from neuros.research.swarm import SealedSwarmTask, run_council
+
+_H = "a" * 64
+
+
+def _task():
+    return SealedSwarmTask(
+        repository="repo",
+        source_revision="sha",
+        objective="audit",
+        claim_boundary="advisory",
+        authority_sha256s=(_H,),
+        public_context={"x": 1},
+    )
+
+
+def _finding(finding_id):
+    return {
+        "finding_id": finding_id,
+        "severity": "medium",
+        "category": "implementation",
+        "claim": "specific concern",
+        "evidence": "specific evidence",
+        "falsification_test": "specific test",
+        "proposed_repair": "",
+        "confidence": 0.5,
+        "requires_human_judgment": False,
+        "reference": "",
+    }
+
+
+class _Client:
+    def __init__(self):
+        self.calls = []
+
+    def chat_json(self, **kwargs):
+        self.calls.append(kwargs)
+        role = kwargs["role"].split(":", 1)[1]
+        return {"findings": [_finding(role)]}, object()
+
+
+def test_builds_five_distinct_roles():
+    members = build_nvidia_council(("m1", "m2", "m3"))
+    assert len(members) == 5
+    assert len({member.role for member in members}) == 5
+
+
+def test_models_round_robin_across_roles():
+    members = build_nvidia_council(("m1", "m2", "m3"))
+    assert [member.model for member in members] == ["m1", "m2", "m3", "m1", "m2"]
+
+
+def test_duplicate_models_are_deduplicated():
+    members = build_nvidia_council(("m1", "m1", "m2"))
+    assert [member.model for member in members][:3] == ["m1", "m2", "m1"]
+
+
+def test_empty_model_set_rejected():
+    try:
+        build_nvidia_council(())
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("empty model set should fail")
+
+
+def test_configuration_hash_independent_of_member_input_order():
+    members = build_nvidia_council(("m1", "m2"))
+    assert council_configuration_sha256(members) == council_configuration_sha256(
+        tuple(reversed(members))
+    )
+
+
+def test_prompt_contains_task_hash_boundary_and_schema():
+    task = _task()
+    prompt = _user_prompt(task)
+    assert task.sha256 in prompt
+    assert "llm_output_is_authority" in prompt
+    assert "falsification_test" in prompt
+
+
+def test_transport_reuses_existing_chat_json_contract():
+    client = _Client()
+    member = build_nvidia_council(("m1",))[0]
+    output = asyncio.run(NvidiaCouncilTransport(client).review(_task(), member))
+    assert output["findings"]
+    assert client.calls[0]["temperature"] == 0.1
+
+
+def test_full_five_member_council_composes_with_core_runner():
+    client = _Client()
+    members = build_nvidia_council(("m1", "m2", "m3"))
+    run = asyncio.run(
+        run_council(
+            _task(),
+            members,
+            NvidiaCouncilTransport(client),
+        )
+    )
+    assert len(run.reviews) == 5
+    assert len(client.calls) == 5
+    assert len(run.findings) == 5
+
+
+def test_adapter_prompt_contract_contains_no_credential_name():
+    prompt = _user_prompt(_task()).lower()
+    assert "nvidia_api_key" not in prompt
+    assert "authorization" not in prompt
+
+
+def test_max_tokens_is_bounded():
+    try:
+        NvidiaCouncilTransport(_Client(), max_tokens=100)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("too-small token budget should fail")

--- a/packages/neuros-research/tests/test_swarm.py
+++ b/packages/neuros-research/tests/test_swarm.py
@@ -1,0 +1,250 @@
+import asyncio
+import copy
+
+from neuros.research.swarm import (
+    CouncilMember,
+    SealedSwarmTask,
+    finding_support,
+    parse_review_payload,
+    run_council,
+)
+
+_H = "a" * 64
+
+
+def _task(**overrides):
+    payload = dict(
+        repository="sidhulyalkar/neurOS-v1",
+        source_revision="5d75e0d",
+        objective="Find defects",
+        claim_boundary="advisory only",
+        allowed_paths=("x.py",),
+        authority_sha256s=(_H,),
+        forbidden_actions=("merge",),
+        public_context={"issue": 178},
+    )
+    payload.update(overrides)
+    return SealedSwarmTask(**payload)
+
+
+def _member(member_id="a", model="m1"):
+    return CouncilMember(
+        member_id,
+        "scientific_adversary",
+        model,
+        "Return exact JSON.",
+    )
+
+
+def _finding(finding_id="f1", **overrides):
+    payload = dict(
+        finding_id=finding_id,
+        severity="high",
+        category="scientific_validity",
+        claim="Leakage possible",
+        evidence="split constructed after reveal",
+        falsification_test="freeze split first",
+        proposed_repair="bind split",
+        confidence=0.9,
+        requires_human_judgment=False,
+        reference="x.py:1",
+    )
+    payload.update(overrides)
+    return payload
+
+
+class _MockTransport:
+    def __init__(self, payloads, fail=()):
+        self.payloads = payloads
+        self.fail = set(fail)
+        self.seen = []
+
+    async def review(self, task, member):
+        self.seen.append((task.sha256, member.member_id))
+        await asyncio.sleep(0)
+        if member.member_id in self.fail:
+            raise TimeoutError("secret provider detail")
+        return copy.deepcopy(self.payloads[member.member_id])
+
+
+def test_task_stable_across_context_key_order():
+    first = _task(public_context={"b": 2, "a": 1})
+    second = _task(public_context={"a": 1, "b": 2})
+    assert first.sha256 == second.sha256
+
+
+def test_task_detaches_context():
+    context = {"a": [1]}
+    sealed = _task(public_context=context)
+    context["a"].append(2)
+    assert sealed.public_context == {"a": [1]}
+
+
+def test_task_rejects_secret_key_recursively():
+    try:
+        _task(public_context={"nested": {"api_key": "x"}})
+    except ValueError as exc:
+        assert "forbidden" in str(exc)
+    else:
+        raise AssertionError("secret key should fail")
+
+
+def test_task_rejects_duplicate_authority_hashes():
+    try:
+        _task(authority_sha256s=(_H, _H))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("duplicate authority hashes should fail")
+
+
+def test_finding_requires_exact_schema():
+    payload = {"findings": [_finding()]}
+    payload["findings"][0]["extra"] = 1
+    try:
+        parse_review_payload(payload, task=_task(), member=_member())
+    except ValueError as exc:
+        assert "exactly" in str(exc)
+    else:
+        raise AssertionError("extra finding field should fail")
+
+
+def test_finding_confidence_bounded():
+    try:
+        parse_review_payload(
+            {"findings": [_finding(confidence=1.1)]},
+            task=_task(),
+            member=_member(),
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unbounded confidence should fail")
+
+
+def test_review_binds_task_member_model_and_prompt():
+    task = _task()
+    member = _member()
+    review = parse_review_payload(
+        {"findings": [_finding()]},
+        task=task,
+        member=member,
+    )
+    assert review.task_sha256 == task.sha256
+    assert review.model == "m1"
+    assert len(review.prompt_sha256) == 64
+
+
+def test_duplicate_finding_ids_rejected_per_review():
+    try:
+        parse_review_payload(
+            {"findings": [_finding(), _finding()]},
+            task=_task(),
+            member=_member(),
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("duplicate finding IDs should fail")
+
+
+def test_parallel_council_receives_same_task_identity():
+    task = _task()
+    members = (_member("a", "m1"), _member("b", "m2"), _member("c", "m3"))
+    transport = _MockTransport(
+        {member.member_id: {"findings": [_finding(member.member_id)]} for member in members}
+    )
+    run = asyncio.run(run_council(task, members, transport))
+    assert len(set(identity for identity, _ in transport.seen)) == 1
+    assert len(run.reviews) == 3
+
+
+def test_run_identity_independent_of_member_input_order():
+    task = _task()
+    first = _member("a", "m1")
+    second = _member("b", "m2")
+    payloads = {
+        "a": {"findings": [_finding("x")]},
+        "b": {"findings": [_finding("y")]},
+    }
+    one = asyncio.run(run_council(task, (first, second), _MockTransport(payloads)))
+    two = asyncio.run(run_council(task, (second, first), _MockTransport(payloads)))
+    assert one.sha256 == two.sha256
+
+
+def test_require_all_fails_closed_without_provider_message():
+    task = _task()
+    members = (_member("a"), _member("b"))
+    try:
+        asyncio.run(
+            run_council(
+                task,
+                members,
+                _MockTransport({"a": {"findings": []}}, fail=("b",)),
+            )
+        )
+    except RuntimeError as exc:
+        assert "b:TimeoutError" in str(exc)
+        assert "secret provider detail" not in str(exc)
+    else:
+        raise AssertionError("required member failure should fail closed")
+
+
+def test_partial_mode_preserves_failed_member_identity():
+    task = _task()
+    members = (_member("a"), _member("b"))
+    run = asyncio.run(
+        run_council(
+            task,
+            members,
+            _MockTransport({"a": {"findings": []}}, fail=("b",)),
+            require_all=False,
+        )
+    )
+    assert run.failed_members == ("b:TimeoutError",)
+    assert len(run.reviews) == 1
+
+
+def test_run_manifest_explicitly_denies_authority():
+    task = _task()
+    run = asyncio.run(
+        run_council(
+            task,
+            (_member(),),
+            _MockTransport({"a": {"findings": []}}),
+        )
+    )
+    payload = run.to_dict()
+    assert not payload["merge_authority"]
+    assert not payload["provider_execution_authority"]
+    assert not payload["scientific_promotion_authority"]
+
+
+def test_support_preserves_minority_finding():
+    task = _task()
+    members = (_member("a"), _member("b"), _member("c"))
+    payloads = {
+        "a": {"findings": [_finding("minority")]},
+        "b": {"findings": []},
+        "c": {"findings": []},
+    }
+    run = asyncio.run(run_council(task, members, _MockTransport(payloads)))
+    assert finding_support(run) == {"minority": ("a",)}
+
+
+def test_support_tracks_agreement_without_promoting_it():
+    task = _task()
+    members = (_member("a"), _member("b"))
+    payloads = {key: {"findings": [_finding("same")]} for key in ("a", "b")}
+    run = asyncio.run(run_council(task, members, _MockTransport(payloads)))
+    assert finding_support(run)["same"] == ("a", "b")
+    assert not run.to_dict()["majority_vote_is_authority"]
+
+
+def test_duplicate_member_ids_rejected_before_transport():
+    try:
+        asyncio.run(run_council(_task(), (_member("a"), _member("a")), _MockTransport({})))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("duplicate members should fail")


### PR DESCRIPTION
## Purpose

Add the first #178 implementation tranche: a provider-neutral, dissent-preserving scientific-engineering council layered on top of the already-qualified NVIDIA NIM transport.

This is an **advisory development accelerator only**. It does not modify Kumar2024, scientific evidence authority, provider execution authority, or ORION comparison authority.

## Exact candidate

- base: `main@5d75e0d0193371920894619f93be03f52b1040c7`
- authoritative head: `3c429a1adc70cb64a2bcd259f4ab4785a8146377`
- ancestry: exactly one commit over base
- six additive files, zero deletions

The previous candidate `be8da858c941dee4915c3ced6353e38810fead0d` is explicitly superseded. It discovered two mechanical repository-contract violations: one Ruff UP037 quoted return annotation and two unpinned GitHub Action references. The replacement was rebuilt directly from the same promoted base with only those repairs. No green evidence from the superseded SHA counts toward this candidate.

Files:

1. `packages/neuros-research/src/neuros/research/swarm.py`
2. `packages/neuros-research/src/neuros/research/nim_swarm.py`
3. `packages/neuros-research/tests/test_swarm.py`
4. `packages/neuros-research/tests/test_nim_swarm.py`
5. `docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md`
6. `.github/workflows/neuros-scientific-engineering-swarm.yml`

## Design

`SealedSwarmTask` content-addresses repository/source revision, objective, claim boundary, file allowlist, relevant authority SHA-256 identities, forbidden actions, and public-only context. Recursive public context rejects credential/private-data keys.

The NVIDIA adapter constructs five independent roles: architecture, scientific adversary, reproducibility/evidence, implementation, and experimental design. Roles are distributed round-robin across model IDs that already passed `QualifiedNvidiaNimClient` live qualification. No new network or credential path is introduced.

`run_council()` uses a provider-neutral async transport contract. All members receive the exact same sealed task SHA and body and run independently before any synthesis layer exists.

Every finding requires evidence and a falsification test. `finding_support()` records which members independently emitted a finding ID, but majority agreement has no authority. Minority findings remain present.

The run manifest explicitly fixes:

- `majority_vote_is_authority = false`
- `merge_authority = false`
- `provider_execution_authority = false`
- `scientific_promotion_authority = false`

## Construction evidence

Local isolated construction suite: **26/26 passed** after the mechanical repair.

The first exact-head swarm-specific GitHub matrix on the superseded SHA was 3/3 green, while broader repository contracts correctly rejected the Ruff annotation and unpinned actions. This replacement must independently requalify; the earlier green matrix is not inherited.

## CI boundary

The new CI lane is read-only and fully offline. It requires no NVIDIA secret. It runs Python 3.10/3.11/3.12, compiles the modules, executes the adversarial tests, and AST-audits the provider-neutral core against network/Git/provider/scientific imports and credential tokens. Remote actions are pinned to full immutable commit SHAs.

## Next tranche

After exact-head and fresh-main qualification, build the benchmark corpus from known neurOS historical defects and controlled mutations. Compare single-model, current serial tournament, homogeneous council, and heterogeneous council on validated defect recall, precision, unique valid findings, false positives, latency, cost, and marginal value per added member.

Refs #178.