### PR TITLE
feat(evidence): add canonical scientific claim contracts

### DIFF
--- a/.github/workflows/public-trust-ci.yml
+++ b/.github/workflows/public-trust-ci.yml
@@ -11,6 +11,8 @@ on:
       - "CHANGELOG.md"
       - "docs/**"
       - "mkdocs.yml"
+      - "packages/neuros/src/neuros/evidence/**"
+      - "tests/test_scientific_claim_spec.py"
       - "scripts/check_public_contracts.py"
       - "scripts/check_github_action_pins.py"
       - ".github/workflows/**"
@@ -25,6 +27,8 @@ on:
       - "CHANGELOG.md"
       - "docs/**"
       - "mkdocs.yml"
+      - "packages/neuros/src/neuros/evidence/**"
+      - "tests/test_scientific_claim_spec.py"
       - "scripts/check_public_contracts.py"
       - "scripts/check_github_action_pins.py"
       - ".github/workflows/**"
@@ -42,6 +46,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Require literal clean qualification source
+        shell: bash
+        run: |
+          set -euo pipefail
+          EXPECTED="${{ github.event.pull_request.head.sha || github.sha }}"
+          test "$(git rev-parse HEAD)" = "${EXPECTED}"
+          test -z "$(git status --porcelain)"
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
@@ -51,7 +65,11 @@ jobs:
       - name: Install validation dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyyaml cffconvert
+          python -m pip install pyyaml cffconvert pytest
+      - name: Validate scientific claim contracts
+        env:
+          PYTHONPATH: packages/neuros/src
+        run: pytest -q tests/test_scientific_claim_spec.py
       - name: Validate repository public contracts
         run: python scripts/check_public_contracts.py
       - name: Validate citation metadata against CFF schema
@@ -62,6 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"

--- a/.github/workflows/public-trust-ci.yml
+++ b/.github/workflows/public-trust-ci.yml
@@ -62,13 +62,12 @@ jobs:
           cache: pip
       - name: Enforce immutable GitHub Actions references
         run: python scripts/check_github_action_pins.py
-      - name: Install validation dependencies
+      - name: Install supported validation workspace
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyyaml cffconvert pytest
+          python scripts/bootstrap.py --profile bci --test-tools
+          python -m pip install pyyaml cffconvert
       - name: Validate scientific claim contracts
-        env:
-          PYTHONPATH: packages/neuros/src
         run: pytest -q tests/test_scientific_claim_spec.py
       - name: Validate repository public contracts
         run: python scripts/check_public_contracts.py

