### PR TITLE
test(research): add deterministic swarm defect benchmark

### DIFF
--- a/.github/workflows/neuros-scientific-engineering-swarm.yml
+++ b/.github/workflows/neuros-scientific-engineering-swarm.yml
@@ -5,8 +5,11 @@ on:
     paths:
       - "packages/neuros-research/src/neuros/research/swarm.py"
       - "packages/neuros-research/src/neuros/research/nim_swarm.py"
+      - "packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py"
+      - "packages/neuros-research/src/neuros/research/swarm_benchmark.py"
       - "packages/neuros-research/tests/test_swarm.py"
       - "packages/neuros-research/tests/test_nim_swarm.py"
+      - "packages/neuros-research/tests/test_swarm_benchmark.py"
       - "docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md"
       - ".github/workflows/neuros-scientific-engineering-swarm.yml"
   push:
@@ -14,8 +17,11 @@ on:
     paths:
       - "packages/neuros-research/src/neuros/research/swarm.py"
       - "packages/neuros-research/src/neuros/research/nim_swarm.py"
+      - "packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py"
+      - "packages/neuros-research/src/neuros/research/swarm_benchmark.py"
       - "packages/neuros-research/tests/test_swarm.py"
       - "packages/neuros-research/tests/test_nim_swarm.py"
+      - "packages/neuros-research/tests/test_swarm_benchmark.py"
       - "docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md"
       - ".github/workflows/neuros-scientific-engineering-swarm.yml"
   workflow_dispatch:
@@ -50,7 +56,9 @@ jobs:
         run: |
           python -m py_compile \
             packages/neuros-research/src/neuros/research/swarm.py \
-            packages/neuros-research/src/neuros/research/nim_swarm.py
+            packages/neuros-research/src/neuros/research/nim_swarm.py \
+            packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py \
+            packages/neuros-research/src/neuros/research/swarm_benchmark.py
 
       - name: Run offline adversarial tests
         env:
@@ -58,7 +66,8 @@ jobs:
         run: |
           python -m pytest -q \
             packages/neuros-research/tests/test_swarm.py \
-            packages/neuros-research/tests/test_nim_swarm.py
+            packages/neuros-research/tests/test_nim_swarm.py \
+            packages/neuros-research/tests/test_swarm_benchmark.py
 
       - name: Audit provider-neutral core boundary
         run: |
@@ -66,23 +75,30 @@ jobs:
           import ast
           from pathlib import Path
 
-          path = Path("packages/neuros-research/src/neuros/research/swarm.py")
-          tree = ast.parse(path.read_text(encoding="utf-8"))
+          paths = [
+              Path("packages/neuros-research/src/neuros/research/swarm.py"),
+              Path("packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py"),
+              Path("packages/neuros-research/src/neuros/research/swarm_benchmark.py"),
+          ]
           forbidden = {
               "requests", "httpx", "urllib", "socket", "subprocess",
               "github", "torch", "braindecode", "moabb", "kaggle",
           }
           imports = set()
-          for node in ast.walk(tree):
-              if isinstance(node, ast.Import):
-                  imports.update(alias.name.split(".")[0] for alias in node.names)
-              elif isinstance(node, ast.ImportFrom) and node.module:
-                  imports.add(node.module.split(".")[0])
+          text = ""
+          for path in paths:
+              source = path.read_text(encoding="utf-8")
+              text += "\n" + source.lower()
+              tree = ast.parse(source)
+              for node in ast.walk(tree):
+                  if isinstance(node, ast.Import):
+                      imports.update(alias.name.split(".")[0] for alias in node.names)
+                  elif isinstance(node, ast.ImportFrom) and node.module:
+                      imports.add(node.module.split(".")[0])
           unexpected = sorted(imports & forbidden)
           if unexpected:
               raise SystemExit(f"provider-neutral core imported forbidden modules: {unexpected}")
 
-          text = path.read_text(encoding="utf-8").lower()
           for token in ("nvidia_api_key", "kaggle_key", "authorization: bearer"):
               if token in text:
                   raise SystemExit(f"credential token leaked into provider-neutral core: {token}")

--- a/docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md
+++ b/docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md
@@ -25,7 +25,8 @@ failure modes, not to vote a claim into existence.
 
 The task identity is canonical and content-addressed. Public context rejects secret/private-data
 keys such as credentials, API keys, raw participant data, participant identifiers, hidden targets,
-and private leaderboard feedback.
+and private leaderboard feedback. The stored context is recursively immutable; transport
+serialization returns a detached ordinary JSON copy.
 
 Each `CouncilMember` binds a stable member ID, role, live-qualified model ID, and role prompt hash.
 The NVIDIA adapter constructs five roles:
@@ -92,34 +93,100 @@ copied into the provider-neutral manifest.
 
 The council test lane is fully offline and does not require `NVIDIA_API_KEY`. It uses mock transport
 objects to prove fan-out, deterministic identities, schema enforcement, failure preservation,
-minority-finding retention, model assignment, and compatibility with the existing NIM client
-interface.
+minority-finding retention, model assignment, benchmark scoring, and compatibility with the
+existing NIM client interface.
 
-A future live workflow may use the existing repository `NVIDIA_API_KEY` secret, but the live model
+A future live workflow may use the existing repository `NVIDIA_API_KEY` secret, but live model
 outputs remain advisory proposal material.
 
-## Next qualification tranche
+## Deterministic defect benchmark
 
-The next step is not more orchestration. It is evaluation.
+The benchmark is deliberately split into two surfaces:
 
-Build a benchmark corpus from known neurOS defects and controlled mutations, including stale
-exact-head evidence, leakage-prone splits, duplicate identities, environment drift, malformed
-proofs, outcome-adaptive scheduling, missing dependencies, and scientific overclaiming. Compare:
+- `neuros.research.swarm_benchmark_cases` contains reviewer-visible taxonomy and stimuli, the
+  committed scorer-corpus SHA-256, public manifest generation, and sealed task construction;
+- `neuros.research.swarm_benchmark` owns scorer-side ground truth, metrics, and report comparison.
 
-- one qualified model;
-- the existing serial tournament;
-- homogeneous five-member council;
-- heterogeneous five-member council.
+A live reviewer can therefore construct every sealed benchmark task without importing the module
+that contains the answer key. The scorer independently derives the complete labeled-corpus digest,
+and tests require it to equal the public commitment. The v1 corpus contains:
 
