### PR TITLE
feat(research): add bounded NIM swarm live-eval telemetry

### DIFF
--- a/.github/workflows/nim-swarm-live-eval.yml
+++ b/.github/workflows/nim-swarm-live-eval.yml
@@ -1,0 +1,441 @@
+name: NVIDIA NIM Swarm Live Evaluation
+
+on:
+  pull_request:
+    paths:
+      - "packages/neuros-research/src/neuros/research/nim_observed.py"
+      - "packages/neuros-research/src/neuros/research/swarm_live_eval.py"
+      - "packages/neuros-research/examples/05_nim_swarm_live_eval.py"
+      - "packages/neuros-research/examples/06_score_nim_swarm_live_eval.py"
+      - "packages/neuros-research/tests/test_nim_observed.py"
+      - "packages/neuros-research/tests/test_swarm_live_eval.py"
+      - "docs/NEUROS_NIM_SWARM_LIVE_EVAL.md"
+      - ".github/workflows/nim-swarm-live-eval.yml"
+  push:
+    branches: [main]
+    paths:
+      - "packages/neuros-research/src/neuros/research/nim_observed.py"
+      - "packages/neuros-research/src/neuros/research/swarm_live_eval.py"
+      - "packages/neuros-research/examples/05_nim_swarm_live_eval.py"
+      - "packages/neuros-research/examples/06_score_nim_swarm_live_eval.py"
+      - "packages/neuros-research/tests/test_nim_observed.py"
+      - "packages/neuros-research/tests/test_swarm_live_eval.py"
+      - "docs/NEUROS_NIM_SWARM_LIVE_EVAL.md"
+      - ".github/workflows/nim-swarm-live-eval.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nim-swarm-live-eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  offline-contract:
+    name: live-eval contract / py${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install deterministic test harness
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pytest==9.1.1" "pytest-asyncio==1.4.0" "ruff==0.16.7"
+
+      - name: Compile and lint additive telemetry surfaces
+        run: |
+          python -m py_compile \
+            packages/neuros-research/src/neuros/research/nim_observed.py \
+            packages/neuros-research/src/neuros/research/swarm_live_eval.py \
+            packages/neuros-research/examples/05_nim_swarm_live_eval.py \
+            packages/neuros-research/examples/06_score_nim_swarm_live_eval.py
+          python -m ruff check \
+            packages/neuros-research/src/neuros/research/nim_observed.py \
+            packages/neuros-research/src/neuros/research/swarm_live_eval.py \
+            packages/neuros-research/examples/05_nim_swarm_live_eval.py \
+            packages/neuros-research/examples/06_score_nim_swarm_live_eval.py \
+            packages/neuros-research/tests/test_nim_observed.py \
+            packages/neuros-research/tests/test_swarm_live_eval.py
+
+      - name: Run credential-free telemetry contracts
+        env:
+          PYTHONPATH: packages/neuros-research/src
+        run: |
+          python -m pytest -q \
+            packages/neuros-research/tests/test_nim_observed.py \
+            packages/neuros-research/tests/test_swarm_live_eval.py \
+            packages/neuros-research/tests/test_nim_swarm.py \
+            packages/neuros-research/tests/test_swarm_benchmark.py
+
+      - name: Audit model-facing answer-key isolation
+        run: |
+          python - <<'PY'
+          import ast
+          from pathlib import Path
+
+          paths = [
+              Path("packages/neuros-research/src/neuros/research/swarm_live_eval.py"),
+              Path("packages/neuros-research/examples/05_nim_swarm_live_eval.py"),
+          ]
+          forbidden_modules = {"neuros.research.swarm_benchmark"}
+          for path in paths:
+              source = path.read_text(encoding="utf-8")
+              if "_GROUND_TRUTH" in source:
+                  raise SystemExit(f"scorer answer key leaked into model-facing path: {path}")
+              tree = ast.parse(source)
+              for node in ast.walk(tree):
+                  if isinstance(node, ast.ImportFrom) and node.module in forbidden_modules:
+                      raise SystemExit(f"scorer module imported by model-facing path: {path}")
+          PY
+
+      - name: Exercise scorer CLI on synthetic credential-free raw evidence
+        env:
+          PYTHONPATH: packages/neuros-research/src
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from hashlib import sha256
+          from pathlib import Path
+
+          from neuros.research._canonical import canonical_sha256
+          from neuros.research.nim_observed import NimTokenUsage
+          from neuros.research.nim_provider import DOCUMENTED_NVIDIA_CHAT_MODELS
+          from neuros.research.nim_swarm import _user_prompt
+          from neuros.research.swarm import AgentReview, CouncilRun
+          from neuros.research.swarm_benchmark_cases import (
+              BENCHMARK_CORPUS_SHA256,
+              build_benchmark_task,
+          )
+          from neuros.research.swarm_live_eval import (
+              SCHEDULE_POLICY,
+              SMOKE_CASE_IDS,
+              EvaluationCallReceipt,
+              EvaluationRunManifest,
+              build_counterbalanced_schedule,
+              build_evaluation_configurations,
+          )
+
+          repository = "sidhulyalkar/neurOS-v1"
+          revision = "4" * 64
+          endpoint = "https://integrate.api.nvidia.com/v1"
+          selected_models = (DOCUMENTED_NVIDIA_CHAT_MODELS[0],)
+          configurations = build_evaluation_configurations(selected_models)
+          probes = []
+          for index, model in enumerate(DOCUMENTED_NVIDIA_CHAT_MODELS):
+              if index == 0:
+                  probes.append({
+                      "model": model,
+                      "status": "qualified",
+                      "status_code": None,
+                      "response_sha256": "6" * 64,
+                      "error_excerpt": None,
+                  })
+              else:
+                  probes.append({
+                      "model": model,
+                      "status": "transport_error",
+                      "status_code": None,
+                      "response_sha256": None,
+                      "error_excerpt": "synthetic offline unavailable route",
+                  })
+          qualification = {
+              "schema_version": 1,
+              "endpoint": endpoint,
+              "discovery_mode": "synthetic+bounded_chat_probe",
+              "documented_candidates": list(DOCUMENTED_NVIDIA_CHAT_MODELS),
+              "catalog_models_sha256": None,
+              "catalog_error": None,
+              "probes": probes,
+              "qualified_models": list(selected_models),
+              "discovery_budget": {
+                  "timeout_seconds_per_attempt": 20.0,
+                  "max_attempts_per_route": 2,
+              },
+              "authority_boundary": "synthetic offline qualification",
+          }
+          qualification["fingerprint"] = canonical_sha256(qualification)
+          provider = qualification["fingerprint"]
+          parsed_sha = canonical_sha256({"findings": []})
+          manifests = []
+          counter = 0
+          for configuration in configurations:
+              runs = []
+              receipts = []
+              timings = []
+              for case_index, case_id in enumerate(SMOKE_CASE_IDS, start=1):
+                  task = build_benchmark_task(
+                      case_id,
+                      repository=repository,
+                      source_revision=revision,
+                  )
+                  user_prompt = _user_prompt(task)
+                  reviews = []
+                  for member in configuration.members:
+                      counter += 1
+                      request_payload = {
+                          "model": member.model,
+                          "messages": [
+                              {"role": "system", "content": member.system_prompt},
+                              {"role": "user", "content": user_prompt},
+                          ],
+                          "temperature": 0.1,
+                          "max_tokens": 1200,
+                          "stream": False,
+                          "chat_template_kwargs": {"enable_thinking": False},
+                      }
+                      combined_prompt = f"{member.system_prompt}\n\n{user_prompt}"
+                      reviews.append(
+                          AgentReview(
+                              task_sha256=task.sha256,
+                              member_id=member.member_id,
+                              role=member.role,
+                              model=member.model,
+                              prompt_sha256=member.prompt_sha256,
+                              response_sha256=parsed_sha,
+                              findings=(),
+                          )
+                      )
+                      receipts.append(
+                          EvaluationCallReceipt(
+                              case_id=case_id,
+                              task_sha256=task.sha256,
+                              member_id=member.member_id,
+                              role=member.role,
+                              model=member.model,
+                              member_prompt_sha256=member.prompt_sha256,
+                              provider_qualification_fingerprint=provider,
+                              endpoint=endpoint,
+                              outcome="success",
+                              latency_ms=counter,
+                              call_prompt_sha256=sha256(
+                                  combined_prompt.encode("utf-8")
+                              ).hexdigest(),
+                              request_sha256=canonical_sha256(request_payload),
+                              response_sha256=f"{counter + 200:064x}",
+                              parsed_response_sha256=parsed_sha,
+                              token_usage=NimTokenUsage(
+                                  prompt_tokens=10,
+                                  completion_tokens=2,
+                                  total_tokens=12,
+                                  usage_sha256=f"{counter + 300:064x}",
+                              ),
+                          )
+                      )
+                  runs.append(
+                      (case_id, CouncilRun(task_sha256=task.sha256, reviews=tuple(reviews)))
+                  )
+                  timings.append((case_id, case_index * 5))
+              manifests.append(
+                  EvaluationRunManifest(
+                      repository=repository,
+                      source_revision=revision,
+                      configuration=configuration,
+                      provider_qualification_fingerprint=provider,
+                      case_ids=SMOKE_CASE_IDS,
+                      runs=tuple(runs),
+                      receipts=tuple(receipts),
+                      case_wall_latency_ms=tuple(timings),
+                  )
+              )
+
+          schedule = build_counterbalanced_schedule(configurations, SMOKE_CASE_IDS)
+          raw = {
+              "kind": "neuros_nim_swarm_live_eval_raw_v1",
+              "repository": repository,
+              "source_revision": revision,
+              "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+              "case_ids": list(SMOKE_CASE_IDS),
+              "discovery_mode": qualification["discovery_mode"],
+              "selected_models": list(selected_models),
+              "provider_qualification": qualification,
+              "schedule_policy": SCHEDULE_POLICY,
+              "execution_schedule": [
+                  {"case_id": case_id, "configuration_id": configuration_id}
+                  for case_id, configuration_id in schedule
+              ],
+              "configurations": [manifest.to_dict() for manifest in manifests],
+              "review_call_count": sum(len(manifest.receipts) for manifest in manifests),
+              "smoke_is_full_benchmark": False,
+              "smoke_is_model_performance_claim": False,
+              "live_review_output_is_scientific_authority": False,
+              "merge_authority": False,
+              "provider_execution_authority": False,
+              "scientific_promotion_authority": False,
+          }
+          raw["artifact_sha256"] = canonical_sha256(raw)
+          Path("/tmp/nim-swarm-live-eval-raw.json").write_text(
+              json.dumps(raw, sort_keys=True, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          python packages/neuros-research/examples/06_score_nim_swarm_live_eval.py \
+            --input /tmp/nim-swarm-live-eval-raw.json \
+            --output /tmp/nim-swarm-live-eval-scored.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          scored = json.loads(
+              Path("/tmp/nim-swarm-live-eval-scored.json").read_text(encoding="utf-8")
+          )
+          expected = {"single-reference-v1", "homogeneous-five-role-v1"}
+          if scored.get("kind") != "neuros_nim_swarm_live_eval_scored_v1":
+              raise SystemExit("unexpected synthetic scored artifact kind")
+          if set(scored.get("reports", {})) != expected:
+              raise SystemExit("synthetic scorer lost frozen configuration identity")
+          if len(scored.get("comparisons", [])) != 1:
+              raise SystemExit("synthetic scorer did not compare council against reference")
+          for report in scored["reports"].values():
+              telemetry = report.get("telemetry", {})
+              if telemetry.get("reviewer_attempts", 0) <= 0:
+                  raise SystemExit("synthetic scorer omitted reviewer telemetry")
+              if "case_wall_latency_ms" not in telemetry:
+                  raise SystemExit("synthetic scorer omitted end-to-end latency telemetry")
+              if telemetry.get("dollar_cost_estimated") is not False:
+                  raise SystemExit("synthetic scorer fabricated dollar cost")
+          if scored.get("benchmark_output_is_scientific_authority") is not False:
+              raise SystemExit("synthetic scored artifact claimed scientific authority")
+          PY
+
+  live-smoke:
+    name: bounded hosted smoke / 3 cases
+    if: github.event_name == 'workflow_dispatch'
+    needs: offline-contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Require exact qualified main source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF_NAME}" = "main"
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain)"
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - name: Install and requalify locally before network
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e "packages/neuros-research[dev]"
+          python -m compileall -q packages/neuros-research/src packages/neuros-research/examples
+          python -m ruff check \
+            packages/neuros-research/src/neuros/research/nim_observed.py \
+            packages/neuros-research/src/neuros/research/swarm_live_eval.py \
+            packages/neuros-research/examples/05_nim_swarm_live_eval.py \
+            packages/neuros-research/examples/06_score_nim_swarm_live_eval.py \
+            packages/neuros-research/tests/test_nim_observed.py \
+            packages/neuros-research/tests/test_swarm_live_eval.py
+          python -m pytest -q \
+            packages/neuros-research/tests/test_nim.py \
+            packages/neuros-research/tests/test_nim_provider.py \
+            packages/neuros-research/tests/test_nim_observed.py \
+            packages/neuros-research/tests/test_swarm.py \
+            packages/neuros-research/tests/test_nim_swarm.py \
+            packages/neuros-research/tests/test_swarm_benchmark.py \
+            packages/neuros-research/tests/test_swarm_live_eval.py
+
+      - name: Run bounded hosted reviewer smoke
+        shell: bash
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY || secrets.NVIDIA_NIM_API_KEY || secrets.NVAPI_KEY }}
+          NVIDIA_NIM_ENDPOINT: https://integrate.api.nvidia.com/v1
+        run: |
+          set -euo pipefail
+          if [ -z "${NVIDIA_API_KEY:-}" ]; then
+            echo "::error::Expected repository secret NVIDIA_API_KEY, NVIDIA_NIM_API_KEY, or NVAPI_KEY."
+            exit 1
+          fi
+          echo "::add-mask::${NVIDIA_API_KEY}"
+          mkdir -p artifacts/nim-swarm-live-eval
+          python packages/neuros-research/examples/05_nim_swarm_live_eval.py \
+            --source-revision "${GITHUB_SHA}" \
+            --output artifacts/nim-swarm-live-eval/raw.json
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          raw = Path("artifacts/nim-swarm-live-eval/raw.json").read_text(encoding="utf-8")
+          key = os.environ["NVIDIA_API_KEY"]
+          if key and key in raw:
+              raise SystemExit("credential material leaked into raw live-evaluation artifact")
+          PY
+
+      - name: Score completed reviews without provider credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          python packages/neuros-research/examples/06_score_nim_swarm_live_eval.py \
+            --input artifacts/nim-swarm-live-eval/raw.json \
+            --output artifacts/nim-swarm-live-eval/scored.json
+          sha256sum artifacts/nim-swarm-live-eval/raw.json \
+            artifacts/nim-swarm-live-eval/scored.json \
+            > artifacts/nim-swarm-live-eval/SHA256SUMS
+
+      - name: Verify bounded non-authoritative smoke evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          raw = json.loads(Path("artifacts/nim-swarm-live-eval/raw.json").read_text())
+          scored = json.loads(Path("artifacts/nim-swarm-live-eval/scored.json").read_text())
+          if raw.get("source_revision") != os.environ["GITHUB_SHA"]:
+              raise SystemExit("raw live-evaluation source revision mismatch")
+          if scored.get("source_revision") != os.environ["GITHUB_SHA"]:
+              raise SystemExit("scored live-evaluation source revision mismatch")
+          if raw.get("case_ids") != ["case-001", "case-015", "case-029"]:
+              raise SystemExit("unexpected live smoke case slice")
+          expected_calls = sum(
+              len(manifest["configuration"]["members"]) * len(raw["case_ids"])
+              for manifest in raw["configurations"]
+          )
+          if raw.get("review_call_count") != expected_calls or expected_calls > 33:
+              raise SystemExit("live smoke exceeded its frozen reviewer-call budget")
+          if raw.get("schedule_policy") != "deterministic_rotating_configuration_order_v1":
+              raise SystemExit("live smoke did not preserve frozen scheduling policy")
+          for report in scored.get("reports", {}).values():
+              telemetry = report.get("telemetry", {})
+              if "case_wall_latency_ms" not in telemetry or "per_call_latency_ms" not in telemetry:
+                  raise SystemExit("scored smoke omitted required latency telemetry")
+          for payload in (raw, scored):
+              if payload.get("merge_authority") is not False:
+                  raise SystemExit("live smoke artifact claimed merge authority")
+              if payload.get("provider_execution_authority") is not False:
+                  raise SystemExit("live smoke artifact claimed provider execution authority")
+              if payload.get("scientific_promotion_authority") is not False:
+                  raise SystemExit("live smoke artifact claimed scientific promotion authority")
+          print(f"qualified bounded reviewer attempts: {expected_calls}")
+          PY
+
+      - name: Preserve live smoke evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: nim-swarm-live-eval-${{ github.sha }}
+          path: artifacts/nim-swarm-live-eval/
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/NEUROS_NIM_SWARM_LIVE_EVAL.md
+++ b/docs/NEUROS_NIM_SWARM_LIVE_EVAL.md
@@ -1,0 +1,191 @@
+# neurOS NVIDIA swarm live evaluation
+
+This tranche measures whether the advisory neurOS reviewer swarm can produce useful,
+verifiable regression-review evidence at bounded operational cost. It does **not** create a
+new scientific or execution authority.
+
+## Promotion dependency
+
+The harness is built on promoted benchmark main:
+
+- source base: `271b0df596f2ce4464e46c7a708aebde027c6c35`;
+- public regression corpus commitment:
+  `122d862b2d43078723b858d5d5520a4ffb24e9e497d0090a52865c20f3aa5e0a`.
+
+The benchmark cases and taxonomy are public regression material. They are not a hidden
+holdout and cannot establish general model capability, neuroscience validity, clinical
+utility, or provider superiority.
+
+## Additive observation contract
+
+`nim_observed.py` leaves the existing `NimCallRecord` serialization unchanged. An observed
+call returns that same record plus a separate `NimTokenUsage` object.
+
+Provider token fields are retained only when the hosted response actually reports them.
+Missing or malformed counts remain unavailable and are never estimated.
+
+The observed machine-output path is intentionally stricter than the older proposal parser.
+After trimming whitespace, the complete response must be exactly one JSON object. Free-form
+prefix/suffix prose, non-object JSON roots, and duplicate object keys are rejected. This keeps
+machine-validated evidence from depending on permissive extraction behavior and prevents the
+evaluator from reproducing benchmark defect D06.
+
+## Truthful failure accounting
+
+Each `EvaluationCallReceipt` classifies one reviewer attempt as exactly one of:
+
+- `success`: provider transport and strict review validation succeeded;
+- `provider_failure`: no usable hosted response reached review validation;
+- `review_validation_failure`: a hosted response arrived but failed exact JSON, schema, or
+  public-taxonomy validation.
+
+A validation-failed response may still have consumed latency and tokens. Its exact transport
+identities and provider-reported usage are preserved rather than making malformed output look
+artificially cheap.
+
+## Frozen reviewer configurations
+
+Live-qualified model ordering is frozen before benchmark outcomes are observed. The first
+qualified route becomes the preregistered reference route. This is an outcome-blind reference,
+not a claim that it is the strongest model.
+
+The v1 smoke reconstructs:
+
+1. `single-reference-v1`: one generalist reviewer on the reference route;
+2. `homogeneous-five-role-v1`: five specialist roles on that same route;
+3. `heterogeneous-five-role-v1`: the same five roles distributed across qualified routes,
+   only when at least two routes qualify.
+
+The third versus second configuration is the cleaner operational contrast for route diversity
+because reviewer count and role prompts remain fixed.
+
+The second versus first configuration does **not** isolate the causal value of role
+specialization. It simultaneously changes reviewer count, independent sampling budget, and
+role-specific prompts. If the five-role council improves, v1 can say that the complete council
+configuration improved on these regression cases, not that specialization alone caused the
+improvement. A future ablation should add five same-model generalist reviewers to separate
+ensemble-size effects from specialist-role effects.
+
+## Exact request reconstruction
+
+The credential-free scorer independently reconstructs the reviewer configuration from the
+live-qualified `selected_models`. For every successful or validation-failed attempt it then
+rebuilds the frozen task prompt and canonical NIM request:
+
+- exact member system prompt;
+- exact benchmark user prompt;
+- exact model route;
+- `temperature=0.1`;
+- `max_tokens=1200`;
+- `stream=false`;
+- `enable_thinking=false`.
+
+The receipt's prompt and request fingerprints must match those reconstructed values. A
+self-rehashed artifact therefore cannot silently substitute a different prompt or request.
+
+## Provider qualification reconstruction
+
+The scorer does not trust `qualified_models` merely because the qualification object hashes.
+It independently requires:
+
+- the pinned endpoint `https://integrate.api.nvidia.com/v1`;
+- the exact documented Nemotron candidate roster;
+- one ordered probe per documented route;
+- valid probe status/failure semantics;
+- `qualified_models` derived exactly from successful probes;
+- a valid complete qualification fingerprint.
+
+This prevents cryptographically self-consistent but semantically invented provider rosters from
+becoming benchmark inputs.
+
+## Counterbalanced hosted schedule
+
+Running every baseline call first and every council call later would confound configuration with
+provider load or route drift. The smoke therefore uses the frozen
+`deterministic_rotating_configuration_order_v1` policy.
+
+For each successive case, configuration order rotates by one position. The exact schedule is
+serialized into the raw artifact and independently reconstructed by the scorer. It is fixed
+before any hosted outcome exists.
+
+With two configurations and three cases this is not perfectly balanced, and with three cases no
+small schedule can remove all time/provider effects. The rotation simply removes the most obvious
+block-order confound. Results remain operational smoke evidence, not causal model comparisons.
+
+## Wall latency versus model-call work
+
+Five council reviewers execute concurrently. Summing their individual call latencies would
+therefore exaggerate user-visible wait time.
+
+Each configuration manifest binds both:
+
+- per-reviewer call latency;
+- per-case end-to-end wall latency.
+
+The scorer reports both, plus outcome counts and provider-reported token totals/coverage. Dollar
+cost is not estimated in v1. A future monetary layer must bind an independently frozen price
+schedule rather than retroactively applying current prices.
+
+## Model-facing / scorer separation
+
+The hosted-review process imports only `swarm_benchmark_cases.py`. It never imports scorer-side
+`swarm_benchmark.py` or `_GROUND_TRUTH`. It emits unscored provider-neutral `CouncilRun` payloads,
+receipts, and case-wall timings.
+
+A separate credential-free scorer verifies, before importing ground truth:
+
+- the outer raw artifact fingerprint;
+- provider qualification semantics and fingerprint;
+- selected-model ordering;
+- the exact counterbalanced schedule and reviewer-call budget;
+- reconstructed reviewer IDs, roles, models, and prompt hashes;
+- exact prompt/request identities;
+- manifest hashes and false authority flags;
+- exact case × reviewer receipt coverage;
+- receipt schema, outcome semantics, token provenance, endpoint, and task binding;
+- council-run reconstruction and run fingerprints;
+- successful receipt-to-review parsed-response identity;
+- failed reviewer-to-error-class consistency;
+- exact case-wall timing coverage.
+
+The offline Python 3.10/3.11/3.12 matrix also fabricates complete content-addressed synthetic
+raw evidence and executes the real scorer CLI. Adversarial unit tests rehash forged inner
+artifacts after semantic substitutions and still require rejection.
+
+## Bounded v1 smoke
+
+The hosted job is manual `workflow_dispatch` only. Pull requests and pushes are credential-free
+and never call NVIDIA.
+
+The first hosted smoke is frozen to:
+
+- `case-001`;
+- `case-015`;
+- `case-029`.
+
+With one qualified route, the maximum is 18 reviewer attempts. With at least two qualified routes,
+the maximum is 33 attempts. A full 29-case A/B/C run would require up to 319 reviewer attempts and
+is intentionally disabled in v1.
+
+Three public cases are sufficient to qualify transport, structured-output behavior, telemetry,
+scorer reconstruction, and obvious operational failure modes. They are not sufficient to estimate
+stable precision/recall differences between reviewer configurations.
+
+## Credential boundary
+
+The workflow reuses the existing repository secret aliases and prefers `NVIDIA_API_KEY`:
+
+- `NVIDIA_API_KEY`;
+- `NVIDIA_NIM_API_KEY`;
+- `NVAPI_KEY`.
+
+Never place a key in source, issue text, artifacts, or chat. The key is scoped only to the hosted
+review step, artifacts are scanned for leakage, and scoring executes without the credential.
+
+## Authority boundary
+
+This tranche grants no merge authority, no future provider-execution authority, no Kumar2024
+execution authorization, no scientific-promotion authority, and no ORION comparison authority.
+Reviewer agreement is measurement data, not a vote that creates truth.
+
+Tracks #178.