--- a/docs/SCIENTIFIC_CLAIM_HORIZON.md
+++ b/docs/SCIENTIFIC_CLAIM_HORIZON.md
@@ -1,0 +1,208 @@
+# Scientific claim horizon
+
+Status: **architecture contract, not a scientific result.**
+
+As generating experiments becomes cheaper, trustworthy evidence becomes more scarce. neurOS should make the boundary between a result and a claim explicit, executable, portable, and independently auditable.
+
+The public claim layer therefore begins with a narrow proposition contract rather than a generic autonomous-scientist framework.
+
+## The core separation
+
+```text
+claim intent
+    |
+    v
+ScientificClaimSpec
+    |
+    | proposition + inference unit + declared evidence requirements
+    v
+protocol / ScientificStudyAuthority / NSQ
+    |
+    | qualified execution and study evidence
+    v
+ORION EvidenceClaim and immutable receipts
+    |
+    | earned authority remains study-local
+    v
+ClaimEvidenceRef
+    |
+    | portable citation to immutable evidence
+    v
+ScientificClaimBundle
+    |
+    v
+human or separately authorized interpretation
+```
+
+The invariant is intentionally strict:
+
+```text
+claim intent != earned qualification != evidence relation != truth
+```
+
+A claim targeting real-data evidence has not earned real-data status. A citation declared to support a claim is not automatically valid support. A structurally qualified execution receipt is not an efficacy result. A collection of supportive artifacts is not a truth score.
+
+## v1 public contracts
+
+`neuros.evidence` exposes six dependency-light contracts:
+
+- `EvidenceTier`: labels the evidence horizon without defining an automatic ordering or promotion rule.
+- `EvidenceRelation`: records a declared relationship such as support, contradiction, replication, or context.
+- `EvidenceRequirement`: predeclares one evidence requirement and the authority type expected to satisfy it.
+- `ScientificClaimSpec`: identifies the proposition, scope, inference unit, target evidence horizon, and requirements.
+- `ClaimEvidenceRef`: binds the claim layer to one immutable evidence digest and explicitly calls its tier `declared_evidence_tier`.
+- `ScientificClaimBundle`: content-addresses one claim plus its cited evidence, protocol identity, and study identities.
+
+These objects are manifests, not adjudicators.
+
+## Identity semantics
+
+Claim portability requires two labs, agents, or audit tools to derive the same identity from semantically identical content. v1 therefore treats several collections as set-like authority surfaces:
+
+- requirements are canonicalized by `requirement_id`;
+- evidence references are canonicalized by reference identity;
+- study digests are canonicalized lexicographically;
+- mapping keys are sorted and must be strings;
+- nested metadata is frozen after validation;
+- unordered Python sets are rejected;
+- NaN and infinity are rejected;
+- negative zero canonicalizes to zero;
+- SHA-256 identities are domain-separated by manifest type.
+
+The same underlying `evidence_sha256` may occur only once in a claim bundle. Changing relation labels, source aliases, or metadata cannot be used to count one artifact repeatedly.
+
+Ordered sequences inside metadata remain ordered because their order may itself be scientific content.
+
+## Evidence tiers are not a ladder implemented in code
+
+v1 names useful strata:
+
+```text
+software_contract
+integration
+replay_or_synthetic
+real_data
+physical_hardware
+closed_loop
+clinical
+```
+
+The enum deliberately does not define `software_contract < real_data < clinical` as an automatic comparison operator. Different claims require different authority graphs, and a nominally "higher" environment does not repair a flawed inference unit, invalid split, missing control, or outcome-dependent retry.
+
+Promotion belongs to explicit scientific policy, not enum arithmetic.
+
+## Relation to ORION
+
+ORION should remain the authority engine that records what an actual study earned. `ScientificClaimSpec` sits upstream and says what proposition is being pursued. `ClaimEvidenceRef` sits downstream and provides a portable citation boundary.
+
+This avoids two failure modes:
+
+1. forcing the public neurOS SDK to import ORION just to describe a proposition;
+2. allowing a lightweight manifest to impersonate ORION qualification.
+
+A future bridge may validate an ORION `EvidenceClaim`, `ScientificStudyAuthority`, protocol seal, or outcome receipt and then create a bound claim-evidence reference. That bridge should prove the authority relationship. The dependency-light claim object should not infer it.
+
+## Relation to the Kumar2024 execution stack
+
+The promoted Kumar2024 stack is a useful demonstration of why this separation matters. neurOS now has independently replayable execution authority, score-blind fleet control, provider-neutral external classical transport, and score-blind external admission.
+
+Those systems can produce strong structural evidence without making the corresponding numerical result interpretable. A future Kumar2024 claim bundle could cite such receipts as software, integration, or transport evidence while still showing that an external scientific floor has not been earned.
+
+The claim layer must never convert successful transport qualification into decoding superiority or ORION comparison permission.
+
+## Near-term product direction
+
+The most defensible neurOS product is not "a framework that runs neuroscience code." Capable labs can increasingly generate bespoke pipelines themselves.
+
+A stronger wedge is an **evidence authority layer** that answers questions ordinary experiment tooling leaves implicit:
+
+- What exact proposition was preregistered?
+- What is the inference unit?
+- What evidence was required before results existed?
+- Which source, data, preprocessing, model, hardware, and protocol identities produced each artifact?
+- Were retries score-blind?
+- Which evidence objects support, contradict, replicate, or merely contextualize the claim?
+- What authority was actually earned?
+- What remains unqualified?
+
+That becomes more valuable as agentic systems can generate hundreds of plausible experiments faster than humans can audit them.
+
+## 1 to 3 year horizon
+
+After claim manifests are exercised by real studies, the next abstractions should be earned by repeated operational need rather than added speculatively.
+
+Likely candidates are:
+
+### ProtocolSeal
+
+An immutable binding of claim intent to protocol, dataset/materialization identities, inference unit, split policy, stopping rule, allowed retries, and analysis authority before outcome visibility.
+
+### OutcomeRevealReceipt
+
+A receipt that proves when outcome-bearing artifacts first became visible relative to protocol freeze, execution settlement, and analysis authorization.
+
+### ExplorationLedger
+
+An action-level ledger for agentic scientific exploration that records proposed experiments, authority-changing decisions, rejected branches, and outcome-visibility boundaries without storing private chain-of-thought.
+
+The ledger should answer "what actions occurred under what information state?" rather than pretending internal reasoning can or should be audited.
+
+## 3 to 5 year horizon
+
+If independent groups adopt the contracts, evidence becomes graph-shaped rather than repository-shaped.
+
+Useful extensions may include:
+
+- cross-site reproduction receipts;
+- site-specific environment and acquisition authorities;
+- blinded replication references;
+- federated evidence bundles where raw neural data cannot leave an institution;
+- signed laboratory or instrument attestations;
+- contradiction-preserving evidence graphs rather than winner-only summaries;
+- revocation or supersession links when a receipt is later invalidated.
+
+The hard problem is not storing a graph. It is preserving meaningful scientific authority while evidence crosses institutional boundaries.
+
+## 5 to 10 year horizon
+
+For autonomous physical neuroscience and BCI experimentation, claim authority will need to compose with action and safety authority.
+
+A mature system may need to bind:
+
+```text
+scientific claim
+      +
+protocol authority
+      +
+participant / device / site authority
+      +
+safety envelope
+      +
+action authorization
+      +
+immutable observation receipts
+```
+
+This is where neurOS and ORION could become infrastructure for trustworthy closed-loop science rather than merely experiment orchestration.
+
+The threshold for this layer is high. Clinical, stimulation, or participant-facing authority must never be inferred from software-contract success.
+
+## What not to build from this horizon
+
+This architecture does not justify:
+
+- a generic autonomous-scientist agent framework;
+- a blockchain for scientific provenance;
+- a universal scalar truth or confidence score;
+- automatic promotion between evidence tiers;
+- a large cloud product before the contracts prove useful in real studies;
+- storing model chain-of-thought as scientific provenance;
+- treating cryptographic integrity as evidence that a scientific claim is correct.
+
+Cryptography can prove that an artifact is the artifact that was authorized. It cannot prove that the hypothesis, experimental design, inference, or interpretation is scientifically valid.
+
+## Immediate validation target
+
+v1 should be judged by whether it improves real scientific work with minimal ceremony. The next useful test is to bind one existing neurOS study from predeclared proposition through qualified execution to a claim bundle while preserving negative and still-unearned evidence states.
+
+A successful demonstration should make the evidence boundary clearer to an external reader without requiring them to understand the entire neurOS repository.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - Neural System Qualification: NEURAL_SYSTEM_QUALIFICATION_V1.md
       - NSQ Runner: NSQ_RUNNER_V1.md
       - Scientific Claims: SCIENTIFIC_CLAIMS.md