-Measure validated defect recall, precision, unique valid findings, false-positive rate, latency,
-token cost, and marginal value of each additional member. The council should remain optional unless
-it demonstrates measurable value over a single strong reviewer.
+- 29 opaque cases;
+- 20 fixed defect classes;
+- 5 clean negative controls;
+- 3 compound-defect cases;
+- a second representation of an import-shadowing failure to reduce single-template memorization.
+
+Cases are based on failure modes that matter to neurOS development: stale exact-head evidence,
+participant leakage, missing participant aggregation, learned-state substitution, environment
+drift, duplicate JSON keys, shadow files, CI dependency omissions, missing/duplicate fleet
+identities, changed frozen seeds, outcome-adaptive scheduling, target leakage, held-out preprocessing
+fit, incomplete provenance, nondeterminism, unit-of-analysis mismatch, retry-ceiling violations,
+unbound artifacts, and scientific overclaiming.
+
+### Anti-leakage contract
+
+Reviewer-visible case IDs are opaque (`case-001`, `case-002`, ...). The task exposes the fixed
+taxonomy and stimulus but never the scorer-side expected labels. The full scorer corpus, including
+labels, is content-addressed by SHA-256; the public module carries only that digest and never imports
+the scorer. The public task carries the digest without revealing the answers.
+
+This public regression corpus is designed for immediate controlled evaluation, not permanent
+hidden-holdout claims. Future long-lived model comparison should add a separately controlled
+holdout or mutation corpus so benchmark familiarity cannot masquerade as reasoning quality.
+
+A benchmark run is rejected if:
+
+- a model emits a finding ID outside the 20-label taxonomy;
+- a result is scored against the wrong case;
+- the task binds a different source revision;
+- a supplied `BenchmarkCase` payload differs from the frozen corpus;
+- a reviewer is simultaneously represented as successful and failed;
+- a failed member identity appears more than once under different error classes.
+
+### Metrics
+
+`score_benchmark()` computes deterministic council-level:
+
+- true positives, false positives, and false negatives;
+- precision, recall, and F1;
+- exact-case accuracy;
+- false-positive rate on clean controls;
+- failed member calls;
+- mean pairwise Jaccard disagreement.
+
+It also reports each member's precision, recall, F1, reviewed/failed case count, and the number of
+valid defects uniquely contributed by that member. This is important because a five-agent council
+should not receive credit for diversity if one strong reviewer finds everything while the others
+only add false alarms.
+
+`compare_benchmark_reports()` compares two reports only when corpus, source identity, and evaluated
+case slice match exactly. It reports metric deltas but explicitly grants no scientific authority.
+
+## Next live evaluation tranche
+
+The measurement apparatus must qualify before any model-performance claim is made. After this
+benchmark is promoted, run the same exact corpus through:
+
+1. one qualified strong NIM reviewer;
+2. a homogeneous five-member council using one model family;
+3. a heterogeneous five-member council using independently selected qualified models;
+4. optionally the existing serial research tournament as a separate architecture.
+
+For each configuration, preserve exact model IDs, prompt identities, call journal identities,
+latency, token usage when available, and benchmark report SHA. Compare defect recall and precision
+first, then operational cost and latency. Measure marginal gain from each additional reviewer rather
+than assuming five agents are better than one.
+
+The council should remain optional unless the heterogeneous configuration demonstrates repeatable
+value over a single strong reviewer without an unacceptable false-positive or cost penalty.
 
 ## Scientific boundary
 
-This layer can propose tests, repairs, controls, and experiments. Only executable tests,
-reproducible computation, bound data, and the existing neurOS evidence authorities can promote a
-result. It cannot authorize the Kumar2024 T4 preflight, the production 810-shard fleet, ORION
-comparison, or any scientific claim.
+This layer can propose tests, repairs, controls, and experiments. Benchmark scores measure reviewer
+performance only. They are not neuroscience results. Only executable tests, reproducible
+computation, bound data, and the existing neurOS evidence authorities can promote a scientific
+result. The swarm cannot authorize the Kumar2024 T4 preflight, the production 810-shard fleet,
+ORION comparison, or any scientific claim.
 
 Tracks #178.

