### PR TITLE
chore(governance): make the active repository state intentional

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# neurOS ownership is intentionally explicit around authority-bearing surfaces.
+# A single maintainer is not independent review; these rules make ownership visible
+# today and provide clean seams for additional scientific/runtime owners later.
+* @sidhulyalkar
+
+# Scientific evidence, study execution, and research authority
+/packages/neuros/src/neuros/evidence/ @sidhulyalkar
+/packages/neuros-research/ @sidhulyalkar
+/scripts/evidence/ @sidhulyalkar
+/requirements/nsq-kumar2024-promoted-py311.constraints.txt @sidhulyalkar
+
+# Runtime and native data plane
+/packages/neuros-core/src/neuros/runtime/ @sidhulyalkar
+/rust/neuros-runtime/ @sidhulyalkar
+/rust/neuros-runtime-py/ @sidhulyalkar
+
+# Foundation / mechanism surfaces
+/packages/neuros-foundation/src/neuros/foundation_models/ @sidhulyalkar
+/packages/neuros-mechint/ @sidhulyalkar
+
+# CI, release, and repository governance
+/.github/workflows/ @sidhulyalkar
+/.github/dependabot.yml @sidhulyalkar
+/release/ @sidhulyalkar
+/scripts/check_github_action_pins.py @sidhulyalkar
+/SECURITY.md @sidhulyalkar
+/GOVERNANCE.md @sidhulyalkar

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps(actions)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
 ## Purpose
 
-<!-- What user, scientific, runtime, or architectural problem does this change solve? -->
+<!-- What user, scientific, runtime, or architectural problem does this change solve? Keep one primary responsibility. -->
+
+## Exact candidate
+
+- Base branch / SHA:
+- Head branch / SHA:
+- Supersedes or depends on:
+- Production candidate, experiment/staging, or historical provenance:
 
 ## Architectural boundary
 
@@ -42,6 +49,11 @@ Select the strongest evidence actually produced by this PR. Do not imply a stron
 - [ ] Missing uncertainty/confidence is not fabricated.
 - [ ] Attribution/attention/sparse features are not described as causal mechanism without intervention evidence.
 - [ ] Synthetic/software evidence is not described as hardware, biological, clinical, or safety validation.
+- [ ] Any change to data identity, preprocessing, model, metric, reveal order, retry policy, provider authority, or ORION comparison authority is called out explicitly below.
+
+### Authority changed, if any
+
+<!-- State the exact authority changed and the strongest claim the resulting evidence can support. -->
 
 ## Reliability, replay, and provenance
 
@@ -50,12 +62,37 @@ Select the strongest evidence actually produced by this PR. Do not imply a stron
 - [ ] Promoted model/data/benchmark artifacts have immutable or reproducible identity where applicable.
 - [ ] A replay/regression path exists for consequential runtime/model changes where practical.
 
+## Qualification integrity
+
+- Exact head being qualified:
+- Required workflows:
+- Focused/adversarial tests:
+- Known skipped or unavailable surfaces:
+
+- [ ] Construction/staging evidence is not being reused as promotion evidence.
+- [ ] Qualification evidence belongs to the exact head above.
+- [ ] Any authority-bearing code change after qualification will require fresh exact-head qualification.
+
+## Merge gate
+
+<!-- State what must be true before merge. Authority-bearing merges should use an expected-head SHA guard. -->
+
+- [ ] PR is current with the intended `main` authority or explicitly documents why it is a historical stack.
+- [ ] No unresolved review thread changes the claimed authority boundary.
+- [ ] Post-merge qualification requirements are stated when the resulting `main` SHA itself becomes an authority identity.
+
 ## Documentation and developer experience
 
 - [ ] Current docs are updated in the same PR when public behavior changes.
 - [ ] Supported examples use current APIs and are executable.
 - [ ] Optional dependencies fail with actionable errors and do not silently alter algorithm identity.
 - [ ] `python scripts/check_repo_hygiene.py` passes for structural changes.
+
+## Lifecycle
+
+- [ ] Production candidate intended for `main`.
+- [ ] Experiment/staging only; close after evidence is recorded and do not merge directly.
+- [ ] Historical/superseded; retain for provenance and close rather than rebasing indefinitely.
 
 ## Known limitations / next layer
 

