### PR TITLE
chore(deps): make major GitHub Action migrations opt-in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "deps(actions)"


### PR DESCRIPTION
## Purpose

Refine the dependency policy using evidence from the first two independent major-update PRs after #188.

#189 (`setup-python` 5 -> 7) rewrites 58 workflow files and #190 (`upload-artifact` 4 -> 7) rewrites 19. Both immediately invalidate the frozen NIM owner-bridge workflow identities and launch large qualification fan-outs before we have even decided to perform those major migrations.

Splitting majors was causally correct, but auto-opening them is still too noisy and compute-expensive for a repository where workflow blobs are themselves authority inputs.

## Change

Keep weekly grouped GitHub Action minor/patch maintenance, but tell Dependabot to ignore semver-major updates:

```yaml
ignore:
  - dependency-name: "*"
    update-types:
      - "version-update:semver-major"
```

Major action migrations become explicit engineering tranches. When desired, we can update one action family deliberately, review runner/runtime and artifact semantic changes, rebind exact workflow authorities where required, and qualify the resulting current-main candidate.

## Boundary

This changes dependency-update orchestration only. It changes no action pin, workflow runtime, scientific authority, evidence interpretation, model, dataset, or experiment.

## Follow-up

Once promoted, #189 and #190 should close unmerged. Their failed NIM bridge checks remain useful evidence that major workflow migrations require explicit authority rebinding.