--- a/packages/neuros-research/src/neuros/research/swarm_benchmark.py
+++ b/packages/neuros-research/src/neuros/research/swarm_benchmark.py
@@ -1,0 +1,439 @@
+"""Scorer-side deterministic evaluation for the neurOS scientific-engineering swarm."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Any
+
+from ._canonical import canonical_sha256, require_nonempty, require_sha256
+from .swarm import CouncilRun, SealedSwarmTask
+from .swarm_benchmark_cases import (
+    BENCHMARK_SCHEMA,
+    DEFECT_IDS,
+    DEFECT_TAXONOMY,
+    BenchmarkCase,
+    benchmark_case,
+    benchmark_cases,
+)
+
+REPORT_SCHEMA = "neuros.scientific_engineering_swarm_benchmark_report.v1"
+
+# Scorer-side answer key. This mapping is never included in reviewer-visible task payloads.
+_GROUND_TRUTH: dict[str, frozenset[str]] = {
+    "case-001": frozenset({"D01"}),
+    "case-002": frozenset({"D02"}),
+    "case-003": frozenset({"D03"}),
+    "case-004": frozenset({"D04"}),
+    "case-005": frozenset({"D05"}),
+    "case-006": frozenset({"D06"}),
+    "case-007": frozenset({"D07"}),
+    "case-008": frozenset({"D08"}),
+    "case-009": frozenset({"D09"}),
+    "case-010": frozenset({"D10"}),
+    "case-011": frozenset({"D11"}),
+    "case-012": frozenset({"D12"}),
+    "case-013": frozenset({"D13"}),
+    "case-014": frozenset({"D14"}),
+    "case-015": frozenset({"D15"}),
+    "case-016": frozenset({"D16"}),
+    "case-017": frozenset({"D17"}),
+    "case-018": frozenset({"D18"}),
+    "case-019": frozenset({"D19"}),
+    "case-020": frozenset({"D20"}),
+    "case-021": frozenset(),
+    "case-022": frozenset(),
+    "case-023": frozenset(),
+    "case-024": frozenset(),
+    "case-025": frozenset(),
+    "case-026": frozenset({"D07"}),
+    "case-027": frozenset({"D01", "D05"}),
+    "case-028": frozenset({"D09", "D10"}),
+    "case-029": frozenset({"D13", "D14"}),
+}
+
+
+def _validate_corpus() -> None:
+    cases = benchmark_cases()
+    case_ids = tuple(case.case_id for case in cases)
+    expected_case_ids = tuple(f"case-{index:03d}" for index in range(1, 30))
+    if case_ids != expected_case_ids:
+        raise RuntimeError("benchmark cases must use the frozen opaque case-001..case-029 sequence")
+    if set(_GROUND_TRUTH) != set(case_ids):
+        raise RuntimeError("benchmark ground truth must cover every case exactly once")
+    if len(DEFECT_TAXONOMY) != 20 or len(DEFECT_IDS) != 20:
+        raise RuntimeError("benchmark taxonomy must contain exactly 20 unique defect IDs")
+    unknown_labels = sorted(set().union(*_GROUND_TRUTH.values()) - DEFECT_IDS)
+    if unknown_labels:
+        raise RuntimeError(f"benchmark ground truth contains unknown labels: {unknown_labels}")
+    represented = set().union(*_GROUND_TRUTH.values())
+    if represented != DEFECT_IDS:
+        raise RuntimeError("every benchmark defect class must be represented by at least one case")
+    if sum(not labels for labels in _GROUND_TRUTH.values()) != 5:
+        raise RuntimeError("benchmark must contain exactly five clean controls")
+    if sum(len(labels) > 1 for labels in _GROUND_TRUTH.values()) != 3:
+        raise RuntimeError("benchmark must contain exactly three compound cases")
+
+
+_validate_corpus()
+
+
+def _corpus_payload() -> dict[str, Any]:
+    return {
+        "schema": BENCHMARK_SCHEMA,
+        "taxonomy": [defect.to_dict() for defect in DEFECT_TAXONOMY],
+        "cases": [
+            {
+                **case.to_public_dict(),
+                "expected_defect_ids": sorted(_GROUND_TRUTH[case.case_id]),
+            }
+            for case in benchmark_cases()
+        ],
+    }
+
+
+BENCHMARK_CORPUS_SHA256 = canonical_sha256(_corpus_payload())
+
+
+def benchmark_public_manifest() -> dict[str, Any]:
+    """Return public corpus metadata without any expected labels."""
+    cases = benchmark_cases()
+    return {
+        "schema": BENCHMARK_SCHEMA,
+        "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+        "case_count": len(cases),
+        "taxonomy": [defect.to_dict() for defect in DEFECT_TAXONOMY],
+        "cases": [case.to_public_dict() for case in cases],
+        "ground_truth_included": False,
+    }
+
+
+def build_benchmark_task(
+    case: BenchmarkCase | str,
+    *,
+    repository: str,
+    source_revision: str,
+) -> SealedSwarmTask:
+    """Build the exact reviewer-visible task for one benchmark case."""
+    if isinstance(case, str):
+        selected = benchmark_case(case)
+    else:
+        selected = benchmark_case(case.case_id)
+        if selected != case:
+            raise ValueError("benchmark case payload does not match the frozen corpus")
+    revision = require_sha256(source_revision, name="source_revision")
+    repo = require_nonempty(repository, name="repository")
+    return SealedSwarmTask(
+        repository=repo,
+        source_revision=revision,
+        objective=(
+            "Identify every defect present in the stimulus. Emit zero findings for a clean case. "
+            "Each finding_id must be one exact defect_id from the supplied taxonomy."
+        ),
+        claim_boundary=(
+            "Benchmark classification only. Model output cannot authorize code, provider execution, "
+            "scientific promotion, Kumar2024 execution, or ORION comparison."
+        ),
+        forbidden_actions=(
+            "merge code",
+            "authorize provider execution",
+            "promote scientific claims",
+            "change benchmark ground truth",
+        ),
+        public_context={
+            "benchmark_schema": BENCHMARK_SCHEMA,
+            "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+            "case": selected.to_public_dict(),
+            "defect_taxonomy": [defect.to_dict() for defect in DEFECT_TAXONOMY],
+            "scoring_rule": (
+                "Report only present defects. Unknown finding IDs are invalid. False positives on "
+                "clean controls reduce precision."
+            ),
+        },
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MemberBenchmarkScore:
+    member_id: str
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    reviewed_cases: int
+    failed_cases: int
+    unique_valid_findings: int
+
+    @property
+    def precision(self) -> float:
+        denominator = self.true_positives + self.false_positives
+        return self.true_positives / denominator if denominator else 1.0
+
+    @property
+    def recall(self) -> float:
+        denominator = self.true_positives + self.false_negatives
+        return self.true_positives / denominator if denominator else 1.0
+
+    @property
+    def f1(self) -> float:
+        denominator = self.precision + self.recall
+        return 2 * self.precision * self.recall / denominator if denominator else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "member_id": self.member_id,
+            "true_positives": self.true_positives,
+            "false_positives": self.false_positives,
+            "false_negatives": self.false_negatives,
+            "precision": self.precision,
+            "recall": self.recall,
+            "f1": self.f1,
+            "reviewed_cases": self.reviewed_cases,
+            "failed_cases": self.failed_cases,
+            "unique_valid_findings": self.unique_valid_findings,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkReport:
+    corpus_sha256: str
+    repository: str
+    source_revision: str
+    evaluated_case_ids: tuple[str, ...]
+    true_positives: int
+    false_positives: int
+    false_negatives: int
+    exact_case_matches: int
+    clean_cases: int
+    clean_cases_with_false_positive: int
+    failed_member_calls: int
+    mean_pairwise_disagreement: float
+    member_scores: tuple[MemberBenchmarkScore, ...]
+    run_sha256s: tuple[tuple[str, str], ...]
+
+    @property
+    def precision(self) -> float:
+        denominator = self.true_positives + self.false_positives
+        return self.true_positives / denominator if denominator else 1.0
+
+    @property
+    def recall(self) -> float:
+        denominator = self.true_positives + self.false_negatives
+        return self.true_positives / denominator if denominator else 1.0
+
+    @property
+    def f1(self) -> float:
+        denominator = self.precision + self.recall
+        return 2 * self.precision * self.recall / denominator if denominator else 0.0
+
+    @property
+    def exact_case_accuracy(self) -> float:
+        return self.exact_case_matches / len(self.evaluated_case_ids)
+
+    @property
+    def clean_control_false_positive_rate(self) -> float:
+        if not self.clean_cases:
+            return 0.0
+        return self.clean_cases_with_false_positive / self.clean_cases
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema": REPORT_SCHEMA,
+            "corpus_sha256": self.corpus_sha256,
+            "repository": self.repository,
+            "source_revision": self.source_revision,
+            "evaluated_case_ids": list(self.evaluated_case_ids),
+            "true_positives": self.true_positives,
+            "false_positives": self.false_positives,
+            "false_negatives": self.false_negatives,
+            "precision": self.precision,
+            "recall": self.recall,
+            "f1": self.f1,
+            "exact_case_matches": self.exact_case_matches,
+            "exact_case_accuracy": self.exact_case_accuracy,
+            "clean_cases": self.clean_cases,
+            "clean_cases_with_false_positive": self.clean_cases_with_false_positive,
+            "clean_control_false_positive_rate": self.clean_control_false_positive_rate,
+            "failed_member_calls": self.failed_member_calls,
+            "mean_pairwise_disagreement": self.mean_pairwise_disagreement,
+            "member_scores": [score.to_dict() for score in self.member_scores],
+            "run_sha256s": [list(item) for item in self.run_sha256s],
+            "benchmark_output_is_scientific_authority": False,
+            "merge_authority": False,
+            "provider_execution_authority": False,
+            "scientific_promotion_authority": False,
+        }
+        payload["report_sha256"] = canonical_sha256(payload)
+        return payload
+
+    @property
+    def sha256(self) -> str:
+        return self.to_dict()["report_sha256"]
+
+
+def _finding_ids(run: CouncilRun) -> dict[str, frozenset[str]]:
+    by_member: dict[str, frozenset[str]] = {}
+    for review in run.reviews:
+        ids = frozenset(finding.finding_id for finding in review.findings)
+        unknown = sorted(ids - DEFECT_IDS)
+        if unknown:
+            raise ValueError(f"review contains unknown benchmark defect IDs: {unknown}")
+        by_member[review.member_id] = ids
+    return by_member
+
+
+def _jaccard_distance(left: frozenset[str], right: frozenset[str]) -> float:
+    union = left | right
+    if not union:
+        return 0.0
+    return 1.0 - len(left & right) / len(union)
+
+
+def score_benchmark(
+    runs: Mapping[str, CouncilRun],
+    *,
+    repository: str,
+    source_revision: str,
+) -> BenchmarkReport:
+    """Score one run per opaque case against scorer-side deterministic ground truth."""
+    if not runs:
+        raise ValueError("benchmark requires at least one case run")
+    repo = require_nonempty(repository, name="repository")
+    revision = require_sha256(source_revision, name="source_revision")
+    case_ids = tuple(sorted(require_nonempty(case_id, name="case_id") for case_id in runs))
+    known_case_ids = {case.case_id for case in benchmark_cases()}
+    unknown_cases = sorted(set(case_ids) - known_case_ids)
+    if unknown_cases:
+        raise ValueError(f"unknown benchmark cases: {unknown_cases}")
+
+    tp = fp = fn = exact = clean_cases = clean_fp = failed_calls = 0
+    member_ids: set[str] = set()
+    predictions_by_case: dict[str, dict[str, frozenset[str]]] = {}
+    failed_by_case: dict[str, set[str]] = {}
+    run_ids: list[tuple[str, str]] = []
+
+    for case_id in case_ids:
+        run = runs[case_id]
+        expected_task = build_benchmark_task(
+            case_id,
+            repository=repo,
+            source_revision=revision,
+        )
+        if run.task_sha256 != expected_task.sha256:
+            raise ValueError(f"run for {case_id} is not bound to the expected benchmark task")
+        per_member = _finding_ids(run)
+        predictions_by_case[case_id] = per_member
+        member_ids.update(per_member)
+        failed_members = {value.split(":", 1)[0] for value in run.failed_members}
+        if len(failed_members) != len(run.failed_members):
+            raise ValueError(f"run for {case_id} repeats a failed member identity")
+        if failed_members & set(per_member):
+            raise ValueError(f"run for {case_id} marks a successful reviewer as failed")
+        failed_by_case[case_id] = failed_members
+        member_ids.update(failed_members)
+        failed_calls += len(run.failed_members)
+        run_ids.append((case_id, run.sha256))
+
+        predicted = frozenset().union(*per_member.values()) if per_member else frozenset()
+        expected = _GROUND_TRUTH[case_id]
+        tp += len(predicted & expected)
+        fp += len(predicted - expected)
+        fn += len(expected - predicted)
+        exact += int(predicted == expected)
+        if not expected:
+            clean_cases += 1
+            clean_fp += int(bool(predicted))
+
+    member_scores: list[MemberBenchmarkScore] = []
+    unique_counts = {member_id: 0 for member_id in member_ids}
+    disagreement_values: list[float] = []
+
+    for case_id in case_ids:
+        per_member = predictions_by_case[case_id]
+        expected = _GROUND_TRUTH[case_id]
+        for defect_id in expected:
+            supporters = [
+                member_id
+                for member_id, predicted in per_member.items()
+                if defect_id in predicted
+            ]
+            if len(supporters) == 1:
+                unique_counts[supporters[0]] += 1
+        for left, right in combinations(sorted(per_member), 2):
+            disagreement_values.append(_jaccard_distance(per_member[left], per_member[right]))
+
+    for member_id in sorted(member_ids):
+        member_tp = member_fp = member_fn = reviewed = failed = 0
+        for case_id in case_ids:
+            predicted = predictions_by_case[case_id].get(member_id, frozenset())
+            expected = _GROUND_TRUTH[case_id]
+            member_tp += len(predicted & expected)
+            member_fp += len(predicted - expected)
+            member_fn += len(expected - predicted)
+            reviewed += int(member_id in predictions_by_case[case_id])
+            failed += int(member_id in failed_by_case[case_id])
+        member_scores.append(
+            MemberBenchmarkScore(
+                member_id=member_id,
+                true_positives=member_tp,
+                false_positives=member_fp,
+                false_negatives=member_fn,
+                reviewed_cases=reviewed,
+                failed_cases=failed,
+                unique_valid_findings=unique_counts[member_id],
+            )
+        )
+
+    mean_disagreement = (
+        sum(disagreement_values) / len(disagreement_values)
+        if disagreement_values
+        else 0.0
+    )
+    return BenchmarkReport(
+        corpus_sha256=BENCHMARK_CORPUS_SHA256,
+        repository=repo,
+        source_revision=revision,
+        evaluated_case_ids=case_ids,
+        true_positives=tp,
+        false_positives=fp,
+        false_negatives=fn,
+        exact_case_matches=exact,
+        clean_cases=clean_cases,
+        clean_cases_with_false_positive=clean_fp,
+        failed_member_calls=failed_calls,
+        mean_pairwise_disagreement=mean_disagreement,
+        member_scores=tuple(member_scores),
+        run_sha256s=tuple(run_ids),
+    )
+
+
+def compare_benchmark_reports(
+    baseline: BenchmarkReport,
+    candidate: BenchmarkReport,
+) -> dict[str, Any]:
+    """Return deterministic deltas for an identical benchmark slice."""
+    if baseline.corpus_sha256 != candidate.corpus_sha256:
+        raise ValueError("benchmark reports bind different corpora")
+    if baseline.evaluated_case_ids != candidate.evaluated_case_ids:
+        raise ValueError("benchmark reports evaluate different case sets")
+    if (
+        baseline.repository != candidate.repository
+        or baseline.source_revision != candidate.source_revision
+    ):
+        raise ValueError("benchmark reports evaluate different source identities")
+    payload = {
+        "schema": "neuros.scientific_engineering_swarm_benchmark_comparison.v1",
+        "corpus_sha256": baseline.corpus_sha256,
+        "baseline_report_sha256": baseline.sha256,
+        "candidate_report_sha256": candidate.sha256,
+        "precision_delta": candidate.precision - baseline.precision,
+        "recall_delta": candidate.recall - baseline.recall,
+        "f1_delta": candidate.f1 - baseline.f1,
+        "exact_case_accuracy_delta": candidate.exact_case_accuracy - baseline.exact_case_accuracy,
+        "clean_control_false_positive_rate_delta": (
+            candidate.clean_control_false_positive_rate
+            - baseline.clean_control_false_positive_rate
+        ),
+        "comparison_is_scientific_authority": False,
+    }
+    payload["comparison_sha256"] = canonical_sha256(payload)
+    return payload

--- a/packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py
+++ b/packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py
@@ -1,0 +1,178 @@
+"""Reviewer-visible defect taxonomy and opaque cases for the neurOS swarm benchmark."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ._canonical import require_nonempty, require_sha256
+from .swarm import SealedSwarmTask
+
+BENCHMARK_SCHEMA = "neuros.scientific_engineering_swarm_benchmark.v1"
+# Commitment to the complete scorer corpus, including hidden labels. The public module
+# intentionally stores only the digest, never the answer key used to derive it.
+BENCHMARK_CORPUS_SHA256 = "122d862b2d43078723b858d5d5520a4ffb24e9e497d0090a52865c20f3aa5e0a"
+
+
+@dataclass(frozen=True, slots=True)
+class DefectDefinition:
+    defect_id: str
+    category: str
+    description: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "defect_id", require_nonempty(self.defect_id, name="defect_id"))
+        object.__setattr__(self, "category", require_nonempty(self.category, name="category"))
+        object.__setattr__(
+            self,
+            "description",
+            require_nonempty(self.description, name="description"),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "defect_id": self.defect_id,
+            "category": self.category,
+            "description": self.description,
+        }
+
+
+DEFECT_TAXONOMY: tuple[DefectDefinition, ...] = (
+    DefectDefinition("D01", "reproducibility", "Evidence belongs to a different Git revision than the candidate being qualified."),
+    DefectDefinition("D02", "scientific_validity", "Train and evaluation partitions share participant identity or otherwise violate subject-disjoint evaluation."),
+    DefectDefinition("D03", "scientific_validity", "Inference treats lower-level samples as independent while the scientific unit is the participant."),
+    DefectDefinition("D04", "reproducibility", "Learned model state is substituted without matching the state identity bound by the authority."),
+    DefectDefinition("D05", "reproducibility", "Runtime environment differs from the frozen environment authority."),
+    DefectDefinition("D06", "security", "Duplicate JSON keys permit parser-dependent or last-key-wins reinterpretation of a sealed field."),
+    DefectDefinition("D07", "security", "Import or file resolution can be redirected to an unbound shadow file instead of the intended implementation."),
+    DefectDefinition("D08", "implementation", "CI omits a dependency or plugin required by the repository's own test configuration."),
+    DefectDefinition("D09", "reproducibility", "A supposedly complete fleet or evaluation is missing an expected terminal shard or case."),
+    DefectDefinition("D10", "reproducibility", "The same logical lease or shard identity is represented more than once."),
+    DefectDefinition("D11", "scientific_validity", "Execution changes a preregistered or frozen random seed."),
+    DefectDefinition("D12", "scientific_validity", "Provider, retry, or scheduling decisions adapt to scientific outcomes."),
+    DefectDefinition("D13", "scientific_validity", "Target-derived information is included in model inputs, features, or preprocessing."),
+    DefectDefinition("D14", "scientific_validity", "A learned preprocessing transform is fit using held-out evaluation data."),
+    DefectDefinition("D15", "reproducibility", "An artifact lacks enough provenance to bind code, data, model, or configuration identity."),
+    DefectDefinition("D16", "reproducibility", "A stochastic operation that affects evaluation is left unseeded or otherwise non-replayable."),
+    DefectDefinition("D17", "scientific_validity", "Reported uncertainty or hypothesis testing uses a unit of analysis inconsistent with the claim."),
+    DefectDefinition("D18", "reproducibility", "Retry or attempt count exceeds the frozen retry ceiling."),
+    DefectDefinition("D19", "reproducibility", "An output is accepted by path/name/existence without a cryptographic binding to its generating assignment."),
+    DefectDefinition("D20", "scientific_validity", "The stated scientific claim is stronger than the experiment or evidence can support."),
+)
+DEFECT_IDS = frozenset(defect.defect_id for defect in DEFECT_TAXONOMY)
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkCase:
+    case_id: str
+    stimulus: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "case_id", require_nonempty(self.case_id, name="case_id"))
+        object.__setattr__(self, "stimulus", require_nonempty(self.stimulus, name="stimulus"))
+
+    def to_public_dict(self) -> dict[str, str]:
+        return {"case_id": self.case_id, "stimulus": self.stimulus}
+
+
+_CASES: tuple[BenchmarkCase, ...] = (
+    BenchmarkCase("case-001", "A PR candidate is at commit 92f0... but the attached passing workflow receipts were generated for commit 1a7c.... The reviewer marks the current candidate qualified without rerunning checks."),
+    BenchmarkCase("case-002", "EEG epochs from every participant are pooled, shuffled, and split 80/20 by row. Epochs from participant 7 appear in both train and test partitions."),
+    BenchmarkCase("case-003", "A paper-level claim is about generalization across people, but confidence intervals are computed by bootstrapping 48,000 epochs after concatenating all 18 participants. No participant-level estimate is formed."),
+    BenchmarkCase("case-004", "An authority records weights_sha256=aaa..., but the worker loads a checkpoint with weights_sha256=bbb... because it has a better validation curve. The artifact is then resealed under the original authority identifier."),
+    BenchmarkCase("case-005", "The frozen environment names package version 2.4.1 and CUDA 12.4. A worker actually runs package version 2.5.0 and CUDA 12.6, yet reuses the older environment authority SHA."),
+    BenchmarkCase("case-006", "A raw JSON authority contains {\"split_seed\":2026,\"split_seed\":3407}. The parser silently keeps the second value and the verifier does not reject duplicate object keys."),
+    BenchmarkCase("case-007", "The verifier prepends the working directory to sys.path before importing neuros.research.verifier. The artifact bundle is allowed to contain its own neuros/research/verifier.py."),
+    BenchmarkCase("case-008", "Repository pytest configuration declares asyncio_default_fixture_loop_scope, but the dedicated CI job installs only pytest. It never installs pytest-asyncio before invoking pytest."),
+    BenchmarkCase("case-009", "The execution plan expects 810 terminal shards. The ledger contains 809 distinct terminal shard identities, but settlement is nevertheless marked complete."),
+    BenchmarkCase("case-010", "Two lease records have different ordinals but the same shard_spec_sha256, participant, session, split seed, model seed, and method. Both are counted toward completeness."),
+    BenchmarkCase("case-011", "The frozen plan specifies split_seed=2026. The worker CLI is invoked with --split-seed 2027, and the produced score is accepted into the planned evaluation."),
+    BenchmarkCase("case-012", "After each completed shard, the scheduler reads validation balanced accuracy and sends later shards to whichever provider has produced the highest accuracy so far."),
+    BenchmarkCase("case-013", "The feature builder appends the true class indicator as an auxiliary channel during both training and evaluation because downstream code expects a fixed channel count."),
+    BenchmarkCase("case-014", "PCA and z-score parameters are fit once on the concatenation of train and held-out participants. The transformed held-out rows are then used for final evaluation."),
+    BenchmarkCase("case-015", "A result artifact records metric values and model name, but omits source revision, input-data hash, preprocessing configuration, and model-state hash."),
+    BenchmarkCase("case-016", "Evaluation order is created with random.shuffle(cases) and stochastic test-time crops are enabled. No seed or RNG state is recorded anywhere in the run manifest."),
+    BenchmarkCase("case-017", "The claimed effect is participant-level, but a p-value is computed over 12,000 windows as if all windows were independent observations. Participants contribute unequal numbers of windows."),
+    BenchmarkCase("case-018", "Fleet authority sets max_attempts_per_lease=2. A lease fails twice, receives a third claim, succeeds on attempt 3, and is accepted into settlement."),
+    BenchmarkCase("case-019", "A worker writes result.json. Settlement accepts any file at that path if it exists; neither the file bytes nor its lease identity are hashed into the receipt."),
+    BenchmarkCase("case-020", "A synthetic benchmark with generated EEG shows a decoder above chance. The report concludes that the decoder is clinically validated for unseen patients with real neurological disease."),
+    BenchmarkCase("case-021", "The candidate commit and every cited check receipt bind the same full source SHA. The reviewer verifies that the receipts were generated after the candidate stopped changing."),
+    BenchmarkCase("case-022", "Participants are assigned to train or test as whole groups before any learned transform is fit. No participant contributes samples to both partitions."),
+    BenchmarkCase("case-023", "A scaler and PCA model are fit using training participants only, serialized with hashes, and applied without refitting to held-out participants."),
+    BenchmarkCase("case-024", "Provider selection uses accelerator type, queue availability, price ceiling, and environment compatibility. Scientific metrics are not visible to the scheduler."),
+    BenchmarkCase("case-025", "A lease allows two attempts. Attempt 1 fails with a trusted infrastructure-preemption class; attempt 2 succeeds. The settlement contains exactly one terminal artifact for every expected lease."),
+    BenchmarkCase("case-026", "The review command executes python -m verifier from an extracted artifact directory. That directory contains verifier.py with the same module name as the trusted verifier, and import origin is never checked."),
+    BenchmarkCase("case-027", "The PR is at commit ccc..., while its evidence receipt binds commit bbb.... In addition, the runtime reports numpy 2.2 although the frozen environment authority binds numpy 2.1."),
+    BenchmarkCase("case-028", "The roster expects identities A, B, and C. Records A and B are present, then B is repeated under a new ordinal. The completeness counter reports three leases."),
+    BenchmarkCase("case-029", "A global normalization transform is fit before the participant split using every row, and one generated feature is the per-row target encoded as an integer."),
+)
+_CASE_BY_ID = {case.case_id: case for case in _CASES}
+
+
+def benchmark_cases() -> tuple[BenchmarkCase, ...]:
+    """Return the frozen reviewer-visible corpus without scorer labels."""
+    return _CASES
+
+
+def benchmark_case(case_id: str) -> BenchmarkCase:
+    normalized = require_nonempty(case_id, name="case_id")
+    try:
+        return _CASE_BY_ID[normalized]
+    except KeyError as exc:
+        raise ValueError(f"unknown benchmark case {normalized!r}") from exc
+
+
+def benchmark_public_manifest() -> dict[str, Any]:
+    """Return public corpus metadata without importing scorer-owned ground truth."""
+    return {
+        "schema": BENCHMARK_SCHEMA,
+        "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+        "case_count": len(_CASES),
+        "taxonomy": [defect.to_dict() for defect in DEFECT_TAXONOMY],
+        "cases": [case.to_public_dict() for case in _CASES],
+        "ground_truth_included": False,
+    }
+
+
+def build_benchmark_task(
+    case: BenchmarkCase | str,
+    *,
+    repository: str,
+    source_revision: str,
+) -> SealedSwarmTask:
+    """Build a reviewer task without importing the scorer or answer key."""
+    if isinstance(case, str):
+        selected = benchmark_case(case)
+    else:
+        selected = benchmark_case(case.case_id)
+        if selected != case:
+            raise ValueError("benchmark case payload does not match the frozen corpus")
+    revision = require_sha256(source_revision, name="source_revision")
+    repo = require_nonempty(repository, name="repository")
+    return SealedSwarmTask(
+        repository=repo,
+        source_revision=revision,
+        objective=(
+            "Identify every defect present in the stimulus. Emit zero findings for a clean case. "
+            "Each finding_id must be one exact defect_id from the supplied taxonomy."
+        ),
+        claim_boundary=(
+            "Benchmark classification only. Model output cannot authorize code, provider execution, "
+            "scientific promotion, Kumar2024 execution, or ORION comparison."
+        ),
+        forbidden_actions=(
+            "merge code",
+            "authorize provider execution",
+            "promote scientific claims",
+            "change benchmark ground truth",
+        ),
+        public_context={
+            "benchmark_schema": BENCHMARK_SCHEMA,
+            "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+            "case": selected.to_public_dict(),
+            "defect_taxonomy": [defect.to_dict() for defect in DEFECT_TAXONOMY],
+            "scoring_rule": (
+                "Report only present defects. Unknown finding IDs are invalid. False positives on "
+                "clean controls reduce precision."
+            ),
+        },
+    )

