### PR TITLE
fix(research): fail-close NIM live smoke artifact upload

### DIFF
--- a/.github/workflows/nim-live-artifact-policy.yml
+++ b/.github/workflows/nim-live-artifact-policy.yml
@@ -1,0 +1,58 @@
+name: NIM Live Artifact Policy
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/nim-swarm-live-eval.yml"
+      - ".github/workflows/nim-live-artifact-policy.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/nim-swarm-live-eval.yml"
+      - ".github/workflows/nim-live-artifact-policy.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-policy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Require fail-closed live-evidence upload policy
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path(".github/workflows/nim-swarm-live-eval.yml")
+          source = path.read_text(encoding="utf-8")
+
+          required = (
+              "RAW_SAFE.sha256",
+              "nim-swarm-live-eval-upload/UPLOAD_READY",
+              "hashFiles('artifacts/nim-swarm-live-eval-upload/UPLOAD_READY')",
+              "path: artifacts/nim-swarm-live-eval-upload/",
+          )
+          for token in required:
+              if token not in source:
+                  raise SystemExit(f"missing fail-closed artifact policy token: {token}")
+
+          leak_scan = source.find("credential material leaked into raw live-evaluation artifact")
+          safe_seal = source.find("RAW_SAFE.sha256")
+          if leak_scan < 0 or safe_seal < 0 or safe_seal <= leak_scan:
+              raise SystemExit("raw evidence must be credential-scanned before upload safety sealing")
+
+          upload_step = source.find("- name: Preserve sealed live smoke evidence")
+          if upload_step < 0:
+              raise SystemExit("sealed evidence upload step is missing")
+          upload_tail = source[upload_step:]
+          if "path: artifacts/nim-swarm-live-eval/\n" in upload_tail:
+              raise SystemExit("raw live-evaluation working directory must never be uploaded directly")
+          if "if: always()" in upload_tail.split("uses: actions/upload-artifact", 1)[0]:
+              raise SystemExit("unsealed always() artifact upload is forbidden")
+          PY

--- a/.github/workflows/nim-swarm-live-eval.yml
+++ b/.github/workflows/nim-swarm-live-eval.yml
@@ -380,6 +380,10 @@ jobs:
           if key and key in raw:
               raise SystemExit("credential material leaked into raw live-evaluation artifact")
           PY
+          (
+            cd artifacts/nim-swarm-live-eval
+            sha256sum raw.json > RAW_SAFE.sha256
+          )
 
       - name: Score completed reviews without provider credential
         shell: bash
@@ -431,11 +435,33 @@ jobs:
           print(f"qualified bounded reviewer attempts: {expected_calls}")
           PY
 
-      - name: Preserve live smoke evidence
-        if: always()
+      - name: Prepare sealed evidence bundle
+        if: ${{ always() && hashFiles('artifacts/nim-swarm-live-eval/RAW_SAFE.sha256') != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            cd artifacts/nim-swarm-live-eval
+            sha256sum -c RAW_SAFE.sha256
+          )
+          rm -rf artifacts/nim-swarm-live-eval-upload
+          mkdir -p artifacts/nim-swarm-live-eval-upload
+          cp artifacts/nim-swarm-live-eval/raw.json \
+            artifacts/nim-swarm-live-eval/RAW_SAFE.sha256 \
+            artifacts/nim-swarm-live-eval-upload/
+          for optional in scored.json SHA256SUMS; do
+            if [ -f "artifacts/nim-swarm-live-eval/${optional}" ]; then
+              cp "artifacts/nim-swarm-live-eval/${optional}" \
+                artifacts/nim-swarm-live-eval-upload/
+            fi
+          done
+          touch artifacts/nim-swarm-live-eval-upload/UPLOAD_READY
+
+      - name: Preserve sealed live smoke evidence
+        if: ${{ always() && hashFiles('artifacts/nim-swarm-live-eval-upload/UPLOAD_READY') != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: nim-swarm-live-eval-${{ github.sha }}
-          path: artifacts/nim-swarm-live-eval/
-          if-no-files-found: warn
+          path: artifacts/nim-swarm-live-eval-upload/
+          if-no-files-found: error
           retention-days: 30

--- a/docs/NEUROS_NIM_SWARM_LIVE_EVAL.md
+++ b/docs/NEUROS_NIM_SWARM_LIVE_EVAL.md
@@ -180,7 +180,18 @@ The workflow reuses the existing repository secret aliases and prefers `NVIDIA_A
 - `NVAPI_KEY`.
 
 Never place a key in source, issue text, artifacts, or chat. The key is scoped only to the hosted
-review step, artifacts are scanned for leakage, and scoring executes without the credential.
+review step and scoring executes without the credential.
+
+Raw hosted evidence is fail-closed for preservation. After `raw.json` is written, the hosted step
+searches it for the exact active credential. Only a clean artifact receives `RAW_SAFE.sha256`.
+Later evidence preservation re-verifies that seal, copies only sealed files into a separate
+`nim-swarm-live-eval-upload/` staging directory, and creates `UPLOAD_READY` there only after the
+copy succeeds. The upload action can see only that staged directory. If credential leakage is
+detected, the safety seal is never created and **no raw evidence is uploaded**, even though the
+job fails. If a later scoring or verification step fails after the raw artifact was safely sealed,
+the sealed raw evidence may still be preserved for diagnosis without exposing the provider key.
+
+A separate CI policy workflow checks these upload invariants whenever the hosted workflow changes.
 
 ## Authority boundary
 


### PR DESCRIPTION
## Purpose

Hardens the promoted NVIDIA NIM live-smoke workflow before the first hosted provider run. This PR does **not** change reviewer models, roles, prompts, benchmark cases, call budgets, scoring semantics, or scientific authority boundaries.

## Base

- promoted base: `main@f8cf30dd01894369e91cf87dc0b273302677b0f2`
- fresh-main promotion evidence: all 6 post-merge push workflows succeeded on that exact SHA.

## Defect found

The promoted workflow correctly scanned `raw.json` for the active NVIDIA credential, but the final artifact step used `if: always()` and uploaded the raw working directory. If the leak scan ever failed because the credential appeared in `raw.json`, the workflow could then preserve the same unsafe artifact.

## Repair

- create `RAW_SAFE.sha256` only **after** the active credential scan passes;
- before preservation, re-verify `raw.json` against that safety seal;
- stage evidence into a separate `artifacts/nim-swarm-live-eval-upload/` directory;
- create `UPLOAD_READY` only after the sealed copy succeeds;
- permit `actions/upload-artifact` to run only when that staged `UPLOAD_READY` exists;
- never upload the raw working directory directly;
- retain safely sealed raw evidence if a later scorer/verification step fails;
- add a dedicated `NIM Live Artifact Policy` CI workflow that rejects regressions in these invariants;
- document the fail-closed behavior.

## Boundary

This is credential/evidence-preservation hardening only. It grants no provider execution authority, no scientific promotion, no model/provider ranking, no Kumar2024 authorization, and no ORION comparison authority.

The manual 3-case hosted smoke should remain unexecuted until this repair is exact-head qualified and promoted.