--- a/docs/REPOSITORY_LIFECYCLE.md
+++ b/docs/REPOSITORY_LIFECYCLE.md
@@ -1,0 +1,80 @@
+# Repository lifecycle policy
+
+neurOS uses exact-source qualification and evidence-bearing pull requests. That makes history valuable, but it also makes stale stacked branches unusually easy to mistake for current authority. This policy keeps provenance without letting historical work become the active project map.
+
+## 1. `main` is the integration authority
+
+`main` is the only long-lived integration line. A production PR should normally target current `main` directly. Short stacks are acceptable while one coherent tranche is being developed, but a deep stack is not a substitute for integration.
+
+If `main` has materially advanced or a stack has grown beyond roughly two dependent production PRs, prefer a fresh current-main consolidation PR that reconstructs the intended net change and requalifies it there.
+
+Historical qualification proves the historical source. It does not automatically transfer to a reconstructed or rebased candidate.
+
+## 2. Classify every PR by lifecycle
+
+Every PR should be one of three things:
+
+### Production candidate
+
+A coherent change intended for `main`. It owns its exact source identity, tests, claim boundary, and merge gate.
+
+### Experiment or staging
+
+A disposable branch used to answer a bounded question, benchmark an implementation, reproduce a failure, or harden a candidate. Its evidence may inform production work, but the staging branch is not promoted directly unless it is explicitly reconstructed as a production candidate and freshly qualified.
+
+Use clear branch/PR naming such as `experiment/` or `[STAGING]` when possible. Close the PR after the result has been recorded.
+
+### Historical or superseded provenance
+
+A PR whose useful semantics have already been consolidated onto `main`, replaced by a stronger architecture, or made obsolete by a newer authority boundary. Keep the PR and its exact-head evidence as provenance, but close it rather than continually rebasing it.
+
+## 3. Exact-head qualification is immutable evidence
+
+Qualification belongs to the exact commit that was tested.
+
+Any authority-bearing source change after qualification resets the qualification state. Documentation-only changes may be treated separately only when the PR explicitly demonstrates that no production/test semantics changed and the repository's governing workflows support that distinction.
+
+Construction evidence, staging evidence, historical green runs, and current promotion evidence must be labeled separately.
+
+## 4. Scientific authority stays narrower than software success
+
+Green CI can establish software, contract, reproducibility, transport, or execution semantics. It does not by itself establish neural efficacy, biological mechanism, hardware validity, clinical validity, or ORION superiority.
+
+A PR that changes any of the following must name the changed authority explicitly:
+
+- dataset or participant identity;
+- preprocessing or materialization;
+- train/evaluation split or reveal order;
+- model or representation identity;
+- metric semantics or comparison authority;
+- retry, settlement, or provider execution authority;
+- external-floor interpretation;
+- ORION comparison or mechanism claims.
+
+## 5. Merge authority is source-bound
+
+Authority-bearing merges should use an expected-head SHA guard. If the resulting `main` commit itself becomes part of an execution or evidence identity, fresh post-merge qualification is required before that identity is promoted.
+
+Do not merge an old stack one PR at a time merely because each historical head was once green. Qualify the intended current composition.
+
+## 6. Keep the active queue small
+
+Prefer fewer than five active production PRs. Experiments should have bounded questions and short lifetimes. Once a consolidation PR lands, close the superseded stack promptly.
+
+A useful open PR should answer at least one of these questions:
+
+1. What current product/scientific capability will this add?
+2. What current defect will this remove?
+3. What bounded experiment is still awaiting an answer?
+
+If none applies, the PR is probably provenance rather than active work.
+
+## 7. Repository settings should match the source policy
+
+The repository should use a `main` ruleset or branch protection with pull-request review flow and required current CI checks. Automatic deletion of merged branches is preferred once branch provenance is safely retained through merged PRs and commits.
+
+`CODEOWNERS` expresses ownership, not independence. A solo maintainer reviewing their own code is still one reviewer. As neurOS gains maintainers, scientific authority, runtime/data-plane authority, and release/governance ownership should be split across people where practical.
+
+## 8. Cleanup is preservation, not erasure
+
+Closing an obsolete PR does not erase its discussion, commits, workflow records, or scientific reasoning. The goal is to make GitHub's *open* state accurately represent what can still change the future of neurOS.


### PR DESCRIPTION
## Purpose

Turn the cleanup rules used in the current repository audit into durable repository policy, while transplanting only the still-valid governance pieces from historical #113 onto current `main`.

## Exact candidate

- base: `main@c15446f58df3a33c914002c160c663deb61f85cb`
- head branch: `chore/repository-governance-v2`
- current head: `eb973443bfbc69d2365132d8743d02e26e99505f`
- supersedes the governance-file portion of #113; it intentionally does **not** copy #113's now-stale Kumar2024 status text

## Changes

- add explicit `CODEOWNERS` boundaries around evidence/execution, runtime/native data-plane, foundation/mechanistic, CI/release, and governance surfaces;
- add low-noise weekly Dependabot maintenance for GitHub Actions only, capped at two open PRs;
- strengthen the existing PR template with exact candidate identity, authority-change disclosure, exact-head qualification integrity, merge gates, and lifecycle classification;
- add `docs/REPOSITORY_LIFECYCLE.md` defining current-main integration, production vs staging vs historical PRs, source-bound qualification, claim boundaries, expected-head merges, and prompt closure of superseded stacks.

## Boundary

Repository governance only. No runtime, model, dataset, benchmark, scientific authority, NIM execution, Kumar2024 execution, ORION comparison, package, or release semantics change.

`CODEOWNERS` makes ownership visible but does not claim independent review while the repository has one maintainer.

## Qualification

This branch should earn fresh current-head Public Trust / repository hygiene / docs qualification before merge. Historical #113 green evidence is provenance only and is not reused.

Refs #113, #112.