--- a/packages/neuros-research/tests/test_swarm_benchmark.py
+++ b/packages/neuros-research/tests/test_swarm_benchmark.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from neuros.research import swarm_benchmark_cases
+from neuros.research.swarm import AgentReview, CouncilRun, Finding
+from neuros.research.swarm_benchmark import (
+    _GROUND_TRUTH,
+    compare_benchmark_reports,
+    score_benchmark,
+)
+from neuros.research.swarm_benchmark import (
+    BENCHMARK_CORPUS_SHA256 as SCORER_CORPUS_SHA256,
+)
+from neuros.research.swarm_benchmark_cases import (
+    BENCHMARK_CORPUS_SHA256,
+    DEFECT_TAXONOMY,
+    benchmark_case,
+    benchmark_cases,
+    benchmark_public_manifest,
+    build_benchmark_task,
+)
+
+REV = "4" * 64
+REPO = "sidhulyalkar/neurOS-v1"
+
+
+def _finding(defect_id: str) -> Finding:
+    return Finding(
+        finding_id=defect_id,
+        severity="high",
+        category="reproducibility",
+        claim="classified defect",
+        evidence="benchmark stimulus",
+        falsification_test="apply deterministic regression",
+        proposed_repair="repair the defect",
+        confidence=0.9,
+        requires_human_judgment=False,
+        reference="benchmark",
+    )
+
+
+def _run(case_id: str, by_member: dict[str, set[str]], failed=()) -> CouncilRun:
+    task = build_benchmark_task(case_id, repository=REPO, source_revision=REV)
+    reviews = []
+    for index, (member, ids) in enumerate(sorted(by_member.items())):
+        reviews.append(
+            AgentReview(
+                task_sha256=task.sha256,
+                member_id=member,
+                role="reviewer",
+                model=f"model-{member}",
+                prompt_sha256=f"{index + 1:064x}",
+                response_sha256=f"{index + 101:064x}",
+                findings=tuple(_finding(defect_id) for defect_id in sorted(ids)),
+            )
+        )
+    return CouncilRun(task.sha256, tuple(reviews), tuple(failed))
+
+
+def _perfect_runs(member="solo"):
+    return {
+        case.case_id: _run(case.case_id, {member: set(_GROUND_TRUTH[case.case_id])})
+        for case in benchmark_cases()
+    }
+
+
+def test_taxonomy_has_exactly_twenty_unique_closed_labels():
+    ids = [item.defect_id for item in DEFECT_TAXONOMY]
+    assert len(ids) == 20
+    assert len(set(ids)) == 20
+    assert ids == [f"D{index:02d}" for index in range(1, 21)]
+
+
+def test_corpus_has_29_opaque_unique_cases():
+    cases = benchmark_cases()
+    assert len(cases) == 29
+    assert len({case.case_id for case in cases}) == 29
+    assert [case.case_id for case in cases] == [f"case-{index:03d}" for index in range(1, 30)]
+
+
+def test_case_ids_do_not_leak_taxonomy_or_diagnostic_words():
+    forbidden = {
+        "leak", "seed", "retry", "duplicate", "stale", "shadow", "environment",
+        "provider", "participant", "artifact", "claim", "preprocess", "shard",
+    }
+    for case in benchmark_cases():
+        lowered = case.case_id.lower()
+        assert not any(token in lowered for token in forbidden)
+
+
+def test_corpus_contains_five_clean_controls_and_three_compound_cases():
+    labels = list(_GROUND_TRUTH.values())
+    assert sum(not value for value in labels) == 5
+    assert sum(len(value) > 1 for value in labels) == 3
+
+
+def test_every_defect_class_is_represented_in_ground_truth():
+    represented = frozenset().union(*_GROUND_TRUTH.values())
+    assert represented == {item.defect_id for item in DEFECT_TAXONOMY}
+
+
+def test_public_corpus_commitment_matches_scorer_answer_key():
+    assert BENCHMARK_CORPUS_SHA256 == SCORER_CORPUS_SHA256
+
+
+def test_public_module_contains_no_answer_key_or_scorer_import():
+    source = inspect.getsource(swarm_benchmark_cases)
+    assert "_GROUND_TRUTH" not in source
+    assert "from .swarm_benchmark import" not in source
+
+
+def test_public_manifest_contains_no_ground_truth_fields():
+    manifest = benchmark_public_manifest()
+    assert manifest["ground_truth_included"] is False
+    text = repr(manifest).lower()
+    assert "expected_defect_ids" not in text
+    assert manifest["corpus_sha256"] == BENCHMARK_CORPUS_SHA256
+
+
+def test_public_task_contains_taxonomy_but_not_case_labels():
+    task = build_benchmark_task("case-001", repository=REPO, source_revision=REV)
+    payload = task.to_dict()
+    context = payload["public_context"]
+    assert context["case"]["case_id"] == "case-001"
+    assert len(context["defect_taxonomy"]) == 20
+    assert "expected_defect_ids" not in repr(context)
+    assert "D01" not in context["case"]["case_id"]
+
+
+def test_task_identity_binds_case_corpus_and_revision():
+    one = build_benchmark_task("case-001", repository=REPO, source_revision=REV)
+    two = build_benchmark_task("case-002", repository=REPO, source_revision=REV)
+    other_rev = build_benchmark_task("case-001", repository=REPO, source_revision="5" * 64)
+    assert one.sha256 != two.sha256
+    assert one.sha256 != other_rev.sha256
+    assert one.to_dict()["public_context"]["corpus_sha256"] == BENCHMARK_CORPUS_SHA256
+
+
+def test_case_payload_substitution_is_rejected():
+    from neuros.research.swarm_benchmark_cases import BenchmarkCase
+
+    forged = BenchmarkCase("case-001", "clean and unrelated")
+    with pytest.raises(ValueError, match="frozen corpus"):
+        build_benchmark_task(forged, repository=REPO, source_revision=REV)
+
+
+def test_perfect_predictions_score_one_everywhere():
+    report = score_benchmark(_perfect_runs(), repository=REPO, source_revision=REV)
+    assert report.precision == 1.0
+    assert report.recall == 1.0
+    assert report.f1 == 1.0
+    assert report.exact_case_accuracy == 1.0
+    assert report.clean_control_false_positive_rate == 0.0
+    assert report.false_positives == 0
+    assert report.false_negatives == 0
+
+
+def test_unknown_finding_id_invalidates_score():
+    runs = {"case-001": _run("case-001", {"a": {"NOT_A_LABEL"}})}
+    with pytest.raises(ValueError, match="unknown benchmark defect IDs"):
+        score_benchmark(runs, repository=REPO, source_revision=REV)
+
+
+def test_swapped_run_to_case_binding_is_rejected():
+    run = _run("case-002", {"a": {"D02"}})
+    with pytest.raises(ValueError, match="not bound"):
+        score_benchmark({"case-001": run}, repository=REPO, source_revision=REV)
+
+
+def test_false_alarm_on_clean_control_reduces_precision_and_clean_score():
+    runs = {"case-021": _run("case-021", {"a": {"D01"}})}
+    report = score_benchmark(runs, repository=REPO, source_revision=REV)
+    assert report.true_positives == 0
+    assert report.false_positives == 1
+    assert report.precision == 0.0
+    assert report.clean_control_false_positive_rate == 1.0
+    assert report.exact_case_accuracy == 0.0
+
+
+def test_missing_defect_reduces_recall():
+    runs = {"case-027": _run("case-027", {"a": {"D01"}})}
+    report = score_benchmark(runs, repository=REPO, source_revision=REV)
+    assert report.true_positives == 1
+    assert report.false_negatives == 1
+    assert report.recall == 0.5
+
+
+def test_member_scores_show_when_one_member_carries_the_council():
+    runs = {
+        "case-027": _run("case-027", {"ultra": {"D01", "D05"}, "light": set()}),
+        "case-021": _run("case-021", {"ultra": set(), "light": {"D03"}}),
+    }
+    report = score_benchmark(runs, repository=REPO, source_revision=REV)
+    scores = {score.member_id: score for score in report.member_scores}
+    assert scores["ultra"].true_positives == 2
+    assert scores["ultra"].false_positives == 0
+    assert scores["light"].true_positives == 0
+    assert scores["light"].false_positives == 1
+
+
+def test_unique_valid_findings_are_attributed_to_the_only_supporter():
+    runs = {
+        "case-027": _run("case-027", {"a": {"D01"}, "b": {"D05"}, "c": set()})
+    }
+    report = score_benchmark(runs, repository=REPO, source_revision=REV)
+    scores = {score.member_id: score.unique_valid_findings for score in report.member_scores}
+    assert scores == {"a": 1, "b": 1, "c": 0}
+
+
+def test_pairwise_disagreement_is_zero_for_identical_reviewers():
+    run = _run("case-001", {"a": {"D01"}, "b": {"D01"}})
+    report = score_benchmark({"case-001": run}, repository=REPO, source_revision=REV)
+    assert report.mean_pairwise_disagreement == 0.0
+
+
+def test_pairwise_disagreement_is_one_for_disjoint_nonempty_reviews():
+    run = _run("case-027", {"a": {"D01"}, "b": {"D05"}})
+    report = score_benchmark({"case-027": run}, repository=REPO, source_revision=REV)
+    assert report.mean_pairwise_disagreement == 1.0
+
+
+def test_failed_member_calls_are_counted_without_provider_diagnostics():
+    run = _run("case-001", {"a": {"D01"}}, failed=("b:TimeoutError",))
+    report = score_benchmark({"case-001": run}, repository=REPO, source_revision=REV)
+    scores = {score.member_id: score for score in report.member_scores}
+    assert report.failed_member_calls == 1
+    assert scores["b"].failed_cases == 1
+    assert scores["b"].reviewed_cases == 0
+
+
+def test_report_identity_is_order_independent_over_mapping_input():
+    first = {
+        "case-002": _run("case-002", {"a": {"D02"}}),
+        "case-001": _run("case-001", {"a": {"D01"}}),
+    }
+    second = dict(reversed(list(first.items())))
+    one = score_benchmark(first, repository=REPO, source_revision=REV)
+    two = score_benchmark(second, repository=REPO, source_revision=REV)
+    assert one.sha256 == two.sha256
+
+
+def test_comparison_reports_metric_deltas_and_denies_authority():
+    baseline = score_benchmark(
+        {"case-027": _run("case-027", {"a": {"D01"}})},
+        repository=REPO,
+        source_revision=REV,
+    )
+    candidate = score_benchmark(
+        {"case-027": _run("case-027", {"a": {"D01", "D05"}})},
+        repository=REPO,
+        source_revision=REV,
+    )
+    comparison = compare_benchmark_reports(baseline, candidate)
+    assert comparison["recall_delta"] == 0.5
+    assert comparison["f1_delta"] > 0
+    assert comparison["comparison_is_scientific_authority"] is False
+    assert len(comparison["comparison_sha256"]) == 64
+
+
+def test_comparison_rejects_different_case_slices():
+    baseline = score_benchmark(
+        {"case-001": _run("case-001", {"a": {"D01"}})},
+        repository=REPO,
+        source_revision=REV,
+    )
+    candidate = score_benchmark(
+        {"case-002": _run("case-002", {"a": {"D02"}})},
+        repository=REPO,
+        source_revision=REV,
+    )
+    with pytest.raises(ValueError, match="different case sets"):
+        compare_benchmark_reports(baseline, candidate)
+
+
+def test_report_manifest_explicitly_denies_authority():
+    report = score_benchmark(
+        {"case-001": _run("case-001", {"a": {"D01"}})},
+        repository=REPO,
+        source_revision=REV,
+    ).to_dict()
+    assert report["benchmark_output_is_scientific_authority"] is False
+    assert report["merge_authority"] is False
+    assert report["provider_execution_authority"] is False
+    assert report["scientific_promotion_authority"] is False
+
+
+def test_unknown_case_fails_closed():
+    with pytest.raises(ValueError, match="unknown benchmark case"):
+        benchmark_case("case-999")
+
+
+def test_scorer_rejects_successful_member_also_marked_failed():
+    run = _run("case-001", {"a": {"D01"}}, failed=("a:TimeoutError",))
+    with pytest.raises(ValueError, match="successful reviewer as failed"):
+        score_benchmark({"case-001": run}, repository=REPO, source_revision=REV)
+
+
+def test_scorer_rejects_repeated_failed_member_identity():
+    run = _run(
+        "case-001",
+        {},
+        failed=("a:TimeoutError", "a:RuntimeError"),
+    )
+    with pytest.raises(ValueError, match="repeats a failed member identity"):
+        score_benchmark({"case-001": run}, repository=REPO, source_revision=REV)


