### PR TITLE
chore(deps): separate major GitHub Actions migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,11 @@ updates:
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 2
     groups:
-      github-actions:
+      github-actions-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "deps(actions)"


### PR DESCRIPTION
## Purpose

Keep dependency automation low-noise without allowing unrelated major GitHub Action migrations to collapse into one repository-wide authority change.

PR #186 grouped five independent majors across 58 workflow files. Most suites passed, but `NIM Owner Live-Smoke Bridge Policy` correctly failed when the rewritten workflow blobs no longer matched its frozen bridge identities. That is an authority re-binding event, not a failure we should suppress.

## Change

Dependabot now groups only GitHub Actions **minor and patch** updates.

Major updates remain independent PRs, bounded by the existing open-PR limit, so each migration can be evaluated against:

- runtime/runner requirements;
- artifact behavior changes;
- security/default changes;
- exact workflow-blob authorities;
- any required downstream receipt or bridge re-binding.

## Boundary

This PR changes dependency update orchestration only. It changes no workflow action pin, scientific authority, experiment code, runtime behavior, model behavior, or evidence interpretation.

## Follow-up

Once this policy qualifies, #186 should close rather than merge. Future major-action updates should be promoted independently with explicit authority re-binding where required.