### PR TITLE
fix(research): recursively freeze sealed swarm context

### DIFF
--- a/packages/neuros-research/src/neuros/research/swarm.py
+++ b/packages/neuros-research/src/neuros/research/swarm.py
@@ -7,11 +7,17 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
 
-from ._canonical import canonical_sha256, require_nonempty, require_sha256
+from ._canonical import (
+    canonical_sha256,
+    freeze_json,
+    require_nonempty,
+    require_sha256,
+    thaw_json,
+)
 
 Severity = Literal["info", "low", "medium", "high", "critical"]
 Category = Literal[
@@ -49,7 +55,7 @@ _FORBIDDEN_TASK_KEYS = {
 
 
 def _contains_forbidden_key(value: Any) -> bool:
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         for key, item in value.items():
             if str(key).strip().lower() in _FORBIDDEN_TASK_KEYS:
                 return True
@@ -58,16 +64,6 @@ def _contains_forbidden_key(value: Any) -> bool:
     elif isinstance(value, (list, tuple)):
         return any(_contains_forbidden_key(item) for item in value)
     return False
-
-
-def _canonical_bytes(value: Any) -> bytes:
-    return json.dumps(
-        value,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        allow_nan=False,
-    ).encode("utf-8")
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,7 +75,7 @@ class SealedSwarmTask:
     allowed_paths: tuple[str, ...] = ()
     authority_sha256s: tuple[str, ...] = ()
     forbidden_actions: tuple[str, ...] = ()
-    public_context: dict[str, Any] = field(default_factory=dict, repr=False)
+    public_context: Mapping[str, Any] = field(default_factory=dict, repr=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "repository", require_nonempty(self.repository, name="repository"))
@@ -105,7 +101,7 @@ class SealedSwarmTask:
         if len(set(hashes)) != len(hashes):
             raise ValueError("authority_sha256s values must be unique")
         object.__setattr__(self, "authority_sha256s", hashes)
-        context = json.loads(_canonical_bytes(self.public_context).decode("utf-8"))
+        context = freeze_json(self.public_context, path="swarm.public_context")
         if _contains_forbidden_key(context):
             raise ValueError("public_context contains a forbidden secret/private-data key")
         object.__setattr__(self, "public_context", context)
@@ -120,7 +116,7 @@ class SealedSwarmTask:
             "allowed_paths": list(self.allowed_paths),
             "authority_sha256s": list(self.authority_sha256s),
             "forbidden_actions": list(self.forbidden_actions),
-            "public_context": self.public_context,
+            "public_context": thaw_json(self.public_context),
             "llm_output_is_authority": False,
         }
 

--- a/packages/neuros-research/tests/test_swarm.py
+++ b/packages/neuros-research/tests/test_swarm.py
@@ -77,7 +77,39 @@ def test_task_detaches_context():
     context = {"a": [1]}
     sealed = _task(public_context=context)
     context["a"].append(2)
-    assert sealed.public_context == {"a": [1]}
+    assert sealed.to_dict()["public_context"] == {"a": [1]}
+
+
+def test_task_public_context_is_recursively_immutable():
+    sealed = _task(public_context={"nested": {"items": [1]}})
+    original_sha = sealed.sha256
+
+    try:
+        sealed.public_context["new"] = 1  # type: ignore[index]
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("sealed top-level context should be immutable")
+
+    nested = sealed.public_context["nested"]
+    try:
+        nested["new"] = 2
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("sealed nested context should be immutable")
+
+    assert nested["items"] == (1,)
+    assert sealed.sha256 == original_sha
+
+
+def test_task_to_dict_returns_detached_plain_json():
+    sealed = _task(public_context={"nested": {"items": [1]}})
+    payload = sealed.to_dict()
+    assert payload["public_context"] == {"nested": {"items": [1]}}
+
+    payload["public_context"]["nested"]["items"].append(2)
+    assert sealed.to_dict()["public_context"] == {"nested": {"items": [1]}}
 
 
 def test_task_rejects_secret_key_recursively():


### PR DESCRIPTION
## Purpose

Repair a post-merge integrity defect discovered while constructing the #178 swarm benchmark: `SealedSwarmTask` detached caller-owned `public_context`, but stored the detached nested object as mutable dictionaries/lists inside a frozen dataclass. Code holding the sealed task could therefore mutate nested context after construction and silently change the task SHA.

This corrective tranche restores the intended meaning of **sealed** before any benchmark or live NIM council work is layered on top.

## Exact candidate

- base: `main@012ee1ae3bc14fe04f50f86d6c2e78a0488a3dd4`
- head: `429ca28abe232ae50933f871518949eab4ea3b63`
- ancestry: exactly one commit over base
- changed files: exactly two

Files:

1. `packages/neuros-research/src/neuros/research/swarm.py`
2. `packages/neuros-research/tests/test_swarm.py`

## Repair

- reuse existing `neuros.research._canonical.freeze_json()` for recursively immutable context storage;
- make forbidden-key traversal accept generic mappings, including `MappingProxyType`;
- reuse `thaw_json()` when producing the transport dictionary so downstream JSON serialization remains ordinary `dict` / `list` data;
- remove the redundant local JSON canonicalization helper;
- preserve the existing task schema and canonical SHA computation.

## Regression coverage

The test suite now proves:

- mutation of the caller's original context cannot affect the sealed task;
- top-level mutation through `task.public_context` fails;
- nested mapping mutation fails;
- nested list-like data is frozen as tuples;
- attempted mutation leaves the task SHA unchanged;
- `to_dict()` returns detached ordinary JSON containers;
- mutating the returned transport dictionary cannot mutate the sealed task;
- recursive secret/private-data key rejection still applies.

Local combined council + adapter + benchmark construction suite after this repair: **39/39 passed**. The benchmark itself is not included in this PR.

## Boundary

This is an integrity correction only. It adds no model calls, credentials, provider execution, benchmark labels, scientific promotion, Kumar2024 authority, or ORION authority.

Refs #178.