### PR DESCRIPTION
## Purpose

Add a deterministic, scorer-owned benchmark so the neurOS scientific-engineering swarm must demonstrate measurable defect-discovery value before live NVIDIA NIM scaling.

## Authoritative candidate

- qualified base: `main@40468ab576df5cbcf3e80b7634d6557d0b590e1b`
- current head: `e56dfdffddbef5f9b8e7b8ba13975b13fb019d49`
- ancestry: exactly one commit over base
- changed files: exactly five
- labeled-corpus commitment: `122d862b2d43078723b858d5d5520a4ffb24e9e497d0090a52865c20f3aa5e0a`

All earlier heads (`a3545d7f...`, `f6f7926b...`, `4ff7118e...`, `2fb0a0d4...`) are superseded and contribute **no promotion evidence**. The first two exposed Ruff import organization issues; `4ff7118e...` corrected those. The architecture was then strengthened so live task construction no longer imports the scorer/answer-key module. `2fb0a0d4...` exposed one final Ruff `I001` rule requiring the aliased corpus constant to be split into its own import statement. The current head applies Ruff's exact suggested organization. No benchmark labels, stimuli, scorer logic, corpus commitment, workflow logic, or scientific boundary changed in that repair.

## Five-file tranche

1. `packages/neuros-research/src/neuros/research/swarm_benchmark_cases.py`
2. `packages/neuros-research/src/neuros/research/swarm_benchmark.py`
3. `packages/neuros-research/tests/test_swarm_benchmark.py`
4. `.github/workflows/neuros-scientific-engineering-swarm.yml`
5. `docs/NEUROS_SCIENTIFIC_ENGINEERING_SWARM.md`