--- a/packages/neuros-research/examples/05_nim_swarm_live_eval.py
+++ b/packages/neuros-research/examples/05_nim_swarm_live_eval.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Run the bounded model-facing NVIDIA swarm telemetry smoke.
+
+This process intentionally never imports scorer-side benchmark ground truth.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+from neuros.research._canonical import canonical_sha256, require_sha256
+from neuros.research.nim import DEFAULT_NVIDIA_ENDPOINT
+from neuros.research.nim_observed import ObservedQualifiedNvidiaNimClient
+from neuros.research.swarm import run_council
+from neuros.research.swarm_benchmark_cases import (
+    BENCHMARK_CORPUS_SHA256,
+    build_benchmark_task,
+)
+from neuros.research.swarm_live_eval import (
+    SCHEDULE_POLICY,
+    SMOKE_CASE_IDS,
+    EvaluationRunManifest,
+    ObservedNvidiaCouncilTransport,
+    build_counterbalanced_schedule,
+    build_evaluation_configurations,
+)
+
+REPOSITORY = "sidhulyalkar/neurOS-v1"
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--endpoint",
+        default=os.environ.get("NVIDIA_NIM_ENDPOINT", DEFAULT_NVIDIA_ENDPOINT),
+    )
+    return parser.parse_args()
+
+
+def _elapsed_ms(started_ns: int) -> int:
+    return max(0, (time.perf_counter_ns() - started_ns + 999_999) // 1_000_000)
+
+
+async def _run_all_configurations(
+    *,
+    client: ObservedQualifiedNvidiaNimClient,
+    configurations,  # type: ignore[no-untyped-def]
+    source_revision: str,
+    provider_fingerprint: str,
+):  # type: ignore[no-untyped-def]
+    transports = {
+        configuration.configuration_id: ObservedNvidiaCouncilTransport(
+            client,
+            provider_qualification_fingerprint=provider_fingerprint,
+            max_tokens=1200,
+        )
+        for configuration in configurations
+    }
+    runs = {configuration.configuration_id: [] for configuration in configurations}
+    timings = {configuration.configuration_id: [] for configuration in configurations}
+    by_id = {configuration.configuration_id: configuration for configuration in configurations}
+    schedule = build_counterbalanced_schedule(configurations, SMOKE_CASE_IDS)
+
+    for case_id, configuration_id in schedule:
+        configuration = by_id[configuration_id]
+        task = build_benchmark_task(
+            case_id,
+            repository=REPOSITORY,
+            source_revision=source_revision,
+        )
+        started_ns = time.perf_counter_ns()
+        run = await run_council(
+            task,
+            configuration.members,
+            transports[configuration_id],
+            require_all=False,
+        )
+        runs[configuration_id].append((case_id, run))
+        timings[configuration_id].append((case_id, _elapsed_ms(started_ns)))
+
+    manifests = []
+    for configuration in configurations:
+        configuration_id = configuration.configuration_id
+        manifests.append(
+            EvaluationRunManifest(
+                repository=REPOSITORY,
+                source_revision=source_revision,
+                configuration=configuration,
+                provider_qualification_fingerprint=provider_fingerprint,
+                case_ids=SMOKE_CASE_IDS,
+                runs=tuple(runs[configuration_id]),
+                receipts=transports[configuration_id].receipts,
+                case_wall_latency_ms=tuple(timings[configuration_id]),
+            )
+        )
+    return tuple(manifests), schedule
+
+
+async def _main() -> None:
+    args = _args()
+    revision = require_sha256(args.source_revision, name="source_revision")
+    api_key = os.environ.get("NVIDIA_API_KEY", "").strip()
+    if not api_key:
+        raise SystemExit("NVIDIA_API_KEY is required")
+
+    client = ObservedQualifiedNvidiaNimClient(api_key, endpoint=args.endpoint)
+    available, discovery_mode = client.discover_models()
+    selected_models = client.select_models(available, count=3)
+    qualification = client.provider_qualification()
+    provider_fingerprint = require_sha256(
+        qualification["fingerprint"],
+        name="provider_qualification_fingerprint",
+    )
+    configurations = build_evaluation_configurations(selected_models)
+    manifests, schedule = await _run_all_configurations(
+        client=client,
+        configurations=configurations,
+        source_revision=revision,
+        provider_fingerprint=provider_fingerprint,
+    )
+
+    payload = {
+        "kind": "neuros_nim_swarm_live_eval_raw_v1",
+        "repository": REPOSITORY,
+        "source_revision": revision,
+        "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+        "case_ids": list(SMOKE_CASE_IDS),
+        "discovery_mode": discovery_mode,
+        "selected_models": list(selected_models),
+        "provider_qualification": qualification,
+        "schedule_policy": SCHEDULE_POLICY,
+        "execution_schedule": [
+            {"case_id": case_id, "configuration_id": configuration_id}
+            for case_id, configuration_id in schedule
+        ],
+        "configurations": [manifest.to_dict() for manifest in manifests],
+        "review_call_count": sum(len(manifest.receipts) for manifest in manifests),
+        "smoke_is_full_benchmark": False,
+        "smoke_is_model_performance_claim": False,
+        "live_review_output_is_scientific_authority": False,
+        "merge_authority": False,
+        "provider_execution_authority": False,
+        "scientific_promotion_authority": False,
+    }
+    payload["artifact_sha256"] = canonical_sha256(payload)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/packages/neuros-research/examples/06_score_nim_swarm_live_eval.py
+++ b/packages/neuros-research/examples/06_score_nim_swarm_live_eval.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+"""Score a completed raw NIM swarm smoke in a separate non-network process."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from neuros.research._canonical import canonical_sha256, require_sha256
+from neuros.research.nim_provider import DOCUMENTED_NVIDIA_CHAT_MODELS
+from neuros.research.nim_swarm import _user_prompt
+from neuros.research.swarm import CouncilMember
+from neuros.research.swarm_benchmark_cases import (
+    BENCHMARK_CORPUS_SHA256,
+    build_benchmark_task,
+)
+from neuros.research.swarm_live_eval import (
+    SCHEDULE_POLICY,
+    SMOKE_CASE_IDS,
+    EvaluationConfiguration,
+    build_counterbalanced_schedule,
+    build_evaluation_configurations,
+    council_run_from_dict,
+)
+
+_LIVE_MAX_TOKENS = 1200
+_LIVE_TEMPERATURE = 0.1
+_PROVIDER_FIELDS = {
+    "schema_version",
+    "endpoint",
+    "discovery_mode",
+    "documented_candidates",
+    "catalog_models_sha256",
+    "catalog_error",
+    "probes",
+    "qualified_models",
+    "discovery_budget",
+    "authority_boundary",
+    "fingerprint",
+}
+_PROBE_FIELDS = {"model", "status", "status_code", "response_sha256", "error_excerpt"}
+_RECEIPT_FIELDS = {
+    "schema",
+    "case_id",
+    "task_sha256",
+    "member_id",
+    "role",
+    "model",
+    "member_prompt_sha256",
+    "provider_qualification_fingerprint",
+    "endpoint",
+    "outcome",
+    "latency_ms",
+    "call_prompt_sha256",
+    "request_sha256",
+    "response_sha256",
+    "parsed_response_sha256",
+    "token_usage",
+    "error_class",
+    "token_counts_are_provider_reported_not_estimated",
+    "receipt_is_scientific_authority",
+    "receipt_sha256",
+}
+_MANIFEST_FIELDS = {
+    "schema",
+    "repository",
+    "source_revision",
+    "corpus_sha256",
+    "configuration",
+    "configuration_sha256",
+    "provider_qualification_fingerprint",
+    "case_ids",
+    "runs",
+    "receipts",
+    "case_wall_latency_ms",
+    "token_counts_are_provider_reported_not_estimated",
+    "dollar_cost_estimated",
+    "live_review_output_is_scientific_authority",
+    "merge_authority",
+    "provider_execution_authority",
+    "scientific_promotion_authority",
+    "manifest_sha256",
+}
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _require_false(payload: dict[str, Any], key: str) -> None:
+    if payload.get(key) is not False:
+        raise ValueError(f"{key} must remain false")
+
+
+def _nonnegative_int(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _optional_nonnegative_int(value: Any, *, name: str) -> int | None:
+    if value is None:
+        return None
+    return _nonnegative_int(value, name=name)
+
+
+def _validated_provider_qualification(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict) or set(payload) != _PROVIDER_FIELDS:
+        raise ValueError("provider qualification fields do not match the frozen schema")
+    fingerprint = require_sha256(payload.get("fingerprint", ""), name="provider_fingerprint")
+    unhashed = dict(payload)
+    del unhashed["fingerprint"]
+    if canonical_sha256(unhashed) != fingerprint:
+        raise ValueError("provider qualification fingerprint mismatch")
+    if payload.get("schema_version") != 1:
+        raise ValueError("unsupported provider qualification schema")
+    if payload.get("endpoint") != "https://integrate.api.nvidia.com/v1":
+        raise ValueError("provider qualification endpoint is not the pinned NVIDIA endpoint")
+    if payload.get("documented_candidates") != list(DOCUMENTED_NVIDIA_CHAT_MODELS):
+        raise ValueError("provider qualification candidate roster differs from frozen roster")
+
+    probes = payload.get("probes")
+    if not isinstance(probes, list) or len(probes) != len(DOCUMENTED_NVIDIA_CHAT_MODELS):
+        raise ValueError("provider qualification must contain one probe per documented candidate")
+    derived_qualified: list[str] = []
+    for expected_model, probe in zip(DOCUMENTED_NVIDIA_CHAT_MODELS, probes, strict=True):
+        if not isinstance(probe, dict) or set(probe) != _PROBE_FIELDS:
+            raise ValueError("provider probe fields do not match the frozen schema")
+        if probe.get("model") != expected_model:
+            raise ValueError("provider probe order/model identity differs from frozen roster")
+        status = probe.get("status")
+        if status == "qualified":
+            require_sha256(probe.get("response_sha256", ""), name="probe_response_sha256")
+            if probe.get("status_code") is not None or probe.get("error_excerpt") is not None:
+                raise ValueError("qualified provider probe cannot carry failure evidence")
+            derived_qualified.append(expected_model)
+        elif status in {"http_error", "transport_error", "invalid_response"}:
+            error = probe.get("error_excerpt")
+            if not isinstance(error, str) or not error.strip():
+                raise ValueError("failed provider probe requires bounded failure evidence")
+            if probe.get("response_sha256") is not None:
+                raise ValueError("failed provider probe cannot claim successful response identity")
+        else:
+            raise ValueError("unsupported provider probe status")
+    if payload.get("qualified_models") != derived_qualified or not derived_qualified:
+        raise ValueError("qualified_models must be derived exactly from successful probes")
+
+    budget = payload.get("discovery_budget")
+    expected_budget_fields = {"timeout_seconds_per_attempt", "max_attempts_per_route"}
+    if not isinstance(budget, dict) or set(budget) != expected_budget_fields:
+        raise ValueError("provider discovery budget fields do not match the frozen schema")
+    timeout = budget["timeout_seconds_per_attempt"]
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or timeout <= 0:
+        raise ValueError("provider discovery timeout must be positive")
+    attempts = budget["max_attempts_per_route"]
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 1:
+        raise ValueError("provider discovery attempt budget must be positive")
+    return payload
+
+
+def _validated_raw(path: Path) -> tuple[dict[str, Any], tuple[EvaluationConfiguration, ...]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("kind") != "neuros_nim_swarm_live_eval_raw_v1":
+        raise ValueError("unexpected raw live-evaluation artifact")
+    claimed = require_sha256(payload.get("artifact_sha256", ""), name="artifact_sha256")
+    unhashed = dict(payload)
+    del unhashed["artifact_sha256"]
+    if canonical_sha256(unhashed) != claimed:
+        raise ValueError("raw live-evaluation artifact fingerprint mismatch")
+    if payload.get("corpus_sha256") != BENCHMARK_CORPUS_SHA256:
+        raise ValueError("raw artifact benchmark corpus mismatch")
+    if tuple(payload.get("case_ids", ())) != SMOKE_CASE_IDS:
+        raise ValueError("raw artifact does not contain the frozen smoke case slice")
+    require_sha256(payload.get("source_revision", ""), name="source_revision")
+    for key in (
+        "smoke_is_full_benchmark",
+        "smoke_is_model_performance_claim",
+        "live_review_output_is_scientific_authority",
+        "merge_authority",
+        "provider_execution_authority",
+        "scientific_promotion_authority",
+    ):
+        _require_false(payload, key)
+
+    qualification = _validated_provider_qualification(payload.get("provider_qualification"))
+    if payload.get("discovery_mode") != qualification.get("discovery_mode"):
+        raise ValueError("raw discovery mode differs from provider qualification")
+    selected = payload.get("selected_models")
+    if not isinstance(selected, list) or not selected:
+        raise ValueError("raw artifact requires selected_models")
+    selected_models = tuple(str(model).strip() for model in selected)
+    if any(not model for model in selected_models) or len(set(selected_models)) != len(selected_models):
+        raise ValueError("selected model identities must be non-empty and unique")
+    qualified_models = tuple(str(model) for model in qualification["qualified_models"])
+    if selected_models != qualified_models[:3]:
+        raise ValueError("selected models differ from frozen qualified-model preference order")
+
+    expected_configurations = build_evaluation_configurations(selected_models)
+    if payload.get("schedule_policy") != SCHEDULE_POLICY:
+        raise ValueError("raw artifact schedule policy mismatch")
+    expected_schedule = [
+        {"case_id": case_id, "configuration_id": configuration_id}
+        for case_id, configuration_id in build_counterbalanced_schedule(
+            expected_configurations,
+            SMOKE_CASE_IDS,
+        )
+    ]
+    if payload.get("execution_schedule") != expected_schedule:
+        raise ValueError("raw artifact execution schedule mismatch")
+    configurations = payload.get("configurations")
+    if not isinstance(configurations, list) or len(configurations) != len(expected_configurations):
+        raise ValueError("raw artifact configuration count differs from frozen plan")
+    expected_calls = sum(
+        len(configuration.members) * len(SMOKE_CASE_IDS) for configuration in expected_configurations
+    )
+    if _nonnegative_int(payload.get("review_call_count"), name="review_call_count") != expected_calls:
+        raise ValueError("raw artifact reviewer-call count differs from frozen plan")
+    if expected_calls > 33:
+        raise ValueError("raw artifact exceeds bounded v1 reviewer-call budget")
+    return payload, expected_configurations
+
+
+def _validated_token_usage(payload: Any) -> dict[str, Any]:
+    expected = {"source", "prompt_tokens", "completion_tokens", "total_tokens", "usage_sha256"}
+    if not isinstance(payload, dict) or set(payload) != expected:
+        raise ValueError("token usage fields do not match the v1 schema")
+    prompt = _optional_nonnegative_int(payload.get("prompt_tokens"), name="prompt_tokens")
+    completion = _optional_nonnegative_int(payload.get("completion_tokens"), name="completion_tokens")
+    total = _optional_nonnegative_int(payload.get("total_tokens"), name="total_tokens")
+    usage_sha = payload.get("usage_sha256")
+    if payload.get("source") == "unavailable":
+        if any(value is not None for value in (prompt, completion, total, usage_sha)):
+            raise ValueError("unavailable token usage cannot contain provider-reported values")
+    elif payload.get("source") == "provider_response":
+        require_sha256(usage_sha or "", name="usage_sha256")
+    else:
+        raise ValueError("unsupported token usage source")
+    return payload
+
+
+def _expected_call_identity(*, task: Any, member: CouncilMember) -> tuple[str, str]:
+    user_prompt = _user_prompt(task)
+    combined_prompt = f"{member.system_prompt}\n\n{user_prompt}"
+    prompt_sha256 = sha256(combined_prompt.encode("utf-8")).hexdigest()
+    request_payload = {
+        "model": member.model,
+        "messages": [
+            {"role": "system", "content": member.system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": float(_LIVE_TEMPERATURE),
+        "max_tokens": int(_LIVE_MAX_TOKENS),
+        "stream": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    return prompt_sha256, canonical_sha256(request_payload)
+
+
+def _validated_receipt(
+    receipt: Any,
+    *,
+    raw: dict[str, Any],
+    expected_member: CouncilMember,
+    case_id: str,
+) -> dict[str, Any]:
+    if not isinstance(receipt, dict) or set(receipt) != _RECEIPT_FIELDS:
+        raise ValueError("live-evaluation receipt fields do not match the v1 schema")
+    receipt_claim = require_sha256(receipt.get("receipt_sha256", ""), name="receipt_sha256")
+    receipt_unhashed = dict(receipt)
+    del receipt_unhashed["receipt_sha256"]
+    if canonical_sha256(receipt_unhashed) != receipt_claim:
+        raise ValueError("live-evaluation receipt fingerprint mismatch")
+    if receipt.get("schema") != "neuros.nim_swarm_evaluation_call_receipt.v1":
+        raise ValueError("unexpected live-evaluation receipt schema")
+    if receipt.get("case_id") != case_id:
+        raise ValueError("receipt case identity mismatch")
+    task = build_benchmark_task(
+        case_id,
+        repository=raw["repository"],
+        source_revision=raw["source_revision"],
+    )
+    if receipt.get("task_sha256") != task.sha256:
+        raise ValueError("receipt task identity mismatch")
+    qualification = raw["provider_qualification"]
+    if receipt.get("provider_qualification_fingerprint") != qualification["fingerprint"]:
+        raise ValueError("receipt provider qualification mismatch")
+    if receipt.get("endpoint") != qualification["endpoint"]:
+        raise ValueError("receipt endpoint differs from provider qualification")
+    if (
+        receipt.get("member_id") != expected_member.member_id
+        or receipt.get("role") != expected_member.role
+        or receipt.get("model") != expected_member.model
+        or receipt.get("member_prompt_sha256") != expected_member.prompt_sha256
+    ):
+        raise ValueError("receipt member identity differs from frozen configuration")
+    if receipt.get("token_counts_are_provider_reported_not_estimated") is not True:
+        raise ValueError("receipt token-count provenance flag must remain true")
+    _require_false(receipt, "receipt_is_scientific_authority")
+    _nonnegative_int(receipt.get("latency_ms"), name="latency_ms")
+    usage = _validated_token_usage(receipt.get("token_usage"))
+
+    outcome = receipt.get("outcome")
+    names = ("call_prompt_sha256", "request_sha256", "response_sha256")
+    values = tuple(receipt.get(name) for name in names)
+    parsed_sha = receipt.get("parsed_response_sha256")
+    error_class = receipt.get("error_class")
+    has_transport = outcome in {"success", "review_validation_failure"}
+    if has_transport:
+        for name, value in zip(names, values, strict=True):
+            require_sha256(value or "", name=name)
+        expected_prompt, expected_request = _expected_call_identity(task=task, member=expected_member)
+        if receipt.get("call_prompt_sha256") != expected_prompt:
+            raise ValueError("receipt call-prompt identity differs from frozen request contract")
+        if receipt.get("request_sha256") != expected_request:
+            raise ValueError("receipt request identity differs from frozen request contract")
+
+    if outcome == "success":
+        require_sha256(parsed_sha or "", name="parsed_response_sha256")
+        if error_class is not None:
+            raise ValueError("successful receipt cannot carry an error class")
+    elif outcome == "provider_failure":
+        if any(value is not None for value in (*values, parsed_sha)):
+            raise ValueError("provider failure cannot claim unavailable transport identities")
+        if usage.get("source") != "unavailable":
+            raise ValueError("provider failure cannot claim provider token usage")
+        if not isinstance(error_class, str) or not error_class.strip():
+            raise ValueError("provider failure requires a non-empty error class")
+    elif outcome == "review_validation_failure":
+        if parsed_sha is not None:
+            require_sha256(parsed_sha, name="parsed_response_sha256")
+        if not isinstance(error_class, str) or not error_class.strip():
+            raise ValueError("review-validation failure requires a non-empty error class")
+    else:
+        raise ValueError("unsupported receipt outcome")
+    return receipt
+
+
+def _validated_manifest(
+    manifest: dict[str, Any],
+    *,
+    raw: dict[str, Any],
+    expected_configuration: EvaluationConfiguration,
+) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]], dict[str, int]]:
+    if set(manifest) != _MANIFEST_FIELDS:
+        raise ValueError("live-evaluation manifest fields do not match the v1 schema")
+    claimed = require_sha256(manifest.get("manifest_sha256", ""), name="manifest_sha256")
+    unhashed = dict(manifest)
+    del unhashed["manifest_sha256"]
+    if canonical_sha256(unhashed) != claimed:
+        raise ValueError("live-evaluation manifest fingerprint mismatch")
+    if manifest.get("schema") != "neuros.nim_swarm_live_evaluation_manifest.v1":
+        raise ValueError("unexpected live-evaluation manifest schema")
+    if manifest.get("repository") != raw["repository"]:
+        raise ValueError("live-evaluation manifest repository mismatch")
+    if manifest.get("source_revision") != raw["source_revision"]:
+        raise ValueError("live-evaluation manifest source revision mismatch")
+    if manifest.get("corpus_sha256") != BENCHMARK_CORPUS_SHA256:
+        raise ValueError("live-evaluation manifest corpus mismatch")
+    if tuple(manifest.get("case_ids", ())) != SMOKE_CASE_IDS:
+        raise ValueError("live-evaluation manifest case slice mismatch")
+    if manifest.get("token_counts_are_provider_reported_not_estimated") is not True:
+        raise ValueError("manifest token-count provenance flag must remain true")
+    _require_false(manifest, "dollar_cost_estimated")
+    for key in (
+        "live_review_output_is_scientific_authority",
+        "merge_authority",
+        "provider_execution_authority",
+        "scientific_promotion_authority",
+    ):
+        _require_false(manifest, key)
+
+    expected_configuration_dict = expected_configuration.to_dict()
+    if manifest.get("configuration") != expected_configuration_dict:
+        raise ValueError("serialized configuration differs from the frozen reconstructed plan")
+    if manifest.get("configuration_sha256") != expected_configuration.sha256:
+        raise ValueError("configuration fingerprint mismatch")
+    if manifest.get("provider_qualification_fingerprint") != raw["provider_qualification"]["fingerprint"]:
+        raise ValueError("manifest provider qualification mismatch")
+
+    timings = manifest.get("case_wall_latency_ms")
+    if not isinstance(timings, dict) or set(timings) != set(SMOKE_CASE_IDS):
+        raise ValueError("case wall timings do not cover the exact smoke case slice")
+    validated_timings = {
+        case_id: _nonnegative_int(timings[case_id], name=f"case_wall_latency_ms[{case_id}]")
+        for case_id in SMOKE_CASE_IDS
+    }
+
+    members = {member.member_id: member for member in expected_configuration.members}
+    receipts = manifest.get("receipts")
+    if not isinstance(receipts, list):
+        raise ValueError("live-evaluation manifest receipts must be a list")
+    receipt_map: dict[tuple[str, str], dict[str, Any]] = {}
+    for receipt in receipts:
+        if not isinstance(receipt, dict):
+            raise ValueError("live-evaluation receipt must be a JSON object")
+        pair = (receipt.get("case_id"), receipt.get("member_id"))
+        if pair in receipt_map:
+            raise ValueError("live-evaluation manifest repeats a case/member receipt")
+        case_id, member_id = pair
+        if case_id not in SMOKE_CASE_IDS or member_id not in members:
+            raise ValueError("receipt references case/member outside frozen configuration")
+        receipt_map[pair] = _validated_receipt(
+            receipt,
+            raw=raw,
+            expected_member=members[member_id],
+            case_id=case_id,
+        )
+    expected_pairs = {
+        (case_id, member_id) for case_id in SMOKE_CASE_IDS for member_id in members
+    }
+    if set(receipt_map) != expected_pairs:
+        raise ValueError("receipts do not cover the exact frozen case/member plan")
+
+    runs_payload = manifest.get("runs")
+    if not isinstance(runs_payload, dict) or set(runs_payload) != set(SMOKE_CASE_IDS):
+        raise ValueError("configuration does not contain the exact smoke case slice")
+    runs = {case_id: council_run_from_dict(runs_payload[case_id]) for case_id in SMOKE_CASE_IDS}
+    serialized_members = {
+        row["member_id"]: row for row in expected_configuration_dict["members"]
+    }
+    for case_id, run in runs.items():
+        task = build_benchmark_task(
+            case_id,
+            repository=raw["repository"],
+            source_revision=raw["source_revision"],
+        )
+        if run.task_sha256 != task.sha256:
+            raise ValueError("serialized council run task identity mismatch")
+        successful = {review.member_id: review for review in run.reviews}
+        failed: dict[str, str] = {}
+        for entry in run.failed_members:
+            member_id, separator, error_class = entry.rpartition(":")
+            if not separator or not member_id or not error_class or member_id in failed:
+                raise ValueError("serialized failed reviewer identity is malformed or repeated")
+            failed[member_id] = error_class
+        if set(successful) | set(failed) != set(members) or set(successful) & set(failed):
+            raise ValueError("serialized council run does not account for the frozen member plan")
+        for member_id, expected_member in serialized_members.items():
+            receipt = receipt_map[(case_id, member_id)]
+            if member_id in successful:
+                review = successful[member_id]
+                if (
+                    review.role != expected_member["role"]
+                    or review.model != expected_member["model"]
+                    or review.prompt_sha256 != expected_member["prompt_sha256"]
+                ):
+                    raise ValueError("serialized review member identity differs from frozen plan")
+                if receipt["outcome"] != "success":
+                    raise ValueError("successful serialized review lacks successful receipt")
+                if receipt["parsed_response_sha256"] != review.response_sha256:
+                    raise ValueError("receipt parsed-response identity differs from serialized review")
+            else:
+                if receipt["outcome"] not in {"provider_failure", "review_validation_failure"}:
+                    raise ValueError("failed serialized review lacks failure receipt")
+                if receipt["error_class"] != failed[member_id]:
+                    raise ValueError("failed serialized review error class differs from receipt")
+    return expected_configuration_dict, runs, list(receipt_map.values()), validated_timings
+
+
+def _p95(values: list[int]) -> int:
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(0.95 * len(ordered)) - 1)]
+
+
+def _telemetry_summary(receipts: list[dict[str, Any]], timings: dict[str, int]) -> dict[str, Any]:
+    latencies = [_nonnegative_int(row["latency_ms"], name="latency_ms") for row in receipts]
+    outcome_counts = {
+        outcome: sum(row["outcome"] == outcome for row in receipts)
+        for outcome in ("success", "provider_failure", "review_validation_failure")
+    }
+    token_rows = [row["token_usage"] for row in receipts]
+
+    def token_metric(name: str) -> dict[str, Any]:
+        known = [row[name] for row in token_rows if row[name] is not None]
+        return {
+            "reported_receipts": len(known),
+            "total_reported": sum(known) if known else None,
+            "all_receipts_reported": len(known) == len(token_rows),
+        }
+
+    wall = [timings[case_id] for case_id in SMOKE_CASE_IDS]
+    return {
+        "reviewer_attempts": len(receipts),
+        "outcomes": outcome_counts,
+        "provider_usage_receipts": sum(
+            row["source"] == "provider_response" for row in token_rows
+        ),
+        "per_call_latency_ms": {
+            "total": sum(latencies),
+            "mean": (sum(latencies) / len(latencies)) if latencies else None,
+            "p95_nearest_rank": _p95(latencies) if latencies else None,
+            "max": max(latencies) if latencies else None,
+        },
+        "case_wall_latency_ms": {
+            "total": sum(wall),
+            "mean": sum(wall) / len(wall),
+            "p95_nearest_rank": _p95(wall),
+            "max": max(wall),
+            "by_case": {case_id: timings[case_id] for case_id in SMOKE_CASE_IDS},
+        },
+        "prompt_tokens": token_metric("prompt_tokens"),
+        "completion_tokens": token_metric("completion_tokens"),
+        "total_tokens": token_metric("total_tokens"),
+        "token_counts_are_provider_reported_not_estimated": True,
+        "dollar_cost_estimated": False,
+    }
+
+
+def main() -> None:
+    args = _args()
+    raw, expected_configurations = _validated_raw(args.input)
+
+    validated = []
+    for manifest, expected_configuration in zip(
+        raw["configurations"],
+        expected_configurations,
+        strict=True,
+    ):
+        if not isinstance(manifest, dict):
+            raise ValueError("configuration manifest must be a JSON object")
+        configuration, runs, receipts, timings = _validated_manifest(
+            manifest,
+            raw=raw,
+            expected_configuration=expected_configuration,
+        )
+        validated.append(
+            (
+                manifest,
+                expected_configuration,
+                configuration,
+                runs,
+                receipts,
+                timings,
+            )
+        )
+
+    # Ground truth is deliberately imported only after the complete raw artifact and every
+    # configuration/receipt/run has passed credential-free structural verification.
+    from neuros.research.swarm_benchmark import (  # noqa: PLC0415
+        compare_benchmark_reports,
+        score_benchmark,
+    )
+
+    reports: dict[str, dict[str, Any]] = {}
+    report_objects = {}
+    for manifest, expected_configuration, configuration, runs, receipts, timings in validated:
+        configuration_id = expected_configuration.configuration_id
+        report = score_benchmark(
+            runs,
+            repository=raw["repository"],
+            source_revision=raw["source_revision"],
+        )
+        report_objects[configuration_id] = report
+        reports[configuration_id] = {
+            "kind": expected_configuration.kind,
+            "configuration": configuration,
+            "live_manifest_sha256": require_sha256(
+                manifest.get("manifest_sha256", ""),
+                name="manifest_sha256",
+            ),
+            "benchmark_report": report.to_dict(),
+            "telemetry": _telemetry_summary(receipts, timings),
+        }
+
+    baseline_id = "single-reference-v1"
+    if baseline_id not in reports:
+        raise ValueError("single-reference configuration is required for comparison")
+    comparisons = []
+    for configuration_id, payload in reports.items():
+        if configuration_id == baseline_id:
+            continue
+        comparisons.append(
+            {
+                "baseline_configuration_id": baseline_id,
+                "candidate_configuration_id": configuration_id,
+                "candidate_kind": payload["kind"],
+                "comparison": compare_benchmark_reports(
+                    report_objects[baseline_id],
+                    report_objects[configuration_id],
+                ),
+            }
+        )
+
+    scored = {
+        "kind": "neuros_nim_swarm_live_eval_scored_v1",
+        "repository": raw["repository"],
+        "source_revision": raw["source_revision"],
+        "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+        "case_ids": list(SMOKE_CASE_IDS),
+        "selected_models": raw["selected_models"],
+        "reference_model": raw["selected_models"][0],
+        "schedule_policy": SCHEDULE_POLICY,
+        "raw_artifact_sha256": raw["artifact_sha256"],
+        "reports": reports,
+        "comparisons": comparisons,
+        "public_smoke_is_full_benchmark": False,
+        "benchmark_scores_are_scientific_results": False,
+        "benchmark_output_is_scientific_authority": False,
+        "merge_authority": False,
+        "provider_execution_authority": False,
+        "scientific_promotion_authority": False,
+    }
+    scored["artifact_sha256"] = canonical_sha256(scored)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(scored, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/neuros-research/src/neuros/research/nim_observed.py
+++ b/packages/neuros-research/src/neuros/research/nim_observed.py
@@ -1,0 +1,196 @@
+"""Additive observation surface for qualified NVIDIA NIM chat calls.
+
+This module preserves the existing ``NimCallRecord`` contract. Telemetry is returned
+separately so old request/response identities and serialized evidence do not change.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from ._canonical import canonical_sha256, require_nonempty, require_sha256
+from .nim import NimCallRecord, _sha256_text
+from .nim_provider import QualifiedNvidiaNimClient
+
+
+def _optional_nonnegative_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+class _DuplicateObjectKeyError(ValueError):
+    pass
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateObjectKeyError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _extract_json_object_strict(text: str) -> dict[str, Any]:
+    """Require the complete non-whitespace response to be exactly one JSON object."""
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("NIM response did not contain a JSON object")
+    decoder = json.JSONDecoder(object_pairs_hook=_reject_duplicate_pairs)
+    try:
+        value, end = decoder.raw_decode(stripped)
+    except _DuplicateObjectKeyError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ValueError("NIM response was not exactly one JSON object") from exc
+    if not isinstance(value, dict):
+        raise ValueError("NIM response must be exactly one JSON object")
+    if stripped[end:].strip():
+        raise ValueError("NIM response contained trailing content outside the JSON object")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class NimTokenUsage:
+    """Provider-reported token counts, without estimating missing values."""
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    usage_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        counts = (self.prompt_tokens, self.completion_tokens, self.total_tokens)
+        for value in counts:
+            if value is not None and _optional_nonnegative_int(value) != value:
+                raise ValueError("provider token counts must be non-negative integers or None")
+        if self.usage_sha256 is None:
+            if any(value is not None for value in counts):
+                raise ValueError("provider token counts require an exact usage-object fingerprint")
+        else:
+            object.__setattr__(
+                self,
+                "usage_sha256",
+                require_sha256(self.usage_sha256, name="usage_sha256"),
+            )
+
+    @classmethod
+    def from_response(cls, response: dict[str, Any]) -> NimTokenUsage:
+        usage = response.get("usage")
+        if not isinstance(usage, dict):
+            return cls()
+        return cls(
+            prompt_tokens=_optional_nonnegative_int(usage.get("prompt_tokens")),
+            completion_tokens=_optional_nonnegative_int(usage.get("completion_tokens")),
+            total_tokens=_optional_nonnegative_int(usage.get("total_tokens")),
+            usage_sha256=canonical_sha256(usage),
+        )
+
+    @property
+    def provider_reported(self) -> bool:
+        return self.usage_sha256 is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": "provider_response" if self.provider_reported else "unavailable",
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "usage_sha256": self.usage_sha256,
+        }
+
+
+class ObservedNimResponseError(ValueError):
+    """Hosted response reached us but could not become a valid strict review payload."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        record: NimCallRecord,
+        token_usage: NimTokenUsage,
+    ) -> None:
+        self.record = record
+        self.token_usage = token_usage
+        super().__init__(message)
+
+
+class ObservedQualifiedNvidiaNimClient(QualifiedNvidiaNimClient):
+    """Qualified client that returns telemetry without altering ``NimCallRecord``."""
+
+    def chat_json_observed(
+        self,
+        *,
+        role: str,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4000,
+        temperature: float = 0.2,
+    ) -> tuple[dict[str, Any], NimCallRecord, NimTokenUsage]:
+        role = require_nonempty(role, name="role")
+        model = require_nonempty(model, name="model")
+        system_prompt = require_nonempty(system_prompt, name="system_prompt")
+        user_prompt = require_nonempty(user_prompt, name="user_prompt")
+        if max_tokens < 128 or max_tokens > 16384:
+            raise ValueError("max_tokens must be in [128, 16384]")
+        if temperature < 0.0 or temperature > 1.0:
+            raise ValueError("temperature must be in [0, 1]")
+
+        request_payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "temperature": float(temperature),
+            "max_tokens": int(max_tokens),
+            "stream": False,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        response = self._request("chat/completions", payload=request_payload)
+        choices = response.get("choices")
+        message = (
+            choices[0].get("message")
+            if isinstance(choices, list) and choices and isinstance(choices[0], dict)
+            else None
+        )
+        content = message.get("content") if isinstance(message, dict) else None
+        response_text = content if isinstance(content, str) else ""
+        combined_prompt = f"{system_prompt}\n\n{user_prompt}"
+        record = NimCallRecord(
+            role=role,
+            model=model,
+            endpoint=self.endpoint,
+            prompt_sha256=_sha256_text(combined_prompt),
+            request_sha256=canonical_sha256(request_payload),
+            response_sha256=canonical_sha256(response),
+            response_text=response_text,
+        )
+        token_usage = NimTokenUsage.from_response(response)
+
+        if not isinstance(choices, list) or not choices:
+            raise ObservedNimResponseError(
+                "NIM chat response missing choices",
+                record=record,
+                token_usage=token_usage,
+            )
+        if not isinstance(content, str) or not content.strip():
+            raise ObservedNimResponseError(
+                "NIM chat response missing message content",
+                record=record,
+                token_usage=token_usage,
+            )
+        try:
+            parsed = _extract_json_object_strict(content)
+        except ValueError as exc:
+            raise ObservedNimResponseError(
+                f"NIM chat response failed strict JSON parsing: {type(exc).__name__}",
+                record=record,
+                token_usage=token_usage,
+            ) from exc
+
+        self.call_journal.append(record)
+        return parsed, record, token_usage

--- a/packages/neuros-research/src/neuros/research/swarm_live_eval.py
+++ b/packages/neuros-research/src/neuros/research/swarm_live_eval.py
@@ -1,0 +1,685 @@
+"""Bounded live-evaluation telemetry for the neurOS scientific-engineering swarm.
+
+The model-facing path imports only the public benchmark surface. Scorer-side ground
+truth remains outside this module and can be applied later in a separate process.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from ._canonical import canonical_sha256, require_nonempty, require_sha256
+from .nim_observed import (
+    NimTokenUsage,
+    ObservedNimResponseError,
+    ObservedQualifiedNvidiaNimClient,
+)
+from .nim_swarm import ROLE_PROMPTS, _user_prompt, build_nvidia_council
+from .swarm import (
+    AgentReview,
+    CouncilMember,
+    CouncilRun,
+    Finding,
+    SealedSwarmTask,
+    parse_review_payload,
+)
+from .swarm_benchmark_cases import (
+    BENCHMARK_CORPUS_SHA256,
+    DEFECT_IDS,
+    benchmark_case,
+    build_benchmark_task,
+)
+
+EvaluationKind = Literal[
+    "single_reference",
+    "homogeneous_five_role",
+    "heterogeneous_five_role",
+]
+ReceiptOutcome = Literal[
+    "success",
+    "provider_failure",
+    "review_validation_failure",
+]
+
+# Intentionally fixed before any hosted-model result is observed. This is a transport/schema
+# smoke slice, not a statistically meaningful model benchmark.
+SMOKE_CASE_IDS = ("case-001", "case-015", "case-029")
+SCHEDULE_POLICY = "deterministic_rotating_configuration_order_v1"
+
+_GENERALIST_PROMPT = (
+    "You are one independent neurOS scientific-engineering reviewer. You are advisory only: "
+    "you cannot merge code, authorize provider execution, alter frozen scientific authority, "
+    "or promote a scientific claim. Return exactly one JSON object matching the requested "
+    "schema. Audit across architecture, scientific validity, reproducibility, implementation, "
+    "and experimental design. Preserve concrete minority concerns rather than forcing consensus. "
+    + " ".join(ROLE_PROMPTS.values())
+)
+
+
+def _require_nonnegative_int(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationConfiguration:
+    configuration_id: str
+    kind: EvaluationKind
+    members: tuple[CouncilMember, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "configuration_id",
+            require_nonempty(self.configuration_id, name="configuration_id"),
+        )
+        if self.kind not in {
+            "single_reference",
+            "homogeneous_five_role",
+            "heterogeneous_five_role",
+        }:
+            raise ValueError(f"unsupported evaluation kind {self.kind!r}")
+        if not self.members:
+            raise ValueError("evaluation configuration requires at least one member")
+        member_ids = [member.member_id for member in self.members]
+        if len(member_ids) != len(set(member_ids)):
+            raise ValueError("evaluation member IDs must be unique")
+        if self.kind == "single_reference" and len(self.members) != 1:
+            raise ValueError("single_reference requires exactly one reviewer")
+        if self.kind != "single_reference" and len(self.members) != 5:
+            raise ValueError("council configurations require exactly five reviewers")
+        models = {member.model for member in self.members}
+        if self.kind == "homogeneous_five_role" and len(models) != 1:
+            raise ValueError("homogeneous council must use one model route")
+        if self.kind == "heterogeneous_five_role" and len(models) < 2:
+            raise ValueError("heterogeneous council requires at least two model routes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "configuration_id": self.configuration_id,
+            "kind": self.kind,
+            "members": [
+                {
+                    "member_id": member.member_id,
+                    "role": member.role,
+                    "model": member.model,
+                    "prompt_sha256": member.prompt_sha256,
+                }
+                for member in sorted(self.members, key=lambda item: item.member_id)
+            ],
+        }
+
+    @property
+    def sha256(self) -> str:
+        return canonical_sha256(self.to_dict())
+
+
+def build_evaluation_configurations(
+    qualified_models: tuple[str, ...],
+) -> tuple[EvaluationConfiguration, ...]:
+    """Freeze reference, homogeneous, and available heterogeneous configurations.
+
+    The first qualified route is the preregistered reference. It is not declared to be the
+    strongest route based on benchmark outcomes, preventing outcome-adaptive model selection.
+    """
+    models = tuple(
+        dict.fromkeys(str(model).strip() for model in qualified_models if str(model).strip())
+    )
+    if not models:
+        raise ValueError("at least one qualified model route is required")
+    reference = models[0]
+    single = EvaluationConfiguration(
+        configuration_id="single-reference-v1",
+        kind="single_reference",
+        members=(
+            CouncilMember(
+                member_id="generalist:1",
+                role="generalist",
+                model=reference,
+                system_prompt=_GENERALIST_PROMPT,
+            ),
+        ),
+    )
+    homogeneous = EvaluationConfiguration(
+        configuration_id="homogeneous-five-role-v1",
+        kind="homogeneous_five_role",
+        members=build_nvidia_council((reference,)),
+    )
+    configurations = [single, homogeneous]
+    if len(models) >= 2:
+        configurations.append(
+            EvaluationConfiguration(
+                configuration_id="heterogeneous-five-role-v1",
+                kind="heterogeneous_five_role",
+                members=build_nvidia_council(models),
+            )
+        )
+    return tuple(configurations)
+
+
+def build_counterbalanced_schedule(
+    configurations: tuple[EvaluationConfiguration, ...],
+    case_ids: tuple[str, ...] = SMOKE_CASE_IDS,
+) -> tuple[tuple[str, str], ...]:
+    """Rotate frozen configuration order by case to reduce simple temporal confounding."""
+    if not configurations:
+        raise ValueError("counterbalanced schedule requires at least one configuration")
+    if not case_ids or len(case_ids) != len(set(case_ids)):
+        raise ValueError("counterbalanced schedule case IDs must be non-empty and unique")
+    for case_id in case_ids:
+        benchmark_case(case_id)
+    rows: list[tuple[str, str]] = []
+    size = len(configurations)
+    for case_index, case_id in enumerate(case_ids):
+        offset = case_index % size
+        ordered = configurations[offset:] + configurations[:offset]
+        rows.extend((case_id, configuration.configuration_id) for configuration in ordered)
+    return tuple(rows)
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationCallReceipt:
+    case_id: str
+    task_sha256: str
+    member_id: str
+    role: str
+    model: str
+    member_prompt_sha256: str
+    provider_qualification_fingerprint: str
+    endpoint: str
+    outcome: ReceiptOutcome
+    latency_ms: int
+    call_prompt_sha256: str | None = None
+    request_sha256: str | None = None
+    response_sha256: str | None = None
+    parsed_response_sha256: str | None = None
+    token_usage: NimTokenUsage = field(default_factory=NimTokenUsage)
+    error_class: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("case_id", "member_id", "role", "model", "endpoint"):
+            object.__setattr__(
+                self,
+                name,
+                require_nonempty(getattr(self, name), name=name),
+            )
+        for name in (
+            "task_sha256",
+            "member_prompt_sha256",
+            "provider_qualification_fingerprint",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_sha256(getattr(self, name), name=name),
+            )
+        if self.outcome not in {
+            "success",
+            "provider_failure",
+            "review_validation_failure",
+        }:
+            raise ValueError(f"unsupported receipt outcome {self.outcome!r}")
+        object.__setattr__(
+            self,
+            "latency_ms",
+            _require_nonnegative_int(self.latency_ms, name="latency_ms"),
+        )
+
+        transport_hashes = (
+            self.call_prompt_sha256,
+            self.request_sha256,
+            self.response_sha256,
+        )
+        if self.outcome == "success":
+            if any(value is None for value in (*transport_hashes, self.parsed_response_sha256)):
+                raise ValueError("successful receipt requires complete call identities")
+            if self.error_class is not None:
+                raise ValueError("successful receipt cannot carry error_class")
+        elif self.outcome == "provider_failure":
+            if any(value is not None for value in (*transport_hashes, self.parsed_response_sha256)):
+                raise ValueError("provider failure cannot claim unavailable call identities")
+            if self.token_usage.provider_reported:
+                raise ValueError("provider failure cannot claim provider token usage")
+            object.__setattr__(
+                self,
+                "error_class",
+                require_nonempty(self.error_class or "", name="error_class"),
+            )
+        else:
+            if any(value is None for value in transport_hashes):
+                raise ValueError("review-validation failure requires transport call identities")
+            object.__setattr__(
+                self,
+                "error_class",
+                require_nonempty(self.error_class or "", name="error_class"),
+            )
+
+        for index, value in enumerate(transport_hashes):
+            if value is not None:
+                require_sha256(value, name=f"transport_hash_{index}")
+        if self.parsed_response_sha256 is not None:
+            require_sha256(self.parsed_response_sha256, name="parsed_response_sha256")
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "schema": "neuros.nim_swarm_evaluation_call_receipt.v1",
+            "case_id": self.case_id,
+            "task_sha256": self.task_sha256,
+            "member_id": self.member_id,
+            "role": self.role,
+            "model": self.model,
+            "member_prompt_sha256": self.member_prompt_sha256,
+            "provider_qualification_fingerprint": self.provider_qualification_fingerprint,
+            "endpoint": self.endpoint,
+            "outcome": self.outcome,
+            "latency_ms": self.latency_ms,
+            "call_prompt_sha256": self.call_prompt_sha256,
+            "request_sha256": self.request_sha256,
+            "response_sha256": self.response_sha256,
+            "parsed_response_sha256": self.parsed_response_sha256,
+            "token_usage": self.token_usage.to_dict(),
+            "error_class": self.error_class,
+            "token_counts_are_provider_reported_not_estimated": True,
+            "receipt_is_scientific_authority": False,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._payload()
+        payload["receipt_sha256"] = canonical_sha256(payload)
+        return payload
+
+    @property
+    def sha256(self) -> str:
+        return canonical_sha256(self._payload())
+
+
+def _benchmark_case_id(task: SealedSwarmTask) -> str:
+    context = task.public_context
+    if context.get("corpus_sha256") != BENCHMARK_CORPUS_SHA256:
+        raise ValueError("task is not bound to the promoted benchmark corpus")
+    case = context.get("case")
+    if not isinstance(case, Mapping):
+        raise ValueError("benchmark task is missing public case payload")
+    case_id = require_nonempty(str(case.get("case_id", "")), name="case_id")
+    if benchmark_case(case_id).to_public_dict() != dict(case):
+        raise ValueError("benchmark task case payload differs from frozen public corpus")
+    return case_id
+
+
+def _latency_ms(started_ns: int) -> int:
+    return max(0, (time.perf_counter_ns() - started_ns + 999_999) // 1_000_000)
+
+
+class ObservedNvidiaCouncilTransport:
+    """Concurrent NIM transport that binds each reviewer result to exact telemetry."""
+
+    def __init__(
+        self,
+        client: ObservedQualifiedNvidiaNimClient,
+        *,
+        provider_qualification_fingerprint: str,
+        max_tokens: int = 1200,
+    ) -> None:
+        self.client = client
+        self.provider_qualification_fingerprint = require_sha256(
+            provider_qualification_fingerprint,
+            name="provider_qualification_fingerprint",
+        )
+        self.max_tokens = int(max_tokens)
+        if self.max_tokens < 512 or self.max_tokens > 8192:
+            raise ValueError("max_tokens must be in [512, 8192]")
+        self._receipts: list[EvaluationCallReceipt] = []
+
+    @property
+    def receipts(self) -> tuple[EvaluationCallReceipt, ...]:
+        return tuple(
+            sorted(
+                self._receipts,
+                key=lambda receipt: (receipt.case_id, receipt.member_id),
+            )
+        )
+
+    def _receipt_from_record(
+        self,
+        *,
+        task: SealedSwarmTask,
+        case_id: str,
+        member: CouncilMember,
+        outcome: ReceiptOutcome,
+        latency_ms: int,
+        record,  # type: ignore[no-untyped-def]
+        usage: NimTokenUsage,
+        parsed: dict[str, Any] | None = None,
+        error_class: str | None = None,
+    ) -> EvaluationCallReceipt:
+        return EvaluationCallReceipt(
+            case_id=case_id,
+            task_sha256=task.sha256,
+            member_id=member.member_id,
+            role=member.role,
+            model=member.model,
+            member_prompt_sha256=member.prompt_sha256,
+            provider_qualification_fingerprint=self.provider_qualification_fingerprint,
+            endpoint=record.endpoint,
+            outcome=outcome,
+            latency_ms=latency_ms,
+            call_prompt_sha256=record.prompt_sha256,
+            request_sha256=record.request_sha256,
+            response_sha256=record.response_sha256,
+            parsed_response_sha256=(canonical_sha256(parsed) if parsed is not None else None),
+            token_usage=usage,
+            error_class=error_class,
+        )
+
+    async def review(
+        self,
+        task: SealedSwarmTask,
+        member: CouncilMember,
+    ) -> dict[str, Any]:
+        case_id = _benchmark_case_id(task)
+        user_prompt = _user_prompt(task)
+        started_ns = time.perf_counter_ns()
+        try:
+            parsed, record, usage = await asyncio.to_thread(
+                self.client.chat_json_observed,
+                role=f"swarm:{member.role}",
+                model=member.model,
+                system_prompt=member.system_prompt,
+                user_prompt=user_prompt,
+                max_tokens=self.max_tokens,
+                temperature=0.1,
+            )
+        except ObservedNimResponseError as exc:
+            self._receipts.append(
+                self._receipt_from_record(
+                    task=task,
+                    case_id=case_id,
+                    member=member,
+                    outcome="review_validation_failure",
+                    latency_ms=_latency_ms(started_ns),
+                    record=exc.record,
+                    usage=exc.token_usage,
+                    error_class=type(exc).__name__,
+                )
+            )
+            raise
+        except Exception as exc:
+            self._receipts.append(
+                EvaluationCallReceipt(
+                    case_id=case_id,
+                    task_sha256=task.sha256,
+                    member_id=member.member_id,
+                    role=member.role,
+                    model=member.model,
+                    member_prompt_sha256=member.prompt_sha256,
+                    provider_qualification_fingerprint=self.provider_qualification_fingerprint,
+                    endpoint=self.client.endpoint,
+                    outcome="provider_failure",
+                    latency_ms=_latency_ms(started_ns),
+                    error_class=type(exc).__name__,
+                )
+            )
+            raise
+
+        try:
+            if record.role != f"swarm:{member.role}":
+                raise ValueError("provider call record role differs from council member")
+            if record.model != member.model:
+                raise ValueError("provider call record model differs from council member")
+            if record.endpoint != self.client.endpoint:
+                raise ValueError("provider call record endpoint differs from qualified client")
+            validated = parse_review_payload(parsed, task=task, member=member)
+            unknown = sorted({finding.finding_id for finding in validated.findings} - DEFECT_IDS)
+            if unknown:
+                raise ValueError("review emitted unknown benchmark defect IDs: " + ",".join(unknown))
+        except Exception as exc:
+            self._receipts.append(
+                self._receipt_from_record(
+                    task=task,
+                    case_id=case_id,
+                    member=member,
+                    outcome="review_validation_failure",
+                    latency_ms=_latency_ms(started_ns),
+                    record=record,
+                    usage=usage,
+                    parsed=parsed,
+                    error_class=type(exc).__name__,
+                )
+            )
+            raise
+
+        self._receipts.append(
+            self._receipt_from_record(
+                task=task,
+                case_id=case_id,
+                member=member,
+                outcome="success",
+                latency_ms=_latency_ms(started_ns),
+                record=record,
+                usage=usage,
+                parsed=parsed,
+            )
+        )
+        return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationRunManifest:
+    repository: str
+    source_revision: str
+    configuration: EvaluationConfiguration
+    provider_qualification_fingerprint: str
+    case_ids: tuple[str, ...]
+    runs: tuple[tuple[str, CouncilRun], ...]
+    receipts: tuple[EvaluationCallReceipt, ...]
+    case_wall_latency_ms: tuple[tuple[str, int], ...]
+
+    def __post_init__(self) -> None:
+        repo = require_nonempty(self.repository, name="repository")
+        revision = require_sha256(self.source_revision, name="source_revision")
+        provider = require_sha256(
+            self.provider_qualification_fingerprint,
+            name="provider_qualification_fingerprint",
+        )
+        object.__setattr__(self, "repository", repo)
+        object.__setattr__(self, "source_revision", revision)
+        object.__setattr__(self, "provider_qualification_fingerprint", provider)
+
+        case_ids = tuple(require_nonempty(case_id, name="case_id") for case_id in self.case_ids)
+        if not case_ids or len(case_ids) != len(set(case_ids)):
+            raise ValueError("case_ids must be non-empty and unique")
+        for case_id in case_ids:
+            benchmark_case(case_id)
+        object.__setattr__(self, "case_ids", case_ids)
+
+        run_map = dict(self.runs)
+        if len(run_map) != len(self.runs) or set(run_map) != set(case_ids):
+            raise ValueError("runs must contain exactly one entry for every case_id")
+        timing_map = dict(self.case_wall_latency_ms)
+        if len(timing_map) != len(self.case_wall_latency_ms) or set(timing_map) != set(case_ids):
+            raise ValueError("case wall timings must contain exactly one entry for every case_id")
+        normalized_timings = tuple(
+            (
+                case_id,
+                _require_nonnegative_int(
+                    timing_map[case_id],
+                    name=f"case_wall_latency_ms[{case_id}]",
+                ),
+            )
+            for case_id in case_ids
+        )
+        object.__setattr__(self, "case_wall_latency_ms", normalized_timings)
+
+        member_map = {member.member_id: member for member in self.configuration.members}
+        expected_pairs = {(case_id, member_id) for case_id in case_ids for member_id in member_map}
+        receipt_map = {(receipt.case_id, receipt.member_id): receipt for receipt in self.receipts}
+        if len(receipt_map) != len(self.receipts) or set(receipt_map) != expected_pairs:
+            raise ValueError("receipts must contain exactly one attempt per case/member pair")
+
+        for case_id in case_ids:
+            task = build_benchmark_task(
+                case_id,
+                repository=repo,
+                source_revision=revision,
+            )
+            run = run_map[case_id]
+            if run.task_sha256 != task.sha256:
+                raise ValueError("council run is not bound to expected benchmark task")
+            successful = {review.member_id: review for review in run.reviews}
+            failed: dict[str, str] = {}
+            for entry in run.failed_members:
+                member_id, separator, error_class = entry.rpartition(":")
+                if not separator or not member_id or not error_class:
+                    raise ValueError("failed member identity is malformed")
+                if member_id in failed:
+                    raise ValueError("run repeats a failed reviewer identity")
+                failed[member_id] = error_class
+            if set(successful) | set(failed) != set(member_map):
+                raise ValueError("run does not account for every configured reviewer")
+            if set(successful) & set(failed):
+                raise ValueError("reviewer cannot be both successful and failed")
+
+            for member_id, member in member_map.items():
+                receipt = receipt_map[(case_id, member_id)]
+                if receipt.task_sha256 != task.sha256:
+                    raise ValueError("receipt task identity mismatch")
+                if receipt.provider_qualification_fingerprint != provider:
+                    raise ValueError("receipt provider qualification mismatch")
+                if (
+                    receipt.role != member.role
+                    or receipt.model != member.model
+                    or receipt.member_prompt_sha256 != member.prompt_sha256
+                ):
+                    raise ValueError("receipt member configuration mismatch")
+                if member_id in successful:
+                    review = successful[member_id]
+                    if (
+                        review.role != member.role
+                        or review.model != member.model
+                        or review.prompt_sha256 != member.prompt_sha256
+                    ):
+                        raise ValueError("successful review member configuration mismatch")
+                    if receipt.outcome != "success":
+                        raise ValueError("successful review lacks successful receipt")
+                    if receipt.parsed_response_sha256 != review.response_sha256:
+                        raise ValueError("receipt parsed-response identity mismatch")
+                else:
+                    if receipt.outcome not in {
+                        "provider_failure",
+                        "review_validation_failure",
+                    }:
+                        raise ValueError("failed review lacks failure receipt")
+                    if receipt.error_class != failed[member_id]:
+                        raise ValueError("failed review error class does not match receipt")
+
+    def _payload(self) -> dict[str, Any]:
+        run_map = dict(self.runs)
+        timing_map = dict(self.case_wall_latency_ms)
+        return {
+            "schema": "neuros.nim_swarm_live_evaluation_manifest.v1",
+            "repository": self.repository,
+            "source_revision": self.source_revision,
+            "corpus_sha256": BENCHMARK_CORPUS_SHA256,
+            "configuration": self.configuration.to_dict(),
+            "configuration_sha256": self.configuration.sha256,
+            "provider_qualification_fingerprint": self.provider_qualification_fingerprint,
+            "case_ids": list(self.case_ids),
+            "runs": {case_id: run_map[case_id].to_dict() for case_id in sorted(run_map)},
+            "receipts": [receipt.to_dict() for receipt in self.receipts],
+            "case_wall_latency_ms": {
+                case_id: timing_map[case_id] for case_id in sorted(timing_map)
+            },
+            "token_counts_are_provider_reported_not_estimated": True,
+            "dollar_cost_estimated": False,
+            "live_review_output_is_scientific_authority": False,
+            "merge_authority": False,
+            "provider_execution_authority": False,
+            "scientific_promotion_authority": False,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self._payload()
+        payload["manifest_sha256"] = canonical_sha256(payload)
+        return payload
+
+    @property
+    def sha256(self) -> str:
+        return canonical_sha256(self._payload())
+
+
+def council_run_from_dict(payload: dict[str, Any]) -> CouncilRun:
+    """Reconstruct and verify a provider-neutral council run for scorer-side use."""
+    expected = {
+        "schema",
+        "task_sha256",
+        "reviews",
+        "failed_members",
+        "majority_vote_is_authority",
+        "merge_authority",
+        "provider_execution_authority",
+        "scientific_promotion_authority",
+        "run_sha256",
+    }
+    if set(payload) != expected:
+        raise ValueError("council run fields do not match the v1 schema")
+    if payload["schema"] != "neuros.scientific_engineering_swarm_run.v1":
+        raise ValueError("unexpected council run schema")
+    for key in (
+        "majority_vote_is_authority",
+        "merge_authority",
+        "provider_execution_authority",
+        "scientific_promotion_authority",
+    ):
+        if payload[key] is not False:
+            raise ValueError(f"council authority flag {key} must remain false")
+    rows = payload["reviews"]
+    if not isinstance(rows, list):
+        raise ValueError("council reviews must be a list")
+    reviews = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("council review must be a JSON object")
+        review_expected = {
+            "task_sha256",
+            "member_id",
+            "role",
+            "model",
+            "prompt_sha256",
+            "response_sha256",
+            "findings",
+        }
+        if set(row) != review_expected or not isinstance(row["findings"], list):
+            raise ValueError("council review fields do not match the v1 schema")
+        findings = tuple(
+            Finding.from_dict(finding)
+            for finding in row["findings"]
+            if isinstance(finding, dict)
+        )
+        if len(findings) != len(row["findings"]):
+            raise ValueError("every serialized finding must be a JSON object")
+        reviews.append(
+            AgentReview(
+                task_sha256=row["task_sha256"],
+                member_id=row["member_id"],
+                role=row["role"],
+                model=row["model"],
+                prompt_sha256=row["prompt_sha256"],
+                response_sha256=row["response_sha256"],
+                findings=findings,
+            )
+        )
+    failed_members = payload["failed_members"]
+    if not isinstance(failed_members, list):
+        raise ValueError("failed_members must be a list")
+    run = CouncilRun(
+        task_sha256=payload["task_sha256"],
+        reviews=tuple(reviews),
+        failed_members=tuple(str(value) for value in failed_members),
+    )
+    if run.sha256 != require_sha256(payload["run_sha256"], name="run_sha256"):
+        raise ValueError("serialized council run fingerprint mismatch")
+    return run

--- a/packages/neuros-research/tests/test_nim_observed.py
+++ b/packages/neuros-research/tests/test_nim_observed.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pytest
+from neuros.research.nim_observed import (
+    NimTokenUsage,
+    ObservedNimResponseError,
+    ObservedQualifiedNvidiaNimClient,
+)
+
+
+class _Stub(ObservedQualifiedNvidiaNimClient):
+    def __init__(self, response):  # type: ignore[no-untyped-def]
+        super().__init__("secret-for-test-only")
+        self.response = response
+        self.requests = []
+
+    def _request(self, path: str, *, payload=None, **kwargs):  # type: ignore[no-untyped-def]
+        del kwargs
+        assert path == "chat/completions"
+        self.requests.append(payload)
+        return self.response
+
+
+def _response(usage=None, *, content='{"findings":[]}'):  # type: ignore[no-untyped-def]
+    payload = {"choices": [{"message": {"content": content}}]}
+    if usage is not None:
+        payload["usage"] = usage
+    return payload
+
+
+def _kwargs():
+    return {
+        "role": "swarm:reviewer",
+        "model": "model-a",
+        "system_prompt": "system",
+        "user_prompt": "user",
+        "max_tokens": 900,
+        "temperature": 0.1,
+    }
+
+
+def test_observed_call_preserves_existing_request_and_call_record_contract():
+    standard = _Stub(_response({"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14}))
+    observed = _Stub(_response({"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14}))
+
+    parsed_standard, record_standard = standard.chat_json(**_kwargs())
+    parsed_observed, record_observed, usage = observed.chat_json_observed(**_kwargs())
+
+    assert parsed_standard == parsed_observed == {"findings": []}
+    assert standard.requests == observed.requests
+    assert record_standard.to_dict() == record_observed.to_dict()
+    assert record_standard.response_sha256 == record_observed.response_sha256
+    assert set(record_observed.to_dict()) == {
+        "role",
+        "model",
+        "endpoint",
+        "prompt_sha256",
+        "request_sha256",
+        "response_sha256",
+    }
+    assert usage.prompt_tokens == 10
+    assert usage.completion_tokens == 4
+    assert usage.total_tokens == 14
+    assert usage.provider_reported is True
+    assert len(usage.usage_sha256 or "") == 64
+    assert len(observed.call_journal) == 1
+
+
+def test_missing_usage_is_preserved_as_unavailable_not_estimated():
+    client = _Stub(_response())
+    _, _, usage = client.chat_json_observed(**_kwargs())
+    assert usage.to_dict() == {
+        "source": "unavailable",
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+        "usage_sha256": None,
+    }
+
+
+def test_malformed_usage_counts_are_not_coerced_into_fake_exact_counts():
+    client = _Stub(
+        _response(
+            {
+                "prompt_tokens": True,
+                "completion_tokens": -1,
+                "total_tokens": "14",
+            }
+        )
+    )
+    _, _, usage = client.chat_json_observed(**_kwargs())
+    assert usage.provider_reported is True
+    assert usage.prompt_tokens is None
+    assert usage.completion_tokens is None
+    assert usage.total_tokens is None
+    assert len(usage.usage_sha256 or "") == 64
+
+
+def test_token_usage_rejects_forged_counts_without_provider_fingerprint():
+    with pytest.raises(ValueError, match="require an exact usage-object fingerprint"):
+        NimTokenUsage(prompt_tokens=10)
+    with pytest.raises(ValueError, match="non-negative"):
+        NimTokenUsage(prompt_tokens=-1, usage_sha256="a" * 64)
+
+
+def test_observed_parser_rejects_duplicate_json_keys_and_preserves_transport_evidence():
+    client = _Stub(
+        _response(
+            {"prompt_tokens": 11, "completion_tokens": 3, "total_tokens": 14},
+            content='{"findings":[],"findings":[]}',
+        )
+    )
+    with pytest.raises(ObservedNimResponseError, match="strict JSON parsing") as error:
+        client.chat_json_observed(**_kwargs())
+    assert len(error.value.record.request_sha256) == 64
+    assert len(error.value.record.response_sha256) == 64
+    assert error.value.token_usage.total_tokens == 14
+    assert error.value.token_usage.provider_reported is True
+    assert client.call_journal == []
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        'Here is the answer: {"findings":[]}',
+        '{"findings":[]} trailing prose',
+        '[{"findings":[]}]',
+    ),
+)
+def test_observed_parser_requires_entire_response_to_be_one_json_object(content: str):
+    client = _Stub(_response(content=content))
+    with pytest.raises(ObservedNimResponseError, match="strict JSON parsing"):
+        client.chat_json_observed(**_kwargs())
+    assert client.call_journal == []
+
+
+def test_observed_parser_accepts_surrounding_whitespace_only():
+    client = _Stub(_response(content='  \n {"findings":[]} \t '))
+    parsed, _, _ = client.chat_json_observed(**_kwargs())
+    assert parsed == {"findings": []}
+
+
+def test_invalid_provider_response_structure_preserves_usage_for_failure_accounting():
+    client = _Stub(
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 0, "total_tokens": 8},
+        }
+    )
+    with pytest.raises(ObservedNimResponseError, match="missing choices") as error:
+        client.chat_json_observed(**_kwargs())
+    assert error.value.token_usage.total_tokens == 8
+    assert len(error.value.record.response_sha256) == 64

--- a/packages/neuros-research/tests/test_swarm_live_eval.py
+++ b/packages/neuros-research/tests/test_swarm_live_eval.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib.util
+import inspect
+from dataclasses import replace
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+from neuros.research import swarm_live_eval
+from neuros.research._canonical import canonical_sha256
+from neuros.research.nim import NimCallRecord
+from neuros.research.nim_observed import NimTokenUsage
+from neuros.research.nim_provider import DOCUMENTED_NVIDIA_CHAT_MODELS
+from neuros.research.swarm import run_council
+from neuros.research.swarm_benchmark_cases import build_benchmark_task
+from neuros.research.swarm_live_eval import (
+    SCHEDULE_POLICY,
+    SMOKE_CASE_IDS,
+    EvaluationRunManifest,
+    ObservedNvidiaCouncilTransport,
+    build_counterbalanced_schedule,
+    build_evaluation_configurations,
+    council_run_from_dict,
+)
+
+REV = "4" * 64
+REPO = "sidhulyalkar/neurOS-v1"
+ENDPOINT = "https://integrate.api.nvidia.com/v1"
+REFERENCE_MODEL = DOCUMENTED_NVIDIA_CHAT_MODELS[0]
+
+
+def _provider_qualification() -> dict[str, object]:
+    probes = []
+    for index, model in enumerate(DOCUMENTED_NVIDIA_CHAT_MODELS):
+        if index == 0:
+            probes.append(
+                {
+                    "model": model,
+                    "status": "qualified",
+                    "status_code": None,
+                    "response_sha256": "6" * 64,
+                    "error_excerpt": None,
+                }
+            )
+        else:
+            probes.append(
+                {
+                    "model": model,
+                    "status": "transport_error",
+                    "status_code": None,
+                    "response_sha256": None,
+                    "error_excerpt": "synthetic offline unavailable route",
+                }
+            )
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "endpoint": ENDPOINT,
+        "discovery_mode": "synthetic+bounded_chat_probe",
+        "documented_candidates": list(DOCUMENTED_NVIDIA_CHAT_MODELS),
+        "catalog_models_sha256": None,
+        "catalog_error": None,
+        "probes": probes,
+        "qualified_models": [REFERENCE_MODEL],
+        "discovery_budget": {
+            "timeout_seconds_per_attempt": 20.0,
+            "max_attempts_per_route": 2,
+        },
+        "authority_boundary": "synthetic test qualification",
+    }
+    payload["fingerprint"] = canonical_sha256(payload)
+    return payload
+
+
+QUALIFICATION = _provider_qualification()
+PROVIDER = str(QUALIFICATION["fingerprint"])
+
+
+def _finding(defect_id="D01"):
+    return {
+        "finding_id": defect_id,
+        "severity": "high",
+        "category": "reproducibility",
+        "claim": "specific concern",
+        "evidence": "benchmark stimulus",
+        "falsification_test": "run deterministic check",
+        "proposed_repair": "repair",
+        "confidence": 0.9,
+        "requires_human_judgment": False,
+        "reference": "benchmark",
+    }
+
+
+class _Client:
+    endpoint = ENDPOINT
+
+    def __init__(self, *, fail_role=None, invalid_role=None, unknown_role=None):  # type: ignore[no-untyped-def]
+        self.fail_role = fail_role
+        self.invalid_role = invalid_role
+        self.unknown_role = unknown_role
+        self.calls = []
+
+    def chat_json_observed(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.calls.append(kwargs)
+        if kwargs["role"] == self.fail_role:
+            raise TimeoutError("synthetic timeout")
+        if kwargs["role"] == self.invalid_role:
+            payload = {"findings": [{"unexpected": True}]}
+        elif kwargs["role"] == self.unknown_role:
+            payload = {"findings": [_finding("D99")]}
+        else:
+            payload = {"findings": [_finding()]}
+        index = len(self.calls)
+        request_payload = {
+            "model": kwargs["model"],
+            "messages": [
+                {"role": "system", "content": kwargs["system_prompt"]},
+                {"role": "user", "content": kwargs["user_prompt"]},
+            ],
+            "temperature": float(kwargs["temperature"]),
+            "max_tokens": int(kwargs["max_tokens"]),
+            "stream": False,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+        combined_prompt = f'{kwargs["system_prompt"]}\n\n{kwargs["user_prompt"]}'
+        record = NimCallRecord(
+            role=kwargs["role"],
+            model=kwargs["model"],
+            endpoint=self.endpoint,
+            prompt_sha256=sha256(combined_prompt.encode("utf-8")).hexdigest(),
+            request_sha256=canonical_sha256(request_payload),
+            response_sha256=f"{index + 200:064x}",
+            response_text="{}",
+        )
+        return (
+            payload,
+            record,
+            NimTokenUsage(
+                prompt_tokens=10,
+                completion_tokens=2,
+                total_tokens=12,
+                usage_sha256=f"{index + 300:064x}",
+            ),
+        )
+
+
+def _single_configuration():
+    return build_evaluation_configurations((REFERENCE_MODEL,))[0]
+
+
+def _task(case_id="case-001"):
+    return build_benchmark_task(case_id, repository=REPO, source_revision=REV)
+
+
+def _successful_single_manifest() -> EvaluationRunManifest:
+    configuration = _single_configuration()
+    transport = ObservedNvidiaCouncilTransport(
+        _Client(),
+        provider_qualification_fingerprint=PROVIDER,
+    )
+    run = asyncio.run(run_council(_task(), configuration.members, transport, require_all=False))
+    return EvaluationRunManifest(
+        repository=REPO,
+        source_revision=REV,
+        configuration=configuration,
+        provider_qualification_fingerprint=PROVIDER,
+        case_ids=("case-001",),
+        runs=(("case-001", run),),
+        receipts=transport.receipts,
+        case_wall_latency_ms=(("case-001", 7),),
+    )
+
+
+def _successful_smoke_single_manifest() -> EvaluationRunManifest:
+    configuration = _single_configuration()
+    transport = ObservedNvidiaCouncilTransport(
+        _Client(),
+        provider_qualification_fingerprint=PROVIDER,
+    )
+    runs = []
+    timings = []
+    for index, case_id in enumerate(SMOKE_CASE_IDS, start=1):
+        run = asyncio.run(
+            run_council(_task(case_id), configuration.members, transport, require_all=False)
+        )
+        runs.append((case_id, run))
+        timings.append((case_id, index * 7))
+    return EvaluationRunManifest(
+        repository=REPO,
+        source_revision=REV,
+        configuration=configuration,
+        provider_qualification_fingerprint=PROVIDER,
+        case_ids=SMOKE_CASE_IDS,
+        runs=tuple(runs),
+        receipts=transport.receipts,
+        case_wall_latency_ms=tuple(timings),
+    )
+
+
+def _scorer_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "examples" / "06_score_nim_swarm_live_eval.py"
+
+
+def _scorer_module():
+    path = _scorer_path()
+    spec = importlib.util.spec_from_file_location("neuros_score_live_eval_test", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load live-evaluation scorer module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _raw_identity() -> dict[str, object]:
+    return {
+        "repository": REPO,
+        "source_revision": REV,
+        "provider_qualification": QUALIFICATION,
+    }
+
+
+def _rehash_receipt_and_manifest(manifest: dict[str, object], receipt: dict[str, object]) -> None:
+    receipt_unhashed = dict(receipt)
+    del receipt_unhashed["receipt_sha256"]
+    receipt["receipt_sha256"] = canonical_sha256(receipt_unhashed)
+    manifest_unhashed = dict(manifest)
+    del manifest_unhashed["manifest_sha256"]
+    manifest["manifest_sha256"] = canonical_sha256(manifest_unhashed)
+
+
+def test_configuration_plan_freezes_reference_before_outcomes():
+    configs = build_evaluation_configurations(DOCUMENTED_NVIDIA_CHAT_MODELS)
+    assert [config.kind for config in configs] == [
+        "single_reference",
+        "homogeneous_five_role",
+        "heterogeneous_five_role",
+    ]
+    assert configs[0].members[0].model == REFERENCE_MODEL
+    assert {member.model for member in configs[1].members} == {REFERENCE_MODEL}
+    assert len({member.model for member in configs[2].members}) == 3
+
+
+def test_one_qualified_route_omits_fake_heterogeneous_configuration():
+    configs = build_evaluation_configurations((REFERENCE_MODEL,))
+    assert [config.kind for config in configs] == [
+        "single_reference",
+        "homogeneous_five_role",
+    ]
+
+
+def test_counterbalanced_schedule_rotates_configuration_order_without_outcomes():
+    configs = build_evaluation_configurations(DOCUMENTED_NVIDIA_CHAT_MODELS[:2])
+    schedule = build_counterbalanced_schedule(configs)
+    assert SCHEDULE_POLICY == "deterministic_rotating_configuration_order_v1"
+    width = len(configs)
+    expected = [config.configuration_id for config in configs]
+    assert [configuration_id for _, configuration_id in schedule[:width]] == expected
+    assert [
+        configuration_id for _, configuration_id in schedule[width : 2 * width]
+    ] == expected[1:] + expected[:1]
+    assert [
+        configuration_id for _, configuration_id in schedule[2 * width : 3 * width]
+    ] == expected[2:] + expected[:2]
+
+
+def test_smoke_slice_is_fixed_public_and_small():
+    assert len(SMOKE_CASE_IDS) == 3
+    assert len(set(SMOKE_CASE_IDS)) == 3
+    for case_id in SMOKE_CASE_IDS:
+        assert _task(case_id).to_dict()["public_context"]["case"]["case_id"] == case_id
+
+
+def test_model_facing_live_eval_module_never_imports_scorer_answer_key():
+    source = inspect.getsource(swarm_live_eval)
+    assert "from .swarm_benchmark import" not in source
+    assert "_GROUND_TRUTH" not in source
+
+
+def test_scorer_has_no_top_level_ground_truth_import():
+    tree = ast.parse(_scorer_path().read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            assert node.module != "neuros.research.swarm_benchmark"
+
+
+def test_successful_transport_receipt_binds_exact_review_and_wall_timing():
+    manifest = _successful_single_manifest()
+    run = manifest.runs[0][1]
+    receipt = manifest.receipts[0]
+    assert len(run.reviews) == 1
+    assert receipt.outcome == "success"
+    assert receipt.parsed_response_sha256 == run.reviews[0].response_sha256
+    assert receipt.token_usage.total_tokens == 12
+    assert manifest.to_dict()["case_wall_latency_ms"] == {"case-001": 7}
+    assert manifest.to_dict()["scientific_promotion_authority"] is False
+
+
+def test_manifest_rejects_missing_or_negative_case_wall_timing():
+    manifest = _successful_single_manifest()
+    with pytest.raises(ValueError, match="case wall timings"):
+        EvaluationRunManifest(
+            repository=manifest.repository,
+            source_revision=manifest.source_revision,
+            configuration=manifest.configuration,
+            provider_qualification_fingerprint=manifest.provider_qualification_fingerprint,
+            case_ids=manifest.case_ids,
+            runs=manifest.runs,
+            receipts=manifest.receipts,
+            case_wall_latency_ms=(),
+        )
+    with pytest.raises(ValueError, match="non-negative"):
+        EvaluationRunManifest(
+            repository=manifest.repository,
+            source_revision=manifest.source_revision,
+            configuration=manifest.configuration,
+            provider_qualification_fingerprint=manifest.provider_qualification_fingerprint,
+            case_ids=manifest.case_ids,
+            runs=manifest.runs,
+            receipts=manifest.receipts,
+            case_wall_latency_ms=(("case-001", -1),),
+        )
+
+
+def test_manifest_rejects_tampered_parsed_response_identity():
+    manifest = _successful_single_manifest()
+    forged = replace(manifest.receipts[0], parsed_response_sha256="9" * 64)
+    with pytest.raises(ValueError, match="parsed-response identity mismatch"):
+        EvaluationRunManifest(
+            repository=manifest.repository,
+            source_revision=manifest.source_revision,
+            configuration=manifest.configuration,
+            provider_qualification_fingerprint=manifest.provider_qualification_fingerprint,
+            case_ids=manifest.case_ids,
+            runs=manifest.runs,
+            receipts=(forged,),
+            case_wall_latency_ms=manifest.case_wall_latency_ms,
+        )
+
+
+def test_provider_failure_preserves_failure_without_inventing_call_evidence():
+    configuration = build_evaluation_configurations((REFERENCE_MODEL,))[1]
+    transport = ObservedNvidiaCouncilTransport(
+        _Client(fail_role="swarm:implementation"),
+        provider_qualification_fingerprint=PROVIDER,
+    )
+    run = asyncio.run(run_council(_task(), configuration.members, transport, require_all=False))
+    assert len(run.reviews) == 4
+    assert run.failed_members == ("implementation:4:TimeoutError",)
+    failed = [receipt for receipt in transport.receipts if receipt.outcome != "success"]
+    assert len(failed) == 1
+    assert failed[0].outcome == "provider_failure"
+    assert failed[0].request_sha256 is None
+    assert failed[0].token_usage.provider_reported is False
+
+
+def test_review_validation_failure_preserves_hashes_and_consumed_tokens():
+    configuration = _single_configuration()
+    transport = ObservedNvidiaCouncilTransport(
+        _Client(invalid_role="swarm:generalist"),
+        provider_qualification_fingerprint=PROVIDER,
+    )
+    run = asyncio.run(run_council(_task(), configuration.members, transport, require_all=False))
+    assert run.reviews == ()
+    assert run.failed_members == ("generalist:1:ValueError",)
+    receipt = transport.receipts[0]
+    assert receipt.outcome == "review_validation_failure"
+    assert receipt.request_sha256 is not None
+    assert receipt.response_sha256 is not None
+    assert receipt.parsed_response_sha256 is not None
+    assert receipt.token_usage.total_tokens == 12
+
+
+def test_unknown_public_taxonomy_label_becomes_review_validation_failure():
+    configuration = _single_configuration()
+    transport = ObservedNvidiaCouncilTransport(
+        _Client(unknown_role="swarm:generalist"),
+        provider_qualification_fingerprint=PROVIDER,
+    )
+    run = asyncio.run(run_council(_task(), configuration.members, transport, require_all=False))
+    assert run.failed_members == ("generalist:1:ValueError",)
+    assert transport.receipts[0].outcome == "review_validation_failure"
+
+
+def test_manifest_rejects_duplicate_attempt_receipts():
+    manifest = _successful_single_manifest()
+    receipt = manifest.receipts[0]
+    with pytest.raises(ValueError, match="exactly one attempt"):
+        EvaluationRunManifest(
+            repository=manifest.repository,
+            source_revision=manifest.source_revision,
+            configuration=manifest.configuration,
+            provider_qualification_fingerprint=manifest.provider_qualification_fingerprint,
+            case_ids=manifest.case_ids,
+            runs=manifest.runs,
+            receipts=(receipt, receipt),
+            case_wall_latency_ms=manifest.case_wall_latency_ms,
+        )
+
+
+def test_scorer_keeps_exact_three_case_boundary():
+    scorer = _scorer_module()
+    with pytest.raises(ValueError, match="case slice mismatch"):
+        scorer._validated_manifest(
+            _successful_single_manifest().to_dict(),
+            raw=_raw_identity(),
+            expected_configuration=_single_configuration(),
+        )
+
+
+def test_scorer_rejects_rehashed_receipt_member_substitution():
+    scorer = _scorer_module()
+    manifest = _successful_smoke_single_manifest().to_dict()
+    receipt = manifest["receipts"][0]
+    receipt["role"] = "forged-role"
+    _rehash_receipt_and_manifest(manifest, receipt)
+    with pytest.raises(ValueError, match="receipt member identity differs"):
+        scorer._validated_manifest(
+            manifest,
+            raw=_raw_identity(),
+            expected_configuration=_single_configuration(),
+        )
+
+
+def test_scorer_rejects_rehashed_parsed_response_substitution():
+    scorer = _scorer_module()
+    manifest = _successful_smoke_single_manifest().to_dict()
+    receipt = manifest["receipts"][0]
+    receipt["parsed_response_sha256"] = "9" * 64
+    _rehash_receipt_and_manifest(manifest, receipt)
+    with pytest.raises(ValueError, match="parsed-response identity differs"):
+        scorer._validated_manifest(
+            manifest,
+            raw=_raw_identity(),
+            expected_configuration=_single_configuration(),
+        )
+
+
+def test_scorer_rejects_rehashed_request_substitution():
+    scorer = _scorer_module()
+    manifest = _successful_smoke_single_manifest().to_dict()
+    receipt = manifest["receipts"][0]
+    receipt["request_sha256"] = "8" * 64
+    _rehash_receipt_and_manifest(manifest, receipt)
+    with pytest.raises(ValueError, match="request identity differs"):
+        scorer._validated_manifest(
+            manifest,
+            raw=_raw_identity(),
+            expected_configuration=_single_configuration(),
+        )
+
+
+def test_scorer_rejects_semantically_impossible_rehashed_provider_failure():
+    scorer = _scorer_module()
+    manifest = _successful_smoke_single_manifest().to_dict()
+    receipt = manifest["receipts"][0]
+    receipt["outcome"] = "provider_failure"
+    receipt["error_class"] = "TimeoutError"
+    _rehash_receipt_and_manifest(manifest, receipt)
+    with pytest.raises(ValueError, match="provider failure cannot claim"):
+        scorer._validated_manifest(
+            manifest,
+            raw=_raw_identity(),
+            expected_configuration=_single_configuration(),
+        )
+
+
+def test_scorer_rejects_self_hashed_fake_provider_roster():
+    scorer = _scorer_module()
+    forged = dict(QUALIFICATION)
+    forged["documented_candidates"] = ["invented/model"]
+    forged_unhashed = dict(forged)
+    del forged_unhashed["fingerprint"]
+    forged["fingerprint"] = canonical_sha256(forged_unhashed)
+    with pytest.raises(ValueError, match="candidate roster differs"):
+        scorer._validated_provider_qualification(forged)
+
+
+def test_council_run_serialization_round_trip_revalidates_hash():
+    run = _successful_single_manifest().runs[0][1]
+    restored = council_run_from_dict(run.to_dict())
+    assert restored.to_dict() == run.to_dict()
+    forged = run.to_dict()
+    forged["run_sha256"] = canonical_sha256({"forged": True})
+    with pytest.raises(ValueError, match="fingerprint mismatch"):
+        council_run_from_dict(forged)


### PR DESCRIPTION
## Purpose

Add a bounded, additive NVIDIA NIM swarm live-evaluation/telemetry layer on top of the promoted deterministic neurOS swarm benchmark without modifying existing `NimCallRecord`, council, benchmark, or provider-qualification evidence semantics.

## Authoritative candidate

- qualified base: `main@271b0df596f2ce4464e46c7a708aebde027c6c35`
- authoritative head: `1ea1778b86a0df26ac1f8c9f1ef681f7be0eb615`
- ancestry: exactly one commit over qualified base
- changed files: exactly eight, all additive
- public benchmark corpus: `122d862b2d43078723b858d5d5520a4ffb24e9e497d0090a52865c20f3aa5e0a`

Every earlier head is superseded and contributes zero promotion evidence. The prior `ae5c6fe1...` head already enforced exact JSON-object reviewer output and passed its swarm/research/public-trust lanes, but critique found that the credential-free scorer imported `swarm_benchmark` at module load before complete artifact validation. No model or credential could access that process, but it contradicted the intended evidence boundary. This head performs complete raw/configuration/receipt/run verification first, then lazily imports scorer-side ground truth. A regression forbids top-level ground-truth imports in the scoring CLI.

The earlier stray empty `noop` ref-manipulation commit remains fully excluded. Exact base→head comparison contains only the intended eight additive files. No hosted NVIDIA call has been made by PR qualification.

## Core contract

Hosted reviewer content, after whitespace trimming, must be exactly one JSON object. Prefix/suffix prose, non-object roots, malformed JSON, and duplicate keys become `review_validation_failure` evidence.

Each reviewer attempt is classified as `success`, `provider_failure`, or `review_validation_failure`. Validation-failed hosted responses preserve transport hashes, measured latency, and provider-reported token usage, while missing token counts are never estimated.

Before any benchmark ground truth is imported, the separate credential-free scorer verifies the raw artifact hash; exact documented NVIDIA route roster and probe semantics; pinned endpoint; qualified and selected model order; frozen counterbalanced schedule; bounded call count; reconstructed reviewer IDs/roles/models/prompt hashes; exact canonical prompt/request identities (`temperature=0.1`, `max_tokens=1200`, non-streaming, non-thinking); receipt semantics; exact case×reviewer coverage; council-run fingerprints; false authority flags; review↔receipt parsed-response binding; failed-review error binding; and case wall-latency coverage.

Adversarial tests self-rehash forged member, parsed-response, request, failure-state, and provider-roster substitutions and still require rejection. Partial one-case scorer manifests are explicitly rejected.

## Experimental design

- `single-reference-v1`: one generalist on the first live-qualified route.
- `homogeneous-five-role-v1`: five specialist roles on that route.
- `heterogeneous-five-role-v1`: the same five roles distributed across qualified routes when at least two qualify.

Homogeneous→heterogeneous is the cleaner operational route-diversity contrast. Single→five-role is not a causal estimate of specialization because reviewer count, sampling budget, and prompts all change. A future ablation should add five same-model generalists to isolate ensemble size from specialist-role effects.

The three cases `case-001`, `case-015`, and `case-029` use frozen `deterministic_rotating_configuration_order_v1` to reduce obvious block-order/provider-load confounding. Per-call latency and end-to-end per-case wall latency are both bound. Token totals are reported only when supplied by the provider. Dollar cost is not estimated.

## Bounded v1 smoke

- one qualified route: 18 reviewer attempts;
- at least two qualified routes: 33 attempts maximum;
- full 29-case A/B/C run, up to 319 attempts, remains disabled.

The public three-case run is transport/schema/telemetry qualification, not stable reviewer precision/recall estimation or a general model-quality benchmark.

PR/push CI is credential-free. Hosted execution is manual `workflow_dispatch` only, requires exact clean `main`, requalifies before network use, scopes the NVIDIA secret only to the hosted review step, scans artifacts for leakage, and scores without the credential.

## Authority boundary

This tranche grants no merge authority, future provider-execution authority, Kumar2024 execution authorization, scientific promotion, clinical claim, provider ranking, or ORION comparison authority.

Refs #178.