+      - Scientific Claim Horizon: SCIENTIFIC_CLAIM_HORIZON.md
       - Scientific Validation Policy: SCIENTIFIC_VALIDATION_POLICY.md
       - Release Policy: RELEASE_POLICY.md
   - Real-World Evidence:

--- a/packages/neuros/src/neuros/evidence/__init__.py
+++ b/packages/neuros/src/neuros/evidence/__init__.py
@@ -4,8 +4,25 @@ This namespace lives in the user-facing ``neuros`` distribution so studies may
 compose optional ORION scientific authority with optional ecosystem adapters
 without reversing dependency direction in lower-level packages.
 
-Study modules must keep heavyweight scientific imports local to execution paths
-so the base neurOS runtime remains dependency-light.
+The claim contracts are intentionally dependency-light. They describe claim
+intent and immutable evidence references; ORION and qualified study systems
+remain responsible for earned scientific authority.
 """
 
-__all__: list[str] = []
+from .claims import (
+    ClaimEvidenceRef,
+    EvidenceRelation,
+    EvidenceRequirement,
+    EvidenceTier,
+    ScientificClaimBundle,
+    ScientificClaimSpec,
+)
+
+__all__ = [
+    "ClaimEvidenceRef",
+    "EvidenceRelation",
+    "EvidenceRequirement",
+    "EvidenceTier",
+    "ScientificClaimBundle",
+    "ScientificClaimSpec",
+]

--- a/packages/neuros/src/neuros/evidence/claims.py
+++ b/packages/neuros/src/neuros/evidence/claims.py
@@ -54,14 +54,12 @@ def _canonical_json(value: Any) -> Any:
             raise ValueError("claim manifests cannot contain NaN or infinity")
         return 0.0 if value == 0.0 else value
     if isinstance(value, Mapping):
-        normalized: dict[str, Any] = {}
-        for key in sorted(value):
-            if not isinstance(key, str):
-                raise TypeError("claim manifest mapping keys must be strings")
-            if not key.strip():
-                raise ValueError("claim manifest mapping keys must be non-empty")
-            normalized[key] = _canonical_json(value[key])
-        return normalized
+        keys = tuple(value.keys())
+        if any(not isinstance(key, str) for key in keys):
+            raise TypeError("claim manifest mapping keys must be strings")
+        if any(not key.strip() for key in keys):
+            raise ValueError("claim manifest mapping keys must be non-empty")
+        return {key: _canonical_json(value[key]) for key in sorted(keys)}
     if isinstance(value, (list, tuple)):
         return [_canonical_json(item) for item in value]
     if isinstance(value, (set, frozenset)):

--- a/packages/neuros/src/neuros/evidence/claims.py
+++ b/packages/neuros/src/neuros/evidence/claims.py
@@ -1,0 +1,389 @@
+"""Canonical scientific claim manifests for the public neurOS evidence layer.
+
+This module defines proposition and evidence-reference contracts above ORION
+Scientific Authority and NSQ execution evidence. It is intentionally
+stdlib-only: a claim may declare what evidence it seeks and cite immutable
+evidence identities, but it cannot award itself an evidence tier or scientific
+truth value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _nonempty(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    return normalized
+
+
+def _require_sha256(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a SHA-256 string")
+    normalized = value.strip().lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError(f"{name} must be a 64-character SHA-256 digest")
+    return normalized
+
+
+def _canonical_json(value: Any) -> Any:
+    """Return a deterministic JSON-compatible value.
+
+    Mapping keys are intentionally restricted to strings. Silently converting
+    arbitrary Python keys to strings can create cross-language identity
+    collisions in a portable manifest.
+    """
+
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("claim manifests cannot contain NaN or infinity")
+        return 0.0 if value == 0.0 else value
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key in sorted(value):
+            if not isinstance(key, str):
+                raise TypeError("claim manifest mapping keys must be strings")
+            if not key.strip():
+                raise ValueError("claim manifest mapping keys must be non-empty")
+            normalized[key] = _canonical_json(value[key])
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_canonical_json(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        raise TypeError("unordered sets are not valid claim manifest values")
+    raise TypeError(
+        "claim manifest values must be deterministic JSON-compatible primitives, "
+        f"mappings, lists, or tuples; got {type(value).__name__}"
+    )
+
+
+def _freeze_json(value: Any) -> Any:
+    normalized = _canonical_json(value)
+    if isinstance(normalized, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in normalized.items()})
+    if isinstance(normalized, list):
+        return tuple(_freeze_json(item) for item in normalized)
+    return normalized
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _domain_sha256(domain: str, value: Any) -> str:
+    raw = json.dumps(
+        _canonical_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    digest = hashlib.sha256()
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\x00")
+    digest.update(raw)
+    return digest.hexdigest()
+
+
+class EvidenceTier(str, Enum):
+    """Evidence strata.
+
+    These are labels, not an ordered score. Promotion between strata is owned
+    by explicit qualification policy outside this module.
+    """
+
+    SOFTWARE_CONTRACT = "software_contract"
+    INTEGRATION = "integration"
+    REPLAY_OR_SYNTHETIC = "replay_or_synthetic"
+    REAL_DATA = "real_data"
+    PHYSICAL_HARDWARE = "physical_hardware"
+    CLOSED_LOOP = "closed_loop"
+    CLINICAL = "clinical"
+
+
+class EvidenceRelation(str, Enum):
+    """Declared relationship between an immutable evidence object and a claim."""
+
+    SUPPORTS = "supports"
+    CONTRADICTS = "contradicts"
+    REPLICATES = "replicates"
+    CONTEXT = "context"
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRequirement:
+    """One predeclared requirement for evaluating a scientific claim."""
+
+    requirement_id: str
+    authority_type: str
+    description: str
+    required_tier: EvidenceTier
+    required: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("EvidenceRequirement schema_version must be 1")
+        if not isinstance(self.required_tier, EvidenceTier):
+            raise TypeError("required_tier must be EvidenceTier")
+        if not isinstance(self.required, bool):
+            raise TypeError("required must be boolean")
+        object.__setattr__(self, "requirement_id", _nonempty("requirement_id", self.requirement_id))
+        object.__setattr__(self, "authority_type", _nonempty("authority_type", self.authority_type))
+        object.__setattr__(self, "description", _nonempty("description", self.description))
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "requirement_id": self.requirement_id,
+            "authority_type": self.authority_type,
+            "description": self.description,
+            "required_tier": self.required_tier.value,
+            "required": self.required,
+            "metadata": _thaw_json(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ScientificClaimSpec:
+    """Content-addressed proposition-level intent.
+
+    ``target_evidence_tier`` says what the future protocol intends to earn. It
+    is never evidence that the claim has earned that tier.
+    """
+
+    claim_id: str
+    statement: str
+    domain: str
+    scope: str
+    inference_unit: str
+    target_evidence_tier: EvidenceTier
+    requirements: tuple[EvidenceRequirement, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("ScientificClaimSpec schema_version must be 1")
+        if not isinstance(self.target_evidence_tier, EvidenceTier):
+            raise TypeError("target_evidence_tier must be EvidenceTier")
+        object.__setattr__(self, "claim_id", _nonempty("claim_id", self.claim_id))
+        object.__setattr__(self, "statement", _nonempty("statement", self.statement))
+        object.__setattr__(self, "domain", _nonempty("domain", self.domain))
+        object.__setattr__(self, "scope", _nonempty("scope", self.scope))
+        object.__setattr__(self, "inference_unit", _nonempty("inference_unit", self.inference_unit))
+
+        requirements = tuple(self.requirements)
+        if not requirements:
+            raise ValueError("requirements must contain at least one EvidenceRequirement")
+        if any(not isinstance(item, EvidenceRequirement) for item in requirements):
+            raise TypeError("requirements must contain only EvidenceRequirement objects")
+        ids = [item.requirement_id for item in requirements]
+        if len(set(ids)) != len(ids):
+            raise ValueError("requirements cannot contain duplicate requirement_id values")
+        object.__setattr__(
+            self,
+            "requirements",
+            tuple(sorted(requirements, key=lambda item: item.requirement_id)),
+        )
+
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def claim_sha256(self) -> str:
+        return _domain_sha256(
+            "neuros.scientific_claim.v1",
+            self.to_dict(include_identity=False),
+        )
+
+    @property
+    def display_fingerprint(self) -> str:
+        return self.claim_sha256[:16]
+
+    def to_dict(self, *, include_identity: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema": "neuros.scientific_claim.v1",
+            "schema_version": self.schema_version,
+            "claim_id": self.claim_id,
+            "statement": self.statement,
+            "domain": self.domain,
+            "scope": self.scope,
+            "inference_unit": self.inference_unit,
+            "target_evidence_tier": self.target_evidence_tier.value,
+            "requirements": [item.to_dict() for item in self.requirements],
+            "metadata": _thaw_json(self.metadata),
+        }
+        if include_identity:
+            payload["claim_sha256"] = self.claim_sha256
+            payload["display_fingerprint"] = self.display_fingerprint
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimEvidenceRef:
+    """Reference from a claim to one immutable evidence object.
+
+    ``declared_evidence_tier`` is descriptive input, not an earned verdict.
+    A future authority bridge may validate the cited artifact and bind an earned
+    study qualification, but this dependency-light layer cannot do so itself.
+    """
+
+    evidence_sha256: str
+    relation: EvidenceRelation
+    declared_evidence_tier: EvidenceTier
+    source_kind: str
+    source_id: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("ClaimEvidenceRef schema_version must be 1")
+        if not isinstance(self.relation, EvidenceRelation):
+            raise TypeError("relation must be EvidenceRelation")
+        if not isinstance(self.declared_evidence_tier, EvidenceTier):
+            raise TypeError("declared_evidence_tier must be EvidenceTier")
+        object.__setattr__(
+            self,
+            "evidence_sha256",
+            _require_sha256("evidence_sha256", self.evidence_sha256),
+        )
+        object.__setattr__(self, "source_kind", _nonempty("source_kind", self.source_kind))
+        object.__setattr__(self, "source_id", _nonempty("source_id", self.source_id))
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def reference_sha256(self) -> str:
+        return _domain_sha256(
+            "neuros.claim_evidence_ref.v1",
+            self.to_dict(include_identity=False),
+        )
+
+    def to_dict(self, *, include_identity: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema": "neuros.claim_evidence_ref.v1",
+            "schema_version": self.schema_version,
+            "evidence_sha256": self.evidence_sha256,
+            "relation": self.relation.value,
+            "declared_evidence_tier": self.declared_evidence_tier.value,
+            "source_kind": self.source_kind,
+            "source_id": self.source_id,
+            "metadata": _thaw_json(self.metadata),
+        }
+        if include_identity:
+            payload["reference_sha256"] = self.reference_sha256
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ScientificClaimBundle:
+    """Portable binding from one claim intent to cited evidence identities.
+
+    The bundle records what is cited and how it is declared to relate to the
+    claim. It does not infer truth, confidence, a winning model, or an achieved
+    evidence tier.
+    """
+
+    claim: ScientificClaimSpec
+    evidence: tuple[ClaimEvidenceRef, ...]
+    protocol_sha256: str | None = None
+    study_sha256s: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("ScientificClaimBundle schema_version must be 1")
+        if not isinstance(self.claim, ScientificClaimSpec):
+            raise TypeError("claim must be ScientificClaimSpec")
+
+        evidence = tuple(self.evidence)
+        if not evidence:
+            raise ValueError("evidence must contain at least one ClaimEvidenceRef")
+        if any(not isinstance(item, ClaimEvidenceRef) for item in evidence):
+            raise TypeError("evidence must contain only ClaimEvidenceRef objects")
+        evidence_ids = [item.evidence_sha256 for item in evidence]
+        if len(set(evidence_ids)) != len(evidence_ids):
+            raise ValueError(
+                "evidence cannot cite the same underlying evidence_sha256 more than once"
+            )
+        object.__setattr__(
+            self,
+            "evidence",
+            tuple(sorted(evidence, key=lambda item: item.reference_sha256)),
+        )
+
+        if self.protocol_sha256 is not None:
+            object.__setattr__(
+                self,
+                "protocol_sha256",
+                _require_sha256("protocol_sha256", self.protocol_sha256),
+            )
+        study_sha256s = tuple(
+            _require_sha256("study_sha256", value) for value in self.study_sha256s
+        )
+        if len(set(study_sha256s)) != len(study_sha256s):
+            raise ValueError("study_sha256s cannot contain duplicates")
+        object.__setattr__(self, "study_sha256s", tuple(sorted(study_sha256s)))
+
+        metadata = _freeze_json(self.metadata)
+        if not isinstance(metadata, Mapping):
+            raise TypeError("metadata must be a mapping")
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def bundle_sha256(self) -> str:
+        return _domain_sha256(
+            "neuros.scientific_claim_bundle.v1",
+            self.to_dict(include_identity=False),
+        )
+
+    @property
+    def display_fingerprint(self) -> str:
+        return self.bundle_sha256[:16]
+
+    def to_dict(self, *, include_identity: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema": "neuros.scientific_claim_bundle.v1",
+            "schema_version": self.schema_version,
+            "claim": self.claim.to_dict(include_identity=include_identity),
+            "evidence": [
+                item.to_dict(include_identity=include_identity) for item in self.evidence
+            ],
+            "protocol_sha256": self.protocol_sha256,
+            "study_sha256s": list(self.study_sha256s),
+            "metadata": _thaw_json(self.metadata),
+        }
+        if include_identity:
+            payload["bundle_sha256"] = self.bundle_sha256
+            payload["display_fingerprint"] = self.display_fingerprint
+        return payload

--- a/tests/test_scientific_claim_spec.py
+++ b/tests/test_scientific_claim_spec.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from neuros.evidence.claims import (
+    ClaimEvidenceRef,
+    EvidenceRelation,
+    EvidenceRequirement,
+    EvidenceTier,
+    ScientificClaimBundle,
+    ScientificClaimSpec,
+)
+
+
+def _sha(char: str) -> str:
+    return char * 64
+
+
+def _requirement(
+    requirement_id: str,
+    tier: EvidenceTier = EvidenceTier.SOFTWARE_CONTRACT,
+) -> EvidenceRequirement:
+    return EvidenceRequirement(
+        requirement_id=requirement_id,
+        authority_type="test_authority",
+        description=f"require {requirement_id}",
+        required_tier=tier,
+        metadata={"nested": {"b": 2, "a": 1}},
+    )
+
+
+def _claim(*requirements: EvidenceRequirement) -> ScientificClaimSpec:
+    return ScientificClaimSpec(
+        claim_id="decoder-transfer",
+        statement="A frozen decoder transfers across held-out subjects.",
+        domain="neural_decoding",
+        scope="held_out_subjects",
+        inference_unit="subject",
+        target_evidence_tier=EvidenceTier.REAL_DATA,
+        requirements=tuple(requirements) or (_requirement("software"),),
+        metadata={"protocol_family": "subject_disjoint", "version": 1},
+    )
+
+
+def _evidence(
+    char: str,
+    *,
+    relation: EvidenceRelation = EvidenceRelation.SUPPORTS,
+    tier: EvidenceTier = EvidenceTier.SOFTWARE_CONTRACT,
+    source_id: str | None = None,
+) -> ClaimEvidenceRef:
+    return ClaimEvidenceRef(
+        evidence_sha256=_sha(char),
+        relation=relation,
+        declared_evidence_tier=tier,
+        source_kind="qualification_receipt",
+        source_id=source_id or f"receipt-{char}",
+        metadata={"provider": "test", "attempt": 1},
+    )
+
+
+def test_claim_identity_is_independent_of_requirement_and_mapping_order() -> None:
+    left = ScientificClaimSpec(
+        claim_id="decoder-transfer",
+        statement="A frozen decoder transfers across held-out subjects.",
+        domain="neural_decoding",
+        scope="held_out_subjects",
+        inference_unit="subject",
+        target_evidence_tier=EvidenceTier.REAL_DATA,
+        requirements=(_requirement("z-last"), _requirement("a-first")),
+        metadata={"outer": {"z": 2, "a": 1}, "name": "same"},
+    )
+    right = ScientificClaimSpec(
+        claim_id="decoder-transfer",
+        statement="A frozen decoder transfers across held-out subjects.",
+        domain="neural_decoding",
+        scope="held_out_subjects",
+        inference_unit="subject",
+        target_evidence_tier=EvidenceTier.REAL_DATA,
+        requirements=(_requirement("a-first"), _requirement("z-last")),
+        metadata={"name": "same", "outer": {"a": 1, "z": 2}},
+    )
+
+    assert left.claim_sha256 == right.claim_sha256
+    assert [item.requirement_id for item in left.requirements] == ["a-first", "z-last"]
+    assert left.to_dict() == right.to_dict()
+
+
+def test_bundle_identity_is_independent_of_evidence_and_study_order() -> None:
+    claim = _claim(_requirement("software"), _requirement("real-data", EvidenceTier.REAL_DATA))
+    first = _evidence("a")
+    second = _evidence("b", tier=EvidenceTier.REAL_DATA)
+
+    left = ScientificClaimBundle(
+        claim=claim,
+        evidence=(second, first),
+        protocol_sha256=_sha("c"),
+        study_sha256s=(_sha("e"), _sha("d")),
+        metadata={"site": "multi"},
+    )
+    right = ScientificClaimBundle(
+        claim=claim,
+        evidence=(first, second),
+        protocol_sha256=_sha("c"),
+        study_sha256s=(_sha("d"), _sha("e")),
+        metadata={"site": "multi"},
+    )
+
+    assert left.bundle_sha256 == right.bundle_sha256
+    assert left.to_dict() == right.to_dict()
+    assert left.study_sha256s == (_sha("d"), _sha("e"))
+
+
+def test_bundle_rejects_duplicate_underlying_evidence_even_if_reference_differs() -> None:
+    claim = _claim()
+    support = _evidence("a", relation=EvidenceRelation.SUPPORTS, source_id="support-view")
+    context = _evidence("a", relation=EvidenceRelation.CONTEXT, source_id="context-view")
+
+    with pytest.raises(ValueError, match="same underlying evidence_sha256"):
+        ScientificClaimBundle(claim=claim, evidence=(support, context))
+
+
+def test_target_and_declared_tiers_never_become_earned_qualification() -> None:
+    claim = _claim(_requirement("real-data", EvidenceTier.REAL_DATA))
+    ref = _evidence("a", tier=EvidenceTier.SOFTWARE_CONTRACT)
+    bundle = ScientificClaimBundle(claim=claim, evidence=(ref,))
+    payload = bundle.to_dict()
+
+    assert payload["claim"]["target_evidence_tier"] == "real_data"
+    assert payload["evidence"][0]["declared_evidence_tier"] == "software_contract"
+    serialized = repr(payload)
+    assert "achieved_evidence_tier" not in serialized
+    assert "truth" not in serialized
+    assert "confidence" not in serialized
+    assert "winner" not in serialized
+
+
+def test_duplicate_requirement_ids_fail_closed() -> None:
+    with pytest.raises(ValueError, match="duplicate requirement_id"):
+        _claim(_requirement("same"), _requirement("same"))
+
+
+def test_metadata_is_deeply_frozen_and_rejects_unordered_values() -> None:
+    requirement = _requirement("immutable")
+    with pytest.raises(TypeError):
+        requirement.metadata["new"] = "value"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        requirement.metadata["nested"]["new"] = 3  # type: ignore[index]
+    with pytest.raises(FrozenInstanceError):
+        requirement.description = "changed"  # type: ignore[misc]
+
+    with pytest.raises(TypeError, match="unordered sets"):
+        EvidenceRequirement(
+            requirement_id="bad-set",
+            authority_type="test",
+            description="reject nondeterministic metadata",
+            required_tier=EvidenceTier.SOFTWARE_CONTRACT,
+            metadata={"bad": {"unordered", "set"}},
+        )
+
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        EvidenceRequirement(
+            requirement_id="bad-key",
+            authority_type="test",
+            description="reject cross-language key coercion",
+            required_tier=EvidenceTier.SOFTWARE_CONTRACT,
+            metadata={1: "not portable"},  # type: ignore[dict-item]
+        )
+
+
+def test_nonfinite_metadata_and_malformed_digests_fail_closed() -> None:
+    with pytest.raises(ValueError, match="NaN or infinity"):
+        EvidenceRequirement(
+            requirement_id="nan",
+            authority_type="test",
+            description="reject nonfinite value",
+            required_tier=EvidenceTier.SOFTWARE_CONTRACT,
+            metadata={"value": float("nan")},
+        )
+
+    with pytest.raises(ValueError, match="64-character SHA-256"):
+        ClaimEvidenceRef(
+            evidence_sha256="not-a-digest",
+            relation=EvidenceRelation.SUPPORTS,
+            declared_evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
+            source_kind="receipt",
+            source_id="bad",
+        )
+
+
+def test_negative_zero_is_canonicalized_for_cross_runtime_identity() -> None:
+    left = ScientificClaimSpec(
+        claim_id="zero",
+        statement="Zero-valued metadata is canonical.",
+        domain="contract_test",
+        scope="unit",
+        inference_unit="case",
+        target_evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
+        requirements=(_requirement("software"),),
+        metadata={"value": -0.0},
+    )
+    right = ScientificClaimSpec(
+        claim_id="zero",
+        statement="Zero-valued metadata is canonical.",
+        domain="contract_test",
+        scope="unit",
+        inference_unit="case",
+        target_evidence_tier=EvidenceTier.SOFTWARE_CONTRACT,
+        requirements=(_requirement("software"),),
+        metadata={"value": 0.0},
+    )
+
+    assert left.claim_sha256 == right.claim_sha256
+    assert left.to_dict()["metadata"]["value"] == 0.0
+
+
+def test_content_changes_change_domain_separated_identities() -> None:
+    claim = _claim()
+    changed = ScientificClaimSpec(
+        claim_id=claim.claim_id,
+        statement=claim.statement + " Strictly.",
+        domain=claim.domain,
+        scope=claim.scope,
+        inference_unit=claim.inference_unit,
+        target_evidence_tier=claim.target_evidence_tier,
+        requirements=claim.requirements,
+        metadata=claim.metadata,
+    )
+    ref = _evidence("a")
+
+    assert claim.claim_sha256 != changed.claim_sha256
+    assert ref.reference_sha256 != claim.claim_sha256
+    assert ScientificClaimBundle(claim=claim, evidence=(ref,)).bundle_sha256 not in {
+        claim.claim_sha256,
+        ref.reference_sha256,
+    }


### PR DESCRIPTION
## Purpose

Introduce the missing proposition-level evidence layer directly on current promoted `main@5ff769bc6c12e3d6d257b4f91df34d47dd2f7f11`.

This is a clean reconstruction of the useful architectural idea from historical #161, not a transplant of its stale Kumar2024 integration surface.

The core invariant is:

```text
claim intent != earned qualification != evidence relation != truth
```

## Public contracts

`neuros.evidence` now exposes:

- `EvidenceTier`
- `EvidenceRelation`
- `EvidenceRequirement`
- `ScientificClaimSpec`
- `ClaimEvidenceRef`
- `ScientificClaimBundle`

The module is stdlib-only and does not import ORION, NSQ, model code, or neural data tooling.

## Hardening beyond historical #161

Before freezing this v1 surface, this candidate removes several identity ambiguities:

- requirements canonicalize by `requirement_id`, so set-like order cannot perturb the claim digest;
- evidence references canonicalize by reference identity;
- study digests canonicalize lexicographically;
- one underlying `evidence_sha256` may appear only once per claim bundle, preventing metadata/relation aliases from double-counting one artifact;
- the caller-supplied evidence label is explicitly named `declared_evidence_tier`, not an earned tier;
- nested metadata is deeply frozen;
- mapping keys must be strings for cross-language portability;
- unordered sets, NaN, and infinity fail closed;
- `-0.0` canonicalizes to `0.0`;
- claim, evidence-reference, and bundle identities use separate SHA-256 domains.

No automatic ordering or promotion between evidence tiers is defined.

## ORION boundary

`ScientificClaimSpec` is upstream claim intent. ORION `EvidenceClaim` remains downstream, study-local earned authority. This package cannot self-award real-data, hardware, closed-loop, clinical, replicated, or truthful status.

A future authority bridge may validate an ORION or NSQ receipt and create a bound reference. That bridge, not this manifest layer, must prove the relationship.

## Qualification

Public Trust now owns this public scientific contract instead of attaching it to a benchmark-specific workflow. The gate:

- triggers on `neuros.evidence` and claim-contract tests;
- checks out the literal PR head with credentials disabled;
- requires an exact clean checkout;
- runs adversarial claim-contract tests;
- retains immutable-action, public-contract, citation, and strict-doc validation.

The ordinary neurOS CI remains an independent repository-wide integration gate.

## Claim boundary

This PR adds schemas and identity semantics only. It produces no scientific result, confidence value, model ranking, evidence-tier promotion, clinical claim, or ORION comparison permission.

## Follow-up

After this contract is qualified, the next useful demonstration is not another schema. It is one end-to-end claim bundle over an existing neurOS study that preserves both earned and explicitly unearned evidence states.

Supersedes the active integration role of historical #161 while preserving it as design provenance after promotion.