## Structural anti-leakage design

`swarm_benchmark_cases.py` is the reviewer surface. It owns only the fixed taxonomy, opaque stimuli, the labeled-corpus SHA-256 commitment, public manifest generation, and sealed task construction. It does not import or contain `_GROUND_TRUTH`.

`swarm_benchmark.py` is the scorer surface. It owns the hidden answer key and deterministic scoring/comparison logic. Tests require the scorer-derived labeled corpus identity to equal the public commitment. A live NIM evaluation process can therefore construct every reviewer task without importing the answer key.

## Corpus

- 29 opaque cases (`case-001` ... `case-029`)
- 20 closed defect classes (`D01` ... `D20`)
- 5 clean negative controls
- 3 compound-defect cases
- every defect class represented

This is explicitly a **public regression benchmark**, not a permanent hidden holdout. Long-lived model comparison will require a separately controlled holdout/mutation corpus so benchmark familiarity cannot masquerade as reasoning quality.

## Deterministic scoring

Council level: TP/FP/FN, precision, recall, F1, exact-case accuracy, clean-control false-positive rate, failed member calls, and mean pairwise Jaccard disagreement.

Per member: precision/recall/F1, reviewed/failed cases, and unique valid findings. The scorer fails closed on unknown labels, wrong case/task binding, source-revision mismatch, substituted case payloads, duplicate failed-member identities, or a reviewer represented as both successful and failed.

## Current key blobs

- public cases/task construction: `0bc2047c348e97753e67fc8b09c9654cc7577de7`
- scorer: `f8c1577214ff87a9b60f72092932f345e0b2d5f4`
- Ruff-correct benchmark tests: `8983d9942af8818d1894cbc4167990d682c7c860`
- offline workflow: `8d2b8fed46aaaa44ee686be9aab6eac0999a86ac`
- docs: `4fb934a832e4542d510156838fa3c27fecbbe9e0`

The dedicated offline CI compiles and tests the council + benchmark on Python 3.10 / 3.11 / 3.12 and audits provider-neutral modules for network/provider/credential dependencies.

## Boundary

Benchmark reports measure reviewer performance only. They grant no merge authority, provider execution, scientific promotion, Kumar2024 T4/fleet authorization, or ORION comparison authority.

After promotion, the next tranche is a separately qualified telemetry/live-evaluation harness for one strong model vs homogeneous five-member council vs heterogeneous five-member council, with exact call identities and cost/latency telemetry.

Refs #178.